### PR TITLE
no need for RecordCollector to know default serializers

### DIFF
--- a/stream/src/main/java/org/apache/kafka/streaming/processor/internals/RecordCollector.java
+++ b/stream/src/main/java/org/apache/kafka/streaming/processor/internals/RecordCollector.java
@@ -45,19 +45,11 @@ public class RecordCollector {
             }
         }
     };
-    private final Serializer<Object> keySerializer;
-    private final Serializer<Object> valueSerializer;
 
 
-    public RecordCollector(Producer<byte[], byte[]> producer, Serializer<Object> keySerializer, Serializer<Object> valueSerializer) {
+    public RecordCollector(Producer<byte[], byte[]> producer) {
         this.producer = producer;
         this.offsets = new HashMap<>();
-        this.keySerializer = keySerializer;
-        this.valueSerializer = valueSerializer;
-    }
-
-    public void send(ProducerRecord<Object, Object> record) {
-        send(record, this.keySerializer, this.valueSerializer);
     }
 
     public <K, V> void send(ProducerRecord<K, V> record, Serializer<K> keySerializer, Serializer<V> valueSerializer) {

--- a/stream/src/main/java/org/apache/kafka/streaming/processor/internals/StreamTask.java
+++ b/stream/src/main/java/org/apache/kafka/streaming/processor/internals/StreamTask.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streaming.StreamingConfig;
 import org.apache.kafka.streaming.processor.Processor;
 import org.apache.kafka.streaming.processor.ProcessorContext;
@@ -104,9 +103,7 @@ public class StreamTask {
         this.consumedOffsets = new HashMap<>();
 
         // create the record recordCollector that maintains the produced offsets
-        this.recordCollector = new RecordCollector(producer,
-            (Serializer<Object>) config.getConfiguredInstance(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, Serializer.class),
-            (Serializer<Object>) config.getConfiguredInstance(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, Serializer.class));
+        this.recordCollector = new RecordCollector(producer);
 
         // initialize the topology with its own context
         try {


### PR DESCRIPTION
@guozhangwang 
Callers know which serializers to use and always specify them explicitly.