### PR TITLE
Remove dependence of MemoryRecordsBuilder on TransactionState

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -98,8 +98,6 @@
       <allow pkg="org.apache.kafka.common.protocol" />
       <allow pkg="org.apache.kafka.common.protocol.types" />
       <allow pkg="org.apache.kafka.common.errors" />
-      <!-- MemoryRecordsBuilder needs to access TransactionState, which seems to naturally belong in the Producer -->
-      <allow pkg="org.apache.kafka.clients.producer" />
     </subpackage>
 
     <subpackage name="requests">

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
@@ -214,7 +214,7 @@ public final class RecordBatch {
     }
 
     public void setProducerState(TransactionState.PidAndEpoch pidAndEpoch, int baseSequence) {
-        recordsBuilder.setProducerState(pidAndEpoch, baseSequence);
+        recordsBuilder.setProducerState(pidAndEpoch.pid, pidAndEpoch.epoch, baseSequence);
     }
 
     public void close() {

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.record;
 
-import org.apache.kafka.clients.producer.TransactionState;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
@@ -194,8 +193,8 @@ public class MemoryRecordsBuilder {
             return new RecordsInfo(maxTimestamp, compressionType == CompressionType.NONE ? offsetOfMaxTimestamp : lastOffset);
     }
 
-    public void setProducerState(TransactionState.PidAndEpoch pidAndEpoch, int baseSequence) {
-        if (isClosed() && (this.pid != pidAndEpoch.pid || this.epoch != pidAndEpoch.epoch || this.baseSequence != baseSequence)) {
+    public void setProducerState(long pid, short epoch, int baseSequence) {
+        if (isClosed() && (this.pid != pid || this.epoch != epoch || this.baseSequence != baseSequence)) {
             // Sequence numbers are assigned when the batch is closed while the accumulator is being drained.
             // If the resulting ProduceRequest to the partition leader failed for a retriable error, the batch will
             // be re queued. When it is drained again, we expect it to receive the same sequence number as before.
@@ -205,8 +204,8 @@ public class MemoryRecordsBuilder {
             throw new IllegalStateException("Attempting to close the same batch with a different base sequence. "
                     + "Being in this situation indicates data corruption is afoot.");
         }
-        this.pid = pidAndEpoch.pid;
-        this.epoch = pidAndEpoch.epoch;
+        this.pid = pid;
+        this.epoch = epoch;
         this.baseSequence = baseSequence;
     }
 


### PR DESCRIPTION
This enables the import-control checks to go untouched.