### PR TITLE
Add unit tests for KStreamImpl

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreaming.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreaming.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  *    StreamingConfig config = new StreamingConfig(props);
  *
  *    KStreamBuilder builder = new KStreamBuilder();
- *    builder.from("topic1").mapValue(value -&gt; value.length()).sendTo("topic2");
+ *    builder.from("topic1").mapValue(value -&gt; value.length()).to("topic2");
  *
  *    KafkaStreaming streaming = new KafkaStreaming(builder, config);
  *    streaming.start();

--- a/streams/src/main/java/org/apache/kafka/streams/examples/KStreamJob.java
+++ b/streams/src/main/java/org/apache/kafka/streams/examples/KStreamJob.java
@@ -74,8 +74,8 @@ public class KStreamJob {
             }
         );
 
-        streams[0].sendTo("topic2");
-        streams[1].sendTo("topic3");
+        streams[0].to("topic2");
+        streams[1].to("topic3");
 
         KafkaStreaming kstream = new KafkaStreaming(builder, config);
         kstream.start();

--- a/streams/src/main/java/org/apache/kafka/streams/examples/KStreamJob.java
+++ b/streams/src/main/java/org/apache/kafka/streams/examples/KStreamJob.java
@@ -28,13 +28,12 @@ import org.apache.kafka.streams.kstream.KeyValue;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Predicate;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Properties;
 
 public class KStreamJob {
 
     public static void main(String[] args) throws Exception {
-        Map<String, Object> props = new HashMap<>();
+        Properties props = new Properties();
         props.put(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         props.put(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);

--- a/streams/src/main/java/org/apache/kafka/streams/examples/ProcessorJob.java
+++ b/streams/src/main/java/org/apache/kafka/streams/examples/ProcessorJob.java
@@ -32,8 +32,7 @@ import org.apache.kafka.streams.state.InMemoryKeyValueStore;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Properties;
 
 public class ProcessorJob {
 
@@ -87,7 +86,7 @@ public class ProcessorJob {
     }
 
     public static void main(String[] args) throws Exception {
-        Map<String, Object> props = new HashMap<>();
+        Properties props = new Properties();
         props.put(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         props.put(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -101,7 +101,7 @@ public interface KStream<K, V> {
 
     /**
      * Sends key-value to a topic, also creates a new stream from the topic.
-     * This is equivalent to calling sendTo(topic) and from(topic).
+     * This is equivalent to calling to(topic) and from(topic).
      *
      * @param topic           the topic name
      * @param <K1>            the key type of the new stream
@@ -112,7 +112,7 @@ public interface KStream<K, V> {
 
     /**
      * Sends key-value to a topic, also creates a new stream from the topic.
-     * This is equivalent to calling sendTo(topic) and from(topic).
+     * This is equivalent to calling to(topic) and from(topic).
      *
      * @param topic           the topic name
      * @param keySerializer   key serializer used to send key-value pairs,
@@ -134,7 +134,7 @@ public interface KStream<K, V> {
      *
      * @param topic         the topic name
      */
-    void sendTo(String topic);
+    void to(String topic);
 
     /**
      * Sends key-value to a topic.
@@ -145,7 +145,7 @@ public interface KStream<K, V> {
      * @param valSerializer value serializer used to send key-value pairs,
      *                      if not specified the default serializer defined in the configs will be used
      */
-    void sendTo(String topic, Serializer<K> keySerializer, Serializer<V> valSerializer);
+    void to(String topic, Serializer<K> keySerializer, Serializer<V> valSerializer);
 
     /**
      * Processes all elements in this stream by applying a processor.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -101,7 +101,17 @@ public interface KStream<K, V> {
 
     /**
      * Sends key-value to a topic, also creates a new stream from the topic.
-     * The created stream is added to the default synchronization group.
+     * This is equivalent to calling sendTo(topic) and from(topic).
+     *
+     * @param topic           the topic name
+     * @param <K1>            the key type of the new stream
+     * @param <V1>            the value type of the new stream
+     * @return KStream
+     */
+    <K1, V1> KStream<K1, V1> through(String topic);
+
+    /**
+     * Sends key-value to a topic, also creates a new stream from the topic.
      * This is equivalent to calling sendTo(topic) and from(topic).
      *
      * @param topic           the topic name

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -177,14 +177,14 @@ public class KStreamImpl<K, V> implements KStream<K, V> {
     }
 
     @Override
-    public void sendTo(String topic) {
+    public void to(String topic) {
         String name = SEND_NAME + INDEX.getAndIncrement();
 
         topology.addSink(name, topic, this.name);
     }
 
     @Override
-    public void sendTo(String topic, Serializer<K> keySerializer, Serializer<V> valSerializer) {
+    public void to(String topic, Serializer<K> keySerializer, Serializer<V> valSerializer) {
         String name = SEND_NAME + INDEX.getAndIncrement();
 
         topology.addSink(name, topic, keySerializer, valSerializer, this.name);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -172,6 +172,11 @@ public class KStreamImpl<K, V> implements KStream<K, V> {
     }
 
     @Override
+    public <K1, V1> KStream<K1, V1> through(String topic) {
+        return through(topic, (Serializer<K>) null, (Serializer<V>) null, (Deserializer<K1>) null, (Deserializer<V1>) null);
+    }
+
+    @Override
     public void sendTo(String topic) {
         String name = SEND_NAME + INDEX.getAndIncrement();
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/KStreamBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/KStreamBuilderTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.streams.kstream.internals.KStreamImpl;
+import org.apache.kafka.streams.processor.TopologyException;
+import org.junit.Test;
+
+public class KStreamBuilderTest {
+
+    @Test(expected = TopologyException.class)
+    public void testFrom() {
+        final KStreamBuilder builder = new KStreamBuilder();
+
+        builder.from("topic-1", "topic-2");
+
+        builder.addSource(KStreamImpl.SOURCE_NAME + KStreamImpl.INDEX.decrementAndGet(), "topic-3");
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KStreamBuilder;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.test.MockProcessorDef;
+import org.apache.kafka.test.UnlimitedWindowDef;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class KStreamImplTest {
+
+    @Test
+    public void testNumProcesses() {
+        final Deserializer<String> deserializer = new StringDeserializer();
+        final KStreamBuilder builder = new KStreamBuilder();
+
+        KStream<String, String> source1 = builder.from(deserializer, deserializer, "topic-1", "topic-2");
+
+        KStream<String, String> source2 = builder.from(deserializer, deserializer, "topic-3", "topic-4");
+
+        KStream<String, String> stream1 =
+            source1.filter(new Predicate<String, String>() {
+                @Override
+                public boolean apply(String key, String value) {
+                    return true;
+                }
+            }).filterOut(new Predicate<String, String>() {
+                @Override
+                public boolean apply(String key, String value) {
+                    return false;
+                }
+            });
+
+        KStream<String, Integer> stream2 = stream1.mapValues(new ValueMapper<String, Integer>() {
+            @Override
+            public Integer apply(String value) {
+                return new Integer(value);
+            }
+        });
+
+        KStream<String, Integer> stream3 = source2.flatMapValues(new ValueMapper<String, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(String value) {
+                return Collections.singletonList(new Integer(value));
+            }
+        });
+
+        KStream<String, Integer>[] streams2 = stream2.branch(
+            new Predicate<String, Integer>() {
+                @Override
+                public boolean apply(String key, Integer value) {
+                    return (value % 2) == 0;
+                }
+            },
+            new Predicate<String, Integer>() {
+                @Override
+                public boolean apply(String key, Integer value) {
+                    return true;
+                }
+            }
+        );
+
+        KStream<String, Integer>[] streams3 = stream3.branch(
+            new Predicate<String, Integer>() {
+                @Override
+                public boolean apply(String key, Integer value) {
+                    return (value % 2) == 0;
+                }
+            },
+            new Predicate<String, Integer>() {
+                @Override
+                public boolean apply(String key, Integer value) {
+                    return true;
+                }
+            }
+        );
+
+        KStream<String, Integer> stream4 = streams2[0].with(new UnlimitedWindowDef<String, Integer>("window"))
+            .join(streams3[0].with(new UnlimitedWindowDef<String, Integer>("window")), new ValueJoiner<Integer, Integer, Integer>() {
+                @Override
+                public Integer apply(Integer value1, Integer value2) {
+                    return value1 + value2;
+                }
+            });
+
+        KStream<String, Integer> stream5 = streams2[1].with(new UnlimitedWindowDef<String, Integer>("window"))
+            .join(streams3[1].with(new UnlimitedWindowDef<String, Integer>("window")), new ValueJoiner<Integer, Integer, Integer>() {
+                @Override
+                public Integer apply(Integer value1, Integer value2) {
+                    return value1 + value2;
+                }
+            });
+
+        stream4.sendTo("topic-5");
+
+        stream5.through("topic-6").process(new MockProcessorDef<>()).sendTo("topic-7");
+
+        assertEquals(2 + // sources
+            2 + // stream1
+            1 + // stream2
+            1 + // stream3
+            1 + 2 + // streams2
+            1 + 2 + // streams3
+            2 + 3 + // stream4
+            2 + 3 + // stream5
+            1 + // sendTo
+            2 + // through
+            1 + // process
+            1, // sendTo
+            builder.build().processors().size());
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -117,9 +117,9 @@ public class KStreamImplTest {
                 }
             });
 
-        stream4.sendTo("topic-5");
+        stream4.to("topic-5");
 
-        stream5.through("topic-6").process(new MockProcessorDef<>()).sendTo("topic-7");
+        stream5.through("topic-6").process(new MockProcessorDef<>()).to("topic-7");
 
         assertEquals(2 + // sources
             2 + // stream1
@@ -129,10 +129,10 @@ public class KStreamImplTest {
             1 + 2 + // streams3
             2 + 3 + // stream4
             2 + 3 + // stream5
-            1 + // sendTo
+            1 + // to
             2 + // through
             1 + // process
-            1, // sendTo
+            1, // to
             builder.build().processors().size());
     }
 }


### PR DESCRIPTION
@ymatsuda 

Also I am thinking if we can rename KStream.sendTo() to just KStream.to(), which is more symmetric to builder.from().