### PR TITLE
CONFLUENT: Jenkins gradle exit 1 on executor failure, 0 on test failu…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,13 +32,9 @@ def job = {
       }
     }
 
-    stage("Unit Test") {
-      sh "./gradlew --no-daemon unitTest --continue --stacktrace || true"
-    }
-
-    stage("Integration test") {
-        sh "./gradlew integrationTest " +
-                "--no-daemon --stacktrace --continue -PtestLoggingEvents=started,passed,skipped,failed -PmaxParallelForks=6 || true"
+    stage("Test") {
+        sh "./gradlew unitTest integrationTest " +
+                "--no-daemon --stacktrace --continue -PtestLoggingEvents=started,passed,skipped,failed -PmaxParallelForks=4 -PignoreFailures=true"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ ext {
   buildVersionFileName = "kafka-version.properties"
 
   userMaxForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : null
+  userIgnoreFailures = project.hasProperty('ignoreFailures') ? ignoreFailures : false
 
   skipSigning = project.hasProperty('skipSigning') && skipSigning.toBoolean()
   shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && project.gradle.startParameter.taskNames.any { it.contains("upload") }
@@ -313,6 +314,7 @@ subprojects {
 
   task integrationTest(type: Test, dependsOn: compileJava) {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+    ignoreFailures = userIgnoreFailures
 
     minHeapSize = "256m"
     maxHeapSize = "2048m"
@@ -332,6 +334,7 @@ subprojects {
 
   task unitTest(type: Test, dependsOn: compileJava) {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+    ignoreFailures = userIgnoreFailures
 
     minHeapSize = "256m"
     maxHeapSize = "2048m"


### PR DESCRIPTION
…re (#531)

We wish to return a yellow build on a test failure, but wish to fail the
build completely when the gradle executors do not finish cleanly. This
change will achieve that.
(cherry picked from commit 334acf48d40e6a3c627cb71990fa91e1616e4921)

-- This change also reduces the max forks from 6 to 4, to improve stability of builds.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
