### PR TITLE
CONFLUENT: Expect SupportedKafka as the classname in system tests

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -722,4 +722,4 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         return output
 
     def java_class_name(self):
-        return "kafka.Kafka"
+        return "SupportedKafka"

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -722,4 +722,4 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         return output
 
     def java_class_name(self):
-        return "SupportedKafka"
+        return "io.confluent.support.metrics.SupportedKafka"


### PR DESCRIPTION
System tests in https://jenkins.confluent.io/job/system-test-kafka/job/master/ have been failing. Most of the failures are because of a port conflict for `JmxMixin`. This is because of a leak from an earlier test where `KafkaService` startup raises an exception, preventing cleanup of `JmxMixin` which causes all other tests that use `JmxMixin` to fail with a port conflict.

With the change to integrate support metrics in this repo, we should now expect the main class to be `SupportedKafka` instead of `kafka.Kafka`. This fix will address the startup failure.

Kicked off build with fix: https://jenkins.confluent.io/job/system-test-kafka-branch-builder/2549/