### PR TITLE
flush records and state changelog before local state

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -242,12 +242,11 @@ public class StreamTask implements Punctuator {
      * Commit the current task state
      */
     public void commit() {
-        // 1) flush local state
-        stateMgr.flush();
-
-        // 2) flush produced records in the downstream
-        // TODO: this will actually block on all produced records across the tasks
+        // 1) flush produced records in the downstream and change logs of local states
         recordCollector.flush();
+
+        // 2) flush local state
+        stateMgr.flush();
 
         // 3) commit consumed offsets if it is dirty already
         if (commitOffsetNeeded) {
@@ -340,7 +339,7 @@ public class StreamTask implements Punctuator {
             currNode = thisNode;
         }
     }
-    
+
     public ProcessorContext context() {
         return processorContext;
     }


### PR DESCRIPTION
@guozhangwang 
Since a change log is a redo log, it makes sense to flush it before flushing the state store to a local disk.