### PR TITLE
CPKAFKA-1054 : introduce batch expiry config

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -35,7 +35,8 @@
               files="ConfigDef.java"/>
     <suppress checks="ParameterNumber"
               files="DefaultRecordBatch.java"/>
-
+    <suppress checks="ParameterNumber"
+              files="Sender.java" />
     <suppress checks="ClassDataAbstractionCoupling"
               files="(KafkaConsumer|ConsumerCoordinator|Fetcher|KafkaProducer|AbstractRequest|AbstractResponse|TransactionManager|KafkaAdminClient).java"/>
     <suppress checks="ClassDataAbstractionCoupling"

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -401,7 +401,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                     this.requestTimeoutMs,
                     config.getLong(ProducerConfig.RETRY_BACKOFF_MS_CONFIG),
                     this.transactionManager,
-                    apiVersions);
+                    apiVersions,
+                    config.getLong(ProducerConfig.BATCH_EXPIRY_MS));
             String ioThreadName = "kafka-producer-network-thread" + (clientId.length() > 0 ? " | " + clientId : "");
             this.ioThread = new KafkaThread(ioThreadName, this.sender, true);
             this.ioThread.start();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -221,7 +221,7 @@ public class ProducerConfig extends AbstractConfig {
 
 
     /** <code> batch.expiry.ms  </code> */
-    public static final String BATCH_EXPIRY_MS = "batch.expiry.ms";
+    public static final String BATCH_EXPIRY_MS = "confluent.batch.expiry.ms";
     public static final String BATCH_EXPIRY_MS_DOC = "How long the batch should stay in the accumulator and unacknowledged before being expired.";
 
     static {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -219,6 +219,11 @@ public class ProducerConfig extends AbstractConfig {
             "Note that enable.idempotence must be enabled if a TransactionalId is configured. " +
             "The default is empty, which means transactions cannot be used.";
 
+
+    /** <code> batch.expiry.ms  </code> */
+    public static final String BATCH_EXPIRY_MS = "batch.expiry.ms";
+    public static final String BATCH_EXPIRY_MS_DOC = "How long the batch should stay in the accumulator and unacknowledged before being expired.";
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Importance.HIGH, CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
                                 .define(BUFFER_MEMORY_CONFIG, Type.LONG, 32 * 1024 * 1024L, atLeast(0L), Importance.HIGH, BUFFER_MEMORY_DOC)
@@ -326,7 +331,12 @@ public class ProducerConfig extends AbstractConfig {
                                         null,
                                         new ConfigDef.NonEmptyString(),
                                         Importance.LOW,
-                                        TRANSACTIONAL_ID_DOC);
+                                        TRANSACTIONAL_ID_DOC)
+                                .define(BATCH_EXPIRY_MS,
+                                        Type.LONG,
+                                        30 * 1000,
+                                        Importance.LOW,
+                                        BATCH_EXPIRY_MS_DOC);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -332,11 +332,10 @@ public class ProducerConfig extends AbstractConfig {
                                         new ConfigDef.NonEmptyString(),
                                         Importance.LOW,
                                         TRANSACTIONAL_ID_DOC)
-                                .define(BATCH_EXPIRY_MS,
+                                .defineInternal(BATCH_EXPIRY_MS,
                                         Type.LONG,
                                         30 * 1000,
-                                        Importance.LOW,
-                                        BATCH_EXPIRY_MS_DOC);
+                                        Importance.LOW);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -290,8 +290,8 @@ public final class ProducerBatch {
     /**
      * A batch whose metadata is not available should be expired if one of the following is true:
      * <ol>
-     *     <li> the batch is not in retry AND request timeout has elapsed after it is ready (full or linger.ms has reached).
-     *     <li> the batch is in retry AND request timeout has elapsed after the backoff period ended.
+     *     <li> the batch is not in retry AND batch expiry timeout has elapsed after it is ready (full or linger.ms has reached).
+     *     <li> the batch is in retry AND batch expiry timeout has elapsed after the backoff period ended.
      * </ol>
      * This methods closes this batch and sets {@code expiryErrorMessage} if the batch has timed out.
      */

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -295,7 +295,7 @@ public final class ProducerBatch {
      * </ol>
      * This methods closes this batch and sets {@code expiryErrorMessage} if the batch has timed out.
      */
-    boolean maybeExpire(int requestTimeoutMs, long retryBackoffMs, long now, long lingerMs, boolean isFull) {
+    boolean maybeExpire(long requestTimeoutMs, long retryBackoffMs, long now, long lingerMs, boolean isFull) {
         if (!this.inRetry() && isFull && requestTimeoutMs < (now - this.lastAppendTime))
             expiryErrorMessage = (now - this.lastAppendTime) + " ms has passed since last append";
         else if (!this.inRetry() && requestTimeoutMs < (createdTimeMs(now) - lingerMs))

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -295,12 +295,12 @@ public final class ProducerBatch {
      * </ol>
      * This methods closes this batch and sets {@code expiryErrorMessage} if the batch has timed out.
      */
-    boolean maybeExpire(long requestTimeoutMs, long retryBackoffMs, long now, long lingerMs, boolean isFull) {
-        if (!this.inRetry() && isFull && requestTimeoutMs < (now - this.lastAppendTime))
+    boolean maybeExpire(long batchExpiryTimeoutMs, long retryBackoffMs, long now, long lingerMs, boolean isFull) {
+        if (!this.inRetry() && isFull && batchExpiryTimeoutMs < (now - this.lastAppendTime))
             expiryErrorMessage = (now - this.lastAppendTime) + " ms has passed since last append";
-        else if (!this.inRetry() && requestTimeoutMs < (createdTimeMs(now) - lingerMs))
+        else if (!this.inRetry() && batchExpiryTimeoutMs < (createdTimeMs(now) - lingerMs))
             expiryErrorMessage = (createdTimeMs(now) - lingerMs) + " ms has passed since batch creation plus linger time";
-        else if (this.inRetry() && requestTimeoutMs < (waitedTimeMs(now) - retryBackoffMs))
+        else if (this.inRetry() && batchExpiryTimeoutMs < (waitedTimeMs(now) - retryBackoffMs))
             expiryErrorMessage = (waitedTimeMs(now) - retryBackoffMs) + " ms has passed since last attempt plus backoff time";
 
         boolean expired = expiryErrorMessage != null;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -265,7 +265,7 @@ public final class RecordAccumulator {
     /**
      * Get a list of batches which have been sitting in the accumulator too long and need to be expired.
      */
-    public List<ProducerBatch> expiredBatches(int requestTimeout, long now) {
+    public List<ProducerBatch> expiredBatches(long requestTimeout, long now) {
         List<ProducerBatch> expiredBatches = new ArrayList<>();
         for (Map.Entry<TopicPartition, Deque<ProducerBatch>> entry : this.batches.entrySet()) {
             Deque<ProducerBatch> dq = entry.getValue();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -265,7 +265,7 @@ public final class RecordAccumulator {
     /**
      * Get a list of batches which have been sitting in the accumulator too long and need to be expired.
      */
-    public List<ProducerBatch> expiredBatches(long requestTimeout, long now) {
+    public List<ProducerBatch> expiredBatches(long batchExpiryTimeoutMs, long now) {
         List<ProducerBatch> expiredBatches = new ArrayList<>();
         for (Map.Entry<TopicPartition, Deque<ProducerBatch>> entry : this.batches.entrySet()) {
             Deque<ProducerBatch> dq = entry.getValue();
@@ -286,7 +286,7 @@ public final class RecordAccumulator {
                         // are invoked after completing the iterations, since sends invoked from callbacks
                         // may append more batches to the deque being iterated. The batch is deallocated after
                         // callbacks are invoked.
-                        if (batch.maybeExpire(requestTimeout, retryBackoffMs, now, this.lingerMs, isFull)) {
+                        if (batch.maybeExpire(batchExpiryTimeoutMs, retryBackoffMs, now, this.lingerMs, isFull)) {
                             expiredBatches.add(batch);
                             batchIterator.remove();
                         } else {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -121,6 +121,9 @@ public class Sender implements Runnable {
     /* all the state related to transactions, in particular the producer id, producer epoch, and sequence numbers */
     private final TransactionManager transactionManager;
 
+    /* the time to wait before expiring batches in the accumulator */
+    private final long batchExpiryMs;
+
     public Sender(KafkaClient client,
                   Metadata metadata,
                   RecordAccumulator accumulator,
@@ -133,7 +136,8 @@ public class Sender implements Runnable {
                   int requestTimeout,
                   long retryBackoffMs,
                   TransactionManager transactionManager,
-                  ApiVersions apiVersions) {
+                  ApiVersions apiVersions,
+                  long batchExpiryMs) {
         this.client = client;
         this.accumulator = accumulator;
         this.metadata = metadata;
@@ -148,6 +152,7 @@ public class Sender implements Runnable {
         this.retryBackoffMs = retryBackoffMs;
         this.apiVersions = apiVersions;
         this.transactionManager = transactionManager;
+        this.batchExpiryMs = batchExpiryMs;
     }
 
     /**
@@ -261,7 +266,7 @@ public class Sender implements Runnable {
             }
         }
 
-        List<ProducerBatch> expiredBatches = this.accumulator.expiredBatches(this.requestTimeout, now);
+        List<ProducerBatch> expiredBatches = this.accumulator.expiredBatches(this.batchExpiryMs, now);
         boolean needsTransactionStateReset = false;
         // Reset the producer id if an expired batch has previously been sent to the broker. Also update the metrics
         // for expired batches. see the documentation of @TransactionState.resetProducerId to understand why

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -490,12 +490,14 @@ public class KafkaProducerTest {
         Properties props = new Properties();
         props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2002");
         props.setProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "5");
-        KafkaProducer<String, String> producerWithDefaultBatchExpiry = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer());
 
-        assertEquals(5, producerWithDefaultBatchExpiry.batchExpiryMs());
+        try (KafkaProducer<String, String> producerWithDefaultBatchExpiry = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer())) {
+            assertEquals(5, producerWithDefaultBatchExpiry.batchExpiryMs());
+        }
+
         props.setProperty(ProducerConfig.BATCH_EXPIRY_MS, "10");
-
-        KafkaProducer<String, String> producerWithConfiguredBatchExpiry = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer());
-        assertEquals(10L, producerWithConfiguredBatchExpiry.batchExpiryMs());
+        try (KafkaProducer<String, String> producerWithConfiguredBatchExpiry = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer())) {
+            assertEquals(10L, producerWithConfiguredBatchExpiry.batchExpiryMs());
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -484,4 +484,18 @@ public class KafkaProducerTest {
             // expected
         }
     }
+
+    @Test
+    public void testBatchExpiryMs() {
+        Properties props = new Properties();
+        props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2002");
+        props.setProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "5");
+        KafkaProducer<String, String> producerWithDefaultBatchExpiry = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer());
+
+        assertEquals(5, producerWithDefaultBatchExpiry.batchExpiryMs());
+        props.setProperty(ProducerConfig.BATCH_EXPIRY_MS, "10");
+
+        KafkaProducer<String, String> producerWithConfiguredBatchExpiry = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer());
+        assertEquals(10L, producerWithConfiguredBatchExpiry.batchExpiryMs());
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -91,6 +91,7 @@ public class SenderTest {
     private static final double EPS = 0.0001;
     private static final int MAX_BLOCK_TIMEOUT = 1000;
     private static final int REQUEST_TIMEOUT = 1000;
+    private static final int BATCH_EXPIRY_TIMEOUT = 1000;
 
     private TopicPartition tp0 = new TopicPartition("test", 0);
     private TopicPartition tp1 = new TopicPartition("test", 1);
@@ -276,7 +277,7 @@ public class SenderTest {
         Metrics m = new Metrics();
         try {
             Sender sender = new Sender(client, metadata, this.accumulator, false, MAX_REQUEST_SIZE, ACKS_ALL,
-                    maxRetries, m, time, REQUEST_TIMEOUT, 50, null, apiVersions);
+                    maxRetries, m, time, REQUEST_TIMEOUT, 50, null, apiVersions, BATCH_EXPIRY_TIMEOUT);
             // do a successful retry
             Future<RecordMetadata> future = accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT).future;
             sender.run(time.milliseconds()); // connect
@@ -323,7 +324,7 @@ public class SenderTest {
         Metrics m = new Metrics();
         try {
             Sender sender = new Sender(client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                    m, time, REQUEST_TIMEOUT, 50, null, apiVersions);
+                    m, time, REQUEST_TIMEOUT, 50, null, apiVersions, BATCH_EXPIRY_TIMEOUT);
             // Create a two broker cluster, with partition 0 on broker 0 and partition 1 on broker 1
             Cluster cluster1 = TestUtils.clusterWith(2, "test", 2);
             metadata.update(cluster1, Collections.<String>emptySet(), time.milliseconds());
@@ -575,7 +576,7 @@ public class SenderTest {
         int maxRetries = 10;
         Metrics m = new Metrics();
         Sender sender = new Sender(client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                m, time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions);
+                m, time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions, BATCH_EXPIRY_TIMEOUT);
 
         Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT).future;
         client.prepareResponse(new MockClient.RequestMatcher() {
@@ -616,7 +617,7 @@ public class SenderTest {
         int maxRetries = 10;
         Metrics m = new Metrics();
         Sender sender = new Sender(client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                m, time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions);
+                m, time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions, BATCH_EXPIRY_TIMEOUT);
 
         Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT).future;
         sender.run(time.milliseconds());  // connect.
@@ -653,7 +654,7 @@ public class SenderTest {
         int maxRetries = 10;
         Metrics m = new Metrics();
         Sender sender = new Sender(client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                m, time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions);
+                m, time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions, BATCH_EXPIRY_TIMEOUT);
 
         Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT).future;
         sender.run(time.milliseconds());  // connect.
@@ -706,7 +707,7 @@ public class SenderTest {
                 new ApiVersions(), txnManager);
         try {
             Sender sender = new Sender(client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                    m, time, REQUEST_TIMEOUT, 1000L, txnManager, new ApiVersions());
+                    m, time, REQUEST_TIMEOUT, 1000L, txnManager, new ApiVersions(), BATCH_EXPIRY_TIMEOUT);
             // Create a two broker cluster, with partition 0 on broker 0 and partition 1 on broker 1
             Cluster cluster1 = TestUtils.clusterWith(2, topic, 2);
             metadata.update(cluster1, Collections.<String>emptySet(), time.milliseconds());
@@ -828,7 +829,7 @@ public class SenderTest {
         this.accumulator = new RecordAccumulator(batchSize, 1024 * 1024, CompressionType.NONE, 0L, 0L, metrics, time,
                 apiVersions, transactionManager);
         this.sender = new Sender(this.client, this.metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL,
-                MAX_RETRIES, this.metrics, this.time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions);
+                MAX_RETRIES, this.metrics, this.time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions, BATCH_EXPIRY_TIMEOUT);
         this.metadata.update(this.cluster, Collections.<String>emptySet(), time.milliseconds());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -93,6 +93,7 @@ public class TransactionManagerTest {
     private static final String CLIENT_ID = "clientId";
     private static final int MAX_BLOCK_TIMEOUT = 1000;
     private static final int REQUEST_TIMEOUT = 1000;
+    private static final long BATCH_EXPIRY_TIMEOUT = 1000;
     private static final long DEFAULT_RETRY_BACKOFF_MS = 100L;
     private final String transactionalId = "foobar";
     private final int transactionTimeoutMs = 1121;
@@ -122,7 +123,7 @@ public class TransactionManagerTest {
         Metrics metrics = new Metrics(metricConfig, time);
         this.accumulator = new RecordAccumulator(batchSize, 1024 * 1024, CompressionType.NONE, 0L, 0L, metrics, time, apiVersions, transactionManager);
         this.sender = new Sender(this.client, this.metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL,
-                MAX_RETRIES, metrics, this.time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions);
+                MAX_RETRIES, metrics, this.time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions, BATCH_EXPIRY_TIMEOUT);
         this.metadata.update(this.cluster, Collections.<String>emptySet(), time.milliseconds());
         client.setNode(brokerNode);
     }


### PR DESCRIPTION
We solve the problem of expired batches not being retried by providing the a separate config `batch.expiry.ms` which controls how long to wait before batches are expired. Before this patch, we would expire batches once `request.timeout.ms` elapsed. By setting the new config to be very high, we ensure that batches are never expired, which has the same effect as being retried indefinitely.