### PR TITLE
Test cases using ProcessorTopologyTestDriver can now manually punctuate.

### DIFF
--- a/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
@@ -200,6 +200,16 @@ public class ProcessorTopologyTestDriver {
     }
 
     /**
+     * Possibly trigger registered punctuation functions if current time has reached the next defined timestamp for each of the
+     * processors.
+     *
+     * @param timestamp the current timestamp
+     */
+    public void maybePunctuate(long timestamp) {
+        task.maybePunctuate(timestamp);
+    }
+
+    /**
      * Read the next record from the given topic. These records were output by the topology during the previous calls to
      * {@link #process(String, byte[], byte[])}.
      * 


### PR DESCRIPTION
Test cases can call `driver.maybePunctuate(...)` with a "current" timestamp, and if enough time has elapsed for any of the processors that registered a scheduled operation, punctuate will be called on those processors.

This is a simple addition to test-only code.