### PR TITLE
refactor TopologyBuilder

### DIFF
--- a/stream/src/main/java/org/apache/kafka/streaming/processor/TopologyBuilder.java
+++ b/stream/src/main/java/org/apache/kafka/streaming/processor/TopologyBuilder.java
@@ -107,6 +107,8 @@ public class TopologyBuilder {
         for (String topic : topics) {
             if (sourceTopicNames.contains(topic))
                 throw new IllegalArgumentException("Topic " + topic + " has already been registered by another processor.");
+
+            sourceTopicNames.add(topic);
         }
 
         nodeNames.add(name);

--- a/stream/src/main/java/org/apache/kafka/streaming/processor/internals/ProcessorNode.java
+++ b/stream/src/main/java/org/apache/kafka/streaming/processor/internals/ProcessorNode.java
@@ -31,8 +31,6 @@ public class ProcessorNode<K1, V1, K2, V2> {
     private final String name;
     private final Processor<K1, V1> processor;
 
-    public boolean initialized;
-
     public ProcessorNode(String name) {
         this(name, null);
     }
@@ -42,8 +40,6 @@ public class ProcessorNode<K1, V1, K2, V2> {
         this.processor = processor;
         this.parents = new ArrayList<>();
         this.children = new ArrayList<>();
-
-        this.initialized = false;
     }
 
     public String name() {

--- a/stream/src/main/java/org/apache/kafka/streaming/processor/internals/SinkNode.java
+++ b/stream/src/main/java/org/apache/kafka/streaming/processor/internals/SinkNode.java
@@ -26,22 +26,18 @@ import java.util.List;
 
 public class SinkNode<K, V> extends ProcessorNode<K, V, K, V> {
 
+    private final String topic;
     private final Serializer<K> keySerializer;
     private final Serializer<V> valSerializer;
-    private final List<String> topics;
 
     private ProcessorContext context;
 
-    public SinkNode(String name, Serializer<K> keySerializer, Serializer<V> valSerializer) {
+    public SinkNode(String name, String topic, Serializer<K> keySerializer, Serializer<V> valSerializer) {
         super(name);
 
-        this.topics = new ArrayList<>();
+        this.topic = topic;
         this.keySerializer = keySerializer;
         this.valSerializer = valSerializer;
-    }
-
-    public void addTopic(String topic) {
-        this.topics.add(topic);
     }
 
     @Override
@@ -53,9 +49,7 @@ public class SinkNode<K, V> extends ProcessorNode<K, V, K, V> {
     public void process(K key, V value) {
         // send to all the registered topics
         RecordCollector collector = ((ProcessorContextImpl)context).recordCollector();
-        for (String topic : topics) {
-            collector.send(new ProducerRecord<>(topic, key, value), keySerializer, valSerializer);
-        }
+        collector.send(new ProducerRecord<>(topic, key, value), keySerializer, valSerializer);
     }
 
     @Override


### PR DESCRIPTION
@guozhangwang 
Simpler topology construction by taking an advantage that sources/sinks/processors are always added in a topological order. Processor nodes are constructed in the same order as API calls (addSource, addSink, addProcessor). I will use this guarantee in the join support.
