### PR TITLE
KAFKA-8792; Default ZK configuration to disable AdminServer

### DIFF
--- a/config/zookeeper.properties
+++ b/config/zookeeper.properties
@@ -18,3 +18,7 @@ dataDir=/tmp/zookeeper
 clientPort=2181
 # disable the per-ip limit on the number of connections since this is a non-production config
 maxClientCnxns=0
+# Disable the adminserver by default to avoid port conflicts.
+# Set the port to something non-conflicting if choosing to enable this
+admin.enableServer=false
+# admin.serverPort=8080


### PR DESCRIPTION
Kafka ships with default ZK configuration. With the upgrade to ZK 3.5, our defaults include running ZK's AdminServer on port 8080. This is an unfortunate default as it tends to cause conflicts.

I suggest we default to disable ZK's AdminServer in the default ZK configs that we ship. Users who want to use AdminServer can enable it and set the port to something that works for them. Realistically, in most production environments, a different ZK server will be used anyway. So this is mostly to save new users who are trying Kafka on their own machine from running into accidental and frustrating port conflicts.

Author: Gwen Shapira <gwen@confluent.io>

Reviewers: Ismael Juma

Closes #7203 from gwenshap/zk_disable_adminserver

(cherry picked from commit f125c2dfe22a9a51f2881f63673c9b85a863ba14)
