### PR TITLE
Changed how the KeyValueStores use serializers and deserializers

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/examples/ProcessorJob.java
+++ b/streams/src/main/java/org/apache/kafka/streams/examples/ProcessorJob.java
@@ -48,7 +48,7 @@ public class ProcessorJob {
                 public void init(ProcessorContext context) {
                     this.context = context;
                     this.context.schedule(1000);
-                    this.kvStore = new InMemoryKeyValueStore<>("local-state", context);
+                    this.kvStore = InMemoryKeyValueStore.create("local-state", context, String.class, Integer.class);
                 }
 
                 @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/InMemoryKeyValueStore.java
@@ -18,6 +18,8 @@
 package org.apache.kafka.streams.state;
 
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 
@@ -35,26 +37,127 @@ import java.util.TreeMap;
  */
 public class InMemoryKeyValueStore<K, V> extends MeteredKeyValueStore<K, V> {
 
-    public InMemoryKeyValueStore(String name, ProcessorContext context) {
-        this(name, context, new SystemTime());
+    /**
+     * Create an in-memory key value store that records changes to a Kafka topic and the system time provider.
+     * 
+     * @param name the name of the store, used in the name of the topic to which entries are recorded
+     * @param context the processing context
+     * @param keyClass the class for the keys, which must be one of the types for which Kafka has built-in serializers and
+     *            deserializers (e.g., {@code String.class}, {@code Integer.class}, {@code Long.class}, or
+     *            {@code byte[].class})
+     * @param valueClass the class for the values, which must be one of the types for which Kafka has built-in serializers and
+     *            deserializers (e.g., {@code String.class}, {@code Integer.class}, {@code Long.class}, or
+     *            {@code byte[].class})
+     * @return the key-value store
+     */
+    public static <K, V> InMemoryKeyValueStore<K, V> create(String name, ProcessorContext context, Class<K> keyClass, Class<V> valueClass) {
+        return new InMemoryKeyValueStore<>(name, context, Serdes.withBuiltinTypes(name, keyClass, valueClass),
+                new SystemTime());
     }
 
-    public InMemoryKeyValueStore(String name, ProcessorContext context, Time time) {
-        super(name, new MemoryStore<K, V>(name, context), context, "kafka-streams", time);
+    /**
+     * Create an in-memory key value store that records changes to a Kafka topic and the given time provider.
+     * 
+     * @param name the name of the store, used in the name of the topic to which entries are recorded
+     * @param context the processing context
+     * @param keyClass the class for the keys, which must be one of the types for which Kafka has built-in serializers and
+     *            deserializers (e.g., {@code String.class}, {@code Integer.class}, {@code Long.class}, or
+     *            {@code byte[].class})
+     * @param valueClass the class for the values, which must be one of the types for which Kafka has built-in serializers and
+     *            deserializers (e.g., {@code String.class}, {@code Integer.class}, {@code Long.class}, or
+     *            {@code byte[].class})
+     * @param time the time provider; may not be null
+     * @return the key-value store
+     */
+    public static <K, V> InMemoryKeyValueStore<K, V> create(String name, ProcessorContext context, Class<K> keyClass, Class<V> valueClass,
+                                                            Time time) {
+        return new InMemoryKeyValueStore<>(name, context, Serdes.withBuiltinTypes(name, keyClass, valueClass),
+                time);
+    }
+
+    /**
+     * Create an in-memory key value store that records changes to a Kafka topic, the {@link ProcessorContext}'s default
+     * serializers and deserializers, and the system time provider.
+     * <p>
+     * <strong>NOTE:</strong> the default serializers and deserializers in the context <em>must</em> match the key and value types
+     * used as parameters for this key value store.
+     * 
+     * @param name the name of the store, used in the name of the topic to which entries are recorded
+     * @param context the processing context
+     * @return the key-value store
+     */
+    public static <K, V> InMemoryKeyValueStore<K, V> create(String name, ProcessorContext context) {
+        return create(name, context, new SystemTime());
+    }
+
+    /**
+     * Create an in-memory key value store that records changes to a Kafka topic, the {@link ProcessorContext}'s default
+     * serializers and deserializers, and the given time provider.
+     * <p>
+     * <strong>NOTE:</strong> the default serializers and deserializers in the context <em>must</em> match the key and value types
+     * used as parameters for this key value store.
+     * 
+     * @param name the name of the store, used in the name of the topic to which entries are recorded
+     * @param context the processing context
+     * @param time the time provider; may not be null
+     * @return the key-value store
+     */
+    public static <K, V> InMemoryKeyValueStore<K, V> create(String name, ProcessorContext context, Time time) {
+        return new InMemoryKeyValueStore<>(name, context, new Serdes<K, V>(name, context), time);
+    }
+
+    /**
+     * Create an in-memory key value store that records changes to a Kafka topic, the provided serializers and deserializers, and
+     * the system time provider.
+     * 
+     * @param name the name of the store, used in the name of the topic to which entries are recorded
+     * @param context the processing context
+     * @param keySerializer the serializer for keys; may not be null
+     * @param keyDeserializer the deserializer for keys; may not be null
+     * @param valueSerializer the serializer for values; may not be null
+     * @param valueDeserializer the deserializer for values; may not be null
+     * @return the key-value store
+     */
+    public static <K, V> InMemoryKeyValueStore<K, V> create(String name, ProcessorContext context,
+                                                            Serializer<K> keySerializer, Deserializer<K> keyDeserializer,
+                                                            Serializer<V> valueSerializer, Deserializer<V> valueDeserializer) {
+        return create(name, context, keySerializer, keyDeserializer, valueSerializer, valueDeserializer, new SystemTime());
+    }
+
+    /**
+     * Create an in-memory key value store that records changes to a Kafka topic, the provided serializers and deserializers, and
+     * the given time provider.
+     * 
+     * @param name the name of the store, used in the name of the topic to which entries are recorded
+     * @param context the processing context
+     * @param keySerializer the serializer for keys; may not be null
+     * @param keyDeserializer the deserializer for keys; may not be null
+     * @param valueSerializer the serializer for values; may not be null
+     * @param valueDeserializer the deserializer for values; may not be null
+     * @param time the time provider; may not be null
+     * @return the key-value store
+     */
+    public static <K, V> InMemoryKeyValueStore<K, V> create(String name, ProcessorContext context,
+                                                            Serializer<K> keySerializer, Deserializer<K> keyDeserializer,
+                                                            Serializer<V> valueSerializer, Deserializer<V> valueDeserializer,
+                                                            Time time) {
+        Serdes<K, V> serdes = new Serdes<>(name, keySerializer, keyDeserializer, valueSerializer, valueDeserializer);
+        return new InMemoryKeyValueStore<>(name, context, serdes, time);
+    }
+
+    protected InMemoryKeyValueStore(String name, ProcessorContext context, Serdes<K, V> serdes, Time time) {
+        super(name, new MemoryStore<K, V>(name), context, serdes, "kafka-streams", time);
     }
 
     private static class MemoryStore<K, V> implements KeyValueStore<K, V> {
 
         private final String name;
         private final NavigableMap<K, V> map;
-        private final ProcessorContext context;
 
-        @SuppressWarnings("unchecked")
-        public MemoryStore(String name, ProcessorContext context) {
+        public MemoryStore(String name) {
             super();
             this.name = name;
             this.map = new TreeMap<>();
-            this.context = context;
         }
 
         @Override
@@ -101,11 +204,6 @@ public class InMemoryKeyValueStore<K, V> extends MeteredKeyValueStore<K, V> {
         @Override
         public void flush() {
             // do-nothing since it is in-memory
-        }
-
-        public void restore() {
-            // this should not happen since it is in-memory, hence no state to load from disk
-            throw new IllegalStateException("This should not happen");
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/Serdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Serdes.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.processor.ProcessorContext;
+
+final class Serdes<K, V> {
+
+    public static <K, V> Serdes<K, V> withBuiltinTypes(String topic, Class<K> keyClass, Class<V> valueClass) {
+        Serializer<K> keySerializer = serializer(keyClass);
+        Deserializer<K> keyDeserializer = deserializer(keyClass);
+        Serializer<V> valueSerializer = serializer(valueClass);
+        Deserializer<V> valueDeserializer = deserializer(valueClass);
+        return new Serdes<>(topic, keySerializer, keyDeserializer, valueSerializer, valueDeserializer);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Serializer<T> serializer(Class<T> type) {
+        if (String.class.isAssignableFrom(type)) return (Serializer<T>) new StringSerializer();
+        if (Integer.class.isAssignableFrom(type)) return (Serializer<T>) new IntegerSerializer();
+        if (Long.class.isAssignableFrom(type)) return (Serializer<T>) new LongSerializer();
+        if (byte[].class.isAssignableFrom(type)) return (Serializer<T>) new ByteArraySerializer();
+        throw new IllegalArgumentException("Unknown class for built-in serializer");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Deserializer<T> deserializer(Class<T> type) {
+        if (String.class.isAssignableFrom(type)) return (Deserializer<T>) new StringDeserializer();
+        if (Integer.class.isAssignableFrom(type)) return (Deserializer<T>) new IntegerDeserializer();
+        if (Long.class.isAssignableFrom(type)) return (Deserializer<T>) new LongDeserializer();
+        if (byte[].class.isAssignableFrom(type)) return (Deserializer<T>) new ByteArrayDeserializer();
+        throw new IllegalArgumentException("Unknown class for built-in serializer");
+    }
+
+    private final String topic;
+    private final Serializer<K> keySerializer;
+    private final Serializer<V> valueSerializer;
+    private final Deserializer<K> keyDeserializer;
+    private final Deserializer<V> valueDeserializer;
+
+    /**
+     * Create a context for serialization using the specified serializers and deserializers.
+     * 
+     * @param topic the name of the topic
+     * @param keySerializer the serializer for keys; may not be null
+     * @param keyDeserializer the deserializer for keys; may not be null
+     * @param valueSerializer the serializer for values; may not be null
+     * @param valueDeserializer the deserializer for values; may not be null
+     */
+    public Serdes(String topic,
+            Serializer<K> keySerializer, Deserializer<K> keyDeserializer,
+            Serializer<V> valueSerializer, Deserializer<V> valueDeserializer) {
+        this.topic = topic;
+        this.keySerializer = keySerializer;
+        this.keyDeserializer = keyDeserializer;
+        this.valueSerializer = valueSerializer;
+        this.valueDeserializer = valueDeserializer;
+    }
+
+    /**
+     * Create a context for serialization using the specified serializers and deserializers, or if any of them are null the
+     * corresponding {@link ProcessorContext}'s default serializer or deserializer, which
+     * <em>must</em> match the key and value types used as parameters for this object.
+     * 
+     * @param topic the name of the topic
+     * @param keySerializer the serializer for keys; may be null if the {@link ProcessorContext#keySerializer() default
+     *            key serializer} should be used
+     * @param keyDeserializer the deserializer for keys; may be null if the {@link ProcessorContext#keyDeserializer() default
+     *            key deserializer} should be used
+     * @param valueSerializer the serializer for values; may be null if the {@link ProcessorContext#valueSerializer() default
+     *            value serializer} should be used
+     * @param valueDeserializer the deserializer for values; may be null if the {@link ProcessorContext#valueDeserializer()
+     *            default value deserializer} should be used
+     * @param context the processing context
+     */
+    @SuppressWarnings("unchecked")
+    public Serdes(String topic,
+            Serializer<K> keySerializer, Deserializer<K> keyDeserializer,
+            Serializer<V> valueSerializer, Deserializer<V> valueDeserializer,
+            ProcessorContext context) {
+        this.topic = topic;
+        this.keySerializer = keySerializer != null ? keySerializer : (Serializer<K>) context.keySerializer();
+        this.keyDeserializer = keyDeserializer != null ? keyDeserializer : (Deserializer<K>) context.keyDeserializer();
+        this.valueSerializer = valueSerializer != null ? valueSerializer : (Serializer<V>) context.valueSerializer();
+        this.valueDeserializer = valueDeserializer != null ? valueDeserializer : (Deserializer<V>) context.valueDeserializer();
+    }
+
+    /**
+     * Create a context for serialization using the {@link ProcessorContext}'s default serializers and deserializers, which
+     * <em>must</em> match the key and value types used as parameters for this object.
+     * 
+     * @param topic the name of the topic
+     * @param context the processing context
+     */
+    @SuppressWarnings("unchecked")
+    public Serdes(String topic,
+            ProcessorContext context) {
+        this.topic = topic;
+        this.keySerializer = (Serializer<K>) context.keySerializer();
+        this.keyDeserializer = (Deserializer<K>) context.keyDeserializer();
+        this.valueSerializer = (Serializer<V>) context.valueSerializer();
+        this.valueDeserializer = (Deserializer<V>) context.valueDeserializer();
+    }
+
+    public Deserializer<K> keyDeserializer() {
+        return keyDeserializer;
+    }
+
+    public Serializer<K> keySerializer() {
+        return keySerializer;
+    }
+
+    public Deserializer<V> valueDeserializer() {
+        return valueDeserializer;
+    }
+
+    public Serializer<V> valueSerializer() {
+        return valueSerializer;
+    }
+
+    public String topic() {
+        return topic;
+    }
+
+    public K keyFrom(byte[] rawKey) {
+        return keyDeserializer.deserialize(topic, rawKey);
+    }
+
+    public V valueFrom(byte[] rawValue) {
+        return valueDeserializer.deserialize(topic, rawValue);
+    }
+
+    public byte[] rawKey(K key) {
+        return keySerializer.serialize(topic, key);
+    }
+
+    public byte[] rawValue(V value) {
+        return valueSerializer.serialize(topic, value);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -289,7 +289,7 @@ public class ProcessorTopologyTest {
         @Override
         public void init(ProcessorContext context) {
             super.init(context);
-            store = new InMemoryKeyValueStore<>(storeName, context);
+            store = InMemoryKeyValueStore.create(storeName, context, String.class, String.class);
         }
 
         @Override


### PR DESCRIPTION
This is a draft that changes how all of the key value stores use serializers and deserializers. The `Serdes` utility encapsulates much of the logic that most of the stores use. Because each store now requires a full set of serializers and deserializers, I added quite a few static factory methods in each concrete store to make things simpler for end users. Feedback appreciated.