### PR TITLE
CONFLUENT: Change default dir paths from /var/lib to /tmp

### DIFF
--- a/config/server.properties
+++ b/config/server.properties
@@ -57,7 +57,7 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma separated list of directories under which to store log files
-log.dirs=/var/lib/kafka
+log.dirs=/tmp/kafka-logs
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across

--- a/config/zookeeper.properties
+++ b/config/zookeeper.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # the directory where the snapshot is stored.
-dataDir=/var/lib/zookeeper
+dataDir=/tmp/zookeeper
 # the port at which the clients will connect
 clientPort=2181
 # disable the per-ip limit on the number of connections since this is a non-production config

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -494,7 +494,7 @@ public class StreamsConfig extends AbstractConfig {
                     REPLICATION_FACTOR_DOC)
             .define(STATE_DIR_CONFIG,
                     Type.STRING,
-                    "/var/lib/kafka-streams",
+                    "/tmp/kafka-streams",
                     Importance.HIGH,
                     STATE_DIR_DOC)
 


### PR DESCRIPTION
This reverts the changes done in: https://github.com/confluentinc/kafka/commit/e5a6ed3471efa501e3ea96b2302447a10d43b137

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
