### PR TITLE
Handle commit failed exception on stream thread

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -254,7 +254,6 @@ public class StreamTask extends AbstractTask implements Punctuator {
     @Override
     public void commit() {
         commit(true);
-
     }
 
     // visible for testing
@@ -336,6 +335,30 @@ public class StreamTask extends AbstractTask implements Punctuator {
         }
     }
 
+    private void closeTopology() {
+        log.trace("{} Closing processor topology", logPrefix);
+
+        partitionGroup.clear();
+
+        // close the processors
+        // make sure close() is called for each node even when there is a RuntimeException
+        RuntimeException exception = null;
+        for (final ProcessorNode node : topology.processors()) {
+            processorContext.setCurrentNode(node);
+            try {
+                node.close();
+            } catch (final RuntimeException e) {
+                exception = e;
+            } finally {
+                processorContext.setCurrentNode(null);
+            }
+        }
+
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
     /**
      * <pre>
      * - close topology
@@ -365,30 +388,6 @@ public class StreamTask extends AbstractTask implements Punctuator {
         closeTopology(); // should we call this only on clean suspend?
         if (clean) {
             commit(false);
-        }
-    }
-
-    private void closeTopology() {
-        log.trace("{} Closing processor topology", logPrefix);
-
-        partitionGroup.clear();
-
-        // close the processors
-        // make sure close() is called for each node even when there is a RuntimeException
-        RuntimeException exception = null;
-        for (final ProcessorNode node : topology.processors()) {
-            processorContext.setCurrentNode(node);
-            try {
-                node.close();
-            } catch (final RuntimeException e) {
-                exception = e;
-            } finally {
-                processorContext.setCurrentNode(null);
-            }
-        }
-
-        if (exception != null) {
-            throw exception;
         }
     }
 
@@ -430,20 +429,20 @@ public class StreamTask extends AbstractTask implements Punctuator {
         }
     }
 
-        /**
-         * <pre>
-         * - {@link #suspend(boolean) suspend(clean)}
-         *   - close topology
-         *   - if (clean) {@link #commit()}
-         *     - flush state and producer
-         *     - commit offsets
-         * - close state
-         *   - if (clean) write checkpoint
-         * - if (eos) close producer
-         * </pre>
-         * @param clean shut down cleanly (ie, incl. flush and commit) if {@code true} --
-         *              otherwise, just close open resources
-         */
+    /**
+     * <pre>
+     * - {@link #suspend(boolean) suspend(clean)}
+     *   - close topology
+     *   - if (clean) {@link #commit()}
+     *     - flush state and producer
+     *     - commit offsets
+     * - close state
+     *   - if (clean) write checkpoint
+     * - if (eos) close producer
+     * </pre>
+     * @param clean shut down cleanly (ie, incl. flush and commit) if {@code true} --
+     *              otherwise, just close open resources
+     */
     @Override
     public void close(boolean clean) {
         log.debug("{} Closing", logPrefix);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -257,7 +257,7 @@ public class StreamThread extends Thread {
                     } catch (final LockException e) {
                         // ignore and retry
                         if (!retryingTasks.contains(taskId)) {
-                            log.warn("{} Could not create task {}. Will retry: ", logPrefix, taskId, e);
+                            log.warn("{} Could not create task {} due to {}. Will retry: ", logPrefix, taskId, e);
                             retryingTasks.add(taskId);
                         }
                     }
@@ -524,7 +524,7 @@ public class StreamThread extends Thread {
         } catch (final Exception e) {
             // we have caught all Kafka related exceptions, and other runtime exceptions
             // should be due to user application errors
-            log.error("{} Streams application error during processing: ", logPrefix, e);
+            log.error("{} Streams application error during processing", logPrefix, e);
             throw e;
         } finally {
             shutdown(cleanRun);
@@ -729,7 +729,7 @@ public class StreamThread extends Thread {
                 streamsMetrics.punctuateTimeSensor.record(computeLatency(), timerStartedMs);
             }
         } catch (final KafkaException e) {
-            log.error("{} Failed to punctuate active task {}: ", logPrefix, task.id(), e);
+            log.error("{} Failed to punctuate active task {}", logPrefix, task.id(), e);
             throw e;
         }
     }
@@ -820,10 +820,10 @@ public class StreamThread extends Thread {
             task.commit();
         } catch (final CommitFailedException e) {
             // commit failed. Just log it.
-            log.warn("{} Failed to commit {} {} state: ", logPrefix, task.getClass().getSimpleName(), task.id(), e);
+            log.warn("{} Failed to commit {} {} state due to CommitFailedException", logPrefix, task.getClass().getSimpleName(), task.id());
         } catch (final KafkaException e) {
             // commit failed due to an unexpected exception. Log it and rethrow the exception.
-            log.error("{} Failed to commit {} {} state: ", logPrefix, task.getClass().getSimpleName(), task.id(), e);
+            log.error("{} Failed to commit {} {} state", logPrefix, task.getClass().getSimpleName(), task.id(), e);
             throw e;
         }
 
@@ -1052,23 +1052,23 @@ public class StreamThread extends Thread {
             try {
                 threadProducer.close();
             } catch (final Throwable e) {
-                log.error("{} Failed to close producer: ", logPrefix, e);
+                log.error("{} Failed to close producer", logPrefix, e);
             }
         }
         try {
             consumer.close();
         } catch (final Throwable e) {
-            log.error("{} Failed to close consumer: ", logPrefix, e);
+            log.error("{} Failed to close consumer", logPrefix, e);
         }
         try {
             restoreConsumer.close();
         } catch (final Throwable e) {
-            log.error("{} Failed to close restore consumer: ", logPrefix, e);
+            log.error("{} Failed to close restore consumer", logPrefix, e);
         }
         try {
             partitionAssignor.close();
         } catch (final Throwable e) {
-            log.error("{} Failed to close KafkaStreamClient: ", logPrefix, e);
+            log.error("{} Failed to close KafkaStreamClient", logPrefix, e);
         }
 
         removeStreamTasks();
@@ -1091,7 +1091,7 @@ public class StreamThread extends Thread {
             try {
                 task.close(cleanRun);
             } catch (final RuntimeException e) {
-                log.error("{} Failed while closing {} {}: ",
+                log.error("{} Failed while closing {} {}",
                     logPrefix,
                     task.getClass().getSimpleName(),
                     task.id(),
@@ -1123,11 +1123,15 @@ public class StreamThread extends Thread {
             public void apply(final StreamTask task) {
                 try {
                     task.suspend();
+                } catch (final CommitFailedException e) {
+                    // commit failed during suspension. Just log it.
+                    log.warn("{} Failed to commit task {} state when suspending due to CommitFailedException", logPrefix, task.id);
                 } catch (final Exception e) {
+                    log.error("{} Suspending task {} failed", logPrefix, task.id, e);
                     try {
                         task.close(false);
                     } catch (final Exception f) {
-                        log.error("{} Closing task {} failed: ", logPrefix, task.id, f);
+                        log.error("{} Closing task {} due to suspension error failed again", logPrefix, task.id, f);
                     }
                     throw e;
                 }
@@ -1139,10 +1143,11 @@ public class StreamThread extends Thread {
                 try {
                     task.suspend();
                 } catch (final Exception e) {
+                    log.error("{} Suspending standby task {} failed", logPrefix, task.id, e);
                     try {
                         task.close(false);
                     } catch (final Exception f) {
-                        log.error("{} Closing standby task {} failed: ", logPrefix, task.id, f);
+                        log.error("{} Closing standby task {} due to suspension error failed again", logPrefix, task.id, f);
                     }
                     throw e;
                 }
@@ -1166,7 +1171,7 @@ public class StreamThread extends Thread {
             // un-assign the change log partitions
             restoreConsumer.assign(Collections.<TopicPartition>emptyList());
         } catch (final RuntimeException e) {
-            log.error("{} Failed to un-assign change log partitions: ", logPrefix, e);
+            log.error("{} Failed to un-assign change log partitions", logPrefix, e);
             return e;
         }
         return null;
@@ -1218,11 +1223,11 @@ public class StreamThread extends Thread {
             final StreamTask task = next.getValue();
             final Set<TopicPartition> assignedPartitionsForTask = newTaskAssignment.get(next.getKey());
             if (!task.partitions().equals(assignedPartitionsForTask)) {
-                log.debug("{} Closing suspended non-assigned active task {}", logPrefix, task.id());
+                log.debug("{} Closing suspended and not re-assigned task {}", logPrefix, task.id());
                 try {
                     task.closeSuspended(true, null);
                 } catch (final Exception e) {
-                    log.error("{} Failed to remove suspended task {}: ", logPrefix, next.getKey(), e);
+                    log.error("{} Failed to close suspended task {}", logPrefix, next.getKey(), e);
                 } finally {
                     suspendedTaskIterator.remove();
                 }
@@ -1237,11 +1242,11 @@ public class StreamThread extends Thread {
             final Map.Entry<TaskId, StandbyTask> suspendedTask = standByTaskIterator.next();
             if (!currentSuspendedTaskIds.contains(suspendedTask.getKey())) {
                 final StandbyTask task = suspendedTask.getValue();
-                log.debug("{} Closing suspended non-assigned standby task {}", logPrefix, task.id());
+                log.debug("{} Closing suspended and not re-assigned standby task {}", logPrefix, task.id());
                 try {
                     task.close(true);
                 } catch (final Exception e) {
-                    log.error("{} Failed to remove suspended standby task {}: ", logPrefix, task.id(), e);
+                    log.error("{} Failed to remove suspended standby task {}", logPrefix, task.id(), e);
                 } finally {
                     standByTaskIterator.remove();
                 }
@@ -1321,7 +1326,7 @@ public class StreamThread extends Thread {
                         newTasks.put(taskId, partitions);
                     }
                 } catch (final StreamsException e) {
-                    log.error("{} Failed to create an active task {}: ", logPrefix, taskId, e);
+                    log.error("{} Failed to create an active task {}", logPrefix, taskId, e);
                     throw e;
                 }
             } else {
@@ -1434,7 +1439,7 @@ public class StreamThread extends Thread {
             activeTasks.clear();
             activeTasksByPartition.clear();
         } catch (final Exception e) {
-            log.error("{} Failed to remove stream tasks: ", logPrefix, e);
+            log.error("{} Failed to remove stream tasks", logPrefix, e);
         }
     }
 
@@ -1450,11 +1455,11 @@ public class StreamThread extends Thread {
         log.warn("{} Producer of task {} fenced; closing zombie task.", logPrefix, task.id);
         try {
             task.close(false);
-        } catch (final Exception f) {
+        } catch (final Exception e) {
             if (!log.isDebugEnabled() && !log.isTraceEnabled()) {
-                log.warn("{} Failed to close zombie task: {}", logPrefix, f.getMessage());
+                log.warn("{} Failed to close zombie task: {}", logPrefix, e.getMessage());
             }
-            log.debug("{} Failed to close zombie task: ", logPrefix, f);
+            log.debug("{} Failed to close zombie task: ", logPrefix, e);
         }
         activeTasks.remove(task.id);
     }
@@ -1471,7 +1476,7 @@ public class StreamThread extends Thread {
                 closeZombieTask(task);
                 it.remove();
             } catch (final RuntimeException t) {
-                log.error("{} Failed to {} stream task {}: ",
+                log.error("{} Failed to {} stream task {}",
                     logPrefix,
                     action.name(),
                     task.id(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -1531,6 +1532,62 @@ public class StreamThreadTest {
         // store should be closed even if we had an exception
         assertFalse(stateStore.isOpen());
     }
+
+    @Test
+    public void shouldCaptureCommitFailedExceptionOnTaskSuspension() throws Exception {
+        final KStreamBuilder builder = new KStreamBuilder();
+        builder.stream("t1");
+
+        final TestStreamTask testStreamTask = new TestStreamTask(
+                new TaskId(0, 0),
+                applicationId,
+                Utils.mkSet(new TopicPartition("t1", 0)),
+                builder.build(0),
+                clientSupplier.consumer,
+                clientSupplier.getProducer(new HashMap<String, Object>()),
+                clientSupplier.restoreConsumer,
+                config,
+                new MockStreamsMetrics(new Metrics()),
+                new StateDirectory(applicationId, config.getString(StreamsConfig.STATE_DIR_CONFIG), mockTime)) {
+
+            @Override
+            public void suspend() {
+                throw new CommitFailedException();
+            }
+        };
+
+        final StreamThread thread = new StreamThread(
+                builder,
+                config,
+                clientSupplier,
+                applicationId,
+                clientId,
+                processId,
+                metrics,
+                mockTime,
+                new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+                0) {
+
+            @Override
+            protected StreamTask createStreamTask(final TaskId id, final Collection<TopicPartition> partitions) {
+                return testStreamTask;
+            }
+        };
+
+
+        final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
+        activeTasks.put(testStreamTask.id(), testStreamTask.partitions);
+
+        thread.setPartitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
+
+        thread.rebalanceListener.onPartitionsRevoked(Collections.<TopicPartition>emptyList());
+        thread.rebalanceListener.onPartitionsAssigned(testStreamTask.partitions);
+
+        thread.rebalanceListener.onPartitionsRevoked(Collections.<TopicPartition>emptyList());
+
+        assertFalse(testStreamTask.committed);
+    }
+
 
     @Test
     public void shouldNotViolateAtLeastOnceWhenExceptionOccursDuringTaskSuspension() throws Exception {


### PR DESCRIPTION
1. Capture `CommitFailedException` in `StreamThread#suspendTasksAndState`; also fix log4j outputs for error and warn.

2. Minor fixes on `StreamTask` class for comments alignment etc.