### PR TITLE
change timestampextractor signature

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/examples/WallclockTimestampExtractor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/examples/WallclockTimestampExtractor.java
@@ -17,11 +17,12 @@
 
 package org.apache.kafka.streams.examples;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 
 public class WallclockTimestampExtractor implements TimestampExtractor {
     @Override
-    public long extract(String topic, Object key, Object value) {
+    public long extract(ConsumerRecord<Object, Object> record) {
         return System.currentTimeMillis();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TimestampExtractor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TimestampExtractor.java
@@ -17,18 +17,18 @@
 
 package org.apache.kafka.streams.processor;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
 /**
  * An interface that allows the KStream framework to extract a timestamp from a key-value pair
  */
 public interface TimestampExtractor {
 
     /**
-     * Extracts a timestamp from a key-value pair from a topic
+     * Extracts a timestamp from a message
      *
-     * @param topic the topic name
-     * @param key   the key object
-     * @param value the value object
+     * @param record ConsumerRecord
      * @return timestamp
      */
-    long extract(String topic, Object key, Object value);
+    long extract(ConsumerRecord<Object, Object> record);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
@@ -75,12 +75,14 @@ public class RecordQueue {
             // deserialize the raw record, extract the timestamp and put into the queue
             Object key = source.deserializeKey(rawRecord.topic(), rawRecord.key());
             Object value = source.deserializeValue(rawRecord.topic(), rawRecord.value());
-            long timestamp = timestampExtractor.extract(rawRecord.topic(), key, value);
 
-            StampedRecord record = new StampedRecord(new ConsumerRecord<>(rawRecord.topic(), rawRecord.partition(), rawRecord.offset(), key, value), timestamp);
+            ConsumerRecord<Object, Object> record = new ConsumerRecord<>(rawRecord.topic(), rawRecord.partition(), rawRecord.offset(), key, value);
+            long timestamp = timestampExtractor.extract(record);
 
-            fifoQueue.addLast(record);
-            timeTracker.addElement(record);
+            StampedRecord stampedRecord = new StampedRecord(record, timestamp);
+
+            fifoQueue.addLast(stampedRecord);
+            timeTracker.addElement(stampedRecord);
         }
 
         return size();

--- a/streams/src/test/java/org/apache/kafka/test/MockTimestampExtractor.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockTimestampExtractor.java
@@ -17,12 +17,13 @@
 
 package org.apache.kafka.test;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 
 public class MockTimestampExtractor implements TimestampExtractor {
 
     @Override
-    public long extract(String topic, Object key, Object value) {
-        return ((Integer) key).longValue();
+    public long extract(ConsumerRecord<Object, Object> record) {
+        return ((Integer) record.key()).longValue();
     }
 }


### PR DESCRIPTION
@guozhangwang 

Changed the signature of TimestampExtractor.extract(). Now it takes a ConsumerRecord instance. ConsumerRecord can provide more information to TimestampExtractor. Once KIP-32 is implemented, and the createTime and logAppendTime is exposed to a consumer,I expect it will be done through ConsumerRecord. 