### PR TITLE
MINOR: Use confluentinc when CHANGE_FORK is not set

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ def job = {
                     echo "Building cp-downstream-builds"
                     if (config.isPrJob) {
                         def muckrakeBranch = kafkaMuckrakeVersionMap[env.CHANGE_TARGET]
-                        def forkRepo = "${env.CHANGE_FORK}/kafka.git"
+                        def forkRepo = "${env.CHANGE_FORK ?: "confluentinc"}/kafka.git"
                         def forkBranch = env.CHANGE_BRANCH
                         echo "Schedule test-cp-downstream-builds with :"
                         echo "Muckrake branch : ${muckrakeBranch}"


### PR DESCRIPTION
The Jenkinsfile uses `env.CHANGE_FORK` in PR builds, which is not set when a PR is opened from the `confluentinc` fork:
```[Pipeline] echo
17:06:23  Schedule test-cp-downstream-builds with :
[Pipeline] echo
17:06:23  Muckrake branch : 5.3.x
[Pipeline] echo
17:06:23  PR fork repo : null/kafka.git
[Pipeline] echo
17:06:23  PR fork branch : 5.3.2-bump
[Pipeline] build
17:06:23  Scheduling project: test-cp-downstream-builds
```

This change explicitly sets `confluentinc` when the variable is not set.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
