### PR TITLE
CONFLUENT: some support-metrics-common test fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1250,6 +1250,7 @@ project(':support-metrics-client') {
     compile project(':support-metrics-common')
 
     testCompile project(':core').sourceSets.test.output
+    testCompile project(':clients').sourceSets.test.output // for org.apache.kafka.test.IntegrationTest
     testCompile libs.junit
     testCompile libs.mockitoCore
   }
@@ -1325,6 +1326,7 @@ project(':support-metrics-common') {
     compile project(':core')
 
     testCompile project(':core').sourceSets.test.output
+    testCompile project(':clients').sourceSets.test.output // for org.apache.kafka.test.IntegrationTest
     testCompile libs.junit
     testCompile libs.mockitoCore
   }

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/common/FilterTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/common/FilterTest.java
@@ -83,8 +83,8 @@ public class FilterTest {
 
     // Then
     assertEquals(properties.size() - 1, filtered.size());
-    assertFalse(filtered.contains("one"));
-    assertTrue(filtered.contains("two"));
+    assertFalse(filtered.containsKey("one"));
+    assertTrue(filtered.containsKey("two"));
     assertEquals(properties.get("two"), filtered.get("two"));
   }
 
@@ -125,8 +125,8 @@ public class FilterTest {
 
     // Then
     assertEquals(properties.size(), filtered.size());
-    assertTrue(filtered.contains("one"));
-    assertTrue(filtered.contains("two"));
+    assertTrue(filtered.containsKey("one"));
+    assertTrue(filtered.containsKey("two"));
   }
 
 }


### PR DESCRIPTION
Fix a bug where support-metrics-common tests could sometimes not find
the definition of the IntegrationTest annotation.

Fix a bug where FilterTest was using Properties#contains where
Properties#containsKey was appropriate.