### PR TITLE
Enable Producer per Task

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -214,6 +214,9 @@ public class StreamsConfig extends AbstractConfig {
     public static final String REQUEST_TIMEOUT_MS_CONFIG = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
     private static final String REQUEST_TIMEOUT_MS_DOC = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;
 
+    public static final String PROCESSING_GUARANTEE_CONFIG = "processing.guarantee";
+    private static final String PROCESSING_GUARANTEE_DOC = "The processing guarantee that should be used. Possible values are <code>at_least_once</code> (default) and <code>exactly_once</code>.";
+
     static {
         CONFIG = new ConfigDef()
             .define(APPLICATION_ID_CONFIG, // required with no default value
@@ -383,7 +386,13 @@ public class StreamsConfig extends AbstractConfig {
                     40 * 1000,
                     atLeast(0),
                     ConfigDef.Importance.MEDIUM,
-                    REQUEST_TIMEOUT_MS_DOC);
+                    REQUEST_TIMEOUT_MS_DOC)
+            .define(PROCESSING_GUARANTEE_CONFIG,
+                    ConfigDef.Type.STRING,
+                    "at_least_once",
+                    in("at_least_once", "exactly_once"),
+                    Importance.MEDIUM,
+                    PROCESSING_GUARANTEE_DOC);
     }
 
     // this is the list of configs for underlying clients

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -17,29 +17,18 @@
 
 package org.apache.kafka.streams.processor.internals;
 
-import java.io.File;
-import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.UUID;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.internals.PartitionAssignor;
+import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -54,11 +43,26 @@ import org.apache.kafka.test.MockInternalTopicManager;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockStateStoreSupplier;
 import org.apache.kafka.test.MockTimestampExtractor;
-import org.junit.Before;
 import org.apache.kafka.test.TestUtils;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -66,11 +70,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import static org.junit.Assert.assertThat;
 
 public class StreamThreadTest {
 
@@ -154,13 +158,13 @@ public class StreamThreadTest {
                               Collection<TopicPartition> partitions,
                               ProcessorTopology topology,
                               Consumer<byte[], byte[]> consumer,
-                              Producer<byte[], byte[]> producer,
                               Consumer<byte[], byte[]> restoreConsumer,
+                              Producer<byte[], byte[]> producer,
                               StreamsConfig config,
                               StreamsMetrics metrics,
                               StateDirectory stateDirectory) {
-            super(id, applicationId, partitions, topology, consumer, restoreConsumer, config, metrics,
-                stateDirectory, null, new MockTime(), new RecordCollectorImpl(producer, id.toString()));
+            super(id, applicationId, partitions, topology, consumer, restoreConsumer, producer, config, metrics,
+                stateDirectory, null, new MockTime());
         }
 
         @Override
@@ -216,7 +220,7 @@ public class StreamThreadTest {
 
                 ProcessorTopology topology = builder.build(id.topicGroupId);
                 return new TestStreamTask(id, applicationId, partitionsForTask, topology, consumer,
-                    producer, restoreConsumer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
+                    restoreConsumer, new MockClientSupplier().producer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
             }
         };
 
@@ -504,7 +508,7 @@ public class StreamThreadTest {
                 protected StreamTask createStreamTask(TaskId id, Collection<TopicPartition> partitionsForTask) {
                     ProcessorTopology topology = builder.build(id.topicGroupId);
                     return new TestStreamTask(id, applicationId, partitionsForTask, topology, consumer,
-                        producer, restoreConsumer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
+                        restoreConsumer, new MockClientSupplier().producer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
                 }
             };
 
@@ -634,7 +638,7 @@ public class StreamThreadTest {
                 protected StreamTask createStreamTask(TaskId id, Collection<TopicPartition> partitionsForTask) {
                     ProcessorTopology topology = builder.build(id.topicGroupId);
                     return new TestStreamTask(id, applicationId, partitionsForTask, topology, consumer,
-                        producer, restoreConsumer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
+                        restoreConsumer, new MockClientSupplier().producer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
                 }
             };
 
@@ -692,16 +696,147 @@ public class StreamThreadTest {
     }
 
     @Test
-    public void testInjectClients() {
-        TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
-        StreamsConfig config = new StreamsConfig(configProps());
-        MockClientSupplier clientSupplier = new MockClientSupplier();
-        StreamThread thread = new StreamThread(builder, config, clientSupplier, applicationId,
-                                               clientId, processId, new Metrics(), new MockTime(), new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                               0);
-        assertSame(clientSupplier.producer, thread.producer);
+    public void shouldUseClientSupplierToInjectClients() {
+        final TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
+        final StreamsConfig config = new StreamsConfig(configProps());
+        final MockClientSupplier clientSupplier = new MockClientSupplier();
+        final StreamThread thread = new StreamThread(
+            builder,
+            config,
+            clientSupplier,
+            applicationId,
+            clientId,
+            processId,
+            new Metrics(),
+            new MockTime(),
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
+
+        final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
+        assignment.put(new TaskId(0, 0), Collections.singleton(new TopicPartition("someTopic", 0)));
+        assignment.put(new TaskId(0, 1), Collections.singleton(new TopicPartition("someTopic", 1)));
+        thread.partitionAssignor(new MockStreamsPartitionAssignor(assignment));
+
+        thread.rebalanceListener.onPartitionsAssigned(Collections.singleton(new TopicPartition("someTopic", 0)));
+
+        assertSame(clientSupplier.producer, thread.threadProducer);
+        for (final StreamTask task : thread.tasks().values()) {
+            assertSame(clientSupplier.producer, task.producer);
+        }
         assertSame(clientSupplier.consumer, thread.consumer);
         assertSame(clientSupplier.restoreConsumer, thread.restoreConsumer);
+    }
+
+    @Test
+    public void shouldInjectProducerPerTaskForEoS() {
+        final TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
+        final Properties properties = configProps();
+        properties.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, "exactly_once");
+        final StreamsConfig config = new StreamsConfig(properties);
+        final EoSMockClientSupplier clientSupplier = new EoSMockClientSupplier();
+        final StreamThread thread = new StreamThread(
+            builder,
+            config,
+            clientSupplier,
+            applicationId,
+            clientId,
+            processId,
+            new Metrics(),
+            new MockTime(),
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
+
+        final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
+        assignment.put(new TaskId(0, 0), Collections.singleton(new TopicPartition("someTopic", 0)));
+        assignment.put(new TaskId(0, 1), Collections.singleton(new TopicPartition("someTopic", 1)));
+        thread.partitionAssignor(new MockStreamsPartitionAssignor(assignment));
+
+        thread.rebalanceListener.onPartitionsAssigned(Collections.singleton(new TopicPartition("someTopic", 0)));
+
+        assertNull(thread.threadProducer);
+        Iterator it = clientSupplier.producers.iterator();
+        for (final StreamTask task : thread.tasks().values()) {
+            assertSame(it.next(), task.producer);
+        }
+        assertSame(clientSupplier.consumer, thread.consumer);
+        assertSame(clientSupplier.restoreConsumer, thread.restoreConsumer);
+    }
+
+    private static class EoSMockClientSupplier extends MockClientSupplier {
+        private static final ByteArraySerializer BYTE_ARRAY_SERIALIZER = new ByteArraySerializer();
+
+        final List<Producer> producers = new LinkedList<>();
+
+        @Override
+        public Producer<byte[], byte[]> getProducer(Map<String, Object> config) {
+            final Producer producer = new MockedProducer();
+            producers.add(producer);
+            return producer;
+        }
+    }
+
+    @Test
+    public void shouldCloseAllTaskProducers() {
+        final TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
+        final Properties properties = configProps();
+        properties.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, "exactly_once");
+        final StreamsConfig config = new StreamsConfig(properties);
+        final EoSMockClientSupplier clientSupplier = new EoSMockClientSupplier();
+        final StreamThread thread = new StreamThread(
+            builder,
+            config,
+            clientSupplier,
+            applicationId,
+            clientId,
+            processId,
+            new Metrics(),
+            new MockTime(),
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
+
+        final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
+        assignment.put(new TaskId(0, 0), Collections.singleton(new TopicPartition("someTopic", 0)));
+        assignment.put(new TaskId(0, 1), Collections.singleton(new TopicPartition("someTopic", 1)));
+        thread.partitionAssignor(new MockStreamsPartitionAssignor(assignment));
+
+        thread.rebalanceListener.onPartitionsAssigned(Collections.singleton(new TopicPartition("someTopic", 0)));
+
+        thread.close();
+        thread.run();
+
+        for (final StreamTask task : thread.tasks().values()) {
+            assertTrue(((MockedProducer) task.producer).closed);
+        }
+    }
+
+    @Test
+    public void shouldCloseThreadProducer() {
+        final TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
+        final StreamsConfig config = new StreamsConfig(configProps());
+        final EoSMockClientSupplier clientSupplier = new EoSMockClientSupplier();
+        final StreamThread thread = new StreamThread(
+            builder,
+            config,
+            clientSupplier,
+            applicationId,
+            clientId,
+            processId,
+            new Metrics(),
+            new MockTime(),
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
+
+        final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
+        assignment.put(new TaskId(0, 0), Collections.singleton(new TopicPartition("someTopic", 0)));
+        assignment.put(new TaskId(0, 1), Collections.singleton(new TopicPartition("someTopic", 1)));
+        thread.partitionAssignor(new MockStreamsPartitionAssignor(assignment));
+
+        thread.rebalanceListener.onPartitionsAssigned(Collections.singleton(new TopicPartition("someTopic", 0)));
+
+        thread.close();
+        thread.run();
+
+        assertTrue(((MockedProducer) thread.threadProducer).closed);
     }
 
     @Test
@@ -859,7 +994,7 @@ public class StreamThreadTest {
             protected StreamTask createStreamTask(final TaskId id, final Collection<TopicPartition> partitions) {
                 final ProcessorTopology topology = builder.build(id.topicGroupId);
                 final TestStreamTask task = new TestStreamTask(id, applicationId, partitions, topology, consumer,
-                    producer, restoreConsumer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
+                    restoreConsumer, new MockClientSupplier().producer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
                 createdTasks.put(partitions, task);
                 return task;
             }
@@ -910,8 +1045,8 @@ public class StreamThreadTest {
                                                                  Utils.mkSet(new TopicPartition("t1", 0)),
                                                                  builder.build(0),
                                                                  clientSupplier.consumer,
-                                                                 clientSupplier.producer,
                                                                  clientSupplier.restoreConsumer,
+                                                                 clientSupplier.producer,
                                                                  config,
                                                                  new MockStreamsMetrics(new Metrics()),
                                                                  new StateDirectory(applicationId, config.getString(StreamsConfig.STATE_DIR_CONFIG), time)) {
@@ -962,8 +1097,8 @@ public class StreamThreadTest {
                                                                  Utils.mkSet(new TopicPartition("t1", 0)),
                                                                  builder.build(0),
                                                                  clientSupplier.consumer,
-                                                                 clientSupplier.producer,
                                                                  clientSupplier.restoreConsumer,
+                                                                 clientSupplier.producer,
                                                                  config,
                                                                  new MockStreamsMetrics(new Metrics()),
                                                                  new StateDirectory(applicationId, config.getString(StreamsConfig.STATE_DIR_CONFIG), time)) {
@@ -1014,8 +1149,8 @@ public class StreamThreadTest {
                                                                  Utils.mkSet(new TopicPartition("t1", 0)),
                                                                  builder.build(0),
                                                                  clientSupplier.consumer,
-                                                                 clientSupplier.producer,
                                                                  clientSupplier.restoreConsumer,
+                                                                 clientSupplier.producer,
                                                                  config,
                                                                  new MockStreamsMetrics(new Metrics()),
                                                                  new StateDirectory(applicationId, config.getString(StreamsConfig.STATE_DIR_CONFIG), time)) {
@@ -1065,8 +1200,8 @@ public class StreamThreadTest {
                                                                  Utils.mkSet(new TopicPartition("t1", 0)),
                                                                  builder.build(0),
                                                                  clientSupplier.consumer,
-                                                                 clientSupplier.producer,
                                                                  clientSupplier.restoreConsumer,
+                                                                 clientSupplier.producer,
                                                                  config,
                                                                  new MockStreamsMetrics(new Metrics()),
                                                                  new StateDirectory(applicationId, config.getString(StreamsConfig.STATE_DIR_CONFIG), time)) {
@@ -1135,6 +1270,22 @@ public class StreamThreadTest {
             }
             this.oldState = oldState;
             this.newState = newState;
+        }
+    }
+
+    private final static class MockedProducer extends MockProducer {
+        boolean closed = false;
+
+        MockedProducer() {
+            super(false, null, null);
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                throw new IllegalStateException("MockedProducer is already closed.");
+            }
+            closed = true;
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -25,19 +25,18 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TopologyBuilder;
+import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
 import org.apache.kafka.streams.processor.internals.StateDirectory;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsMetadataState;
-import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockProcessorSupplier;
-import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -184,15 +183,22 @@ public class StreamThreadStateStoreProviderTest {
                                          final MockClientSupplier clientSupplier,
                                          final ProcessorTopology topology,
                                          final TaskId taskId) {
-        return new StreamTask(taskId, applicationId, Collections
-                .singletonList(new TopicPartition("topic", taskId.partition)), topology,
-                              clientSupplier.consumer,
-                              clientSupplier.restoreConsumer,
-                              streamsConfig, new MockStreamsMetrics(new Metrics()), stateDirectory, null, new MockTime(), new NoOpRecordCollector()) {
-            @Override
-            protected void initializeOffsetLimits() {
+        return new StreamTask(
+            taskId,
+            applicationId,
+            Collections.singletonList(new TopicPartition("topic", taskId.partition)),
+            topology,
+            clientSupplier.consumer,
+            clientSupplier.restoreConsumer,
+            clientSupplier.producer,
+            streamsConfig,
+            new MockStreamsMetrics(new Metrics()),
+            stateDirectory,
+            null,
+            new MockTime()) {
 
-            }
+            @Override
+            protected void initializeOffsetLimits() {}
         };
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
@@ -16,17 +16,6 @@
  */
 package org.apache.kafka.test;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -50,19 +39,28 @@ import org.apache.kafka.streams.processor.internals.GlobalProcessorContextImpl;
 import org.apache.kafka.streams.processor.internals.GlobalStateManagerImpl;
 import org.apache.kafka.streams.processor.internals.GlobalStateUpdateTask;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
-import org.apache.kafka.streams.processor.internals.RecordCollectorImpl;
 import org.apache.kafka.streams.processor.internals.StateDirectory;
 import org.apache.kafka.streams.processor.internals.StreamTask;
-import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 
-
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * This class makes it easier to write tests to verify the behavior of topologies created with a {@link TopologyBuilder}.
@@ -222,11 +220,11 @@ public class ProcessorTopologyTestDriver {
                                   topology,
                                   consumer,
                                   restoreStateConsumer,
+                                  producer,
                                   config,
                                   streamsMetrics, stateDirectory,
                                   cache,
-                                  new MockTime(),
-                                  new RecordCollectorImpl(producer, "id"));
+                                  new MockTime());
         }
     }
 


### PR DESCRIPTION
Add exactly-once config to StreamsConfig
Enable producer per task if exactly-once config is enabled