### PR TITLE
CONFLUENT: support-metrics should use compileOnly for `core` dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1272,9 +1272,12 @@ project(':support-metrics-client') {
     compile libs.httpmime
     compile libs.slf4jlog4j
     compile project(':clients')
-    compile project(':core')
+    // projects that require the KafkaSubmitter have to add the Core dependency explicitly, typically
+    // they only need ConfluentSubmitter
+    compileOnly project(':core')
     compile project(':support-metrics-common')
 
+    testCompile project(':core')
     testCompile project(':core').sourceSets.test.output
     testCompile project(':clients').sourceSets.test.output // for org.apache.kafka.test.IntegrationTest
     testCompile project(':support-metrics-common').sourceSets.test.output // for io.confluent.support.metrics.common.kafka.EmbeddedKafkaCluster
@@ -1351,8 +1354,11 @@ project(':support-metrics-common') {
     compile libs.httpmime
     compile libs.slf4jlog4j
     compile project(':clients')
-    compile project(':core')
+    // projects that require the KafkaSubmitter have to add the Core dependency explicitly, typically
+    // they only need ConfluentSubmitter
+    compileOnly project(':core')
 
+    testCompile project(':core')
     testCompile project(':core').sourceSets.test.output
     testCompile project(':clients').sourceSets.test.output // for org.apache.kafka.test.IntegrationTest
     testCompile libs.junit


### PR DESCRIPTION
This has 2 benefits:
- Avoid the `core` dependency that is not needed by most projects.
They typically only care about `ConfluentSubmitter`.
- Workaround a bug where any Java project depending on `core`
ends up overwriting the core dependency to have the Scala version
from the last build. That is, if you build 2.12 and then 2.11,
the pom for the Java project will depend on `kafka_2.11`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
