### PR TITLE
CONFLUENT: Remove `gradle` invocation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ def job = {
 
     // Per KAFKA-7524, Scala 2.12 is the default, yet we currently support the previous minor version.
     stage("Check compilation compatibility with Scala 2.11") {
-        sh "gradle"
         sh "./gradlew clean compileJava compileScala compileTestJava compileTestScala " +
                 "--no-daemon --stacktrace -PscalaVersion=2.11"
     }


### PR DESCRIPTION
`gradlew` now downloads the correct gradle version
as needed, so we should not invoke the `gradle`
executable installed in the system.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
