### PR TITLE
Changes for Adding a new Prefix iterator

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -98,7 +98,7 @@ versions += [
   owaspDepCheckPlugin: "5.3.2.1",
   powermock: "2.0.7",
   reflections: "0.9.12",
-  rocksDB: "5.18.4",
+  rocksDB: "5.18.3",
   scalaCollectionCompat: "2.1.6",
   scalafmt: "1.5.1",
   scalaJava8Compat : "0.9.1",

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/streams/processor/internals/RocksDbPrefixStateStoreBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/streams/processor/internals/RocksDbPrefixStateStoreBenchmark.java
@@ -1,0 +1,108 @@
+package org.apache.kafka.jmh.streams.processor.internals;
+
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.metrics.Metrics;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.*;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.internals.RocksDBStore;
+import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.openjdk.jmh.annotations.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class RocksDbPrefixStateStoreBenchmark {
+
+    private int counter;
+
+    private static final int DISTINCT_KEYS = 10_000;
+
+    private static final String KEY = "the_key_to_use";
+
+    private static final String VALUE = "the quick brown fox jumped over the lazy dog the olympics are about to start";
+
+    private final Bytes[] keys = new Bytes[DISTINCT_KEYS];
+
+    private final byte[][] values = new byte[DISTINCT_KEYS][];
+
+    private RocksDBStore prefixedStateStore;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        for (int i = 0; i < DISTINCT_KEYS; ++i) {
+            keys[i] = Bytes.wrap((KEY + i).getBytes(StandardCharsets.UTF_8));
+            values[i] = (VALUE + i).getBytes(StandardCharsets.UTF_8);
+        }
+
+        prefixedStateStore = (RocksDBStore)Stores.persistentKeyValueStore("prefix-state-store").get();
+
+        final StreamsMetricsImpl metrics = new StreamsMetricsImpl(new Metrics(), "prefix-test-metrics", StreamsConfig.METRICS_LATEST);
+        final ThreadCache cache = new ThreadCache(new LogContext("prefixTestCache "), 1_000_000_000, metrics);
+        final StreamsConfig config = new StreamsConfig(mkMap(
+                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "prefix-test"),
+                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "prefix-test")
+        ));
+
+        final TaskId id = new TaskId(0, 0);
+        final ProcessorStateManager stateMgr;
+        stateMgr = new ProcessorStateManager(
+                id,
+                Task.TaskType.ACTIVE,
+                false,
+                new LogContext("jmh"),
+                new StateDirectory(config, Time.SYSTEM, true),
+                null,
+                Collections.emptyMap(),
+                Collections.emptyList()
+        );
+
+        final ProcessorContextImpl context = new ProcessorContextImpl(
+                id,
+                null,
+                config,
+                null,
+                stateMgr,
+                metrics,
+                cache
+        );
+
+        context.setRecordContext(new ProcessorRecordContext(0, 0, 0, "topic", new RecordHeaders()));
+        prefixedStateStore.init(context, prefixedStateStore);
+
+    }
+
+    @Benchmark
+    public KeyValueIterator<Bytes, byte[]> testCachePerformance() {
+        counter++;
+        final int index = counter % DISTINCT_KEYS;
+        // Put multiple keys with the same prefix patterns. This way, the prefix seek use case would be catered.
+        final Bytes key = keys[index];
+        prefixedStateStore.put(key, values[index]);
+        int numIterations = 10;
+        int nextIndex = index + 1;
+        while (numIterations >= 0) {
+            Bytes newKey = keys[nextIndex % DISTINCT_KEYS];
+            prefixedStateStore.put(newKey, values[nextIndex % DISTINCT_KEYS]);
+            numIterations--;
+            nextIndex++;
+        }
+
+        return prefixedStateStore.prefixScan(Bytes.wrap(KEY.getBytes()));
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadOnlyDecorator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadOnlyDecorator.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.streams.processor.internals;
 
 import java.util.List;
+
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -120,6 +122,11 @@ abstract class AbstractReadOnlyDecorator<T extends StateStore, K, V> extends Wra
         @Override
         public V delete(final K key) {
             throw new UnsupportedOperationException(ERROR_MESSAGE);
+        }
+
+        @Override
+        public <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(P prefix, PS prefixKeySerializer) {
+            return null;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadWriteDecorator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadWriteDecorator.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.streams.processor.internals;
 
 import java.util.List;
+
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -114,6 +116,11 @@ abstract class AbstractReadWriteDecorator<T extends StateStore, K, V> extends Wr
         @Override
         public V delete(final K key) {
             return wrapped().delete(key);
+        }
+
+        @Override
+        public <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(P prefix, PS prefixKeySerializer) {
+            return null;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/KeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/KeyValueStore.java
@@ -67,4 +67,5 @@ public interface KeyValueStore<K, V> extends StateStore, ReadOnlyKeyValueStore<K
      * @throws NullPointerException If {@code null} is used for key.
      */
     V delete(K key);
+
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 
 /**
@@ -74,4 +75,16 @@ public interface ReadOnlyKeyValueStore<K, V> {
      * @throws InvalidStateStoreException if the store is not initialized
      */
     long approximateNumEntries();
+
+    /**
+     * Get an iterator over keys which have the specified prefix. The type of the prefix can be different from that of
+     * the key. That's why, callers should also pass a serializer for the prefix to convert the prefix into the
+     * format in which the keys are stored underneath in the stores
+     * @param prefix The prefix.
+     * @param prefixKeySerializer Serializer for the Prefix key type
+     * @param <PS> Prefix Serializer type
+     * @param <P> Prefix Type.
+     * @return The iterator for keys having the specified prefix.
+     */
+    <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(P prefix, PS prefixKeySerializer);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -188,6 +189,11 @@ public class CachingKeyValueStore
         } finally {
             lock.writeLock().unlock();
         }
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(P prefix, PS prefixKeySerializer) {
+        return null;
     }
 
     private byte[] deleteInternal(final Bytes key) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -87,6 +88,11 @@ public class ChangeLoggingKeyValueBytesStore
         final byte[] oldValue = wrapped().delete(key);
         log(key, null);
         return oldValue;
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(P prefix, PS prefixKeySerializer) {
+        return wrapped().prefixScan(prefix, prefixKeySerializer);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.QueryableStoreType;
@@ -109,6 +110,11 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
             }
         }
         return total;
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(P prefix, PS prefixKeySerializer) {
+        throw new UnsupportedOperationException();
     }
 
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -16,11 +16,9 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import java.util.List;
-import java.util.NavigableMap;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.*;
+
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -28,7 +26,6 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 
-import java.util.Iterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,6 +103,19 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
         final byte[] oldValue = map.remove(key);
         size -= oldValue == null ? 0 : 1;
         return oldValue;
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(P prefix, PS prefixKeySerializer) {
+        Objects.requireNonNull(prefix, "prefix cannot be null");
+        Objects.requireNonNull(prefixKeySerializer, "prefixKeySerializer cannot be null");
+
+        Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
+        Bytes to = Bytes.increment(from);
+
+        return new DelegatingPeekingKeyValueIterator<>(
+                name,
+                new InMemoryKeyValueIterator(map.subMap(from, true, to, false).keySet()));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -74,6 +75,11 @@ public class KeyValueToTimestampedKeyValueByteStoreAdapter implements KeyValueSt
     @Override
     public byte[] delete(final Bytes key) {
         return convertToTimestampedFormat(store.delete(key));
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(P prefix, PS prefixKeySerializer) {
+        return null;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -132,6 +133,11 @@ public class MemoryLRUCache implements KeyValueStore<Bytes, byte[]> {
     public synchronized byte[] delete(final Bytes key) {
         Objects.requireNonNull(key);
         return this.map.remove(key);
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(P prefix, PS prefixKeySerializer) {
+        return null;
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
@@ -171,6 +172,15 @@ public class MeteredKeyValueStore<K, V>
             final String message = String.format(e.getMessage(), key);
             throw new ProcessorStateException(message, e);
         }
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(P prefix, PS prefixKeySerializer) {
+
+        return new MeteredKeyValueIterator(
+                wrapped().prefixScan(prefix, prefixKeySerializer),
+                rangeSensor
+        );
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ReadOnlyKeyValueStoreFacade.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ReadOnlyKeyValueStoreFacade.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
@@ -48,5 +49,10 @@ public class ReadOnlyKeyValueStoreFacade<K, V> implements ReadOnlyKeyValueStore<
     @Override
     public long approximateNumEntries() {
         return inner.approximateNumEntries();
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(P prefix, PS prefixKeySerializer) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -313,7 +313,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         validateStoreOpen();
         Bytes prefixBytes = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
 
-        final KeyValueIterator<Bytes, byte[]> rocksDbPrefixSeekIterator = dbAccessor.prefixSeek(prefixBytes);
+        final KeyValueIterator<Bytes, byte[]> rocksDbPrefixSeekIterator = dbAccessor.prefixScan(prefixBytes);
         openIterators.add(rocksDbPrefixSeekIterator);
 
         return rocksDbPrefixSeekIterator;
@@ -493,7 +493,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
         void close();
 
-        KeyValueIterator<Bytes, byte[]> prefixSeek(final Bytes prefix);
+        KeyValueIterator<Bytes, byte[]> prefixScan(final Bytes prefix);
     }
 
     class SingleColumnFamilyAccessor implements RocksDBAccessor {
@@ -595,7 +595,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         }
 
         @Override
-        public KeyValueIterator<Bytes, byte[]> prefixSeek(Bytes prefix) {
+        public KeyValueIterator<Bytes, byte[]> prefixScan(Bytes prefix) {
             return new RocksDBPrefixIterator(name, db.newIterator(columnFamily), openIterators, prefix);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -251,7 +251,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         }
 
         @Override
-        public KeyValueIterator<Bytes, byte[]> prefixSeek(Bytes prefix) {
+        public KeyValueIterator<Bytes, byte[]> prefixScan(Bytes prefix) {
             return null;
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -249,6 +249,11 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             oldColumnFamily.close();
             newColumnFamily.close();
         }
+
+        @Override
+        public KeyValueIterator<Bytes, byte[]> prefixSeek(Bytes prefix) {
+            return null;
+        }
     }
 
     private class RocksDBDualCFIterator extends AbstractIterator<KeyValue<Bytes, byte[]>>

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilder.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
@@ -120,6 +121,11 @@ public class TimestampedKeyValueStoreBuilder<K, V>
         @Override
         public byte[] delete(final Bytes key) {
             return wrapped.delete(key);
+        }
+
+        @Override
+        public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(P prefix, PS prefixKeySerializer) {
+            return null;
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/test/GenericInMemoryKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/GenericInMemoryKeyValueStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
@@ -121,6 +122,11 @@ public class GenericInMemoryKeyValueStore<K extends Comparable, V>
     @Override
     public synchronized V delete(final K key) {
         return this.map.remove(key);
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(P prefix, PS prefixKeySerializer) {
+        return null;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/GenericInMemoryTimestampedKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/GenericInMemoryTimestampedKeyValueStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
@@ -122,6 +123,11 @@ public class GenericInMemoryTimestampedKeyValueStore<K extends Comparable, V>
     @Override
     public synchronized ValueAndTimestamp<V> delete(final K key) {
         return this.map.remove(key);
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<K, ValueAndTimestamp<V>> prefixScan(P prefix, PS prefixKeySerializer) {
+        return null;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/MockKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockKeyValueStore.java
@@ -18,6 +18,7 @@ package org.apache.kafka.test;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
@@ -108,6 +109,11 @@ public class MockKeyValueStore implements KeyValueStore<Object, Object> {
 
     @Override
     public Object delete(final Object key) {
+        return null;
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<Object, Object> prefixScan(P prefix, PS prefixKeySerializer) {
         return null;
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/NoOpReadOnlyStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpReadOnlyStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -62,6 +63,11 @@ public class NoOpReadOnlyStore<K, V> implements ReadOnlyKeyValueStore<K, V>, Sta
     @Override
     public long approximateNumEntries() {
         return 0L;
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(P prefix, PS prefixKeySerializer) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/internals/KeyValueStoreFacade.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/internals/KeyValueStoreFacade.java
@@ -17,9 +17,11 @@
 package org.apache.kafka.streams.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
@@ -63,6 +65,11 @@ public class KeyValueStoreFacade<K, V> extends ReadOnlyKeyValueStoreFacade<K, V>
     @Override
     public V delete(final K key) {
         return getValueOrNull(inner.delete(key));
+    }
+
+    @Override
+    public <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(P prefix, PS prefixKeySerializer) {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
This pull request seeks to add the prefix seek operations to the State stores. The current implementation  in this PR, adds the feature only to the RocksDBStateStore- which provides prefixSeek api via the RocksJava implementation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
