### PR TITLE
Update log4j.properties

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -85,3 +85,10 @@ log4j.additivity.state.change.logger=false
 log4j.logger.kafka.authorizer.logger=WARN, authorizerAppender
 log4j.additivity.kafka.authorizer.logger=false
 
+# Turn on logging for ConfluentMetricsReporter
+#log4j.logger.io.confluent.metrics.reporter.ConfluentMetricsReporter=DEBUG, metricsAppender
+#log4j.appender.metricsAppender=org.apache.log4j.DailyRollingFileAppender
+#log4j.appender.metricsAppender.DatePattern=‘.’yyyy-MM-dd-HH
+#log4j.appender.metricsAppender.File=${kafka.logs.dir}/kafka-metrics.log
+#log4j.appender.metricsAppender.layout=org.apache.log4j.PatternLayout
+#log4j.appender.metricsAppender.layout.ConversionPattern=[%d] %p %m (%c)%n


### PR DESCRIPTION
We should have a comment block for enabling Metrics Reporter logging 