### PR TITLE
KAFKA-6250: Ignore ClusterAuthorizationException when creating topics

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
@@ -233,7 +234,7 @@ public class TopicAdmin implements AutoCloseable {
                     log.debug("Found existing topic '{}' on the brokers at {}", topic, bootstrapServers);
                     continue;
                 }
-                if (cause instanceof UnsupportedVersionException) {
+                if (cause instanceof UnsupportedVersionException || cause instanceof ClusterAuthorizationException) {
                     log.debug("Unable to use Kafka admin client to create topic descriptions for '{}' using the brokers at {}," +
                                       "falling back to assume topic(s) exist or will be auto-created by the broker", topicNameList, bootstrapServers);
                     return Collections.emptySet();


### PR DESCRIPTION
When using Kafka Connect with a cluster that doesn't allow the user to create topics (due to ACL configuration), Connect fails when trying to create its internal topics, _even if these topics already exist_. This is incorrect behavior according to [the documentation](https://docs.confluent.io/current/connect/security.html#worker-acl-requirements), which mentions that R/W access should be enough.

This happens specifically when using Aiven Kafka, which does not permit creation of topics via the Kafka Admin Client API.

The patch ignores the returned error, similar to the behavior for older brokers that don't support the API.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
