### PR TITLE
Updating the Jenkins config file to post to #kafka-warn

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ def config = jobConfig {
     cron = '@midnight'
     nodeLabel = 'docker-oraclejdk8'
     testResultSpecs = ['junit': '**/build/test-results/**/TEST-*.xml']
-    slackChannel = '#kafka'
+    slackChannel = '#kafka-warn'
     timeoutHours = 4
     runMergeCheck = false
 }


### PR DESCRIPTION
As per the new Slack changes we want all the notifications from bots
which are not immediately actionable to go to a different channel. Moving
the jenkins build alerts to #kafka-warn.