### PR TITLE
Fix delete in in-memory store, and let delete return old value

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/InMemoryKeyValueStore.java
@@ -84,8 +84,8 @@ public class InMemoryKeyValueStore<K, V> extends MeteredKeyValueStore<K, V> {
         }
 
         @Override
-        public void delete(K key) {
-            put(key, null);
+        public V delete(K key) {
+            return this.map.remove(key);
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/KeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/KeyValueStore.java
@@ -61,9 +61,10 @@ public interface KeyValueStore<K, V> extends StateStore {
      * Delete the value from the store (if there is one)
      *
      * @param key The key
+     * @return The old value or null if there is no such key.
      * @throws NullPointerException If null is used for key.
      */
-    abstract public void delete(K key);
+    abstract public V delete(K key);
 
     /**
      * Get an iterator over a given range of keys. This iterator MUST be closed after use.

--- a/streams/src/main/java/org/apache/kafka/streams/state/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/MeteredKeyValueStore.java
@@ -173,14 +173,16 @@ public class MeteredKeyValueStore<K, V> implements KeyValueStore<K, V> {
     }
 
     @Override
-    public void delete(K key) {
+    public V delete(K key) {
         long startNs = time.nanoseconds();
         try {
-            this.inner.delete(key);
+            V value = this.inner.delete(key);
 
             this.dirty.add(key);
             if (this.dirty.size() > this.maxDirty)
                 logChange();
+
+            return value;
         } finally {
             recordLatency(this.deleteTime, startNs, time.nanoseconds());
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBKeyValueStore.java
@@ -162,8 +162,10 @@ public class RocksDBKeyValueStore extends MeteredKeyValueStore<byte[], byte[]> {
         }
 
         @Override
-        public void delete(byte[] key) {
+        public byte[] delete(byte[] key) {
+            byte[] value = get(key);
             put(key, null);
+            return value;
         }
 
         @Override


### PR DESCRIPTION
@ymatsuda 

Currently the delete() call does not really remove the key-value pair in the tree map, making it not feasible with nullable values, and also takes unnecessary memory usage.