### PR TITLE
KAFKA-6833: KafkaProducer throws 'Invalid partition given with record…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -49,16 +49,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.errors.ApiException;
-import org.apache.kafka.common.errors.AuthenticationException;
-import org.apache.kafka.common.errors.AuthorizationException;
-import org.apache.kafka.common.errors.InterruptException;
-import org.apache.kafka.common.errors.InvalidTopicException;
-import org.apache.kafka.common.errors.ProducerFencedException;
-import org.apache.kafka.common.errors.RecordTooLargeException;
-import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.errors.TimeoutException;
-import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.errors.*;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
@@ -983,7 +974,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         } while (partitionsCount == null);
 
         if (partition != null && partition >= partitionsCount) {
-            throw new KafkaException(
+            throw new PartitionOutOfRangeException(
                     String.format("Invalid partition given with record: %d is not in the range [0...%d).", partition, partitionsCount));
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/PartitionOutOfRangeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/PartitionOutOfRangeException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+import org.apache.kafka.common.KafkaException;
+
+/**
+ * Partition metadata was requested for a partition that does not exist for the topic
+ */
+public class PartitionOutOfRangeException extends KafkaException {
+    private static final long serialVersionUID = 1L;
+
+    public PartitionOutOfRangeException() {
+        super();
+    }
+
+    public PartitionOutOfRangeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PartitionOutOfRangeException(String message) {
+        super(message);
+    }
+
+    public PartitionOutOfRangeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.errors.PartitionOutOfRangeException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
@@ -375,7 +376,7 @@ public class KafkaProducerTest {
         try {
             producer.send(extendedRecord, null);
             fail("Expected KafkaException to be raised");
-        } catch (KafkaException e) {
+        } catch (PartitionOutOfRangeException e) {
             // expected
         }
         PowerMock.verify(metadata);


### PR DESCRIPTION
…' exception

Create a new exception class, PartitionOutOfRangeException, which is thrown when a producer attempts to fetch metadata for a partition that is outside the range of partitions for the topic. Tested by catching the specific exception class when fetching metadata for an out of range partition.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
