### PR TITLE
HOTFIX: Fix checkstyle failure in KStreams by providing fully qualified class names

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Windowed.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Windowed.java
@@ -17,12 +17,11 @@
 
 package org.apache.kafka.streams.kstream;
 
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serializer;
-
 /**
  * The windowed key interface used in {@link KTable}, used for representing a windowed table result from windowed stream aggregations,
- * i.e. {@link KStream#aggregateByKey(Initializer, Aggregator, Windows, Serializer, Serializer, Deserializer, Deserializer)}
+ * i.e. {@link KStream#aggregateByKey(Initializer, Aggregator, Windows, org.apache.kafka.common.serialization.Serializer,
+ * org.apache.kafka.common.serialization.Serializer, org.apache.kafka.common.serialization.Deserializer,
+ * org.apache.kafka.common.serialization.Deserializer)}
  *
  * @param <T> Type of the key
  */


### PR DESCRIPTION
Author: Ewen Cheslack-Postava <me@ewencp.org>