### PR TITLE
fix state directory cleanup

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -64,7 +64,7 @@ public class ProcessorStateManager {
         // try to acquire the exclusive lock on the state directory
         directoryLock = lockStateDirectory(baseDir);
         if (directoryLock == null) {
-            throw new IOException("failed to lock the state directory: " + baseDir.getCanonicalPath());
+            throw new IOException("Failed to lock the state directory: " + baseDir.getCanonicalPath());
         }
 
         // load the checkpoint information

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -108,7 +108,7 @@ public class StreamTask implements Punctuator {
         try {
             this.processorContext = new ProcessorContextImpl(id, this, config, recordCollector, new Metrics());
         } catch (IOException e) {
-            throw new KafkaException("Error while creating the state manager in processor context.");
+            throw new KafkaException("Error while creating the state manager in processor context", e);
         }
 
         // initialize the task by initializing all its processor nodes in the topology

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -43,6 +43,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileLock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -80,12 +82,14 @@ public class StreamThread extends Thread {
         @Override
         public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> assignment) {
             addPartitions(assignment);
+            lastClean = time.milliseconds(); // start the cleaning cycle
         }
 
         @Override
         public void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<TopicPartition> assignment) {
             commitAll(time.milliseconds());
             removePartitions();
+            lastClean = Long.MAX_VALUE; // stop the cleaning cycle until partitions are assigned
         }
     };
 
@@ -120,7 +124,7 @@ public class StreamThread extends Thread {
         this.cleanTimeMs = config.getLong(StreamingConfig.STATE_CLEANUP_DELAY_MS_CONFIG);
         this.totalRecordsToProcess = config.getLong(StreamingConfig.TOTAL_RECORDS_TO_PROCESS);
 
-        this.lastClean = 0;
+        this.lastClean = Long.MAX_VALUE; // the cleaning cycle won't start until partition assignment
         this.lastCommit = 0;
         this.recordsProcessed = 0;
         this.time = new SystemTime();
@@ -267,9 +271,25 @@ public class StreamThread extends Thread {
                 for (File dir : stateDirs) {
                     try {
                         Integer id = Integer.parseInt(dir.getName());
-                        if (!tasks.containsKey(id)) {
-                            log.info("Deleting obsolete state directory {} after delayed {} ms.", dir.getAbsolutePath(), cleanTimeMs);
-                            Utils.delete(dir);
+
+                        // try to acquire the exclusive lock on the state directory
+                        FileLock directoryLock = null;
+                        try {
+                            directoryLock = ProcessorStateManager.lockStateDirectory(dir);
+                            if (directoryLock != null) {
+                                log.info("Deleting obsolete state directory {} after delayed {} ms.", dir.getAbsolutePath(), cleanTimeMs);
+                                Utils.delete(dir);
+                            }
+                        } catch (IOException e) {
+                            log.error("Failed to lock the state directory", e);
+                        } finally {
+                            if (directoryLock != null) {
+                                try {
+                                    directoryLock.release();
+                                } catch (IOException e) {
+                                    log.error("Failed to release the state directory lock");
+                                }
+                            }
                         }
                     } catch (NumberFormatException e) {
                         // there may be some unknown files that sits in the same directory,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -281,7 +281,7 @@ public class StreamThread extends Thread {
                                 Utils.delete(dir);
                             }
                         } catch (IOException e) {
-                            log.error("Failed to lock the state directory", e);
+                            log.error("Failed to lock the state directory due to an unexpected exception", e);
                         } finally {
                             if (directoryLock != null) {
                                 try {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -78,7 +78,6 @@ public class StreamTaskTest {
 
     private final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
     private final MockProducer<byte[], byte[]> producer = new MockProducer<>(false, bytesSerializer, bytesSerializer);
-    private final StreamTask task = new StreamTask(0, consumer, producer, partitions, topology, config);
 
     @Before
     public void setup() {
@@ -88,6 +87,8 @@ public class StreamTaskTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testProcessOrder() {
+        StreamTask task = new StreamTask(0, consumer, producer, partitions, topology, config);
+
         byte[] recordValue = intSerializer.serialize(null, 10);
 
         task.addRecords(partition1, records(
@@ -125,11 +126,15 @@ public class StreamTaskTest {
         assertEquals(task.process(), 0);
         assertEquals(source1.numReceived, 3);
         assertEquals(source2.numReceived, 3);
+
+        task.close();
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testPauseResume() {
+        StreamTask task = new StreamTask(1, consumer, producer, partitions, topology, config);
+
         byte[] recordValue = intSerializer.serialize(null, 10);
 
         task.addRecords(partition1, records(
@@ -173,6 +178,8 @@ public class StreamTaskTest {
         assertEquals(source2.numReceived, 1);
 
         assertEquals(consumer.paused().size(), 0);
+
+        task.close();
     }
 
     private Iterable<ConsumerRecord<byte[], byte[]>> records(ConsumerRecord<byte[], byte[]>... recs) {


### PR DESCRIPTION
@guozhangwang 

The current implementation of StreamThread.maybeClean() is a nasty time bomb. It destroys local state after the cleanup delay time.

StreamThread cleans up unused state directories after the cleanup delay time. But it knows only the tasks assigned to it. It means it deletes any task directory that does not belong to itself. Thus the threads destroys each other's local state. :(

To solve this, I added a lock file to each state directory as protection. ProcessorStateManager acquires this lock. maybeClean() also tries to acquire this lock before cleaning up the directory. If successful, it can clean the directory, otherwise, skip it. This works when there are multiple instance of KafkaStreaming running either in the same JVM or different JVMs. 

I also added a code to reset lastClean to the current timestamp in onPartitionAssigned because we should time the cleanup delay after partitions are assigned.