### PR TITLE
CONFLUENT: Revert dependency updates including Avro

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -48,7 +48,7 @@ should_include_file() {
 base_dir=$(dirname $0)/..
 
 if [ -z "$SCALA_VERSION" ]; then
-  SCALA_VERSION=2.12.9
+  SCALA_VERSION=2.12.8
 fi
 
 if [ -z "$SCALA_BINARY_VERSION" ]; then

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -27,7 +27,7 @@ set BASE_DIR=%CD%
 popd
 
 IF ["%SCALA_VERSION%"] EQU [""] (
-  set SCALA_VERSION=2.12.9
+  set SCALA_VERSION=2.12.8
 )
 
 IF ["%SCALA_BINARY_VERSION%"] EQU [""] (

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,6 @@ group=org.apache.kafka
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 version=5.4.0-ccs-beta1
-scalaVersion=2.12.9
+scalaVersion=2.12.8
 task=build
 org.gradle.jvmargs=-Xmx1024m -Xss2m

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ ext {
 
 // Add Scala version
 def defaultScala211Version = '2.11.12'
-def defaultScala212Version = '2.12.9'
+def defaultScala212Version = '2.12.8'
 def defaultScala213Version = '2.13.0'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.11') {
@@ -63,20 +63,20 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  avro: "1.9.0",
-  avroPlugin: "0.17.0",
-  bcpkix: "1.62",
+  avro: "1.8.1",
+  avroPlugin: "0.10.0",
+  bcpkix: "1.61",
   checkstyle: "8.20",
   commonsCli: "1.4",
   gradle: "5.4.1",
   gradleVersionsPlugin: "0.21.0",
   grgit: "3.1.1",
-  httpclient: "4.5.9",
+  httpclient: "4.5.8",
   easymock: "4.0.2",
   jackson: "2.9.9",
   jacksonDatabind: "2.9.9.3",
   jacoco: "0.8.3",
-  jetty: "9.4.19.v20190610",
+  jetty: "9.4.18.v20190429",
   jersey: "2.28",
   jmh: "1.21",
   hamcrest: "2.1",
@@ -99,25 +99,25 @@ versions += [
   lz4: "1.6.0",
   mavenArtifact: "3.6.1",
   metrics: "2.2.0",
-  mockito: "3.0.0",
-  owaspDepCheckPlugin: "5.2.1",
+  mockito: "2.27.0",
+  owaspDepCheckPlugin: "4.0.2",
   powermock: "2.0.2",
   reflections: "0.9.11",
   rocksDB: "5.18.3",
-  scalaCollectionCompat: "2.1.2",
+  scalaCollectionCompat: "2.1.0",
   scalafmt: "1.5.1",
   scalaJava8Compat : "0.9.0",
   scalatest: "3.0.8",
   scoverage: "1.4.0",
   scoveragePlugin: "2.5.0",
   shadowPlugin: "4.0.4",
-  slf4j: "1.7.27",
+  slf4j: "1.7.26",
   snappy: "1.1.7.3",
   spotbugs: "3.1.12",
   spotbugsPlugin: "1.6.9",
-  spotlessPlugin: "3.23.1",
+  spotlessPlugin: "3.23.0",
   zookeeper: "3.5.5",
-  zstd: "1.4.2-1"
+  zstd: "1.4.0-1"
 ]
 
 libs += [

--- a/support-metrics-client/src/test/java/io/confluent/support/metrics/collectors/BasicCollectorTest.java
+++ b/support-metrics-client/src/test/java/io/confluent/support/metrics/collectors/BasicCollectorTest.java
@@ -58,7 +58,7 @@ public class BasicCollectorTest {
     assertTrue(basicRecord.getTimestamp() <= time.nowInUnixTime());
     assertEquals(AppInfoParser.getVersion(), basicRecord.getKafkaVersion());
     assertEquals(BasicCollector.cpVersion(AppInfoParser.getVersion()), basicRecord.getConfluentPlatformVersion());
-    assertEquals(metricsCollector.getRuntimeState().stateId(), basicRecord.getCollectorState());
+    assertEquals(metricsCollector.getRuntimeState().stateId(), basicRecord.getCollectorState().intValue());
     assertEquals(uuid.toString(), basicRecord.getBrokerProcessUUID());
   }
 


### PR DESCRIPTION
Avro 1.9.0 removes `JsonProperties.addProp(String, JsonNode)`
which is used by schema registry's AvroData.

The dependency updates cause the following error
during ':support-metrics-client:generateAvro':

> Caused by: org.apache.velocity.exception.MethodInvocationException: Variable $velocityCount has not been set at ...

It's unclear why and given the aim to release 5.4-beta this
week, I have reverted all of them.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
