### PR TITLE
Streaming build fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -506,6 +506,14 @@ project(':stream') {
         dependsOn 'copyDependantLibs'
     }
 
+    artifacts {
+        archives testJar
+    }
+
+    configurations {
+        archives.extendsFrom (testCompile)
+    }
+
     checkstyle {
         configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     }


### PR DESCRIPTION
Modified the `build.gradle` file's configuration for the 'stream' project to include the test JAR when uploading artifacts into Maven. Without these minor changes, the stream project's normal JAR and source JAR are uploaded to Maven, but the test JAR never is.