### PR TITLE
KAFKA-7467: NoSuchElementException is raised because controlBatch is …

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -243,7 +243,8 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
 
     @Override
     public boolean isControlBatch() {
-        return (attributes() & CONTROL_FLAG_MASK) > 0;
+        // Due to KAFKA-7467, we need to check for empty control batches and treat them as non-control batches
+        return (attributes() & CONTROL_FLAG_MASK) > 0 && count() > 0;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -222,7 +222,7 @@ public class MemoryRecords extends AbstractRecords {
                 DefaultRecordBatch.writeEmptyHeader(bufferOutputStream.buffer(), batchMagic, batch.producerId(),
                         batch.producerEpoch(), batch.baseSequence(), batch.baseOffset(), batch.lastOffset(),
                         batch.partitionLeaderEpoch(), batch.timestampType(), batch.maxTimestamp(),
-                        batch.isTransactional(), batch.isControlBatch());
+                        batch.isTransactional(), false);
                 filterResult.updateRetainedBatchMetadata(batch, 0, true);
             }
 

--- a/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordBatchTest.java
@@ -64,7 +64,7 @@ public class DefaultRecordBatchTest {
                     assertEquals(timestampType, batch.timestampType());
                     assertEquals(timestamp, batch.maxTimestamp());
                     assertEquals(RecordBatch.NO_TIMESTAMP, batch.firstTimestamp());
-                    assertEquals(isControlBatch, batch.isControlBatch());
+                    assertFalse(batch.isControlBatch());
                 }
             }
         }

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsTest.java
@@ -246,63 +246,78 @@ public class MemoryRecordsTest {
     public void testFilterToEmptyBatchRetention() {
         if (magic >= RecordBatch.MAGIC_VALUE_V2) {
             for (boolean isTransactional : Arrays.asList(true, false)) {
-                ByteBuffer buffer = ByteBuffer.allocate(2048);
-                long producerId = 23L;
-                short producerEpoch = 5;
-                long baseOffset = 3L;
-                int baseSequence = 10;
-                int partitionLeaderEpoch = 293;
-                int numRecords = 2;
+                for (boolean isControlBatch : Arrays.asList(true, false)) {
+                    if (!isTransactional && isControlBatch) {
+                        continue;
+                    }
 
-                MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, magic, compression, TimestampType.CREATE_TIME,
-                        baseOffset, RecordBatch.NO_TIMESTAMP, producerId, producerEpoch, baseSequence, isTransactional,
-                        partitionLeaderEpoch);
-                builder.append(11L, "2".getBytes(), "b".getBytes());
-                builder.append(12L, "3".getBytes(), "c".getBytes());
-                builder.close();
-                MemoryRecords records = builder.build();
+                    ByteBuffer buffer = ByteBuffer.allocate(2048);
+                    long producerId = 23L;
+                    short producerEpoch = 5;
+                    long baseOffset = 3L;
+                    int baseSequence = 10;
+                    int partitionLeaderEpoch = 293;
+                    int numRecords;
 
-                ByteBuffer filtered = ByteBuffer.allocate(2048);
-                MemoryRecords.FilterResult filterResult = records.filterTo(new TopicPartition("foo", 0),
-                        new MemoryRecords.RecordFilter() {
-                            @Override
-                            protected BatchRetention checkBatchRetention(RecordBatch batch) {
-                                // retain all batches
-                                return BatchRetention.RETAIN_EMPTY;
-                            }
+                    MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, magic, compression, TimestampType.CREATE_TIME,
+                            baseOffset, RecordBatch.NO_TIMESTAMP, producerId, producerEpoch, baseSequence, isTransactional,
+                            isControlBatch, partitionLeaderEpoch);
+                    if (isControlBatch) {
+                        EndTransactionMarker marker = new EndTransactionMarker(ControlRecordType.COMMIT, 0);
+                        builder.appendEndTxnMarker(12L, marker);
+                        numRecords = 1;
+                    } else {
+                        builder.append(11L, "2".getBytes(), "b".getBytes());
+                        builder.append(12L, "3".getBytes(), "c".getBytes());
+                        numRecords = 2;
+                    }
+                    builder.close();
+                    MemoryRecords records = builder.build();
 
-                            @Override
-                            protected boolean shouldRetainRecord(RecordBatch recordBatch, Record record) {
-                                // delete the records
-                                return false;
-                            }
-                        }, filtered, Integer.MAX_VALUE, BufferSupplier.NO_CACHING);
+                    ByteBuffer filtered = ByteBuffer.allocate(2048);
+                    MemoryRecords.FilterResult filterResult = records.filterTo(new TopicPartition("foo", 0),
+                            new MemoryRecords.RecordFilter() {
+                                @Override
+                                protected BatchRetention checkBatchRetention(RecordBatch batch) {
+                                    // retain all batches
+                                    return BatchRetention.RETAIN_EMPTY;
+                                }
 
-                // Verify filter result
-                assertEquals(numRecords, filterResult.messagesRead());
-                assertEquals(records.sizeInBytes(), filterResult.bytesRead());
-                assertEquals(baseOffset + 1, filterResult.maxOffset());
-                assertEquals(0, filterResult.messagesRetained());
-                assertEquals(DefaultRecordBatch.RECORD_BATCH_OVERHEAD, filterResult.bytesRetained());
-                assertEquals(12, filterResult.maxTimestamp());
-                assertEquals(baseOffset + 1, filterResult.shallowOffsetOfMaxTimestamp());
+                                @Override
+                                protected boolean shouldRetainRecord(RecordBatch recordBatch, Record record) {
+                                    // delete the records
+                                    return false;
+                                }
+                            }, filtered, Integer.MAX_VALUE, BufferSupplier.NO_CACHING);
 
-                // Verify filtered records
-                filtered.flip();
-                MemoryRecords filteredRecords = MemoryRecords.readableRecords(filtered);
+                    // Verify filter result
+                    long expectedOffset = isControlBatch ? baseOffset : baseOffset + 1;
+                    assertEquals(numRecords, filterResult.messagesRead());
+                    assertEquals(records.sizeInBytes(), filterResult.bytesRead());
+                    assertEquals(expectedOffset, filterResult.maxOffset());
+                    assertEquals(0, filterResult.messagesRetained());
+                    assertEquals(DefaultRecordBatch.RECORD_BATCH_OVERHEAD, filterResult.bytesRetained());
+                    assertEquals(12, filterResult.maxTimestamp());
+                    assertEquals(expectedOffset, filterResult.shallowOffsetOfMaxTimestamp());
 
-                List<MutableRecordBatch> batches = TestUtils.toList(filteredRecords.batches());
-                assertEquals(1, batches.size());
+                    // Verify filtered records
+                    filtered.flip();
+                    MemoryRecords filteredRecords = MemoryRecords.readableRecords(filtered);
 
-                MutableRecordBatch batch = batches.get(0);
-                assertEquals(0, batch.countOrNull().intValue());
-                assertEquals(12L, batch.maxTimestamp());
-                assertEquals(TimestampType.CREATE_TIME, batch.timestampType());
-                assertEquals(baseOffset, batch.baseOffset());
-                assertEquals(baseOffset + 1, batch.lastOffset());
-                assertEquals(baseSequence, batch.baseSequence());
-                assertEquals(baseSequence + 1, batch.lastSequence());
-                assertEquals(isTransactional, batch.isTransactional());
+                    List<MutableRecordBatch> batches = TestUtils.toList(filteredRecords.batches());
+                    assertEquals(1, batches.size());
+
+                    MutableRecordBatch batch = batches.get(0);
+                    assertEquals(0, batch.countOrNull().intValue());
+                    assertEquals(12L, batch.maxTimestamp());
+                    assertEquals(TimestampType.CREATE_TIME, batch.timestampType());
+                    assertEquals(baseOffset, batch.baseOffset());
+                    assertEquals(expectedOffset, batch.lastOffset());
+                    assertEquals(baseSequence, batch.baseSequence());
+                    assertEquals(isControlBatch ? baseSequence : baseSequence + 1, batch.lastSequence());
+                    assertEquals(isTransactional, batch.isTransactional());
+                    assertFalse(batch.isControlBatch());
+                }
             }
         }
     }

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -424,7 +424,8 @@ object DumpLogSegments {
           print("baseOffset: " + batch.baseOffset + " lastOffset: " + batch.lastOffset + " count: " + batch.countOrNull +
             " baseSequence: " + batch.baseSequence + " lastSequence: " + batch.lastSequence +
             " producerId: " + batch.producerId + " producerEpoch: " + batch.producerEpoch +
-            " partitionLeaderEpoch: " + batch.partitionLeaderEpoch + " isTransactional: " + batch.isTransactional)
+            " partitionLeaderEpoch: " + batch.partitionLeaderEpoch + " isTransactional: " + batch.isTransactional +
+            " isControl: " + batch.isControlBatch)
         else
           print("offset: " + batch.lastOffset)
 


### PR DESCRIPTION
…empty

This patch changes the behavior of MemoryRecords.filterTo() to always mark empty batches as non-control batches, rather than taking the attribute from the original batch. Empty control batches will cause fatal errors in segment recovery or the log cleaner due to trying access a record in an empty batch. In order to prevent errors from logs that are already in this state, this patch also adds a check to DefaultRecordBatch.isControlBatch() so that it will only return true if the batch is non-empty. Finally, it adds isControl to the output of DumpLogSegments. MemoryRecords and DefaultRecordsBatch changes were tested with unit tests, DumpLogSegments change was tested manually.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
