### PR TITLE
CONFLUENT: Sync from apache/kafka (21 January 2020)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2080,6 +2080,7 @@ project(':connect:mirror') {
     compile libs.slf4jApi
 
     testCompile libs.junit
+    testCompile libs.mockitoCore
     testCompile project(':clients').sourceSets.test.output
     testCompile project(':connect:runtime').sourceSets.test.output
     testCompile project(':core')

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3028,7 +3028,9 @@ public class KafkaAdminClient extends AdminClient {
                 new ConstantNodeIdProvider(context.node().get().id())) {
             @Override
             OffsetFetchRequest.Builder createRequest(int timeoutMs) {
-                return new OffsetFetchRequest.Builder(context.groupId(), context.options().topicPartitions());
+                // Set the flag to false as for admin client request,
+                // we don't need to wait for any pending offset state to clear.
+                return new OffsetFetchRequest.Builder(context.groupId(), false, context.options().topicPartitions());
             }
 
             @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Map.Entry;
 
 /**
@@ -156,5 +157,22 @@ public class NewTopic {
                 append(", configs=").append(configs).
                 append(")");
         return bld.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final NewTopic that = (NewTopic) o;
+        return Objects.equals(name, that.name) &&
+            Objects.equals(numPartitions, that.numPartitions) &&
+            Objects.equals(replicationFactor, that.replicationFactor) &&
+            Objects.equals(replicasAssignments, that.replicasAssignments) &&
+            Objects.equals(configs, that.configs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, numPartitions, replicationFactor, replicasAssignments, configs);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -570,7 +570,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
     private Logger log;
     private final String clientId;
-    private String groupId;
+    private final Optional<String> groupId;
     private final ConsumerCoordinator coordinator;
     private final Deserializer<K> keyDeserializer;
     private final Deserializer<V> valueDeserializer;
@@ -673,7 +673,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
                     GroupRebalanceConfig.ProtocolType.CONSUMER);
 
-            this.groupId = groupRebalanceConfig.groupId;
+            this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
             this.clientId = buildClientId(config.getString(CommonClientConfigs.CLIENT_ID_CONFIG), groupRebalanceConfig);
 
             LogContext logContext;
@@ -681,20 +681,22 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             // If group.instance.id is set, we will append it to the log context.
             if (groupRebalanceConfig.groupInstanceId.isPresent()) {
                 logContext = new LogContext("[Consumer instanceId=" + groupRebalanceConfig.groupInstanceId.get() +
-                        ", clientId=" + clientId + ", groupId=" + groupId + "] ");
+                        ", clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
             } else {
-                logContext = new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId + "] ");
+                logContext = new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
             }
 
             this.log = logContext.logger(getClass());
             boolean enableAutoCommit = config.getBoolean(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
-            if (groupId == null) { // overwrite in case of default group id where the config is not explicitly provided
-                if (!config.originals().containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))
+            if (!groupId.isPresent()) { // overwrite in case of default group id where the config is not explicitly provided
+                if (!config.originals().containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)) {
                     enableAutoCommit = false;
-                else if (enableAutoCommit)
+                } else if (enableAutoCommit) {
                     throw new InvalidConfigurationException(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG + " cannot be set to true when default group id (null) is used.");
-            } else if (groupId.isEmpty())
+                }
+            } else if (groupId.get().isEmpty()) {
                 log.warn("Support for using the empty group id by consumers is deprecated and will be removed in the next major release.");
+            }
 
             log.debug("Initializing the Kafka consumer");
             this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
@@ -773,7 +775,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             this.assignors = getAssignorInstances(config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG), config.originals());
 
             // no coordinator will be constructed for the default (null) group id
-            this.coordinator = groupId == null ? null :
+            this.coordinator = !groupId.isPresent() ? null :
                 new ConsumerCoordinator(groupRebalanceConfig,
                         logContext,
                         this.client,
@@ -858,7 +860,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         this.requestTimeoutMs = requestTimeoutMs;
         this.defaultApiTimeoutMs = defaultApiTimeoutMs;
         this.assignors = assignors;
-        this.groupId = groupId;
+        this.groupId = Optional.ofNullable(groupId);
         this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, "consumer");
     }
 
@@ -2436,7 +2438,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     }
 
     private void maybeThrowInvalidGroupIdException() {
-        if (groupId == null)
+        if (!groupId.isPresent())
             throw new InvalidGroupIdException("To use the group management or offset commit APIs, you must " +
                     "provide a valid " + ConsumerConfig.GROUP_ID_CONFIG + " in the consumer configuration.");
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetCommitCallback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetCommitCallback.java
@@ -40,7 +40,7 @@ public interface OffsetCommitCallback {
      *             or if there is an active group with the same groupId which is using group management.
      * @throws org.apache.kafka.common.errors.RebalanceInProgressException if the commit failed because
      *            it is in the middle of a rebalance. In such cases
-     *            commit could be retried after the rebalance is completed with the {@link #poll(Duration)} call.
+     *            commit could be retried after the rebalance is completed with the {@link KafkaConsumer#poll(Duration)} call.
      * @throws org.apache.kafka.common.errors.WakeupException if {@link KafkaConsumer#wakeup()} is called before or while this
      *             function is called
      * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1315,7 +1315,7 @@ public abstract class AbstractCoordinator implements Closeable {
     protected static class Generation {
         public static final Generation NO_GENERATION = new Generation(
                 OffsetCommitRequest.DEFAULT_GENERATION_ID,
-                JoinGroupResponse.UNKNOWN_MEMBER_ID,
+                JoinGroupRequest.UNKNOWN_MEMBER_ID,
                 null);
 
         public final int generationId;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -548,6 +548,8 @@ public class Fetcher<K, V> implements Closeable {
                 remainingToSearch.keySet().retainAll(value.partitionsToRetry);
             } else if (!future.isRetriable()) {
                 throw future.exception();
+            } else {
+                metadata.requestUpdate();
             }
 
             if (metadata.updateRequested())
@@ -1356,7 +1358,7 @@ public class Fetcher<K, V> implements Closeable {
         clearBufferedDataForUnassignedPartitions(currentTopicPartitions);
     }
 
-    // Visibilty for testing
+    // Visible for testing
     protected FetchSessionHandler sessionHandler(int node) {
         return sessionHandlers.get(node);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -802,6 +802,7 @@ public final class RecordAccumulator {
      */
     public void close() {
         this.closed = true;
+        this.free.close();
     }
 
     /*

--- a/clients/src/main/java/org/apache/kafka/common/errors/UnstableOffsetCommitException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnstableOffsetCommitException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+/**
+ * Exception thrown when there are unstable offsets for the requested topic partitions.
+ */
+public class UnstableOffsetCommitException extends RetriableException {
+
+    private static final long serialVersionUID = 1L;
+
+    public UnstableOffsetCommitException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/metrics/MetricConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/MetricConfig.java
@@ -33,7 +33,6 @@ public class MetricConfig {
     private Sensor.RecordingLevel recordingLevel;
 
     public MetricConfig() {
-        super();
         this.quota = null;
         this.samples = 2;
         this.eventWindow = Long.MAX_VALUE;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -78,6 +78,7 @@ import org.apache.kafka.common.errors.OffsetNotAvailableException;
 import org.apache.kafka.common.errors.OffsetOutOfRangeException;
 import org.apache.kafka.common.errors.OperationNotAttemptedException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.errors.UnstableOffsetCommitException;
 import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.errors.PreferredLeaderNotAvailableException;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -317,7 +318,8 @@ public enum Errors {
             NoReassignmentInProgressException::new),
     GROUP_SUBSCRIBED_TO_TOPIC(86, "Deleting offsets of a topic is forbidden while the consumer group is actively subscribed to it.",
         GroupSubscribedToTopicException::new),
-    INVALID_RECORD(87, "This record has failed the validation on broker and hence be rejected.", InvalidRecordException::new);
+    INVALID_RECORD(87, "This record has failed the validation on broker and hence be rejected.", InvalidRecordException::new),
+    UNSTABLE_OFFSET_COMMIT(88, "There are unstable offsets that need to be cleared", UnstableOffsetCommitException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/SchemaException.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/SchemaException.java
@@ -29,4 +29,7 @@ public class SchemaException extends KafkaException {
         super(message);
     }
 
+    public SchemaException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -56,6 +56,8 @@ public class JoinGroupRequest extends AbstractRequest {
     private final JoinGroupRequestData data;
 
     public static final String UNKNOWN_MEMBER_ID = "";
+    public static final int UNKNOWN_GENERATION_ID = -1;
+    public static final String UNKNOWN_PROTOCOL = "";
 
     private static final int MAX_GROUP_INSTANCE_ID_LENGTH = 249;
 
@@ -120,10 +122,10 @@ public class JoinGroupRequest extends AbstractRequest {
         return new JoinGroupResponse(new JoinGroupResponseData()
                 .setThrottleTimeMs(throttleTimeMs)
                 .setErrorCode(Errors.forException(e).code())
-                .setGenerationId(JoinGroupResponse.UNKNOWN_GENERATION_ID)
-                .setProtocolName(JoinGroupResponse.UNKNOWN_PROTOCOL)
-                .setLeader(JoinGroupResponse.UNKNOWN_MEMBER_ID)
-                .setMemberId(JoinGroupResponse.UNKNOWN_MEMBER_ID)
+                .setGenerationId(UNKNOWN_GENERATION_ID)
+                .setProtocolName(UNKNOWN_PROTOCOL)
+                .setLeader(UNKNOWN_MEMBER_ID)
+                .setMemberId(UNKNOWN_MEMBER_ID)
                 .setMembers(Collections.emptyList()));
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
@@ -29,10 +29,6 @@ public class JoinGroupResponse extends AbstractResponse {
 
     private final JoinGroupResponseData data;
 
-    public static final String UNKNOWN_PROTOCOL = "";
-    public static final int UNKNOWN_GENERATION_ID = -1;
-    public static final String UNKNOWN_MEMBER_ID = "";
-
     public JoinGroupResponse(JoinGroupResponseData data) {
         this.data = data;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequest
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -33,6 +35,8 @@ import java.util.Optional;
 
 public class OffsetFetchRequest extends AbstractRequest {
 
+    private static final Logger log = LoggerFactory.getLogger(OffsetFetchRequest.class);
+
     private static final List<OffsetFetchRequestTopic> ALL_TOPIC_PARTITIONS = null;
     public final OffsetFetchRequestData data;
 
@@ -40,7 +44,9 @@ public class OffsetFetchRequest extends AbstractRequest {
 
         public final OffsetFetchRequestData data;
 
-        public Builder(String groupId, List<TopicPartition> partitions) {
+        public Builder(String groupId,
+                       boolean requireStable,
+                       List<TopicPartition> partitions) {
             super(ApiKeys.OFFSET_FETCH);
 
             final List<OffsetFetchRequestTopic> topics;
@@ -61,22 +67,29 @@ public class OffsetFetchRequest extends AbstractRequest {
 
             this.data = new OffsetFetchRequestData()
                             .setGroupId(groupId)
+                            .setRequireStable(requireStable)
                             .setTopics(topics);
         }
 
-        public static Builder allTopicPartitions(String groupId) {
-            return new Builder(groupId, null);
-        }
-
-        public boolean isAllTopicPartitions() {
+        boolean isAllTopicPartitions() {
             return this.data.topics() == ALL_TOPIC_PARTITIONS;
         }
 
         @Override
         public OffsetFetchRequest build(short version) {
-            if (isAllTopicPartitions() && version < 2)
+            if (isAllTopicPartitions() && version < 2) {
                 throw new UnsupportedVersionException("The broker only supports OffsetFetchRequest " +
-                        "v" + version + ", but we need v2 or newer to request all topic partitions.");
+                    "v" + version + ", but we need v2 or newer to request all topic partitions.");
+            }
+
+            if (data.requireStable() && version < 7) {
+                log.info("Fallback the requireStable flag to false as broker " +
+                             "only supports OffsetFetchRequest version {}. Need " +
+                             "v7 or newer to enable this feature", version);
+
+                return new OffsetFetchRequest(data.setRequireStable(false), version);
+            }
+
             return new OffsetFetchRequest(data, version);
         }
 
@@ -101,6 +114,10 @@ public class OffsetFetchRequest extends AbstractRequest {
 
     public String groupId() {
         return data.groupId();
+    }
+
+    public boolean requireStable() {
+        return data.requireStable();
     }
 
     private OffsetFetchRequest(OffsetFetchRequestData data, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
@@ -41,6 +41,7 @@ import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPO
  * - Partition errors:
  *   - {@link Errors#UNKNOWN_TOPIC_OR_PARTITION}
  *   - {@link Errors#TOPIC_AUTHORIZATION_FAILED}
+ *   - {@link Errors#UNSTABLE_OFFSET_COMMIT}
  *
  * - Group or coordinator errors:
  *   - {@link Errors#COORDINATOR_LOAD_IN_PROGRESS}

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslAuthenticateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslAuthenticateRequest.java
@@ -56,7 +56,6 @@ public class SaslAuthenticateRequest extends AbstractRequest {
     }
 
     private final SaslAuthenticateRequestData data;
-    private final short version;
 
     public SaslAuthenticateRequest(SaslAuthenticateRequestData data) {
         this(data, ApiKeys.SASL_AUTHENTICATE.latestVersion());
@@ -65,13 +64,11 @@ public class SaslAuthenticateRequest extends AbstractRequest {
     public SaslAuthenticateRequest(SaslAuthenticateRequestData data, short version) {
         super(ApiKeys.SASL_AUTHENTICATE, version);
         this.data = data;
-        this.version = version;
     }
 
     public SaslAuthenticateRequest(Struct struct, short version) {
         super(ApiKeys.SASL_AUTHENTICATE, version);
         this.data = new SaslAuthenticateRequestData(struct, version);
-        this.version = version;
     }
 
     public SaslAuthenticateRequestData data() {
@@ -92,7 +89,7 @@ public class SaslAuthenticateRequest extends AbstractRequest {
 
     @Override
     protected Struct toStruct() {
-        return data.toStruct(version);
+        return data.toStruct(version());
     }
 }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeRequest.java
@@ -55,7 +55,6 @@ public class SaslHandshakeRequest extends AbstractRequest {
     }
 
     private final SaslHandshakeRequestData data;
-    private final short version;
 
     public SaslHandshakeRequest(SaslHandshakeRequestData data) {
         this(data, ApiKeys.SASL_HANDSHAKE.latestVersion());
@@ -64,13 +63,11 @@ public class SaslHandshakeRequest extends AbstractRequest {
     public SaslHandshakeRequest(SaslHandshakeRequestData data, short version) {
         super(ApiKeys.SASL_HANDSHAKE, version);
         this.data = data;
-        this.version = version;
     }
 
     public SaslHandshakeRequest(Struct struct, short version) {
         super(ApiKeys.SASL_HANDSHAKE, version);
         this.data = new SaslHandshakeRequestData(struct, version);
-        this.version = version;
     }
 
     public SaslHandshakeRequestData data() {
@@ -90,7 +87,7 @@ public class SaslHandshakeRequest extends AbstractRequest {
 
     @Override
     protected Struct toStruct() {
-        return data.toStruct(version);
+        return data.toStruct(version());
     }
 }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
@@ -41,6 +41,9 @@ import java.util.Map;
  *   - {@link Errors#INVALID_COMMIT_OFFSET_SIZE}
  *   - {@link Errors#TRANSACTIONAL_ID_AUTHORIZATION_FAILED}
  *   - {@link Errors#REQUEST_TIMED_OUT}
+ *   - {@link Errors#UNKNOWN_MEMBER_ID}
+ *   - {@link Errors#FENCED_INSTANCE_ID}
+ *   - {@link Errors#ILLEGAL_GENERATION}
  */
 public class TxnOffsetCommitResponse extends AbstractResponse {
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/SecurityUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/SecurityUtils.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.utils;
 
 import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.config.SecurityConfig;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.SecurityProviderCreator;
@@ -26,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.security.Security;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class SecurityUtils {
@@ -34,18 +36,27 @@ public class SecurityUtils {
 
     private static final Map<String, ResourceType> NAME_TO_RESOURCE_TYPES;
     private static final Map<String, AclOperation> NAME_TO_OPERATIONS;
+    private static final Map<String, AclPermissionType> NAME_TO_PERMISSION_TYPES;
 
     static {
         NAME_TO_RESOURCE_TYPES = new HashMap<>(ResourceType.values().length);
         NAME_TO_OPERATIONS = new HashMap<>(AclOperation.values().length);
+        NAME_TO_PERMISSION_TYPES = new HashMap<>(AclPermissionType.values().length);
 
         for (ResourceType resourceType : ResourceType.values()) {
             String resourceTypeName = toPascalCase(resourceType.name());
             NAME_TO_RESOURCE_TYPES.put(resourceTypeName, resourceType);
+            NAME_TO_RESOURCE_TYPES.put(resourceTypeName.toUpperCase(Locale.ROOT), resourceType);
         }
         for (AclOperation operation : AclOperation.values()) {
             String operationName = toPascalCase(operation.name());
             NAME_TO_OPERATIONS.put(operationName, operation);
+            NAME_TO_OPERATIONS.put(operationName.toUpperCase(Locale.ROOT), operation);
+        }
+        for (AclPermissionType permissionType : AclPermissionType.values()) {
+            String permissionName  = toPascalCase(permissionType.name());
+            NAME_TO_PERMISSION_TYPES.put(permissionName, permissionType);
+            NAME_TO_PERMISSION_TYPES.put(permissionName.toUpperCase(Locale.ROOT), permissionType);
         }
     }
 
@@ -86,13 +97,38 @@ public class SecurityUtils {
     }
 
     public static ResourceType resourceType(String name) {
-        ResourceType resourceType = NAME_TO_RESOURCE_TYPES.get(name);
-        return resourceType == null ? ResourceType.UNKNOWN : resourceType;
+        return valueFromMap(NAME_TO_RESOURCE_TYPES, name, ResourceType.UNKNOWN);
     }
 
     public static AclOperation operation(String name) {
-        AclOperation operation = NAME_TO_OPERATIONS.get(name);
-        return operation == null ? AclOperation.UNKNOWN : operation;
+        return valueFromMap(NAME_TO_OPERATIONS, name, AclOperation.UNKNOWN);
+    }
+
+    public static AclPermissionType permissionType(String name) {
+        return valueFromMap(NAME_TO_PERMISSION_TYPES, name, AclPermissionType.UNKNOWN);
+    }
+
+    // We use Pascal-case to store these values, so lookup using provided key first to avoid
+    // case conversion for the common case. For backward compatibility, also perform
+    // case-insensitive look up (without underscores) by converting the key to upper-case.
+    private static <T> T valueFromMap(Map<String, T> map, String key, T unknown) {
+        T value = map.get(key);
+        if (value == null) {
+            value = map.get(key.toUpperCase(Locale.ROOT));
+        }
+        return value == null ? unknown : value;
+    }
+
+    public static String resourceTypeName(ResourceType resourceType) {
+        return toPascalCase(resourceType.name());
+    }
+
+    public static String operationName(AclOperation operation) {
+        return toPascalCase(operation.name());
+    }
+
+    public static String permissionTypeName(AclPermissionType permissionType) {
+        return toPascalCase(permissionType.name());
     }
 
     private static String toPascalCase(String name) {

--- a/clients/src/main/resources/common/message/CreatePartitionsRequest.json
+++ b/clients/src/main/resources/common/message/CreatePartitionsRequest.json
@@ -18,8 +18,9 @@
   "type": "request",
   "name": "CreatePartitionsRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "Topics", "type": "[]CreatePartitionsTopic", "versions": "0+",
       "about": "Each topic that we want to create new partitions inside.",  "fields": [

--- a/clients/src/main/resources/common/message/CreatePartitionsResponse.json
+++ b/clients/src/main/resources/common/message/CreatePartitionsResponse.json
@@ -18,8 +18,9 @@
   "type": "response",
   "name": "CreatePartitionsResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
@@ -18,8 +18,9 @@
   "type": "request",
   "name": "DescribeDelegationTokenRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "Owners", "type": "[]DescribeDelegationTokenOwner", "versions": "0+", "nullableVersions": "0+",
       "about": "Each owner that we want to describe delegation tokens for, or null to describe all tokens.", "fields": [

--- a/clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json
+++ b/clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json
@@ -18,8 +18,9 @@
   "type": "response",
   "name": "DescribeDelegationTokenResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },

--- a/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
@@ -18,8 +18,9 @@
   "type": "request",
   "name": "ExpireDelegationTokenRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "Hmac", "type": "bytes", "versions": "0+",
       "about": "The HMAC of the delegation token to be expired." },

--- a/clients/src/main/resources/common/message/ExpireDelegationTokenResponse.json
+++ b/clients/src/main/resources/common/message/ExpireDelegationTokenResponse.json
@@ -18,8 +18,9 @@
   "type": "response",
   "name": "ExpireDelegationTokenResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },

--- a/clients/src/main/resources/common/message/OffsetFetchRequest.json
+++ b/clients/src/main/resources/common/message/OffsetFetchRequest.json
@@ -28,7 +28,9 @@
   // Version 3, 4, and 5 are the same as version 2.
   //
   // Version 6 is the first flexible version.
-  "validVersions": "0-6",
+  //
+  // Version 7 is adding the require stable flag.
+  "validVersions": "0-7",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
@@ -39,6 +41,8 @@
         "about": "The topic name."},
       { "name": "PartitionIndexes", "type": "[]int32", "versions": "0+",
         "about": "The partition indexes we would like to fetch offsets for." }
-    ]}
+    ]},
+    {"name": "RequireStable", "type": "bool", "versions": "7+", "default": "false",
+     "about": "Whether broker should hold on returning unstable offsets but set a retriable error code for the partition."}
   ]
 }

--- a/clients/src/main/resources/common/message/OffsetFetchResponse.json
+++ b/clients/src/main/resources/common/message/OffsetFetchResponse.json
@@ -28,7 +28,9 @@
   // Version 5 adds the leader epoch to the committed offset.
   //
   // Version 6 is the first flexible version.
-  "validVersions": "0-6",
+  //
+  // Version 7 adds pending offset commit as new error response on partition level.
+  "validVersions": "0-7",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+", "ignorable": true,

--- a/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
@@ -18,8 +18,9 @@
   "type": "request",
   "name": "RenewDelegationTokenRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "Hmac", "type": "bytes", "versions": "0+",
       "about": "The HMAC of the delegation token to be renewed." },

--- a/clients/src/main/resources/common/message/RenewDelegationTokenResponse.json
+++ b/clients/src/main/resources/common/message/RenewDelegationTokenResponse.json
@@ -18,8 +18,9 @@
   "type": "response",
   "name": "RenewDelegationTokenResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },

--- a/clients/src/main/resources/common/message/SaslAuthenticateRequest.json
+++ b/clients/src/main/resources/common/message/SaslAuthenticateRequest.json
@@ -18,8 +18,9 @@
   "type": "request",
   "name": "SaslAuthenticateRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "AuthBytes", "type": "bytes", "versions": "0+",
       "about": "The SASL authentication bytes from the client, as defined by the SASL mechanism." }

--- a/clients/src/main/resources/common/message/SaslAuthenticateResponse.json
+++ b/clients/src/main/resources/common/message/SaslAuthenticateResponse.json
@@ -18,8 +18,9 @@
   "type": "response",
   "name": "SaslAuthenticateResponse",
   // Version 1 adds the session lifetime.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },

--- a/clients/src/main/resources/common/message/SaslHandshakeRequest.json
+++ b/clients/src/main/resources/common/message/SaslHandshakeRequest.json
@@ -18,8 +18,9 @@
   "type": "request",
   "name": "SaslHandshakeRequest",
   // Version 1 supports SASL_AUTHENTICATE.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "Mechanism", "type": "string", "versions": "0+",
       "about": "The SASL mechanism chosen by the client." }

--- a/clients/src/main/resources/common/message/SaslHandshakeResponse.json
+++ b/clients/src/main/resources/common/message/SaslHandshakeResponse.json
@@ -18,8 +18,9 @@
   "type": "response",
   "name": "SaslHandshakeResponse",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },

--- a/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
+++ b/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
@@ -20,8 +20,10 @@
   // Version 1 is the same as version 0.
   //
   // Version 2 adds the committed leader epoch.
-  "validVersions": "0-2",
-  "flexibleVersions": "none",
+  //
+  // Version 3 adds the member.id, group.instance.id and generation.id.
+  "validVersions": "0-3",
+  "flexibleVersions": "3+",
   "fields": [
     { "name": "TransactionalId", "type": "string", "versions": "0+",
       "about": "The ID of the transaction." },
@@ -31,8 +33,15 @@
       "about": "The current producer ID in use by the transactional ID." },
     { "name": "ProducerEpoch", "type": "int16", "versions": "0+",
       "about": "The current epoch associated with the producer ID." },
+    { "name": "GenerationId", "type": "int32", "versions": "3+", "default": "-1",
+      "about": "The generation of the consumer." },
+    { "name": "MemberId", "type": "string", "versions": "3+", "default": "",
+      "about": "The member ID assigned by the group coordinator." },
+    { "name": "GroupInstanceId", "type": "string", "versions": "3+",
+      "nullableVersions": "3+", "default": "null",
+      "about": "The unique identifier of the consumer instance provided by end user." },
     { "name": "Topics", "type" : "[]TxnOffsetCommitRequestTopic", "versions": "0+",
-      "about": "Each topic that we want to committ offsets for.", "fields": [
+      "about": "Each topic that we want to commit offsets for.", "fields": [
       { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
       { "name": "Partitions", "type": "[]TxnOffsetCommitRequestPartition", "versions": "0+",

--- a/clients/src/main/resources/common/message/TxnOffsetCommitResponse.json
+++ b/clients/src/main/resources/common/message/TxnOffsetCommitResponse.json
@@ -18,9 +18,12 @@
   "type": "response",
   "name": "TxnOffsetCommitResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
+  //
   // Version 2 is the same as version 1.
-  "validVersions": "0-2",
-  "flexibleVersions": "none",
+  //
+  // Version 3 adds illegal generation, fenced instance id, and unknown member id errors.
+  "validVersions": "0-3",
+  "flexibleVersions": "3+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
@@ -31,7 +34,7 @@
       { "name": "Partitions", "type": "[]TxnOffsetCommitResponsePartition", "versions": "0+",
         "about": "The responses for each partition in the topic.", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
-          "about": "The partitition index." },
+          "about": "The partition index." },
         { "name": "ErrorCode", "type": "int16", "versions": "0+",
           "about": "The error code, or 0 if there was no error." }
       ]}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1904,7 +1904,7 @@ public class KafkaConsumerTest {
         final ConsumerGroupMetadata groupMetadataOnStart = consumer.groupMetadata();
         assertEquals(groupId, groupMetadataOnStart.groupId());
         assertEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, groupMetadataOnStart.memberId());
-        assertEquals(JoinGroupResponse.UNKNOWN_GENERATION_ID, groupMetadataOnStart.generationId());
+        assertEquals(JoinGroupRequest.UNKNOWN_GENERATION_ID, groupMetadataOnStart.generationId());
         assertEquals(groupInstanceId, groupMetadataOnStart.groupInstanceId());
 
         consumer.subscribe(singleton(topic), getConsumerRebalanceListener(consumer));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -279,7 +279,7 @@ public class AbstractCoordinatorTest {
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(mockTime.timer(0));
 
-        mockClient.prepareResponse(joinGroupFollowerResponse(defaultGeneration, memberId, JoinGroupResponse.UNKNOWN_MEMBER_ID, Errors.GROUP_MAX_SIZE_REACHED));
+        mockClient.prepareResponse(joinGroupFollowerResponse(defaultGeneration, memberId, JoinGroupRequest.UNKNOWN_MEMBER_ID, Errors.GROUP_MAX_SIZE_REACHED));
 
         RequestFuture<ByteBuffer> future = coordinator.sendJoinGroupRequest();
         assertTrue(consumerClient.poll(future, mockTime.timer(REQUEST_TIMEOUT_MS)));
@@ -325,7 +325,7 @@ public class AbstractCoordinatorTest {
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(mockTime.timer(0));
 
-        mockClient.prepareResponse(joinGroupFollowerResponse(defaultGeneration, memberId, JoinGroupResponse.UNKNOWN_MEMBER_ID, Errors.MEMBER_ID_REQUIRED));
+        mockClient.prepareResponse(joinGroupFollowerResponse(defaultGeneration, memberId, JoinGroupRequest.UNKNOWN_MEMBER_ID, Errors.MEMBER_ID_REQUIRED));
 
         mockClient.prepareResponse(body -> {
             if (!(body instanceof JoinGroupRequest)) {
@@ -351,7 +351,7 @@ public class AbstractCoordinatorTest {
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(mockTime.timer(0));
 
-        mockClient.prepareResponse(joinGroupFollowerResponse(defaultGeneration, memberId, JoinGroupResponse.UNKNOWN_MEMBER_ID, Errors.FENCED_INSTANCE_ID));
+        mockClient.prepareResponse(joinGroupFollowerResponse(defaultGeneration, memberId, JoinGroupRequest.UNKNOWN_MEMBER_ID, Errors.FENCED_INSTANCE_ID));
 
         RequestFuture<ByteBuffer> future = coordinator.sendJoinGroupRequest();
         assertTrue(consumerClient.poll(future, mockTime.timer(REQUEST_TIMEOUT_MS)));
@@ -367,7 +367,7 @@ public class AbstractCoordinatorTest {
 
         final int generation = -1;
 
-        mockClient.prepareResponse(joinGroupFollowerResponse(generation, memberId, JoinGroupResponse.UNKNOWN_MEMBER_ID, Errors.NONE));
+        mockClient.prepareResponse(joinGroupFollowerResponse(generation, memberId, JoinGroupRequest.UNKNOWN_MEMBER_ID, Errors.NONE));
         mockClient.prepareResponse(syncGroupResponse(Errors.FENCED_INSTANCE_ID));
 
         assertThrows(FencedInstanceIdException.class, () -> coordinator.ensureActiveGroup());
@@ -380,7 +380,7 @@ public class AbstractCoordinatorTest {
 
         final int generation = -1;
 
-        mockClient.prepareResponse(joinGroupFollowerResponse(generation, memberId, JoinGroupResponse.UNKNOWN_MEMBER_ID, Errors.NONE));
+        mockClient.prepareResponse(joinGroupFollowerResponse(generation, memberId, JoinGroupRequest.UNKNOWN_MEMBER_ID, Errors.NONE));
         mockClient.prepareResponse(syncGroupResponse(Errors.NONE));
         mockClient.prepareResponse(heartbeatResponse(Errors.FENCED_INSTANCE_ID));
 
@@ -404,7 +404,7 @@ public class AbstractCoordinatorTest {
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(mockTime.timer(0));
 
-        mockClient.prepareResponse(joinGroupFollowerResponse(defaultGeneration, memberId, JoinGroupResponse.UNKNOWN_MEMBER_ID, Errors.UNKNOWN_MEMBER_ID));
+        mockClient.prepareResponse(joinGroupFollowerResponse(defaultGeneration, memberId, JoinGroupRequest.UNKNOWN_MEMBER_ID, Errors.UNKNOWN_MEMBER_ID));
 
         RequestFuture<ByteBuffer> future = coordinator.sendJoinGroupRequest();
 
@@ -959,8 +959,8 @@ public class AbstractCoordinatorTest {
     }
 
     private JoinGroupResponse joinGroupResponse(Errors error) {
-        return joinGroupFollowerResponse(JoinGroupResponse.UNKNOWN_GENERATION_ID,
-            JoinGroupResponse.UNKNOWN_MEMBER_ID, JoinGroupResponse.UNKNOWN_MEMBER_ID, error);
+        return joinGroupFollowerResponse(JoinGroupRequest.UNKNOWN_GENERATION_ID,
+            JoinGroupRequest.UNKNOWN_MEMBER_ID, JoinGroupRequest.UNKNOWN_MEMBER_ID, error);
     }
 
     private SyncGroupResponse syncGroupResponse(Errors error) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -1960,7 +1960,7 @@ public class ConsumerCoordinatorTest {
         client.updateMetadata(metadataResponse);
 
         // Load offsets from previous epoch
-        client.prepareResponse(offsetFetchResponse(t1p, Errors.NONE, "", 100L, 3));
+        client.prepareResponse(offsetFetchResponse(t1p, Errors.NONE, "", 100L, Optional.of(3)));
         coordinator.refreshCommittedOffsetsIfNeeded(time.timer(Long.MAX_VALUE));
 
         // Offset gets loaded, but requires validation
@@ -2033,6 +2033,24 @@ public class ConsumerCoordinatorTest {
         } catch (GroupAuthorizationException e) {
             assertEquals(groupId, e.groupId());
         }
+    }
+
+    @Test
+    public void testRefreshOffsetWithPendingTransactions() {
+        client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
+
+        subscriptions.assignFromUser(singleton(t1p));
+        client.prepareResponse(offsetFetchResponse(t1p, Errors.UNSTABLE_OFFSET_COMMIT, "", -1L));
+        client.prepareResponse(offsetFetchResponse(t1p, Errors.NONE, "", 100L));
+        assertEquals(Collections.singleton(t1p), subscriptions.missingFetchPositions());
+        coordinator.refreshCommittedOffsetsIfNeeded(time.timer(0L));
+        assertEquals(Collections.singleton(t1p), subscriptions.missingFetchPositions());
+        coordinator.refreshCommittedOffsetsIfNeeded(time.timer(0L));
+
+        assertEquals(Collections.emptySet(), subscriptions.missingFetchPositions());
+        assertTrue(subscriptions.hasAllFetchPositions());
+        assertEquals(100L, subscriptions.position(t1p).offset);
     }
 
     @Test(expected = KafkaException.class)
@@ -2324,7 +2342,7 @@ public class ConsumerCoordinatorTest {
         final ConsumerGroupMetadata groupMetadata = coordinator.groupMetadata();
         assertNotNull(groupMetadata);
         assertEquals(groupId, groupMetadata.groupId());
-        assertEquals(JoinGroupResponse.UNKNOWN_GENERATION_ID, groupMetadata.generationId());
+        assertEquals(JoinGroupRequest.UNKNOWN_GENERATION_ID, groupMetadata.generationId());
         assertEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, groupMetadata.memberId());
         assertFalse(groupMetadata.groupInstanceId().isPresent());
 
@@ -2616,24 +2634,19 @@ public class ConsumerCoordinatorTest {
     }
 
     private OffsetFetchResponse offsetFetchResponse(TopicPartition tp, Errors partitionLevelError, String metadata, long offset) {
-        OffsetFetchResponse.PartitionData data = new OffsetFetchResponse.PartitionData(offset,
-                Optional.empty(), metadata, partitionLevelError);
-        return new OffsetFetchResponse(Errors.NONE, singletonMap(tp, data));
+        return offsetFetchResponse(tp, partitionLevelError, metadata, offset, Optional.empty());
     }
 
-    private OffsetFetchResponse offsetFetchResponse(TopicPartition tp, Errors partitionLevelError, String metadata, long offset, int epoch) {
+    private OffsetFetchResponse offsetFetchResponse(TopicPartition tp, Errors partitionLevelError, String metadata, long offset, Optional<Integer> epoch) {
         OffsetFetchResponse.PartitionData data = new OffsetFetchResponse.PartitionData(offset,
-                Optional.of(epoch), metadata, partitionLevelError);
+                epoch, metadata, partitionLevelError);
         return new OffsetFetchResponse(Errors.NONE, singletonMap(tp, data));
     }
 
     private OffsetCommitCallback callback(final AtomicBoolean success) {
-        return new OffsetCommitCallback() {
-            @Override
-            public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
-                if (exception == null)
-                    success.set(true);
-            }
+        return (offsets, exception) -> {
+            if (exception == null)
+                success.set(true);
         };
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -1591,7 +1591,7 @@ public class SaslAuthenticatorTest {
                     "but instead we got our generated message echoed back, implying re-auth succeeded when it " +
                     "should not have: " + e,
                     e.getMessage().matches(
-                            ".*\\<\\[" + expectedResponseTextRegex + "]>.*\\<\\[" + receivedResponseTextRegex + "]>"));
+                            ".*\\<\\[" + expectedResponseTextRegex + "]>.*\\<\\[" + receivedResponseTextRegex + ".*?]>"));
             server.verifyReauthenticationMetrics(1, 0); // unchanged
         } finally { 
             selector.close();

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -72,8 +72,8 @@ public class MirrorSourceConnector extends SourceConnector {
     private String connectorName;
     private TopicFilter topicFilter;
     private ConfigPropertyFilter configPropertyFilter;
-    private List<TopicPartition> knownTopicPartitions = Collections.emptyList();
-    private Set<String> knownTargetTopics = Collections.emptySet();
+    private List<TopicPartition> knownSourceTopicPartitions = Collections.emptyList();
+    private List<TopicPartition> knownTargetTopicPartitions = Collections.emptyList();
     private ReplicationPolicy replicationPolicy;
     private int replicationFactor;
     private AdminClient sourceAdminClient;
@@ -84,8 +84,8 @@ public class MirrorSourceConnector extends SourceConnector {
     }
 
     // visible for testing
-    MirrorSourceConnector(List<TopicPartition> knownTopicPartitions, MirrorConnectorConfig config) {
-        this.knownTopicPartitions = knownTopicPartitions;
+    MirrorSourceConnector(List<TopicPartition> knownSourceTopicPartitions, MirrorConnectorConfig config) {
+        this.knownSourceTopicPartitions = knownSourceTopicPartitions;
         this.config = config;
     }
 
@@ -116,14 +116,14 @@ public class MirrorSourceConnector extends SourceConnector {
         scheduler = new Scheduler(MirrorSourceConnector.class, config.adminTimeout());
         scheduler.execute(this::createOffsetSyncsTopic, "creating upstream offset-syncs topic");
         scheduler.execute(this::loadTopicPartitions, "loading initial set of topic-partitions");
-        scheduler.execute(this::createTopicPartitions, "creating downstream topic-partitions");
+        scheduler.execute(this::computeAndCreateTopicPartitions, "creating downstream topic-partitions");
         scheduler.execute(this::refreshKnownTargetTopics, "refreshing known target topics");
         scheduler.scheduleRepeating(this::syncTopicAcls, config.syncTopicAclsInterval(), "syncing topic ACLs");
         scheduler.scheduleRepeating(this::syncTopicConfigs, config.syncTopicConfigsInterval(),
             "syncing topic configs");
         scheduler.scheduleRepeatingDelayed(this::refreshTopicPartitions, config.refreshTopicsInterval(),
             "refreshing topics");
-        log.info("Started {} with {} topic-partitions.", connectorName, knownTopicPartitions.size());
+        log.info("Started {} with {} topic-partitions.", connectorName, knownSourceTopicPartitions.size());
         log.info("Starting {} took {} ms.", connectorName, System.currentTimeMillis() - start);
     }
 
@@ -157,16 +157,16 @@ public class MirrorSourceConnector extends SourceConnector {
     // t3 -> [t0p2, t0p5, t1p0, t2p1]
     @Override
     public List<Map<String, String>> taskConfigs(int maxTasks) {
-        if (!config.enabled() || knownTopicPartitions.isEmpty()) {
+        if (!config.enabled() || knownSourceTopicPartitions.isEmpty()) {
             return Collections.emptyList();
         }
-        int numTasks = Math.min(maxTasks, knownTopicPartitions.size());
+        int numTasks = Math.min(maxTasks, knownSourceTopicPartitions.size());
         List<List<TopicPartition>> roundRobinByTask = new ArrayList<>(numTasks);
         for (int i = 0; i < numTasks; i++) {
             roundRobinByTask.add(new ArrayList<>());
         }
         int count = 0;
-        for (TopicPartition partition : knownTopicPartitions) {
+        for (TopicPartition partition : knownSourceTopicPartitions) {
             int index = count % numTasks;
             roundRobinByTask.get(index).add(partition);
             count++;
@@ -186,61 +186,77 @@ public class MirrorSourceConnector extends SourceConnector {
         return "1";
     }
 
-    private List<TopicPartition> findTopicPartitions()
+    // visible for testing
+    List<TopicPartition> findSourceTopicPartitions()
             throws InterruptedException, ExecutionException {
         Set<String> topics = listTopics(sourceAdminClient).stream()
             .filter(this::shouldReplicateTopic)
             .collect(Collectors.toSet());
-        return describeTopics(topics).stream()
+        return describeTopics(sourceAdminClient, topics).stream()
             .flatMap(MirrorSourceConnector::expandTopicDescription)
             .collect(Collectors.toList());
     }
 
-    private void refreshTopicPartitions()
+    // visible for testing
+    List<TopicPartition> findTargetTopicPartitions()
             throws InterruptedException, ExecutionException {
-        List<TopicPartition> topicPartitions = findTopicPartitions();
+        Set<String> topics = listTopics(targetAdminClient).stream()
+            .filter(t -> sourceAndTarget.source().equals(replicationPolicy.topicSource(t)))
+            .collect(Collectors.toSet());
+        return describeTopics(targetAdminClient, topics).stream()
+                .flatMap(MirrorSourceConnector::expandTopicDescription)
+                .collect(Collectors.toList());
+    }
+
+    // visible for testing
+    void refreshTopicPartitions()
+            throws InterruptedException, ExecutionException {
+        knownSourceTopicPartitions = findSourceTopicPartitions();
+        knownTargetTopicPartitions = findTargetTopicPartitions();
+        List<TopicPartition> upstreamTargetTopicPartitions = knownTargetTopicPartitions.stream()
+                .map(x -> new TopicPartition(replicationPolicy.upstreamTopic(x.topic()), x.partition()))
+                .collect(Collectors.toList());
+
         Set<TopicPartition> newTopicPartitions = new HashSet<>();
-        newTopicPartitions.addAll(topicPartitions);
-        newTopicPartitions.removeAll(knownTopicPartitions);
+        newTopicPartitions.addAll(knownSourceTopicPartitions);
+        newTopicPartitions.removeAll(upstreamTargetTopicPartitions);
         Set<TopicPartition> deadTopicPartitions = new HashSet<>();
-        deadTopicPartitions.addAll(knownTopicPartitions);
-        deadTopicPartitions.removeAll(topicPartitions);
+        deadTopicPartitions.addAll(upstreamTargetTopicPartitions);
+        deadTopicPartitions.removeAll(knownSourceTopicPartitions);
         if (!newTopicPartitions.isEmpty() || !deadTopicPartitions.isEmpty()) {
             log.info("Found {} topic-partitions on {}. {} are new. {} were removed. Previously had {}.",
-                    topicPartitions.size(), sourceAndTarget.source(), newTopicPartitions.size(), 
-                    deadTopicPartitions.size(), knownTopicPartitions.size());
+                    knownSourceTopicPartitions.size(), sourceAndTarget.source(), newTopicPartitions.size(),
+                    deadTopicPartitions.size(), knownSourceTopicPartitions.size());
             log.trace("Found new topic-partitions: {}", newTopicPartitions);
-            knownTopicPartitions = topicPartitions;
-            knownTargetTopics = findExistingTargetTopics(); 
-            createTopicPartitions();
+            computeAndCreateTopicPartitions();
             context.requestTaskReconfiguration();
         }
     }
 
     private void loadTopicPartitions()
             throws InterruptedException, ExecutionException {
-        knownTopicPartitions = findTopicPartitions();
-        knownTargetTopics = findExistingTargetTopics(); 
+        knownSourceTopicPartitions = findSourceTopicPartitions();
+        knownTargetTopicPartitions = findTargetTopicPartitions();
     }
 
     private void refreshKnownTargetTopics()
             throws InterruptedException, ExecutionException {
-        knownTargetTopics = findExistingTargetTopics();
-    }
-
-    private Set<String> findExistingTargetTopics()
-            throws InterruptedException, ExecutionException {
-        return listTopics(targetAdminClient).stream()
-            .filter(x -> sourceAndTarget.source().equals(replicationPolicy.topicSource(x)))
-            .collect(Collectors.toSet());
+        knownTargetTopicPartitions = findTargetTopicPartitions();
     }
 
     private Set<String> topicsBeingReplicated() {
-        return knownTopicPartitions.stream()
+        Set<String> knownTargetTopics = toTopics(knownTargetTopicPartitions);
+        return knownSourceTopicPartitions.stream()
             .map(x -> x.topic())
             .distinct()
             .filter(x -> knownTargetTopics.contains(formatRemoteTopic(x)))
             .collect(Collectors.toSet());
+    }
+
+    private Set<String> toTopics(Collection<TopicPartition> tps) {
+        return tps.stream()
+                .map(x -> x.topic())
+                .collect(Collectors.toSet());
     }
 
     private void syncTopicAcls()
@@ -267,11 +283,13 @@ public class MirrorSourceConnector extends SourceConnector {
         MirrorUtils.createSinglePartitionCompactedTopic(config.offsetSyncsTopic(), config.offsetSyncsTopicReplicationFactor(), config.sourceAdminConfig());
     }
 
-    private void createTopicPartitions()
+    // visible for testing
+    void computeAndCreateTopicPartitions()
             throws InterruptedException, ExecutionException {
-        Map<String, Long> partitionCounts = knownTopicPartitions.stream()
+        Map<String, Long> partitionCounts = knownSourceTopicPartitions.stream()
             .collect(Collectors.groupingBy(x -> x.topic(), Collectors.counting())).entrySet().stream()
             .collect(Collectors.toMap(x -> formatRemoteTopic(x.getKey()), x -> x.getValue()));
+        Set<String> knownTargetTopics = toTopics(knownTargetTopicPartitions);
         List<NewTopic> newTopics = partitionCounts.entrySet().stream()
             .filter(x -> !knownTargetTopics.contains(x.getKey()))
             .map(x -> new NewTopic(x.getKey(), x.getValue().intValue(), (short) replicationFactor))
@@ -279,6 +297,12 @@ public class MirrorSourceConnector extends SourceConnector {
         Map<String, NewPartitions> newPartitions = partitionCounts.entrySet().stream()
             .filter(x -> knownTargetTopics.contains(x.getKey()))
             .collect(Collectors.toMap(x -> x.getKey(), x -> NewPartitions.increaseTo(x.getValue().intValue())));
+        createTopicPartitions(partitionCounts, newTopics, newPartitions);
+    }
+
+    // visible for testing
+    void createTopicPartitions(Map<String, Long> partitionCounts, List<NewTopic> newTopics,
+            Map<String, NewPartitions> newPartitions) {
         targetAdminClient.createTopics(newTopics, new CreateTopicsOptions()).values().forEach((k, v) -> v.whenComplete((x, e) -> {
             if (e != null) {
                 log.warn("Could not create topic {}.", k, e);
@@ -307,9 +331,9 @@ public class MirrorSourceConnector extends SourceConnector {
         return sourceAdminClient.describeAcls(ANY_TOPIC_ACL).values().get();
     }
 
-    private Collection<TopicDescription> describeTopics(Collection<String> topics)
+    private static Collection<TopicDescription> describeTopics(AdminClient adminClient, Collection<String> topics)
             throws InterruptedException, ExecutionException {
-        return sourceAdminClient.describeTopics(topics).all().get().values();
+        return adminClient.describeTopics(topics).all().get().values();
     }
 
     @SuppressWarnings("deprecation")

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1620,7 +1620,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 statusBackingStore.flush();
                 log.info("Finished flushing status backing store in preparation for rebalance");
             } else {
-                log.info("Wasn't unable to resume work after last rebalance, can skip stopping connectors and tasks");
+                log.info("Wasn't able to resume work after last rebalance, can skip stopping connectors and tasks");
             }
         }
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorClientPolicyIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorClientPolicyIntegrationTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @Category(IntegrationTest.class)
-public class ConnectorCientPolicyIntegrationTest {
+public class ConnectorClientPolicyIntegrationTest {
 
     private static final int NUM_TASKS = 1;
     private static final int NUM_WORKERS = 1;

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -21,8 +21,7 @@ import java.util.Properties
 
 import joptsimple._
 import joptsimple.util.EnumConverter
-import kafka.security.auth._
-import kafka.security.authorizer.AuthorizerUtils
+import kafka.security.authorizer.{AclAuthorizer, AclEntry, AuthorizerUtils}
 import kafka.server.KafkaConfig
 import kafka.utils._
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, AdminClient => JAdminClient}
@@ -33,7 +32,7 @@ import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourceP
 import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.{Utils, SecurityUtils => JSecurityUtils}
-import org.apache.kafka.server.authorizer.{Authorizer => JAuthorizer}
+import org.apache.kafka.server.authorizer.Authorizer
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
@@ -58,18 +57,12 @@ object AclCommand extends Logging {
       if (opts.options.has(opts.bootstrapServerOpt)) {
         new AdminClientService(opts)
       } else {
-        val authorizerClass = if (opts.options.has(opts.authorizerOpt)) {
-          val className = opts.options.valueOf(opts.authorizerOpt)
-          Class.forName(className, true, Utils.getContextOrKafkaClassLoader)
-        } else
-          classOf[SimpleAclAuthorizer]
-
-        if (classOf[JAuthorizer].isAssignableFrom(authorizerClass))
-          new JAuthorizerService(authorizerClass.asSubclass(classOf[JAuthorizer]), opts)
-        else if (classOf[Authorizer].isAssignableFrom(authorizerClass))
-          new AuthorizerService(authorizerClass.asSubclass(classOf[Authorizer]), opts)
+        val authorizerClassName = if (opts.options.has(opts.authorizerOpt))
+          opts.options.valueOf(opts.authorizerOpt)
         else
-          throw new IllegalArgumentException(s"Authorizer $authorizerClass does not implement ${classOf[Authorizer]} or ${classOf[JAuthorizer]}.")
+          classOf[AclAuthorizer].getName
+
+        new AuthorizerService(authorizerClassName, opts)
       }
     }
 
@@ -190,8 +183,7 @@ object AclCommand extends Logging {
     }
   }
 
-  @deprecated("Use JAuthorizerService", "Since 2.4")
-  class AuthorizerService(val authorizerClass: Class[_ <: Authorizer], val opts: AclCommandOptions) extends AclCommandService with Logging {
+  class AuthorizerService(val authorizerClassName: String, val opts: AclCommandOptions) extends AclCommandService with Logging {
 
     private def withAuthorizer()(f: Authorizer => Unit): Unit = {
       val defaultProps = Map(KafkaConfig.ZkEnableSecureAclsProp -> JaasUtils.isZkSecurityEnabled)
@@ -203,105 +195,7 @@ object AclCommand extends Logging {
           defaultProps
         }
 
-      val authZ = Utils.newInstance(authorizerClass)
-      try {
-        authZ.configure(authorizerProperties.asJava)
-        f(authZ)
-      }
-      finally CoreUtils.swallow(authZ.close(), this)
-    }
-
-    def addAcls(): Unit = {
-      val resourceToAcl = getResourceToAcls(opts)
-      withAuthorizer() { authorizer =>
-        for ((resource, acls) <- resourceToAcl) {
-          println(s"Adding ACLs for resource `$resource`: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline")
-          authorizer.addAcls(acls.map(AuthorizerUtils.convertToAcl), AuthorizerUtils.convertToResource(resource))
-        }
-
-        listAcls()
-      }
-    }
-
-    def removeAcls(): Unit = {
-      withAuthorizer() { authorizer =>
-        val filterToAcl = getResourceFilterToAcls(opts)
-
-        for ((filter, acls) <- filterToAcl) {
-          if (acls.isEmpty) {
-            if (confirmAction(opts, s"Are you sure you want to delete all ACLs for resource filter `$filter`? (y/n)"))
-              removeAcls(authorizer, acls, filter)
-          } else {
-            if (confirmAction(opts, s"Are you sure you want to remove ACLs: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline from resource filter `$filter`? (y/n)"))
-              removeAcls(authorizer, acls, filter)
-          }
-        }
-
-        listAcls()
-      }
-    }
-
-    def listAcls(): Unit = {
-      withAuthorizer() { authorizer =>
-        val filters = getResourceFilter(opts, dieIfNoResourceFound = false)
-        val listPrincipals = getPrincipals(opts, opts.listPrincipalsOpt)
-
-        if (listPrincipals.isEmpty) {
-          val resourceToAcls =  getFilteredResourceToAcls(authorizer, filters)
-          for ((resource, acls) <- resourceToAcls)
-            println(s"Current ACLs for resource `$resource`: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline")
-        } else {
-          listPrincipals.foreach(principal => {
-            println(s"ACLs for principal `$principal`")
-            val resourceToAcls =  getFilteredResourceToAcls(authorizer, filters, Some(principal))
-            for ((resource, acls) <- resourceToAcls)
-              println(s"Current ACLs for resource `$resource`: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline")
-          })
-        }
-      }
-    }
-
-    private def removeAcls(authorizer: Authorizer, acls: Set[AccessControlEntry], filter: ResourcePatternFilter): Unit = {
-      getAcls(authorizer, filter)
-        .keys
-        .foreach(resource =>
-          if (acls.isEmpty) authorizer.removeAcls(resource)
-          else authorizer.removeAcls(acls.map(AuthorizerUtils.convertToAcl), resource)
-        )
-    }
-
-    private def getFilteredResourceToAcls(authorizer: Authorizer, filters: Set[ResourcePatternFilter],
-                                          listPrincipal: Option[KafkaPrincipal] = None): Iterable[(Resource, Set[Acl])] = {
-      if (filters.isEmpty)
-        if (listPrincipal.isEmpty)
-          authorizer.getAcls()
-        else
-          authorizer.getAcls(listPrincipal.get)
-      else filters.flatMap(filter => getAcls(authorizer, filter, listPrincipal))
-    }
-
-    private def getAcls(authorizer: Authorizer, filter: ResourcePatternFilter,
-                        listPrincipal: Option[KafkaPrincipal] = None): Map[Resource, Set[Acl]] =
-      if (listPrincipal.isEmpty)
-        authorizer.getAcls().filter { case (resource, _) => filter.matches(resource.toPattern) }
-      else
-        authorizer.getAcls(listPrincipal.get).filter { case (resource, _) => filter.matches(resource.toPattern) }
-
-  }
-
-  class JAuthorizerService(val authorizerClass: Class[_ <: JAuthorizer], val opts: AclCommandOptions) extends AclCommandService with Logging {
-
-    private def withAuthorizer()(f: JAuthorizer => Unit) {
-      val defaultProps = Map(KafkaConfig.ZkEnableSecureAclsProp -> JaasUtils.isZkSecurityEnabled)
-      val authorizerProperties =
-        if (opts.options.has(opts.authorizerPropertiesOpt)) {
-          val authorizerProperties = opts.options.valuesOf(opts.authorizerPropertiesOpt).asScala
-          defaultProps ++ CommandLineUtils.parseKeyValueArgs(authorizerProperties, acceptMissingValue = false).asScala
-        } else {
-          defaultProps
-        }
-
-      val authZ = Utils.newInstance(authorizerClass)
+      val authZ = AuthorizerUtils.createAuthorizer(authorizerClassName)
       try {
         authZ.configure(authorizerProperties.asJava)
         f(authZ)
@@ -367,7 +261,7 @@ object AclCommand extends Logging {
       }
     }
 
-    private def removeAcls(authorizer: JAuthorizer, acls: Set[AccessControlEntry], filter: ResourcePatternFilter): Unit = {
+    private def removeAcls(authorizer: Authorizer, acls: Set[AccessControlEntry], filter: ResourcePatternFilter): Unit = {
       val result = if (acls.isEmpty)
         authorizer.deleteAcls(null, List(new AclBindingFilter(filter, AccessControlEntryFilter.ANY)).asJava)
       else {
@@ -388,7 +282,7 @@ object AclCommand extends Logging {
       }
     }
 
-    private def getAcls(authorizer: JAuthorizer, filters: Set[ResourcePatternFilter]): Map[ResourcePattern, Set[AccessControlEntry]] = {
+    private def getAcls(authorizer: Authorizer, filters: Set[ResourcePatternFilter]): Map[ResourcePattern, Set[AccessControlEntry]] = {
       val aclBindings =
         if (filters.isEmpty) authorizer.acls(AclBindingFilter.ANY).asScala
         else {
@@ -500,7 +394,8 @@ object AclCommand extends Logging {
   }
 
   private def getAcl(opts: AclCommandOptions): Set[AccessControlEntry] = {
-    val operations = opts.options.valuesOf(opts.operationsOpt).asScala.map(operation => Operation.fromString(operation.trim)).map(_.toJava).toSet
+    val operations = opts.options.valuesOf(opts.operationsOpt).asScala
+      .map(operation => JSecurityUtils.operation(operation.trim)).toSet
     getAcl(opts, operations)
   }
 
@@ -518,7 +413,7 @@ object AclCommand extends Logging {
     if (opts.options.has(hostOptionSpec))
       opts.options.valuesOf(hostOptionSpec).asScala.map(_.trim).toSet
     else if (opts.options.has(principalOptionSpec))
-      Set[String](Acl.WildCardHost)
+      Set[String](AclEntry.WildcardHost)
     else
       Set.empty[String]
   }
@@ -565,8 +460,8 @@ object AclCommand extends Logging {
 
   private def validateOperation(opts: AclCommandOptions, resourceToAcls: Map[ResourcePatternFilter, Set[AccessControlEntry]]): Unit = {
     for ((resource, acls) <- resourceToAcls) {
-      val validOps = ResourceType.fromJava(resource.resourceType).supportedOperations + All
-      if ((acls.map(_.operation) -- validOps.map(_.toJava)).nonEmpty)
+      val validOps = AclEntry.supportedOperations(resource.resourceType) + AclOperation.ALL
+      if ((acls.map(_.operation) -- validOps).nonEmpty)
         CommandLineUtils.printUsageAndDie(opts.parser, s"ResourceType ${resource.resourceType} only supports operations ${validOps.mkString(",")}")
     }
   }
@@ -585,7 +480,7 @@ object AclCommand extends Logging {
       .describedAs("command-config")
       .ofType(classOf[String])
 
-    val authorizerOpt = parser.accepts("authorizer", "Fully qualified class name of the authorizer, defaults to kafka.security.auth.SimpleAclAuthorizer.")
+    val authorizerOpt = parser.accepts("authorizer", "Fully qualified class name of the authorizer, defaults to kafka.security.authorizer.AclAuthorizer.")
       .withRequiredArg
       .describedAs("authorizer")
       .ofType(classOf[String])
@@ -641,10 +536,10 @@ object AclCommand extends Logging {
     val listOpt = parser.accepts("list", "List ACLs for the specified resource, use --topic <topic> or --group <group> or --cluster to specify a resource.")
 
     val operationsOpt = parser.accepts("operation", "Operation that is being allowed or denied. Valid operation names are: " + Newline +
-      Operation.values.map("\t" + _).mkString(Newline) + Newline)
+      AclEntry.AclOperations.map("\t" + JSecurityUtils.operationName(_)).mkString(Newline) + Newline)
       .withRequiredArg
       .ofType(classOf[String])
-      .defaultsTo(All.name)
+      .defaultsTo(JSecurityUtils.operationName(AclOperation.ALL))
 
     val allowPrincipalsOpt = parser.accepts("allow-principal", "principal is in principalType:name format." +
       " Note that principalType must be supported by the Authorizer being used." +

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -27,8 +27,8 @@ import kafka.log._
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server._
 import kafka.server.checkpoints.OffsetCheckpoints
-import kafka.utils.CoreUtils.{inReadLock, inWriteLock}
 import kafka.utils._
+import kafka.utils.CoreUtils.{inReadLock, inWriteLock}
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.apache.kafka.common.errors._
@@ -174,6 +174,19 @@ case class SimpleAssignmentState(replicas: Seq[Int]) extends AssignmentState
 
 /**
  * Data structure that represents a topic partition. The leader maintains the AR, ISR, CUR, RAR
+ *
+ * Concurrency notes:
+ * 1) Partition is thread-safe. Operations on partitions may be invoked concurrently from different
+ *    request handler threads
+ * 2) ISR updates are synchronized using a read-write lock. Read lock is used to check if an update
+ *    is required to avoid acquiring write lock in the common case of replica fetch when no update
+ *    is performed. ISR update condition is checked a second time under write lock before performing
+ *    the update
+ * 3) Various other operations like leader changes are processed while holding the ISR write lock.
+ *    This can introduce delays in produce and replica fetch requests, but these operations are typically
+ *    infrequent.
+ * 4) HW updates are synchronized using ISR read lock. @Log lock is acquired during the update with
+ *    locking order Partition lock -> Log lock.
  */
 class Partition(val topicPartition: TopicPartition,
                 val replicaLagTimeMaxMs: Long,
@@ -716,19 +729,26 @@ class Partition(val topicPartition: TopicPartition,
    * This function can be triggered when a replica's LEO has incremented.
    */
   private def maybeExpandIsr(followerReplica: Replica, followerFetchTimeMs: Long): Unit = {
-    inWriteLock(leaderIsrUpdateLock) {
-      // check if this replica needs to be added to the ISR
-      leaderLogIfLocal.foreach { leaderLog =>
-        val leaderHighwatermark = leaderLog.highWatermark
-        if (!inSyncReplicaIds.contains(followerReplica.brokerId) && isFollowerInSync(followerReplica, leaderHighwatermark)) {
+    val needsIsrUpdate = inReadLock(leaderIsrUpdateLock) {
+      needsExpandIsr(followerReplica)
+    }
+    if (needsIsrUpdate) {
+      inWriteLock(leaderIsrUpdateLock) {
+        // check if this replica needs to be added to the ISR
+        if (needsExpandIsr(followerReplica)) {
           val newInSyncReplicaIds = inSyncReplicaIds + followerReplica.brokerId
-          info(s"Expanding ISR from ${inSyncReplicaIds.mkString(",")} " +
-            s"to ${newInSyncReplicaIds.mkString(",")}")
-
+          info(s"Expanding ISR from ${inSyncReplicaIds.mkString(",")} to ${newInSyncReplicaIds.mkString(",")}")
           // update ISR in ZK and cache
           expandIsr(newInSyncReplicaIds)
         }
       }
+    }
+  }
+
+  private def needsExpandIsr(followerReplica: Replica): Boolean = {
+    leaderLogIfLocal.exists { leaderLog =>
+      val leaderHighwatermark = leaderLog.highWatermark
+      !inSyncReplicaIds.contains(followerReplica.brokerId) && isFollowerInSync(followerReplica, leaderHighwatermark)
     }
   }
 
@@ -866,7 +886,10 @@ class Partition(val topicPartition: TopicPartition,
   private def tryCompleteDelayedRequests(): Unit = delayedOperations.checkAndCompleteAll()
 
   def maybeShrinkIsr(): Unit = {
-    val leaderHWIncremented = inWriteLock(leaderIsrUpdateLock) {
+    val needsIsrUpdate = inReadLock(leaderIsrUpdateLock) {
+      needsShrinkIsr()
+    }
+    val leaderHWIncremented = needsIsrUpdate && inWriteLock(leaderIsrUpdateLock) {
       leaderLogIfLocal match {
         case Some(leaderLog) =>
           val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
@@ -900,6 +923,15 @@ class Partition(val topicPartition: TopicPartition,
     // some delayed operations may be unblocked after HW changed
     if (leaderHWIncremented)
       tryCompleteDelayedRequests()
+  }
+
+  private def needsShrinkIsr(): Boolean = {
+    if (isLeader) {
+      val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
+      outOfSyncReplicaIds.nonEmpty
+    } else {
+      false
+    }
   }
 
   private def isFollowerOutOfSync(replicaId: Int,
@@ -1203,13 +1235,13 @@ class Partition(val topicPartition: TopicPartition,
     maybeUpdateIsrAndVersion(newIsr, zkVersionOpt)
   }
 
-  private def shrinkIsr(newIsr: Set[Int]): Unit = {
+  private[cluster] def shrinkIsr(newIsr: Set[Int]): Unit = {
     val newLeaderAndIsr = new LeaderAndIsr(localBrokerId, leaderEpoch, newIsr.toList, zkVersion)
     val zkVersionOpt = stateStore.shrinkIsr(controllerEpoch, newLeaderAndIsr)
     maybeUpdateIsrAndVersion(newIsr, zkVersionOpt)
   }
 
-  private def maybeUpdateIsrAndVersion(isr: Set[Int], zkVersionOpt: Option[Int]): Unit = {
+  private[cluster] def maybeUpdateIsrAndVersion(isr: Set[Int], zkVersionOpt: Option[Int]): Unit = {
     zkVersionOpt match {
       case Some(newVersion) =>
         inSyncReplicaIds = isr

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1629,13 +1629,15 @@ class KafkaController(val config: KafkaConfig,
       val partitionsToReassign = mutable.Map.empty[TopicPartition, ReplicaAssignment]
 
       reassignments.foreach { case (tp, targetReplicas) =>
-        if (replicasAreValid(tp, targetReplicas)) {
-          maybeBuildReassignment(tp, targetReplicas) match {
-            case Some(context) => partitionsToReassign.put(tp, context)
-            case None => reassignmentResults.put(tp, new ApiError(Errors.NO_REASSIGNMENT_IN_PROGRESS))
-          }
-        } else {
-          reassignmentResults.put(tp, new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT))
+        val maybeApiError = targetReplicas.flatMap(validateReplicas(tp, _))
+        maybeApiError match {
+          case None =>
+            maybeBuildReassignment(tp, targetReplicas) match {
+              case Some(context) => partitionsToReassign.put(tp, context)
+              case None => reassignmentResults.put(tp, new ApiError(Errors.NO_REASSIGNMENT_IN_PROGRESS))
+            }
+          case Some(err) =>
+            reassignmentResults.put(tp, err)
         }
       }
 
@@ -1648,22 +1650,27 @@ class KafkaController(val config: KafkaConfig,
     }
   }
 
-  private def replicasAreValid(topicPartition: TopicPartition, replicasOpt: Option[Seq[Int]]): Boolean = {
-    replicasOpt match {
-      case Some(replicas) =>
-        val replicaSet = replicas.toSet
-        if (replicas.isEmpty || replicas.size != replicaSet.size)
-          false
-        else if (replicas.exists(_ < 0))
-          false
-        else {
-          // Ensure that any new replicas are among the live brokers
-          val currentAssignment = controllerContext.partitionFullReplicaAssignment(topicPartition)
-          val newAssignment = currentAssignment.reassignTo(replicas)
-          newAssignment.addingReplicas.toSet.subsetOf(controllerContext.liveBrokerIds)
-        }
-
-      case None => true
+  private def validateReplicas(topicPartition: TopicPartition, replicas: Seq[Int]): Option[ApiError] = {
+    val replicaSet = replicas.toSet
+    if (replicas.isEmpty)
+      Some(new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
+          s"Empty replica list specified in partition reassignment."))
+    else if (replicas.size != replicaSet.size) {
+      Some(new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
+          s"Duplicate replica ids in partition reassignment replica list: $replicas"))
+    } else if (replicas.exists(_ < 0))
+      Some(new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
+          s"Invalid broker id in replica list: $replicas"))
+    else {
+      // Ensure that any new replicas are among the live brokers
+      val currentAssignment = controllerContext.partitionFullReplicaAssignment(topicPartition)
+      val newAssignment = currentAssignment.reassignTo(replicas)
+      val areNewReplicasAlive = newAssignment.addingReplicas.toSet.subsetOf(controllerContext.liveBrokerIds)
+      if (!areNewReplicasAlive)
+        Some(new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
+          s"Replica assignment has brokers that are not alive. Replica list: " +
+            s"${newAssignment.addingReplicas}, live broker list: ${controllerContext.liveBrokerIds}"))
+      else None
     }
   }
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -43,6 +43,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.protocol.types.Type._
 import org.apache.kafka.common.protocol.types._
 import org.apache.kafka.common.record._
+import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.{OffsetCommitRequest, OffsetFetchResponse}
 import org.apache.kafka.common.utils.{Time, Utils}
@@ -474,12 +475,12 @@ class GroupMetadataManager(brokerId: Int,
    * The most important guarantee that this API provides is that it should never return a stale offset. i.e., it either
    * returns the current offset or it begins to sync the cache from the log (and returns an error code).
    */
-  def getOffsets(groupId: String, topicPartitionsOpt: Option[Seq[TopicPartition]]): Map[TopicPartition, OffsetFetchResponse.PartitionData] = {
+  def getOffsets(groupId: String, requireStable: Boolean, topicPartitionsOpt: Option[Seq[TopicPartition]]): Map[TopicPartition, PartitionData] = {
     trace("Getting offsets of %s for group %s.".format(topicPartitionsOpt.getOrElse("all partitions"), groupId))
     val group = groupMetadataCache.get(groupId)
     if (group == null) {
       topicPartitionsOpt.getOrElse(Seq.empty[TopicPartition]).map { topicPartition =>
-        val partitionData = new OffsetFetchResponse.PartitionData(OffsetFetchResponse.INVALID_OFFSET,
+        val partitionData = new PartitionData(OffsetFetchResponse.INVALID_OFFSET,
           Optional.empty(), "", Errors.NONE)
         topicPartition -> partitionData
       }.toMap
@@ -487,33 +488,29 @@ class GroupMetadataManager(brokerId: Int,
       group.inLock {
         if (group.is(Dead)) {
           topicPartitionsOpt.getOrElse(Seq.empty[TopicPartition]).map { topicPartition =>
-            val partitionData = new OffsetFetchResponse.PartitionData(OffsetFetchResponse.INVALID_OFFSET,
+            val partitionData = new PartitionData(OffsetFetchResponse.INVALID_OFFSET,
               Optional.empty(), "", Errors.NONE)
             topicPartition -> partitionData
           }.toMap
         } else {
-          topicPartitionsOpt match {
-            case None =>
-              // Return offsets for all partitions owned by this consumer group. (this only applies to consumers
-              // that commit offsets to Kafka.)
-              group.allOffsets.map { case (topicPartition, offsetAndMetadata) =>
-                topicPartition -> new OffsetFetchResponse.PartitionData(offsetAndMetadata.offset,
-                  offsetAndMetadata.leaderEpoch, offsetAndMetadata.metadata, Errors.NONE)
-              }
+          val topicPartitions = topicPartitionsOpt.getOrElse(group.allOffsets.keySet)
 
-            case Some(topicPartitions) =>
-              topicPartitions.map { topicPartition =>
-                val partitionData = group.offset(topicPartition) match {
-                  case None =>
-                    new OffsetFetchResponse.PartitionData(OffsetFetchResponse.INVALID_OFFSET,
-                      Optional.empty(), "", Errors.NONE)
-                  case Some(offsetAndMetadata) =>
-                    new OffsetFetchResponse.PartitionData(offsetAndMetadata.offset,
-                      offsetAndMetadata.leaderEpoch, offsetAndMetadata.metadata, Errors.NONE)
-                }
-                topicPartition -> partitionData
-              }.toMap
-          }
+          topicPartitions.map { topicPartition =>
+            if (requireStable && group.hasPendingOffsetCommitsForTopicPartition(topicPartition)) {
+              topicPartition -> new PartitionData(OffsetFetchResponse.INVALID_OFFSET,
+                Optional.empty(), "", Errors.UNSTABLE_OFFSET_COMMIT)
+            } else {
+              val partitionData = group.offset(topicPartition) match {
+                case None =>
+                  new PartitionData(OffsetFetchResponse.INVALID_OFFSET,
+                    Optional.empty(), "", Errors.NONE)
+                case Some(offsetAndMetadata) =>
+                  new PartitionData(offsetAndMetadata.offset,
+                    offsetAndMetadata.leaderEpoch, offsetAndMetadata.metadata, Errors.NONE)
+              }
+              topicPartition -> partitionData
+            }
+          }.toMap
         }
       }
     }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -133,7 +133,7 @@ class TransactionCoordinator(brokerId: Int,
             state = Empty,
             topicPartitions = collection.mutable.Set.empty[TopicPartition],
             txnLastUpdateTimestamp = time.milliseconds())
-          txnManager.putTransactionStateIfNotExists(transactionalId, createdMetadata)
+          txnManager.putTransactionStateIfNotExists(createdMetadata)
 
         case Some(epochAndTxnMetadata) => Right(epochAndTxnMetadata)
       }
@@ -306,7 +306,13 @@ class TransactionCoordinator(brokerId: Int,
     }
   }
 
-  def handleTxnImmigration(txnTopicPartitionId: Int, coordinatorEpoch: Int): Unit = {
+  /**
+   * Load state from the given partition and begin handling requests for groups which map to this partition.
+   *
+   * @param txnTopicPartitionId The partition that we are now leading
+   * @param coordinatorEpoch The partition coordinator (or leader) epoch from the received LeaderAndIsr request
+   */
+  def onElection(txnTopicPartitionId: Int, coordinatorEpoch: Int): Unit = {
     // The operations performed during immigration must be resilient to any previous errors we saw or partial state we
     // left off during the unloading phase. Ensure we remove all associated state for this partition before we continue
     // loading it.
@@ -316,8 +322,20 @@ class TransactionCoordinator(brokerId: Int,
     txnManager.loadTransactionsForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch, txnMarkerChannelManager.addTxnMarkersToSend)
   }
 
-  def handleTxnEmigration(txnTopicPartitionId: Int, coordinatorEpoch: Int): Unit = {
-    txnManager.removeTransactionsForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch)
+  /**
+   * Clear coordinator caches for the given partition after giving up leadership.
+   *
+   * @param txnTopicPartitionId The partition that we are no longer leading
+   * @param coordinatorEpoch The partition coordinator (or leader) epoch, which may be absent if we
+   *                         are resigning after receiving a StopReplica request from the controller
+   */
+  def onResignation(txnTopicPartitionId: Int, coordinatorEpoch: Option[Int]): Unit = {
+    coordinatorEpoch match {
+      case Some(epoch) =>
+        txnManager.removeTransactionsForTxnTopicPartition(txnTopicPartitionId, epoch)
+      case None =>
+        txnManager.removeTransactionsForTxnTopicPartition(txnTopicPartitionId)
+    }
     txnMarkerChannelManager.removeMarkersForTxnTopicPartition(txnTopicPartitionId)
   }
 
@@ -483,47 +501,52 @@ class TransactionCoordinator(brokerId: Int,
   def partitionFor(transactionalId: String): Int = txnManager.partitionFor(transactionalId)
 
   private def abortTimedOutTransactions(): Unit = {
+    def onComplete(txnIdAndPidEpoch: TransactionalIdAndProducerIdEpoch)(error: Errors): Unit = {
+      error match {
+        case Errors.NONE =>
+          info("Completed rollback of ongoing transaction for transactionalId " +
+            s"${txnIdAndPidEpoch.transactionalId} due to timeout")
+
+        case error@(Errors.INVALID_PRODUCER_ID_MAPPING |
+                    Errors.INVALID_PRODUCER_EPOCH |
+                    Errors.CONCURRENT_TRANSACTIONS) =>
+          debug(s"Rollback of ongoing transaction for transactionalId ${txnIdAndPidEpoch.transactionalId} " +
+            s"has been cancelled due to error $error")
+
+        case error =>
+          warn(s"Rollback of ongoing transaction for transactionalId ${txnIdAndPidEpoch.transactionalId} " +
+            s"failed due to error $error")
+      }
+    }
+
     txnManager.timedOutTransactions().foreach { txnIdAndPidEpoch =>
-      txnManager.getTransactionState(txnIdAndPidEpoch.transactionalId).right.flatMap {
+      txnManager.getTransactionState(txnIdAndPidEpoch.transactionalId).right.foreach {
         case None =>
-          error(s"Could not find transaction metadata when trying to timeout transaction with transactionalId " +
-            s"${txnIdAndPidEpoch.transactionalId}. ProducerId: ${txnIdAndPidEpoch.producerId}. ProducerEpoch: " +
-            s"${txnIdAndPidEpoch.producerEpoch}")
-          Left(Errors.INVALID_TXN_STATE)
+          error(s"Could not find transaction metadata when trying to timeout transaction for $txnIdAndPidEpoch")
 
         case Some(epochAndTxnMetadata) =>
           val txnMetadata = epochAndTxnMetadata.transactionMetadata
-          val transitMetadata = txnMetadata.inLock {
+          val transitMetadataOpt = txnMetadata.inLock {
             if (txnMetadata.producerId != txnIdAndPidEpoch.producerId) {
               error(s"Found incorrect producerId when expiring transactionalId: ${txnIdAndPidEpoch.transactionalId}. " +
                 s"Expected producerId: ${txnIdAndPidEpoch.producerId}. Found producerId: " +
                 s"${txnMetadata.producerId}")
-              Left(Errors.INVALID_PRODUCER_ID_MAPPING)
+              None
             } else if (txnMetadata.pendingTransitionInProgress) {
-              Left(Errors.CONCURRENT_TRANSACTIONS)
+              debug(s"Skipping abort of timed out transaction $txnIdAndPidEpoch since there is a " +
+                "pending state transition")
+              None
             } else {
-              Right(txnMetadata.prepareFenceProducerEpoch())
+              Some(txnMetadata.prepareFenceProducerEpoch())
             }
           }
-          transitMetadata match {
-            case Right(txnTransitMetadata) =>
-              handleEndTransaction(txnMetadata.transactionalId,
-                txnTransitMetadata.producerId,
-                txnTransitMetadata.producerEpoch,
-                TransactionResult.ABORT,
-                {
-                  case Errors.NONE =>
-                    info(s"Completed rollback ongoing transaction of transactionalId: ${txnIdAndPidEpoch.transactionalId} due to timeout")
-                  case e @ (Errors.INVALID_PRODUCER_ID_MAPPING |
-                            Errors.INVALID_PRODUCER_EPOCH |
-                            Errors.CONCURRENT_TRANSACTIONS) =>
-                    debug(s"Rolling back ongoing transaction of transactionalId: ${txnIdAndPidEpoch.transactionalId} has aborted due to ${e.exceptionName}")
-                  case e =>
-                    warn(s"Rolling back ongoing transaction of transactionalId: ${txnIdAndPidEpoch.transactionalId} failed due to ${e.exceptionName}")
-                })
-              Right(txnTransitMetadata)
-            case (error) =>
-              Left(error)
+
+          transitMetadataOpt.foreach { txnTransitMetadata =>
+            handleEndTransaction(txnMetadata.transactionalId,
+              txnTransitMetadata.producerId,
+              txnTransitMetadata.producerEpoch,
+              TransactionResult.ABORT,
+              onComplete(txnIdAndPidEpoch))
           }
       }
     }
@@ -536,7 +559,7 @@ class TransactionCoordinator(brokerId: Int,
     info("Starting up.")
     scheduler.startup()
     scheduler.schedule("transaction-abort",
-      () => abortTimedOutTransactions,
+      abortTimedOutTransactions,
       txnConfig.abortTimedOutTransactionsIntervalMs,
       txnConfig.abortTimedOutTransactionsIntervalMs
     )

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -90,9 +90,6 @@ class TransactionStateManager(brokerId: Int,
   /** partitions of transaction topic that are being loaded, state lock should be called BEFORE accessing this set */
   private[transaction] val loadingPartitions: mutable.Set[TransactionPartitionAndLeaderEpoch] = mutable.Set()
 
-  /** partitions of transaction topic that are being removed, state lock should be called BEFORE accessing this set */
-  private[transaction] val leavingPartitions: mutable.Set[TransactionPartitionAndLeaderEpoch] = mutable.Set()
-
   /** transaction metadata cache indexed by assigned transaction topic partition ids */
   private[transaction] val transactionMetadataCache: mutable.Map[Int, TxnMetadataCacheEntry] = mutable.Map()
 
@@ -112,9 +109,7 @@ class TransactionStateManager(brokerId: Int,
   // visible for testing only
   private[transaction] def addLoadingPartition(partitionId: Int, coordinatorEpoch: Int): Unit = {
     val partitionAndLeaderEpoch = TransactionPartitionAndLeaderEpoch(partitionId, coordinatorEpoch)
-
     inWriteLock(stateLock) {
-      leavingPartitions.remove(partitionAndLeaderEpoch)
       loadingPartitions.add(partitionAndLeaderEpoch)
     }
   }
@@ -127,9 +122,7 @@ class TransactionStateManager(brokerId: Int,
   def timedOutTransactions(): Iterable[TransactionalIdAndProducerIdEpoch] = {
     val now = time.milliseconds()
     inReadLock(stateLock) {
-      transactionMetadataCache.filter { case (txnPartitionId, _) =>
-        !leavingPartitions.exists(_.txnPartitionId == txnPartitionId)
-      }.flatMap { case (_, entry) =>
+      transactionMetadataCache.flatMap { case (_, entry) =>
         entry.metadataPerTransactionalId.filter { case (_, txnMetadata) =>
           if (txnMetadata.pendingTransitionInProgress) {
             false
@@ -227,9 +220,8 @@ class TransactionStateManager(brokerId: Int,
     getAndMaybeAddTransactionState(transactionalId, None)
   }
 
-  def putTransactionStateIfNotExists(transactionalId: String,
-                                     txnMetadata: TransactionMetadata): Either[Errors, CoordinatorEpochAndTxnMetadata] = {
-    getAndMaybeAddTransactionState(transactionalId, Some(txnMetadata))
+  def putTransactionStateIfNotExists(txnMetadata: TransactionMetadata): Either[Errors, CoordinatorEpochAndTxnMetadata] = {
+    getAndMaybeAddTransactionState(txnMetadata.transactionalId, Some(txnMetadata))
       .right.map(_.getOrElse(throw new IllegalStateException(s"Unexpected empty transaction metadata returned while putting $txnMetadata")))
   }
 
@@ -246,8 +238,6 @@ class TransactionStateManager(brokerId: Int,
       val partitionId = partitionFor(transactionalId)
       if (loadingPartitions.exists(_.txnPartitionId == partitionId))
         Left(Errors.COORDINATOR_LOAD_IN_PROGRESS)
-      else if (leavingPartitions.exists(_.txnPartitionId == partitionId))
-        Left(Errors.NOT_COORDINATOR)
       else {
         transactionMetadataCache.get(partitionId) match {
           case Some(cacheEntry) =>
@@ -400,7 +390,6 @@ class TransactionStateManager(brokerId: Int,
     val partitionAndLeaderEpoch = TransactionPartitionAndLeaderEpoch(partitionId, coordinatorEpoch)
 
     inWriteLock(stateLock) {
-      leavingPartitions.remove(partitionAndLeaderEpoch)
       loadingPartitions.add(partitionAndLeaderEpoch)
     }
 
@@ -427,7 +416,7 @@ class TransactionStateManager(brokerId: Int,
                     transactionsPendingForCompletion +=
                       TransactionalIdCoordinatorEpochAndTransitMetadata(transactionalId, coordinatorEpoch, TransactionResult.COMMIT, txnMetadata, txnMetadata.prepareComplete(time.milliseconds()))
                   case _ =>
-                    // nothing need to be done
+                    // nothing needs to be done
                 }
               }
           }
@@ -446,7 +435,18 @@ class TransactionStateManager(brokerId: Int,
       info(s"Completed loading transaction metadata from $topicPartition for coordinator epoch $coordinatorEpoch")
     }
 
-    scheduler.schedule(s"load-txns-for-partition-$topicPartition", () => loadTransactions)
+    scheduler.schedule(s"load-txns-for-partition-$topicPartition", loadTransactions)
+  }
+
+  def removeTransactionsForTxnTopicPartition(partitionId: Int): Unit = {
+    val topicPartition = new TopicPartition(Topic.TRANSACTION_STATE_TOPIC_NAME, partitionId)
+    inWriteLock(stateLock) {
+      loadingPartitions.retain(_.txnPartitionId != partitionId)
+      transactionMetadataCache.remove(partitionId).foreach { txnMetadataCacheEntry =>
+        info(s"Unloaded transaction metadata $txnMetadataCacheEntry for $topicPartition following " +
+          s"local partition deletion")
+      }
+    }
   }
 
   /**
@@ -459,26 +459,14 @@ class TransactionStateManager(brokerId: Int,
 
     inWriteLock(stateLock) {
       loadingPartitions.remove(partitionAndLeaderEpoch)
-      leavingPartitions.add(partitionAndLeaderEpoch)
-    }
+      transactionMetadataCache.remove(partitionId) match {
+        case Some(txnMetadataCacheEntry) =>
+          info(s"Unloaded transaction metadata $txnMetadataCacheEntry for $topicPartition on become-follower transition")
 
-    def removeTransactions(): Unit = {
-      inWriteLock(stateLock) {
-        if (leavingPartitions.contains(partitionAndLeaderEpoch)) {
-          transactionMetadataCache.remove(partitionId) match {
-            case Some(txnMetadataCacheEntry) =>
-              info(s"Unloaded transaction metadata $txnMetadataCacheEntry for $topicPartition on become-follower transition")
-
-            case None =>
-              info(s"No cached transaction metadata found for $topicPartition during become-follower transition")
-          }
-
-          leavingPartitions.remove(partitionAndLeaderEpoch)
-        }
+        case None =>
+          info(s"No cached transaction metadata found for $topicPartition during become-follower transition")
       }
     }
-
-    scheduler.schedule(s"remove-txns-for-partition-$topicPartition", () => removeTransactions)
   }
 
   private def validateTransactionTopicPartitionCountIsStable(): Unit = {
@@ -684,7 +672,11 @@ private[transaction] case class TransactionConfig(transactionalIdExpirationMs: I
                                                   removeExpiredTransactionalIdsIntervalMs: Int = TransactionStateManager.DefaultRemoveExpiredTransactionalIdsIntervalMs,
                                                   requestTimeoutMs: Int = Defaults.RequestTimeoutMs)
 
-case class TransactionalIdAndProducerIdEpoch(transactionalId: String, producerId: Long, producerEpoch: Short)
+case class TransactionalIdAndProducerIdEpoch(transactionalId: String, producerId: Long, producerEpoch: Short) {
+  override def toString: String = {
+    s"(transactionalId=$transactionalId, producerId=$producerId, producerEpoch=$producerEpoch)"
+  }
+}
 
 case class TransactionPartitionAndLeaderEpoch(txnPartitionId: Int, coordinatorEpoch: Int)
 

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.common.record._
 import org.apache.kafka.common.utils.Time
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 import scala.collection.{Iterable, Seq, Set, mutable}
 import scala.util.control.ControlThrowable
 
@@ -878,6 +879,11 @@ private[log] class Cleaner(val id: Int,
                                   stats: CleanerStats): Unit = {
     map.clear()
     val dirty = log.logSegments(start, end).toBuffer
+    val nextSegmentStartOffsets = new ListBuffer[Long]
+    if (dirty.nonEmpty) {
+      for (nextSegment <- dirty.tail) nextSegmentStartOffsets.append(nextSegment.baseOffset)
+      nextSegmentStartOffsets.append(end)
+    }
     info("Building offset map for log %s for %d segments in offset range [%d, %d).".format(log.name, dirty.size, start, end))
 
     val transactionMetadata = new CleanedTransactionMetadata
@@ -887,10 +893,10 @@ private[log] class Cleaner(val id: Int,
     // Add all the cleanable dirty segments. We must take at least map.slots * load_factor,
     // but we may be able to fit more (if there is lots of duplication in the dirty section of the log)
     var full = false
-    for (segment <- dirty if !full) {
+    for ( (segment, nextSegmentStartOffset) <- dirty.zip(nextSegmentStartOffsets) if !full) {
       checkDone(log.topicPartition)
 
-      full = buildOffsetMapForSegment(log.topicPartition, segment, map, start, log.config.maxMessageSize,
+      full = buildOffsetMapForSegment(log.topicPartition, segment, map, start, nextSegmentStartOffset, log.config.maxMessageSize,
         transactionMetadata, stats)
       if (full)
         debug("Offset map is full, %d segments fully mapped, segment with base offset %d is partially mapped".format(dirty.indexOf(segment), segment.baseOffset))
@@ -911,6 +917,7 @@ private[log] class Cleaner(val id: Int,
                                        segment: LogSegment,
                                        map: OffsetMap,
                                        startOffset: Long,
+                                       nextSegmentStartOffset: Long,
                                        maxLogMessageSize: Int,
                                        transactionMetadata: CleanedTransactionMetadata,
                                        stats: CleanerStats): Boolean = {
@@ -964,6 +971,10 @@ private[log] class Cleaner(val id: Int,
       if(position == startPosition)
         growBuffersOrFail(segment.log, position, maxLogMessageSize, records)
     }
+
+    // In the case of offsets gap, fast forward to latest expected offset in this segment.
+    map.updateLatestOffset(nextSegmentStartOffset - 1L)
+
     restoreBuffers()
     false
   }

--- a/core/src/main/scala/kafka/security/auth/Operation.scala
+++ b/core/src/main/scala/kafka/security/auth/Operation.scala
@@ -22,56 +22,68 @@ import org.apache.kafka.common.acl.AclOperation
 /**
  * Different operations a client may perform on kafka resources.
  */
-
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 sealed trait Operation extends BaseEnum {
   def toJava : AclOperation
 }
 
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object Read extends Operation {
   val name = "Read"
   val toJava = AclOperation.READ
 }
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object Write extends Operation {
   val name = "Write"
   val toJava = AclOperation.WRITE
 }
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object Create extends Operation {
   val name = "Create"
   val toJava = AclOperation.CREATE
 }
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object Delete extends Operation {
   val name = "Delete"
   val toJava = AclOperation.DELETE
 }
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object Alter extends Operation {
   val name = "Alter"
   val toJava = AclOperation.ALTER
 }
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object Describe extends Operation {
   val name = "Describe"
   val toJava = AclOperation.DESCRIBE
 }
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object ClusterAction extends Operation {
   val name = "ClusterAction"
   val toJava = AclOperation.CLUSTER_ACTION
 }
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object DescribeConfigs extends Operation {
   val name = "DescribeConfigs"
   val toJava = AclOperation.DESCRIBE_CONFIGS
 }
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object AlterConfigs extends Operation {
   val name = "AlterConfigs"
   val toJava = AclOperation.ALTER_CONFIGS
 }
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object IdempotentWrite extends Operation {
   val name = "IdempotentWrite"
   val toJava = AclOperation.IDEMPOTENT_WRITE
 }
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 case object All extends Operation {
   val name = "All"
   val toJava = AclOperation.ALL
 }
 
+@deprecated("Use org.apache.kafka.common.acl.AclOperation", "Since 2.5")
 object Operation {
 
   def fromString(operation: String): Operation = {

--- a/core/src/main/scala/kafka/security/auth/PermissionType.scala
+++ b/core/src/main/scala/kafka/security/auth/PermissionType.scala
@@ -19,20 +19,24 @@ package kafka.security.auth
 import kafka.common.{BaseEnum, KafkaException}
 import org.apache.kafka.common.acl.AclPermissionType
 
+@deprecated("Use org.apache.kafka.common.acl.AclPermissionType", "Since 2.5")
 sealed trait PermissionType extends BaseEnum {
   val toJava: AclPermissionType
 }
 
+@deprecated("Use org.apache.kafka.common.acl.AclPermissionType", "Since 2.5")
 case object Allow extends PermissionType {
   val name = "Allow"
   val toJava = AclPermissionType.ALLOW
 }
 
+@deprecated("Use org.apache.kafka.common.acl.AclPermissionType", "Since 2.5")
 case object Deny extends PermissionType {
   val name = "Deny"
   val toJava = AclPermissionType.DENY
 }
 
+@deprecated("Use org.apache.kafka.common.acl.AclPermissionType", "Since 2.5")
 object PermissionType {
   def fromString(permissionType: String): PermissionType = {
     val pType = values.find(pType => pType.name.equalsIgnoreCase(permissionType))

--- a/core/src/main/scala/kafka/security/auth/Resource.scala
+++ b/core/src/main/scala/kafka/security/auth/Resource.scala
@@ -17,13 +17,15 @@
 package kafka.security.auth
 
 import kafka.common.KafkaException
+import kafka.security.authorizer.AclEntry
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern}
 
+@deprecated("Use org.apache.kafka.common.resource.ResourcePattern", "Since 2.5")
 object Resource {
-  val Separator = ":"
+  val Separator = AclEntry.ResourceSeparator
   val ClusterResourceName = "kafka-cluster"
   val ClusterResource = Resource(Cluster, Resource.ClusterResourceName, PatternType.LITERAL)
-  val WildCardResource = "*"
+  val WildCardResource = AclEntry.WildcardResource
 
   @deprecated("This resource name is not used by Kafka and will be removed in a future release", since = "2.1")
   val ProducerIdResourceName = "producer-id" // This is not used since we don't have a producer id resource
@@ -53,6 +55,7 @@ object Resource {
  *             it will be a constant string kafka-cluster.
  * @param patternType non-null resource pattern type: literal, prefixed, etc.
  */
+@deprecated("Use org.apache.kafka.common.resource.ResourcePattern", "Since 2.5")
 case class Resource(resourceType: ResourceType, name: String, patternType: PatternType) {
 
   if (!patternType.isSpecific)

--- a/core/src/main/scala/kafka/security/auth/ResourceType.scala
+++ b/core/src/main/scala/kafka/security/auth/ResourceType.scala
@@ -20,6 +20,7 @@ import kafka.common.{BaseEnum, KafkaException}
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.resource.{ResourceType => JResourceType}
 
+@deprecated("Use org.apache.kafka.common.resource.ResourceType", "Since 2.5")
 sealed trait ResourceType extends BaseEnum with Ordered[ ResourceType ] {
   def error: Errors
   def toJava: JResourceType
@@ -29,6 +30,7 @@ sealed trait ResourceType extends BaseEnum with Ordered[ ResourceType ] {
   override def compare(that: ResourceType): Int = this.name compare that.name
 }
 
+@deprecated("Use org.apache.kafka.common.resource.ResourceType", "Since 2.5")
 case object Topic extends ResourceType {
   val name = "Topic"
   val error = Errors.TOPIC_AUTHORIZATION_FAILED
@@ -36,6 +38,7 @@ case object Topic extends ResourceType {
   val supportedOperations = Set(Read, Write, Create, Describe, Delete, Alter, DescribeConfigs, AlterConfigs)
 }
 
+@deprecated("Use org.apache.kafka.common.resource.ResourceType", "Since 2.5")
 case object Group extends ResourceType {
   val name = "Group"
   val error = Errors.GROUP_AUTHORIZATION_FAILED
@@ -43,6 +46,7 @@ case object Group extends ResourceType {
   val supportedOperations = Set(Read, Describe, Delete)
 }
 
+@deprecated("Use org.apache.kafka.common.resource.ResourceType", "Since 2.5")
 case object Cluster extends ResourceType {
   val name = "Cluster"
   val error = Errors.CLUSTER_AUTHORIZATION_FAILED
@@ -50,6 +54,7 @@ case object Cluster extends ResourceType {
   val supportedOperations = Set(Create, ClusterAction, DescribeConfigs, AlterConfigs, IdempotentWrite, Alter, Describe)
 }
 
+@deprecated("Use org.apache.kafka.common.resource.ResourceType", "Since 2.5")
 case object TransactionalId extends ResourceType {
   val name = "TransactionalId"
   val error = Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
@@ -57,6 +62,7 @@ case object TransactionalId extends ResourceType {
   val supportedOperations = Set(Describe, Write)
 }
 
+@deprecated("Use org.apache.kafka.common.resource.ResourceType", "Since 2.5")
 case object DelegationToken extends ResourceType {
   val name = "DelegationToken"
   val error = Errors.DELEGATION_TOKEN_AUTHORIZATION_FAILED
@@ -64,6 +70,7 @@ case object DelegationToken extends ResourceType {
   val supportedOperations : Set[Operation] = Set(Describe)
 }
 
+@deprecated("Use org.apache.kafka.common.resource.ResourceType", "Since 2.5")
 object ResourceType {
 
   def fromString(resourceType: String): ResourceType = {

--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -23,21 +23,22 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import com.typesafe.scalalogging.Logger
 import kafka.api.KAFKA_2_0_IV1
 import kafka.security.authorizer.AclAuthorizer.VersionedAcls
-import kafka.security.auth.{Acl, Operation, PermissionType, Resource, ResourceType}
-import kafka.security.auth.{All, Allow, Alter, AlterConfigs, Delete, Deny, Describe, DescribeConfigs, Read, Write}
+import kafka.security.authorizer.AclEntry.ResourceSeparator
 import kafka.server.KafkaConfig
 import kafka.utils.CoreUtils.{inReadLock, inWriteLock}
 import kafka.utils._
 import kafka.zk._
 import org.apache.kafka.common.Endpoint
 import org.apache.kafka.common.acl._
+import org.apache.kafka.common.acl.AclOperation._
+import org.apache.kafka.common.acl.AclPermissionType.{ALLOW, DENY}
 import org.apache.kafka.common.errors.{ApiException, InvalidRequestException, UnsupportedVersionException}
 import org.apache.kafka.common.protocol.ApiKeys
-import org.apache.kafka.common.resource.{PatternType, ResourcePatternFilter}
+import org.apache.kafka.common.resource._
 import org.apache.kafka.common.security.auth.KafkaPrincipal
-import org.apache.kafka.common.utils.{Time, SecurityUtils => JSecurityUtils}
+import org.apache.kafka.common.utils.{Time, SecurityUtils}
 import org.apache.kafka.server.authorizer.AclDeleteResult.AclBindingDeleteResult
-import org.apache.kafka.server.authorizer.{AclCreateResult, AclDeleteResult, Action, AuthorizableRequestContext, AuthorizationResult, Authorizer, AuthorizerServerInfo}
+import org.apache.kafka.server.authorizer._
 
 import scala.collection.mutable
 import scala.collection.JavaConverters._
@@ -57,20 +58,21 @@ object AclAuthorizer {
   // If set to true when no acls are found for a resource, authorizer allows access to everyone. Defaults to false.
   val AllowEveryoneIfNoAclIsFoundProp = "allow.everyone.if.no.acl.found"
 
-  case class VersionedAcls(acls: Set[Acl], zkVersion: Int) {
+  case class VersionedAcls(acls: Set[AclEntry], zkVersion: Int) {
     def exists: Boolean = zkVersion != ZkVersion.UnknownVersion
   }
   val NoAcls = VersionedAcls(Set.empty, ZkVersion.UnknownVersion)
+  val WildcardHost = "*"
 
   // Orders by resource type, then resource pattern type and finally reverse ordering by name.
-  private object ResourceOrdering extends Ordering[Resource] {
+  private object ResourceOrdering extends Ordering[ResourcePattern] {
 
-    def compare(a: Resource, b: Resource): Int = {
-      val rt = a.resourceType compare b.resourceType
+    def compare(a: ResourcePattern, b: ResourcePattern): Int = {
+      val rt = a.resourceType.compareTo(b.resourceType)
       if (rt != 0)
         rt
       else {
-        val rnt = a.patternType compareTo b.patternType
+        val rnt = a.patternType.compareTo(b.patternType)
         if (rnt != 0)
           rnt
         else
@@ -89,7 +91,7 @@ class AclAuthorizer extends Authorizer with Logging {
   private var extendedAclSupport: Boolean = _
 
   @volatile
-  private var aclCache = new scala.collection.immutable.TreeMap[Resource, VersionedAcls]()(AclAuthorizer.ResourceOrdering)
+  private var aclCache = new scala.collection.immutable.TreeMap[ResourcePattern, VersionedAcls]()(AclAuthorizer.ResourceOrdering)
   private val lock = new ReentrantReadWriteLock()
 
   // The maximum number of times we should try to update the resource acls in zookeeper before failing;
@@ -108,7 +110,7 @@ class AclAuthorizer extends Authorizer with Logging {
     configs.foreach { case (key, value) => props.put(key, value.toString) }
 
     superUsers = configs.get(AclAuthorizer.SuperUsersProp).collect {
-      case str: String if str.nonEmpty => str.split(";").map(s => JSecurityUtils.parseKafkaPrincipal(s.trim)).toSet
+      case str: String if str.nonEmpty => str.split(";").map(s => SecurityUtils.parseKafkaPrincipal(s.trim)).toSet
     }.getOrElse(Set.empty[KafkaPrincipal])
 
     shouldAllowEveryoneIfNoAclIsFound = configs.get(AclAuthorizer.AllowEveryoneIfNoAclIsFoundProp).exists(_.toString.toBoolean)
@@ -167,8 +169,8 @@ class AclAuthorizer extends Authorizer with Logging {
       inWriteLock(lock) {
         aclsToCreate.foreach { case (resource, aclsWithIndex) =>
           try {
-            updateResourceAcls(AuthorizerUtils.convertToResource(resource)) { currentAcls =>
-              val newAcls = aclsWithIndex.map { case (acl, index) => AuthorizerUtils.convertToAcl(acl.entry) }
+            updateResourceAcls(resource) { currentAcls =>
+              val newAcls = aclsWithIndex.map { case (acl, index) => new AclEntry(acl.entry) }
               currentAcls ++ newAcls
             }
             aclsWithIndex.foreach { case (_, index) => results(index) = AclCreateResult.SUCCESS }
@@ -192,7 +194,7 @@ class AclAuthorizer extends Authorizer with Logging {
       val resources = aclCache.keys ++ filters.map(_._1.patternFilter).filter(_.matchesAtMostOne).flatMap(filterToResources)
       val resourcesToUpdate = resources.map { resource =>
         val matchingFilters = filters.filter { case (filter, _) =>
-          filter.patternFilter.matches(resource.toPattern)
+          filter.patternFilter.matches(resource)
         }
         resource -> matchingFilters
       }.toMap.filter(_._2.nonEmpty)
@@ -203,9 +205,9 @@ class AclAuthorizer extends Authorizer with Logging {
           updateResourceAcls(resource) { currentAcls =>
             val aclsToRemove = currentAcls.filter { acl =>
               matchingFilters.exists { case (filter, index) =>
-                val matches = filter.entryFilter.matches(AuthorizerUtils.convertToAccessControlEntry(acl))
+                val matches = filter.entryFilter.matches(acl)
                 if (matches) {
-                  val binding = AuthorizerUtils.convertToAclBinding(resource, acl)
+                  val binding = new AclBinding(resource, acl)
                   deletedBindings.getOrElseUpdate(binding, index)
                   resourceBindingsBeingDeleted.getOrElseUpdate(binding, index)
                 }
@@ -232,7 +234,7 @@ class AclAuthorizer extends Authorizer with Logging {
   override def acls(filter: AclBindingFilter): lang.Iterable[AclBinding] = {
     inReadLock(lock) {
       unorderedAcls.flatMap { case (resource, versionedAcls) =>
-        versionedAcls.acls.map(acl => AuthorizerUtils.convertToAclBinding(resource, acl))
+        versionedAcls.acls.map(acl => new AclBinding(resource, acl.ace))
             .filter(filter.matches)
       }.asJava
     }
@@ -244,7 +246,7 @@ class AclAuthorizer extends Authorizer with Logging {
   }
 
   private def authorizeAction(requestContext: AuthorizableRequestContext, action: Action): AuthorizationResult = {
-    val resource = AuthorizerUtils.convertToResource(action.resourcePattern)
+    val resource = action.resourcePattern
     if (resource.patternType != PatternType.LITERAL) {
       throw new IllegalArgumentException("Only literal resources are supported. Got: " + resource.patternType)
     }
@@ -257,9 +259,9 @@ class AclAuthorizer extends Authorizer with Logging {
       sessionPrincipal
 
     val host = requestContext.clientAddress.getHostAddress
-    val operation = Operation.fromJava(action.operation)
+    val operation = action.operation
 
-    def isEmptyAclAndAuthorized(acls: Set[Acl]): Boolean = {
+    def isEmptyAclAndAuthorized(acls: Set[AclEntry]): Boolean = {
       if (acls.isEmpty) {
         // No ACLs found for this resource, permission is determined by value of config allow.everyone.if.no.acl.found
         authorizerLogger.debug(s"No acl found for resource $resource, authorized = $shouldAllowEveryoneIfNoAclIsFound")
@@ -267,21 +269,21 @@ class AclAuthorizer extends Authorizer with Logging {
       } else false
     }
 
-    def denyAclExists(acls: Set[Acl]): Boolean = {
+    def denyAclExists(acls: Set[AclEntry]): Boolean = {
       // Check if there are any Deny ACLs which would forbid this operation.
-      matchingAclExists(operation, resource, principal, host, Deny, acls)
+      matchingAclExists(operation, resource, principal, host, DENY, acls)
     }
 
-    def allowAclExists(acls: Set[Acl]): Boolean = {
+    def allowAclExists(acls: Set[AclEntry]): Boolean = {
       // Check if there are any Allow ACLs which would allow this operation.
       // Allowing read, write, delete, or alter implies allowing describe.
       // See #{org.apache.kafka.common.acl.AclOperation} for more details about ACL inheritance.
       val allowOps = operation match {
-        case Describe => Set[Operation](Describe, Read, Write, Delete, Alter)
-        case DescribeConfigs => Set[Operation](DescribeConfigs, AlterConfigs)
-        case _ => Set[Operation](operation)
+        case DESCRIBE => Set[AclOperation](DESCRIBE, READ, WRITE, DELETE, ALTER)
+        case DESCRIBE_CONFIGS => Set[AclOperation](DESCRIBE_CONFIGS, ALTER_CONFIGS)
+        case _ => Set[AclOperation](operation)
       }
-      allowOps.exists(operation => matchingAclExists(operation, resource, principal, host, Allow, acls))
+      allowOps.exists(operation => matchingAclExists(operation, resource, principal, host, ALLOW, acls))
     }
 
     def aclsAllowAccess = {
@@ -305,19 +307,19 @@ class AclAuthorizer extends Authorizer with Logging {
     } else false
   }
 
-  private def matchingAcls(resourceType: ResourceType, resourceName: String): Set[Acl] = {
+  private def matchingAcls(resourceType: ResourceType, resourceName: String): Set[AclEntry] = {
     inReadLock(lock) {
-      val wildcard = aclCache.get(Resource(resourceType, Acl.WildCardResource, PatternType.LITERAL))
+      val wildcard = aclCache.get(new ResourcePattern(resourceType, ResourcePattern.WILDCARD_RESOURCE, PatternType.LITERAL))
         .map(_.acls)
-        .getOrElse(Set.empty[Acl])
+        .getOrElse(Set.empty)
 
-      val literal = aclCache.get(Resource(resourceType, resourceName, PatternType.LITERAL))
+      val literal = aclCache.get(new ResourcePattern(resourceType, resourceName, PatternType.LITERAL))
         .map(_.acls)
-        .getOrElse(Set.empty[Acl])
+        .getOrElse(Set.empty)
 
       val prefixed = aclCache
-        .from(Resource(resourceType, resourceName, PatternType.PREFIXED))
-        .to(Resource(resourceType, resourceName.take(1), PatternType.PREFIXED))
+        .from(new ResourcePattern(resourceType, resourceName, PatternType.PREFIXED))
+        .to(new ResourcePattern(resourceType, resourceName.take(1), PatternType.PREFIXED))
         .filterKeys(resource => resourceName.startsWith(resource.name))
         .values
         .flatMap { _.acls }
@@ -327,12 +329,17 @@ class AclAuthorizer extends Authorizer with Logging {
     }
   }
 
-  private def matchingAclExists(operation: Operation, resource: Resource, principal: KafkaPrincipal, host: String, permissionType: PermissionType, acls: Set[Acl]): Boolean = {
+  private def matchingAclExists(operation: AclOperation,
+                                resource: ResourcePattern,
+                                principal: KafkaPrincipal,
+                                host: String,
+                                permissionType: AclPermissionType,
+                                acls: Set[AclEntry]): Boolean = {
     acls.find { acl =>
       acl.permissionType == permissionType &&
-        (acl.principal == principal || acl.principal == Acl.WildCardPrincipal) &&
-        (operation == acl.operation || acl.operation == All) &&
-        (acl.host == host || acl.host == Acl.WildCardHost)
+        (acl.kafkaPrincipal == principal || acl.kafkaPrincipal == AclEntry.WildcardPrincipal) &&
+        (operation == acl.operation || acl.operation == AclOperation.ALL) &&
+        (acl.host == host || acl.host == AclEntry.WildcardHost)
     }.exists { acl =>
       authorizerLogger.debug(s"operation = $operation on resource = $resource from host = $host is $permissionType based on acl = $acl")
       true
@@ -344,12 +351,12 @@ class AclAuthorizer extends Authorizer with Logging {
       ZkAclStore.stores.foreach(store => {
         val resourceTypes = zkClient.getResourceTypes(store.patternType)
         for (rType <- resourceTypes) {
-          val resourceType = Try(ResourceType.fromString(rType))
+          val resourceType = Try(SecurityUtils.resourceType(rType))
           resourceType match {
             case Success(resourceTypeObj) =>
               val resourceNames = zkClient.getResourceNames(store.patternType, resourceTypeObj)
               for (resourceName <- resourceNames) {
-                val resource = new Resource(resourceTypeObj, resourceName, store.patternType)
+                val resource = new ResourcePattern(resourceTypeObj, resourceName, store.patternType)
                 val versionedAcls = getAclsFromZk(resource)
                 updateCache(resource, versionedAcls)
               }
@@ -365,13 +372,13 @@ class AclAuthorizer extends Authorizer with Logging {
       .map(store => store.createListener(AclChangedNotificationHandler, zkClient))
   }
 
-  private def filterToResources(filter: ResourcePatternFilter): Set[Resource] = {
+  private def filterToResources(filter: ResourcePatternFilter): Set[ResourcePattern] = {
     filter.patternType match {
       case PatternType.LITERAL | PatternType.PREFIXED =>
-        Set(Resource(ResourceType.fromJava(filter.resourceType), filter.name, filter.patternType))
+        Set(new ResourcePattern(filter.resourceType, filter.name, filter.patternType))
       case PatternType.ANY =>
-        Set(Resource(ResourceType.fromJava(filter.resourceType), filter.name, PatternType.LITERAL),
-          Resource(ResourceType.fromJava(filter.resourceType), filter.name, PatternType.PREFIXED))
+        Set(new ResourcePattern(filter.resourceType, filter.name, PatternType.LITERAL),
+          new ResourcePattern(filter.resourceType, filter.name, PatternType.PREFIXED))
       case _ => throw new IllegalArgumentException(s"Cannot determine matching resources for patternType $filter")
     }
   }
@@ -379,12 +386,14 @@ class AclAuthorizer extends Authorizer with Logging {
   def logAuditMessage(requestContext: AuthorizableRequestContext, action: Action, authorized: Boolean): Unit = {
     def logMessage: String = {
       val principal = requestContext.principal
-      val operation = Operation.fromJava(action.operation)
+      val operation = SecurityUtils.operationName(action.operation)
       val host = requestContext.clientAddress.getHostAddress
-      val resource = AuthorizerUtils.convertToResource(action.resourcePattern)
+      val resourceType = SecurityUtils.resourceTypeName(action.resourcePattern.resourceType)
+      val resource = s"$resourceType$ResourceSeparator${action.resourcePattern.patternType}$ResourceSeparator${action.resourcePattern.name}"
       val authResult = if (authorized) "Allowed" else "Denied"
       val apiKey = if (ApiKeys.hasId(requestContext.requestType)) ApiKeys.forId(requestContext.requestType).name else requestContext.requestType
       val refCount = action.resourceReferenceCount
+
       s"Principal = $principal is $authResult Operation = $operation from host = $host on resource = $resource for request = $apiKey with resourceRefCount = $refCount"
     }
 
@@ -418,7 +427,7 @@ class AclAuthorizer extends Authorizer with Logging {
     * @param getNewAcls function to transform existing acls to new ACLs
     * @return boolean indicating if a change was made
     */
-  private def updateResourceAcls(resource: Resource)(getNewAcls: Set[Acl] => Set[Acl]): Boolean = {
+  private def updateResourceAcls(resource: ResourcePattern)(getNewAcls: Set[AclEntry] => Set[AclEntry]): Boolean = {
     var currentVersionedAcls =
       if (aclCache.contains(resource))
         getAclsFromCache(resource)
@@ -468,17 +477,17 @@ class AclAuthorizer extends Authorizer with Logging {
 
   // Returns Map instead of SortedMap since most callers don't care about ordering. In Scala 2.13, mapping from SortedMap
   // to Map is restricted by default
-  private def unorderedAcls: Map[Resource, VersionedAcls] = aclCache
+  private def unorderedAcls: Map[ResourcePattern, VersionedAcls] = aclCache
 
-  private def getAclsFromCache(resource: Resource): VersionedAcls = {
+  private def getAclsFromCache(resource: ResourcePattern): VersionedAcls = {
     aclCache.getOrElse(resource, throw new IllegalArgumentException(s"ACLs do not exist in the cache for resource $resource"))
   }
 
-  private def getAclsFromZk(resource: Resource): VersionedAcls = {
+  private def getAclsFromZk(resource: ResourcePattern): VersionedAcls = {
     zkClient.getVersionedAclsForResource(resource)
   }
 
-  private def updateCache(resource: Resource, versionedAcls: VersionedAcls): Unit = {
+  private def updateCache(resource: ResourcePattern, versionedAcls: VersionedAcls): Unit = {
     if (versionedAcls.acls.nonEmpty) {
       aclCache = aclCache + (resource -> versionedAcls)
     } else {
@@ -486,7 +495,7 @@ class AclAuthorizer extends Authorizer with Logging {
     }
   }
 
-  private def updateAclChangedFlag(resource: Resource): Unit = {
+  private def updateAclChangedFlag(resource: ResourcePattern): Unit = {
       zkClient.createAclChangeNotification(resource)
   }
 
@@ -502,7 +511,7 @@ class AclAuthorizer extends Authorizer with Logging {
   }
 
   object AclChangedNotificationHandler extends AclChangeNotificationHandler {
-    override def processNotification(resource: Resource): Unit = {
+    override def processNotification(resource: ResourcePattern): Unit = {
       inWriteLock(lock) {
         val versionedAcls = getAclsFromZk(resource)
         updateCache(resource, versionedAcls)

--- a/core/src/main/scala/kafka/security/authorizer/AclEntry.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclEntry.scala
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.security.authorizer
+
+import kafka.utils.Json
+import org.apache.kafka.common.acl.{AccessControlEntry, AclOperation, AclPermissionType}
+import org.apache.kafka.common.acl.AclOperation.{READ, WRITE, CREATE, DESCRIBE, DELETE, ALTER, DESCRIBE_CONFIGS, ALTER_CONFIGS, CLUSTER_ACTION, IDEMPOTENT_WRITE}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.resource.{ResourcePattern, ResourceType}
+import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.apache.kafka.common.utils.SecurityUtils
+
+import scala.collection.JavaConverters._
+
+object AclEntry {
+  val WildcardPrincipal: KafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "*")
+  val WildcardPrincipalString: String = WildcardPrincipal.toString
+  val WildcardHost: String = "*"
+  val WildcardResource: String = ResourcePattern.WILDCARD_RESOURCE
+
+  val ResourceSeparator = ":"
+  val ResourceTypes: Set[ResourceType] = ResourceType.values.toSet
+    .filterNot(t => t == ResourceType.UNKNOWN || t == ResourceType.ANY)
+  val AclOperations: Set[AclOperation] = AclOperation.values.toSet
+    .filterNot(t => t == AclOperation.UNKNOWN || t == AclOperation.ANY)
+
+  val PrincipalKey = "principal"
+  val PermissionTypeKey = "permissionType"
+  val OperationKey = "operation"
+  val HostsKey = "host"
+  val VersionKey = "version"
+  val CurrentVersion = 1
+  val AclsKey = "acls"
+
+  def apply(principal: KafkaPrincipal,
+            permissionType: AclPermissionType,
+            host: String,
+            operation: AclOperation): AclEntry = {
+    new AclEntry(new AccessControlEntry(if (principal == null) null else principal.toString,
+      host, operation, permissionType))
+  }
+
+  /**
+   * Parse JSON representation of ACLs
+   * @param bytes of acls json string
+   *
+   * <p>
+      {
+        "version": 1,
+        "acls": [
+          {
+            "host":"host1",
+            "permissionType": "Deny",
+            "operation": "Read",
+            "principal": "User:alice"
+          }
+        ]
+      }
+   * </p>
+   *
+   * @return set of AclEntry objects from the JSON string
+   */
+  def fromBytes(bytes: Array[Byte]): Set[AclEntry] = {
+    if (bytes == null || bytes.isEmpty)
+      return collection.immutable.Set.empty[AclEntry]
+
+    Json.parseBytes(bytes).map(_.asJsonObject).map { js =>
+      //the acl json version.
+      require(js(VersionKey).to[Int] == CurrentVersion)
+      js(AclsKey).asJsonArray.iterator.map(_.asJsonObject).map { itemJs =>
+        val principal = SecurityUtils.parseKafkaPrincipal(itemJs(PrincipalKey).to[String])
+        val permissionType = SecurityUtils.permissionType(itemJs(PermissionTypeKey).to[String])
+        val host = itemJs(HostsKey).to[String]
+        val operation = SecurityUtils.operation(itemJs(OperationKey).to[String])
+        AclEntry(principal, permissionType, host, operation)
+      }.toSet
+    }.getOrElse(Set.empty)
+  }
+
+  def toJsonCompatibleMap(acls: Set[AclEntry]): Map[String, Any] = {
+    Map(AclEntry.VersionKey -> AclEntry.CurrentVersion, AclEntry.AclsKey -> acls.map(acl => acl.toMap.asJava).toList.asJava)
+  }
+
+  def supportedOperations(resourceType: ResourceType): Set[AclOperation] = {
+    resourceType match {
+      case ResourceType.TOPIC => Set(READ, WRITE, CREATE, DESCRIBE, DELETE, ALTER, DESCRIBE_CONFIGS, ALTER_CONFIGS)
+      case ResourceType.GROUP => Set(READ, DESCRIBE, DELETE)
+      case ResourceType.CLUSTER => Set(CREATE, CLUSTER_ACTION, DESCRIBE_CONFIGS, ALTER_CONFIGS, IDEMPOTENT_WRITE, ALTER, DESCRIBE)
+      case ResourceType.TRANSACTIONAL_ID => Set(DESCRIBE, WRITE)
+      case ResourceType.DELEGATION_TOKEN => Set(DESCRIBE)
+      case _ => throw new IllegalArgumentException("Not a concrete resource type")
+    }
+  }
+
+  def authorizationError(resourceType: ResourceType): Errors = {
+    resourceType match {
+      case ResourceType.TOPIC => Errors.TOPIC_AUTHORIZATION_FAILED
+      case ResourceType.GROUP => Errors.GROUP_AUTHORIZATION_FAILED
+      case ResourceType.CLUSTER => Errors.CLUSTER_AUTHORIZATION_FAILED
+      case ResourceType.TRANSACTIONAL_ID => Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
+      case ResourceType.DELEGATION_TOKEN => Errors.DELEGATION_TOKEN_AUTHORIZATION_FAILED
+      case _ => throw new IllegalArgumentException("Authorization error type not known")
+    }
+  }
+}
+
+class AclEntry(val ace: AccessControlEntry)
+  extends AccessControlEntry(ace.principal, ace.host, ace.operation, ace.permissionType) {
+
+  val kafkaPrincipal: KafkaPrincipal = if (principal == null)
+    null
+  else
+    SecurityUtils.parseKafkaPrincipal(principal)
+
+  def toMap: Map[String, Any] = {
+    Map(AclEntry.PrincipalKey -> principal,
+      AclEntry.PermissionTypeKey -> SecurityUtils.permissionTypeName(permissionType),
+      AclEntry.OperationKey -> SecurityUtils.operationName(operation),
+      AclEntry.HostsKey -> host)
+  }
+
+  override def hashCode(): Int = ace.hashCode()
+
+  override def equals(o: scala.Any): Boolean = super.equals(o) // to keep spotbugs happy
+
+  override def toString: String = {
+    "%s has %s permission for operations: %s from hosts: %s".format(principal, permissionType.name, operation, host)
+  }
+
+}
+

--- a/core/src/main/scala/kafka/security/authorizer/AuthorizerUtils.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AuthorizerUtils.scala
@@ -20,53 +20,23 @@ package kafka.security.authorizer
 import java.net.InetAddress
 
 import kafka.network.RequestChannel.Session
-import kafka.security.auth._
-import org.apache.kafka.common.acl.{AccessControlEntry, AclBinding, AclBindingFilter, AclOperation}
-import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.ApiError
-import org.apache.kafka.common.resource.{ResourcePattern, ResourceType => JResourceType}
+import kafka.security.auth.{Authorizer => LegacyAuthorizer}
+import org.apache.kafka.common.acl._
+import org.apache.kafka.common.config.ConfigException
+import org.apache.kafka.common.resource.Resource
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
-import org.apache.kafka.common.utils.SecurityUtils._
-import org.apache.kafka.server.authorizer.AuthorizableRequestContext
-
-import scala.util.{Failure, Success, Try}
+import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.server.authorizer.{AuthorizableRequestContext, Authorizer}
 
 
 object AuthorizerUtils {
-  val WildcardPrincipal = "User:*"
-  val WildcardHost = "*"
 
-  def convertToResourceAndAcl(filter: AclBindingFilter): Either[ApiError, (Resource, Acl)] = {
-    (for {
-      resourceType <- Try(ResourceType.fromJava(filter.patternFilter.resourceType))
-      principal <- Try(parseKafkaPrincipal(filter.entryFilter.principal))
-      operation <- Try(Operation.fromJava(filter.entryFilter.operation))
-      permissionType <- Try(PermissionType.fromJava(filter.entryFilter.permissionType))
-      resource = Resource(resourceType, filter.patternFilter.name, filter.patternFilter.patternType)
-      acl = Acl(principal, permissionType, filter.entryFilter.host, operation)
-    } yield (resource, acl)) match {
-      case Failure(throwable) => Left(new ApiError(Errors.INVALID_REQUEST, throwable.getMessage))
-      case Success(s) => Right(s)
+  def createAuthorizer(className: String): Authorizer = {
+    Utils.newInstance(className, classOf[Object]) match {
+      case auth: Authorizer => auth
+      case auth: kafka.security.auth.Authorizer => new AuthorizerWrapper(auth)
+      case _ => throw new ConfigException(s"Authorizer does not implement ${classOf[Authorizer].getName} or ${classOf[LegacyAuthorizer].getName}.")
     }
-  }
-
-  def convertToAclBinding(resource: Resource, acl: Acl): AclBinding = {
-    val resourcePattern = new ResourcePattern(resource.resourceType.toJava, resource.name, resource.patternType)
-    new AclBinding(resourcePattern, convertToAccessControlEntry(acl))
-  }
-
-  def convertToAccessControlEntry(acl: Acl): AccessControlEntry = {
-    new AccessControlEntry(acl.principal.toString, acl.host.toString,
-      acl.operation.toJava, acl.permissionType.toJava)
-  }
-
-  def convertToAcl(ace: AccessControlEntry): Acl = {
-    new Acl(parseKafkaPrincipal(ace.principal), PermissionType.fromJava(ace.permissionType), ace.host,
-      Operation.fromJava(ace.operation))
-  }
-
-  def convertToResource(resourcePattern: ResourcePattern): Resource = {
-    Resource(ResourceType.fromJava(resourcePattern.resourceType), resourcePattern.name, resourcePattern.patternType)
   }
 
   def validateAclBinding(aclBinding: AclBinding): Unit = {
@@ -74,11 +44,7 @@ object AuthorizerUtils {
       throw new IllegalArgumentException("ACL binding contains unknown elements")
   }
 
-  def supportedOperations(resourceType: JResourceType): Set[AclOperation] = {
-    ResourceType.fromJava(resourceType).supportedOperations.map(_.toJava)
-  }
-
-  def isClusterResource(name: String): Boolean = name.equals(Resource.ClusterResourceName)
+  def isClusterResource(name: String): Boolean = name.equals(Resource.CLUSTER_NAME)
 
   def sessionToRequestContext(session: Session): AuthorizableRequestContext = {
     new AuthorizableRequestContext {

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -77,6 +77,7 @@ class CachedPartition(val topic: String,
                       var maxBytes: Int,
                       var fetchOffset: Long,
                       var highWatermark: Long,
+                      var leaderEpoch: Optional[Integer],
                       var fetcherLogStartOffset: Long,
                       var localLogStartOffset: Long)
     extends ImplicitLinkedHashCollection.Element {
@@ -84,37 +85,34 @@ class CachedPartition(val topic: String,
   var cachedNext: Int = ImplicitLinkedHashCollection.INVALID_INDEX
   var cachedPrev: Int = ImplicitLinkedHashCollection.INVALID_INDEX
 
-  override def next = cachedNext
-  override def setNext(next: Int) = this.cachedNext = next
-  override def prev = cachedPrev
-  override def setPrev(prev: Int) = this.cachedPrev = prev
+  override def next: Int = cachedNext
+  override def setNext(next: Int): Unit = this.cachedNext = next
+  override def prev: Int = cachedPrev
+  override def setPrev(prev: Int): Unit = this.cachedPrev = prev
 
   def this(topic: String, partition: Int) =
-    this(topic, partition, -1, -1, -1, -1, -1)
+    this(topic, partition, -1, -1, -1, Optional.empty(), -1, -1)
 
   def this(part: TopicPartition) =
     this(part.topic, part.partition)
 
   def this(part: TopicPartition, reqData: FetchRequest.PartitionData) =
-    this(part.topic, part.partition,
-      reqData.maxBytes, reqData.fetchOffset, -1,
-      reqData.logStartOffset, -1)
+    this(part.topic, part.partition, reqData.maxBytes, reqData.fetchOffset, -1,
+      reqData.currentLeaderEpoch, reqData.logStartOffset, -1)
 
   def this(part: TopicPartition, reqData: FetchRequest.PartitionData,
            respData: FetchResponse.PartitionData[Records]) =
-    this(part.topic, part.partition,
-      reqData.maxBytes, reqData.fetchOffset, respData.highWatermark,
-      reqData.logStartOffset, respData.logStartOffset)
+    this(part.topic, part.partition, reqData.maxBytes, reqData.fetchOffset, respData.highWatermark,
+      reqData.currentLeaderEpoch, reqData.logStartOffset, respData.logStartOffset)
 
-  def topicPartition = new TopicPartition(topic, partition)
-
-  def reqData = new FetchRequest.PartitionData(fetchOffset, fetcherLogStartOffset, maxBytes, Optional.empty())
+  def reqData = new FetchRequest.PartitionData(fetchOffset, fetcherLogStartOffset, maxBytes, leaderEpoch)
 
   def updateRequestParams(reqData: FetchRequest.PartitionData): Unit = {
     // Update our cached request parameters.
     maxBytes = reqData.maxBytes
     fetchOffset = reqData.fetchOffset
     fetcherLogStartOffset = reqData.logStartOffset
+    leaderEpoch = reqData.currentLeaderEpoch
   }
 
   /**
@@ -159,19 +157,21 @@ class CachedPartition(val topic: String,
     mustRespond
   }
 
-  override def hashCode = (31 * partition) + topic.hashCode
+  override def hashCode: Int = (31 * partition) + topic.hashCode
 
   def canEqual(that: Any) = that.isInstanceOf[CachedPartition]
 
   override def equals(that: Any): Boolean =
     that match {
-      case that: CachedPartition => that.canEqual(this) &&
-        this.topic.equals(that.topic) &&
-        this.partition.equals(that.partition)
+      case that: CachedPartition =>
+        this.eq(that) ||
+          (that.canEqual(this) &&
+            this.partition.equals(that.partition) &&
+            this.topic.equals(that.topic))
       case _ => false
     }
 
-  override def toString = synchronized {
+  override def toString: String = synchronized {
     "CachedPartition(topic=" + topic +
       ", partition=" + partition +
       ", maxBytes=" + maxBytes +
@@ -198,12 +198,12 @@ class CachedPartition(val topic: String,
   *                     FetchSessionCache#touch.
   * @param epoch        The fetch session sequence number.
   */
-case class FetchSession(val id: Int,
-                        val privileged: Boolean,
-                        val partitionMap: FetchSession.CACHE_MAP,
-                        val creationMs: Long,
-                        var lastUsedMs: Long,
-                        var epoch: Int) {
+class FetchSession(val id: Int,
+                   val privileged: Boolean,
+                   val partitionMap: FetchSession.CACHE_MAP,
+                   val creationMs: Long,
+                   var lastUsedMs: Long,
+                   var epoch: Int) {
   // This is used by the FetchSessionCache to store the last known size of this session.
   // If this is -1, the Session is not in the cache.
   var cachedSize = -1
@@ -406,9 +406,9 @@ class IncrementalFetchContext(private val time: Time,
   override def foreachPartition(fun: (TopicPartition, FetchRequest.PartitionData) => Unit): Unit = {
     // Take the session lock and iterate over all the cached partitions.
     session.synchronized {
-      session.partitionMap.iterator.asScala.foreach(part => {
+      session.partitionMap.iterator.asScala.foreach { part =>
         fun(new TopicPartition(part.topic, part.partition), part.reqData)
-      })
+      }
     }
   }
 
@@ -502,15 +502,12 @@ class IncrementalFetchContext(private val time: Time,
   }
 }
 
-case class LastUsedKey(val lastUsedMs: Long,
-                       val id: Int) extends Comparable[LastUsedKey] {
+case class LastUsedKey(lastUsedMs: Long, id: Int) extends Comparable[LastUsedKey] {
   override def compareTo(other: LastUsedKey): Int =
     (lastUsedMs, id) compare (other.lastUsedMs, other.id)
 }
 
-case class EvictableKey(val privileged: Boolean,
-                        val size: Int,
-                        val id: Int) extends Comparable[EvictableKey] {
+case class EvictableKey(privileged: Boolean, size: Int, id: Int) extends Comparable[EvictableKey] {
   override def compareTo(other: EvictableKey): Int =
     (privileged, size, id) compare (other.privileged, other.size, other.id)
 }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -25,7 +25,7 @@ import kafka.cluster.EndPoint
 import kafka.coordinator.group.OffsetConfig
 import kafka.coordinator.transaction.{TransactionLog, TransactionStateManager}
 import kafka.message.{BrokerCompressionCodec, CompressionCodec, ZStdCompressionCodec}
-import kafka.security.authorizer.AuthorizerWrapper
+import kafka.security.authorizer.AuthorizerUtils
 import kafka.utils.CoreUtils
 import kafka.utils.Implicits._
 import org.apache.kafka.clients.CommonClientConfigs
@@ -1183,12 +1183,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
     if (className == null || className.isEmpty)
       None
     else {
-      val authZ = Utils.newInstance(className, classOf[Object]) match {
-        case auth: Authorizer => auth
-        case auth: kafka.security.auth.Authorizer => new AuthorizerWrapper(auth)
-        case auth => throw new ConfigException(s"Authorizer does not implement ${classOf[Authorizer].getName} or kafka.security.auth.Authorizer .")
-      }
-      Some(authZ)
+      Some(AuthorizerUtils.createAuthorizer(className))
     }
   }
 

--- a/core/src/main/scala/kafka/utils/json/DecodeJson.scala
+++ b/core/src/main/scala/kafka/utils/json/DecodeJson.scala
@@ -19,7 +19,6 @@ package kafka.utils.json
 
 import scala.collection.{Map, Seq}
 import scala.collection.compat._
-import scala.language.higherKinds
 import scala.collection.JavaConverters._
 
 import com.fasterxml.jackson.databind.{JsonMappingException, JsonNode}

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -26,19 +26,18 @@ import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1, LeaderAndIsr}
 import kafka.cluster.{Broker, EndPoint}
 import kafka.common.{NotificationHandler, ZkNodeChangeNotificationListener}
 import kafka.controller.{IsrChangeNotificationHandler, LeaderIsrAndControllerEpoch, ReplicaAssignment}
-import kafka.security.auth.Resource.Separator
 import kafka.security.authorizer.AclAuthorizer.VersionedAcls
-import kafka.security.auth.{Acl, Resource, ResourceType}
+import kafka.security.authorizer.AclEntry
 import kafka.server.{ConfigType, DelegationTokenManager}
 import kafka.utils.Json
 import kafka.utils.json.JsonObject
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.UnsupportedVersionException
 import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.resource.PatternType
+import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourceType}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.token.delegation.{DelegationToken, TokenInformation}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{SecurityUtils, Time}
 import org.apache.zookeeper.ZooDefs
 import org.apache.zookeeper.data.{ACL, Stat}
 
@@ -526,9 +525,9 @@ sealed trait ZkAclStore {
   val patternType: PatternType
   val aclPath: String
 
-  def path(resourceType: ResourceType): String = s"$aclPath/$resourceType"
+  def path(resourceType: ResourceType): String = s"$aclPath/${SecurityUtils.resourceTypeName(resourceType)}"
 
-  def path(resourceType: ResourceType, resourceName: String): String = s"$aclPath/$resourceType/$resourceName"
+  def path(resourceType: ResourceType, resourceName: String): String = s"$aclPath/${SecurityUtils.resourceTypeName(resourceType)}/$resourceName"
 
   def changeStore: ZkAclChangeStore
 }
@@ -580,7 +579,7 @@ object ExtendedAclZNode {
 }
 
 trait AclChangeNotificationHandler {
-  def processNotification(resource: Resource): Unit
+  def processNotification(resource: ResourcePattern): Unit
 }
 
 trait AclChangeSubscription extends AutoCloseable {
@@ -593,11 +592,11 @@ sealed trait ZkAclChangeStore {
   val aclChangePath: String
   def createPath: String = s"$aclChangePath/${ZkAclChangeStore.SequenceNumberPrefix}"
 
-  def decode(bytes: Array[Byte]): Resource
+  def decode(bytes: Array[Byte]): ResourcePattern
 
-  protected def encode(resource: Resource): Array[Byte]
+  protected def encode(resource: ResourcePattern): Array[Byte]
 
-  def createChangeNode(resource: Resource): AclChangeNode = AclChangeNode(createPath, encode(resource))
+  def createChangeNode(resource: ResourcePattern): AclChangeNode = AclChangeNode(createPath, encode(resource))
 
   def createListener(handler: AclChangeNotificationHandler, zkClient: KafkaZkClient): AclChangeSubscription = {
     val rawHandler: NotificationHandler = new NotificationHandler {
@@ -626,18 +625,18 @@ case object LiteralAclChangeStore extends ZkAclChangeStore {
   val name = "LiteralAclChangeStore"
   val aclChangePath: String = "/kafka-acl-changes"
 
-  def encode(resource: Resource): Array[Byte] = {
+  def encode(resource: ResourcePattern): Array[Byte] = {
     if (resource.patternType != PatternType.LITERAL)
       throw new IllegalArgumentException("Only literal resource patterns can be encoded")
 
-    val legacyName = resource.resourceType + Resource.Separator + resource.name
+    val legacyName = resource.resourceType + AclEntry.ResourceSeparator + resource.name
     legacyName.getBytes(UTF_8)
   }
 
-  def decode(bytes: Array[Byte]): Resource = {
+  def decode(bytes: Array[Byte]): ResourcePattern = {
     val string = new String(bytes, UTF_8)
-    string.split(Separator, 2) match {
-        case Array(resourceType, resourceName, _*) => new Resource(ResourceType.fromString(resourceType), resourceName, PatternType.LITERAL)
+    string.split(AclEntry.ResourceSeparator, 2) match {
+        case Array(resourceType, resourceName, _*) => new ResourcePattern(ResourceType.fromString(resourceType), resourceName, PatternType.LITERAL)
         case _ => throw new IllegalArgumentException("expected a string in format ResourceType:ResourceName but got " + string)
       }
   }
@@ -647,7 +646,7 @@ case object ExtendedAclChangeStore extends ZkAclChangeStore {
   val name = "ExtendedAclChangeStore"
   val aclChangePath: String = "/kafka-acl-extended-changes"
 
-  def encode(resource: Resource): Array[Byte] = {
+  def encode(resource: ResourcePattern): Array[Byte] = {
     if (resource.patternType == PatternType.LITERAL)
       throw new IllegalArgumentException("Literal pattern types are not supported")
 
@@ -658,7 +657,7 @@ case object ExtendedAclChangeStore extends ZkAclChangeStore {
       resource.patternType.name))
   }
 
-  def decode(bytes: Array[Byte]): Resource = {
+  def decode(bytes: Array[Byte]): ResourcePattern = {
     val changeEvent = Json.parseBytesAs[ExtendedAclChangeEvent](bytes) match {
       case Right(event) => event
       case Left(e) => throw new IllegalArgumentException("Failed to parse ACL change event", e)
@@ -672,10 +671,10 @@ case object ExtendedAclChangeStore extends ZkAclChangeStore {
 }
 
 object ResourceZNode {
-  def path(resource: Resource): String = ZkAclStore(resource.patternType).path(resource.resourceType, resource.name)
+  def path(resource: ResourcePattern): String = ZkAclStore(resource.patternType).path(resource.resourceType, resource.name)
 
-  def encode(acls: Set[Acl]): Array[Byte] = Json.encodeAsBytes(Acl.toJsonCompatibleMap(acls).asJava)
-  def decode(bytes: Array[Byte], stat: Stat): VersionedAcls = VersionedAcls(Acl.fromBytes(bytes), stat.getVersion)
+  def encode(acls: Set[AclEntry]): Array[Byte] = Json.encodeAsBytes(AclEntry.toJsonCompatibleMap(acls).asJava)
+  def decode(bytes: Array[Byte], stat: Stat): VersionedAcls = VersionedAcls(AclEntry.fromBytes(bytes), stat.getVersion)
 }
 
 object ExtendedAclChangeEvent {
@@ -689,11 +688,11 @@ case class ExtendedAclChangeEvent(@BeanProperty @JsonProperty("version") version
   if (version > ExtendedAclChangeEvent.currentVersion)
     throw new UnsupportedVersionException(s"Acl change event received for unsupported version: $version")
 
-  def toResource: Try[Resource] = {
+  def toResource: Try[ResourcePattern] = {
     for {
       resType <- Try(ResourceType.fromString(resourceType))
       patType <- Try(PatternType.fromString(patternType))
-      resource = Resource(resType, name, patType)
+      resource = new ResourcePattern(resType, name, patType)
     } yield resource
   }
 }

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -12,18 +12,64 @@
   */
 package kafka.admin
 
+import java.util.Optional
+
 import kafka.admin.TopicCommand.ZookeeperTopicService
+import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.TestUtils
 import kafka.zk.ZooKeeperTestHarness
-import org.junit.Test
+import org.apache.kafka.clients.admin.{AdminClientConfig, NewPartitionReassignment, NewTopic, AdminClient => JAdminClient}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.InvalidReplicaAssignmentException
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.test.{TestUtils => JTestUtils}
+import org.junit.{After, Before, Test}
+
+import scala.collection.JavaConverters._
+import scala.collection.Seq
 
 class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness with RackAwareTest {
+  import ReassignPartitionsIntegrationTest._
+
+  var servers: Seq[KafkaServer] = Seq()
+  val broker1 = 0
+  val broker2 = 1
+  val broker3 = 2
+  val broker4 = 3
+  val broker5 = 4
+  val broker6 = 5
+  val rack = Map(
+    broker1 -> "rack1",
+    broker2 -> "rack2",
+    broker3 -> "rack2",
+    broker4 -> "rack1",
+    broker5 -> "rack3",
+    broker6 -> "rack3"
+  )
+
+  @Before
+  override def setUp(): Unit = {
+    super.setUp()
+
+    val brokerConfigs = TestUtils.createBrokerConfigs(6, zkConnect, enableControlledShutdown = true)
+    servers = brokerConfigs.map { config =>
+      config.setProperty(KafkaConfig.RackProp, rack(config.getProperty(KafkaConfig.BrokerIdProp).toInt))
+      config.setProperty(KafkaConfig.AutoLeaderRebalanceEnableProp, "false")
+      config.setProperty(KafkaConfig.ControlledShutdownMaxRetriesProp, "1")
+      config.setProperty(KafkaConfig.ControlledShutdownRetryBackoffMsProp, "1000")
+      config.setProperty(KafkaConfig.ReplicaLagTimeMaxMsProp, "1000")
+      TestUtils.createServer(KafkaConfig.fromProps(config))
+    }
+  }
+
+  @After
+  override def tearDown(): Unit = {
+    TestUtils.shutdownServers(servers)
+    super.tearDown()
+  }
 
   @Test
   def testRackAwareReassign(): Unit = {
-    val rackInfo = Map(0 -> "rack1", 1 -> "rack2", 2 -> "rack2", 3 -> "rack1", 4 -> "rack3", 5 -> "rack3")
-    TestUtils.createBrokersInZk(toBrokerMetadata(rackInfo), zkClient)
-
     val numPartitions = 18
     val replicationFactor = 3
 
@@ -37,11 +83,93 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness with RackAw
 
     val topicJson = """{"topics": [{"topic": "foo"}], "version":1}"""
     val (proposedAssignment, currentAssignment) = ReassignPartitionsCommand.generateAssignment(zkClient,
-      rackInfo.keys.toSeq.sorted, topicJson, disableRackAware = false)
+      rack.keys.toSeq.sorted, topicJson, disableRackAware = false)
 
     val assignment = proposedAssignment map { case (topicPartition, replicas) =>
       (topicPartition.partition, replicas)
     }
-    checkReplicaDistribution(assignment, rackInfo, rackInfo.size, numPartitions, replicationFactor)
+    checkReplicaDistribution(assignment, rack, rack.size, numPartitions, replicationFactor)
+  }
+
+  @Test
+  def testReassignPartition(): Unit = {
+    TestUtils.resource(JAdminClient.create(createConfig(servers).asJava)) { client =>
+      val topic = "test-topic"
+      val partition = 0: Integer
+
+      val partitionAssignment = Map(partition -> Seq(broker1: Integer, broker2:Integer).asJava).asJava
+      val newTopic = new NewTopic(topic, partitionAssignment)
+      client.createTopics(Seq(newTopic).asJava).all().get()
+
+      val topicPartition = new TopicPartition(topic, partition)
+
+      // All sync replicas are in the ISR
+      TestUtils.waitForBrokersInIsr(client, topicPartition, Set(broker1, broker2))
+
+      // Reassign replicas to different brokers
+      client.alterPartitionReassignments(
+        Map(topicPartition -> reassignmentEntry(Seq(broker3, broker4))).asJava
+      ).all().get()
+
+      waitForAllReassignmentsToComplete(client)
+
+      // Metadata info is eventually consistent wait for update
+      TestUtils.waitForReplicasAssigned(client, topicPartition, Seq(broker3, broker4))
+      // All sync replicas are in the ISR
+      TestUtils.waitForBrokersInIsr(client, topicPartition, Set(broker3, broker4))
+    }
+  }
+
+  @Test
+  def testInvalidReplicaIds(): Unit = {
+    TestUtils.resource(JAdminClient.create(createConfig(servers).asJava)) { client =>
+      val topic = "test-topic"
+      val partition = 0: Integer
+
+      val partitionAssignment = Map(partition -> Seq(broker1: Integer, broker2: Integer).asJava).asJava
+      val newTopic = new NewTopic(topic, partitionAssignment)
+      client.createTopics(Seq(newTopic).asJava).all().get()
+
+      val topicPartition = new TopicPartition(topic, partition)
+
+      // All sync replicas are in the ISR
+      TestUtils.waitForBrokersInIsr(client, topicPartition, Set(broker1, broker2))
+
+      // Test reassignment with duplicate broker ids
+      var future = client.alterPartitionReassignments(
+        Map(topicPartition -> reassignmentEntry(Seq(broker4, broker5, broker5))).asJava
+      ).all()
+      JTestUtils.assertFutureThrows(future, classOf[InvalidReplicaAssignmentException])
+
+      // Test reassignment with invalid broker ids
+      future = client.alterPartitionReassignments(
+        Map(topicPartition -> reassignmentEntry(Seq(-1, broker3))).asJava
+      ).all()
+      JTestUtils.assertFutureThrows(future, classOf[InvalidReplicaAssignmentException])
+
+      // Test reassignment with extra broker ids
+      future = client.alterPartitionReassignments(
+        Map(topicPartition -> reassignmentEntry(Seq(6, broker2, broker3))).asJava
+      ).all()
+      JTestUtils.assertFutureThrows(future, classOf[InvalidReplicaAssignmentException])
+    }
+  }
+}
+
+object ReassignPartitionsIntegrationTest {
+  def createConfig(servers: Seq[KafkaServer]): Map[String, Object] = {
+    Map(
+      AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> TestUtils.bootstrapServers(servers, new ListenerName("PLAINTEXT")),
+      AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG -> "20000"
+    )
+  }
+
+  def reassignmentEntry(replicas: Seq[Int]): Optional[NewPartitionReassignment] = {
+    Optional.of(new NewPartitionReassignment(replicas.map(r => r: Integer).asJava))
+  }
+
+  def waitForAllReassignmentsToComplete(client: JAdminClient): Unit = {
+    TestUtils.waitUntilTrue(() => client.listPartitionReassignments().reassignments().get().isEmpty,
+      s"There still are ongoing reassignments", pause = 100L)
   }
 }

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -20,8 +20,8 @@ import java.util.{Collections, Optional, Properties}
 
 import kafka.admin.ConsumerGroupCommand.{ConsumerGroupCommandOptions, ConsumerGroupService}
 import kafka.log.LogConfig
-import kafka.security.auth.{SimpleAclAuthorizer, Topic, ResourceType => AuthResourceType}
-import kafka.security.authorizer.AuthorizerUtils.WildcardHost
+import kafka.security.authorizer.AclEntry
+import kafka.security.authorizer.AclEntry.WildcardHost
 import kafka.server.{BaseRequestTest, KafkaConfig}
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.{Admin, AdminClient, AdminClientConfig, AlterConfigOp}
@@ -117,7 +117,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, group)
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[SimpleAclAuthorizer].getName)
+    properties.put(KafkaConfig.AuthorizerClassNameProp, "kafka.security.auth.SimpleAclAuthorizer")
     properties.put(KafkaConfig.BrokerIdProp, brokerId.toString)
     properties.put(KafkaConfig.OffsetsTopicPartitionsProp, "1")
     properties.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "1")
@@ -289,7 +289,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   }
 
   private def createOffsetFetchRequest = {
-    new requests.OffsetFetchRequest.Builder(group, List(tp).asJava).build()
+    new requests.OffsetFetchRequest.Builder(group, false, List(tp).asJava).build()
   }
 
   private def createFindCoordinatorRequest = {
@@ -1148,7 +1148,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     // note there's only one broker, so no need to lookup the group coordinator
 
     // without describe permission on the topic, we shouldn't be able to fetch offsets
-    val offsetFetchRequest = requests.OffsetFetchRequest.Builder.allTopicPartitions(group).build()
+    val offsetFetchRequest = new requests.OffsetFetchRequest.Builder(group, false, null).build()
     var offsetFetchResponse = connectAndReceive[OffsetFetchResponse](offsetFetchRequest)
     assertEquals(Errors.NONE, offsetFetchResponse.error)
     assertTrue(offsetFetchResponse.responseData.isEmpty)
@@ -1663,11 +1663,11 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val authorizationErrors = resources.flatMap { resourceType =>
       if (resourceType == TOPIC) {
         if (isAuthorized)
-          Set(Errors.UNKNOWN_TOPIC_OR_PARTITION, Topic.error)
+          Set(Errors.UNKNOWN_TOPIC_OR_PARTITION, AclEntry.authorizationError(ResourceType.TOPIC))
         else
-          Set(Topic.error)
+          Set(AclEntry.authorizationError(ResourceType.TOPIC))
       } else {
-        Set(AuthResourceType.fromJava(resourceType).error)
+        Set(AclEntry.authorizationError(resourceType))
       }
     }
 

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -20,13 +20,14 @@ import java.util
 import java.util.Properties
 import java.util.concurrent.ExecutionException
 
-import kafka.security.auth.{Cluster, Topic}
+import kafka.security.authorizer.AclEntry
 import kafka.server.KafkaConfig
 import kafka.utils.Logging
 import kafka.utils.TestUtils._
 import org.apache.kafka.clients.admin.{Admin, AdminClient, AdminClientConfig, CreateTopicsOptions, CreateTopicsResult, DescribeClusterOptions, DescribeTopicsOptions, NewTopic, TopicDescription}
 import org.apache.kafka.common.acl.AclOperation
 import org.apache.kafka.common.errors.{TopicExistsException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.common.utils.Utils
 import org.junit.Assert._
 import org.junit.rules.Timeout
@@ -176,13 +177,12 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
 
     //with includeAuthorizedOperations flag
     topicResult = getTopicMetadata(client, topic, new DescribeTopicsOptions().includeAuthorizedOperations(true))
-    expectedOperations = Topic.supportedOperations
-      .map(operation => operation.toJava).asJava
+    expectedOperations = AclEntry.supportedOperations(ResourceType.TOPIC).asJava
     assertEquals(expectedOperations, topicResult.authorizedOperations)
   }
 
   def configuredClusterPermissions(): Set[AclOperation] = {
-    Cluster.supportedOperations.map(operation => operation.toJava)
+    AclEntry.supportedOperations(ResourceType.CLUSTER)
   }
 
   override def modifyConfigs(configs: Seq[Properties]): Unit = {

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.ExecutionException
 
 import kafka.admin.AclCommand
 import kafka.security.authorizer.AclAuthorizer
-import kafka.security.authorizer.AuthorizerUtils.WildcardHost
+import kafka.security.authorizer.AclEntry.WildcardHost
 import kafka.server._
 import kafka.utils._
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerRecords}

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -26,7 +26,7 @@ import java.util.{Collections, Optional, Properties}
 import java.{time, util}
 
 import kafka.log.LogConfig
-import kafka.security.auth.Group
+import kafka.security.authorizer.AclEntry
 import kafka.server.{Defaults, KafkaConfig, KafkaServer}
 import kafka.utils.TestUtils._
 import kafka.utils.{Log4jController, TestUtils}
@@ -1077,8 +1077,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           assertEquals(testNumPartitions, topicPartitions.size())
           assertEquals(testNumPartitions, topicPartitions.asScala.
             count(tp => tp.topic().equals(testTopicName)))
-          val expectedOperations = Group.supportedOperations
-            .map(operation => operation.toJava).asJava
+          val expectedOperations = AclEntry.supportedOperations(ResourceType.GROUP).asJava
           assertEquals(expectedOperations, testGroupDescription.authorizedOperations())
 
           // Test that the fake group is listed as dead.

--- a/core/src/test/scala/integration/kafka/api/SaslGssapiSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslGssapiSslEndToEndAuthorizationTest.scala
@@ -22,6 +22,8 @@ import kafka.utils.JaasTestUtils
 
 import scala.collection.immutable.List
 
+// Note: this test currently uses the deprecated SimpleAclAuthorizer to ensure we have test coverage
+// It must be replaced with the new AclAuthorizer when SimpleAclAuthorizer is removed
 class SaslGssapiSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
   override val clientPrincipal = JaasTestUtils.KafkaClientPrincipalUnqualifiedName
   override val kafkaPrincipal = JaasTestUtils.KafkaServerPrincipalUnqualifiedName

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -16,13 +16,13 @@ import java.io.File
 import java.util
 
 import kafka.log.LogConfig
-import kafka.security.auth.{All, Allow, Alter, AlterConfigs, Authorizer, ClusterAction, Create, Delete, Deny, Describe, Group, Operation, PermissionType, SimpleAclAuthorizer, Topic, Acl => AuthAcl, Resource => AuthResource}
-import kafka.security.authorizer.AuthorizerWrapper
 import kafka.server.{Defaults, KafkaConfig}
 import kafka.utils.{CoreUtils, JaasTestUtils, TestUtils}
 import kafka.utils.TestUtils._
 import org.apache.kafka.clients.admin._
 import org.apache.kafka.common.acl._
+import org.apache.kafka.common.acl.AclOperation.{ALTER, ALTER_CONFIGS, CLUSTER_ACTION, CREATE, DELETE, DESCRIBE}
+import org.apache.kafka.common.acl.AclPermissionType.{ALLOW, DENY}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors.{ClusterAuthorizationException, InvalidRequestException, TopicAuthorizationException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourcePatternFilter, ResourceType}
@@ -36,32 +36,29 @@ import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionException
 import scala.util.{Failure, Success, Try}
 
+abstract class AuthorizationAdmin {
+  def authorizerClassName: String
+  def initializeAcls(): Unit
+  def addClusterAcl(permissionType: AclPermissionType, operation: AclOperation): Unit
+  def removeClusterAcl(permissionType: AclPermissionType, operation: AclOperation): Unit
+}
+
+// Note: this test currently uses the deprecated SimpleAclAuthorizer to ensure we have test coverage
+// It must be replaced with the new AclAuthorizer when SimpleAclAuthorizer is removed
 class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetup {
+  val authorizationAdmin: AuthorizationAdmin = new LegacyAuthorizationAdmin
   this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
-  // This tests the old SimpleAclAuthorizer, we have another test for the new AclAuthorizer
-  this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, classOf[SimpleAclAuthorizer].getName)
 
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
 
-  override def configureSecurityBeforeServersStart(): Unit = {
-    val authorizer = CoreUtils.createObject[Authorizer](classOf[SimpleAclAuthorizer].getName)
-    try {
-      authorizer.configure(this.configs.head.originals())
-      authorizer.addAcls(Set(new AuthAcl(AuthAcl.WildCardPrincipal, Allow,
-                             AuthAcl.WildCardHost, All)), new AuthResource(Topic, "*", PatternType.LITERAL))
-      authorizer.addAcls(Set(new AuthAcl(AuthAcl.WildCardPrincipal, Allow,
-                             AuthAcl.WildCardHost, All)), new AuthResource(Group, "*", PatternType.LITERAL))
+  override def generateConfigs: Seq[KafkaConfig] = {
+    this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, authorizationAdmin.authorizerClassName)
+    super.generateConfigs
+  }
 
-      authorizer.addAcls(Set(clusterAcl(Allow, Create),
-                             clusterAcl(Allow, Delete),
-                             clusterAcl(Allow, ClusterAction),
-                             clusterAcl(Allow, AlterConfigs),
-                             clusterAcl(Allow, Alter)),
-                             AuthResource.ClusterResource)
-    } finally {
-      authorizer.close()
-    }
+  override def configureSecurityBeforeServersStart(): Unit = {
+    authorizationAdmin.initializeAcls()
   }
 
   @Before
@@ -72,27 +69,6 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
 
   def setUpSasl(): Unit = {
     startSasl(jaasSections(Seq("GSSAPI"), Some("GSSAPI"), Both, JaasTestUtils.KafkaServerContextName))
-  }
-
-  private def clusterAcl(permissionType: PermissionType, operation: Operation): AuthAcl = {
-    new AuthAcl(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "*"), permissionType,
-      AuthAcl.WildCardHost, operation)
-  }
-
-  def addClusterAcl(permissionType: PermissionType, operation: Operation): Unit = {
-    val acls = Set(clusterAcl(permissionType, operation))
-    val authorizer = simpleAclAuthorizer
-    val prevAcls = authorizer.getAcls(AuthResource.ClusterResource)
-    authorizer.addAcls(acls, AuthResource.ClusterResource)
-    TestUtils.waitAndVerifyAcls(prevAcls ++ acls, authorizer, AuthResource.ClusterResource)
-  }
-
-  def removeClusterAcl(permissionType: PermissionType, operation: Operation): Unit = {
-    val acls = Set(clusterAcl(permissionType, operation))
-    val authorizer = simpleAclAuthorizer
-    val prevAcls = authorizer.getAcls(AuthResource.ClusterResource)
-    Assert.assertTrue(authorizer.removeAcls(acls, AuthResource.ClusterResource))
-    TestUtils.waitAndVerifyAcls(prevAcls -- acls, authorizer, AuthResource.ClusterResource)
   }
 
   @After
@@ -380,30 +356,30 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
   def testAclAuthorizationDenied(): Unit = {
     client = AdminClient.create(createConfig())
 
-    // Test that we cannot create or delete ACLs when Alter is denied.
-    addClusterAcl(Deny, Alter)
+    // Test that we cannot create or delete ACLs when ALTER is denied.
+    authorizationAdmin.addClusterAcl(DENY, ALTER)
     testAclGet(expectAuth = true)
     testAclCreateGetDelete(expectAuth = false)
 
-    // Test that we cannot do anything with ACLs when Describe and Alter are denied.
-    addClusterAcl(Deny, Describe)
+    // Test that we cannot do anything with ACLs when DESCRIBE and ALTER are denied.
+    authorizationAdmin.addClusterAcl(DENY, DESCRIBE)
     testAclGet(expectAuth = false)
     testAclCreateGetDelete(expectAuth = false)
 
     // Test that we can create, delete, and get ACLs with the default ACLs.
-    removeClusterAcl(Deny, Describe)
-    removeClusterAcl(Deny, Alter)
+    authorizationAdmin.removeClusterAcl(DENY, DESCRIBE)
+    authorizationAdmin.removeClusterAcl(DENY, ALTER)
     testAclGet(expectAuth = true)
     testAclCreateGetDelete(expectAuth = true)
 
-    // Test that we can't do anything with ACLs without the Allow Alter ACL in place.
-    removeClusterAcl(Allow, Alter)
-    removeClusterAcl(Allow, Delete)
+    // Test that we can't do anything with ACLs without the ALLOW ALTER ACL in place.
+    authorizationAdmin.removeClusterAcl(ALLOW, ALTER)
+    authorizationAdmin.removeClusterAcl(ALLOW, DELETE)
     testAclGet(expectAuth = false)
     testAclCreateGetDelete(expectAuth = false)
 
-    // Test that we can describe, but not alter ACLs, with only the Allow Describe ACL in place.
-    addClusterAcl(Allow, Describe)
+    // Test that we can describe, but not alter ACLs, with only the ALLOW DESCRIBE ACL in place.
+    authorizationAdmin.addClusterAcl(ALLOW, DESCRIBE)
     testAclGet(expectAuth = true)
     testAclCreateGetDelete(expectAuth = false)
   }
@@ -498,8 +474,58 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
     client.describeAcls(allTopicAcls).values.get().asScala.toSet
   }
 
-  private def simpleAclAuthorizer: Authorizer = {
-    val authorizerWrapper = servers.head.dataPlaneRequestProcessor.authorizer.get.asInstanceOf[AuthorizerWrapper]
-    authorizerWrapper.baseAuthorizer
+  @deprecated("Use kafka.security.authorizer.AclAuthorizer", "Since 2.5")
+  class LegacyAuthorizationAdmin extends AuthorizationAdmin {
+    import kafka.security.auth._
+    import kafka.security.authorizer.AuthorizerWrapper
+
+    override def authorizerClassName: String = classOf[SimpleAclAuthorizer].getName
+
+    override def initializeAcls(): Unit = {
+      val authorizer = CoreUtils.createObject[Authorizer](classOf[SimpleAclAuthorizer].getName)
+      try {
+        authorizer.configure(configs.head.originals())
+        authorizer.addAcls(Set(new Acl(Acl.WildCardPrincipal, Allow,
+          Acl.WildCardHost, All)), new Resource(Topic, "*", PatternType.LITERAL))
+        authorizer.addAcls(Set(new Acl(Acl.WildCardPrincipal, Allow,
+          Acl.WildCardHost, All)), new Resource(Group, "*", PatternType.LITERAL))
+
+        authorizer.addAcls(Set(clusterAcl(ALLOW, CREATE),
+          clusterAcl(ALLOW, DELETE),
+          clusterAcl(ALLOW, CLUSTER_ACTION),
+          clusterAcl(ALLOW, ALTER_CONFIGS),
+          clusterAcl(ALLOW, ALTER)),
+          Resource.ClusterResource)
+      } finally {
+        authorizer.close()
+      }
+    }
+
+    override def addClusterAcl(permissionType: AclPermissionType, operation: AclOperation): Unit = {
+      val acls = Set(clusterAcl(permissionType, operation))
+      val authorizer = simpleAclAuthorizer
+      val prevAcls = authorizer.getAcls(Resource.ClusterResource)
+      authorizer.addAcls(acls, Resource.ClusterResource)
+      TestUtils.waitAndVerifyAcls(prevAcls ++ acls, authorizer, Resource.ClusterResource)
+    }
+
+    override def removeClusterAcl(permissionType: AclPermissionType, operation: AclOperation): Unit = {
+      val acls = Set(clusterAcl(permissionType, operation))
+      val authorizer = simpleAclAuthorizer
+      val prevAcls = authorizer.getAcls(Resource.ClusterResource)
+      Assert.assertTrue(authorizer.removeAcls(acls, Resource.ClusterResource))
+      TestUtils.waitAndVerifyAcls(prevAcls -- acls, authorizer, Resource.ClusterResource)
+    }
+
+
+    private def clusterAcl(permissionType: AclPermissionType, operation: AclOperation): Acl = {
+      new Acl(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "*"), PermissionType.fromJava(permissionType),
+        Acl.WildCardHost, Operation.fromJava(operation))
+    }
+
+    private def simpleAclAuthorizer: Authorizer = {
+      val authorizerWrapper = servers.head.dataPlaneRequestProcessor.authorizer.get.asInstanceOf[AuthorizerWrapper]
+      authorizerWrapper.baseAuthorizer
+    }
   }
 }

--- a/core/src/test/scala/integration/kafka/api/SslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslAdminIntegrationTest.scala
@@ -21,8 +21,7 @@ import java.util.function.BiConsumer
 import com.yammer.metrics.Metrics
 import com.yammer.metrics.core.Gauge
 import kafka.security.authorizer.AclAuthorizer
-import kafka.security.authorizer.AuthorizerUtils.{WildcardHost, WildcardPrincipal}
-import kafka.security.auth.{Operation, PermissionType}
+import kafka.security.authorizer.AclEntry.{WildcardHost, WildcardPrincipalString}
 import kafka.server.KafkaConfig
 import kafka.utils.{CoreUtils, TestUtils}
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, CreateAclsResult}
@@ -89,33 +88,14 @@ object SslAdminIntegrationTest {
 }
 
 class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
+  override val authorizationAdmin = new AclAuthorizationAdmin
   val clusterResourcePattern = new ResourcePattern(ResourceType.CLUSTER, Resource.CLUSTER_NAME, PatternType.LITERAL)
 
   this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
-  this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, classOf[SslAdminIntegrationTest.TestableAclAuthorizer].getName)
 
   override protected def securityProtocol = SecurityProtocol.SSL
   override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
   private val adminClients = mutable.Buffer.empty[AdminClient]
-
-  override def configureSecurityBeforeServersStart(): Unit = {
-    val authorizer = CoreUtils.createObject[Authorizer](classOf[AclAuthorizer].getName)
-    try {
-      authorizer.configure(this.configs.head.originals())
-      val ace = new AccessControlEntry(WildcardPrincipal, WildcardHost, ALL, ALLOW)
-      authorizer.createAcls(null, List(new AclBinding(new ResourcePattern(TOPIC, "*", LITERAL), ace)).asJava)
-      authorizer.createAcls(null, List(new AclBinding(new ResourcePattern(GROUP, "*", LITERAL), ace)).asJava)
-
-      authorizer.createAcls(null, List(clusterAcl(ALLOW, CREATE),
-                             clusterAcl(ALLOW, DELETE),
-                             clusterAcl(ALLOW, CLUSTER_ACTION),
-                             clusterAcl(ALLOW, ALTER_CONFIGS),
-                             clusterAcl(ALLOW, ALTER))
-        .map(ace => new AclBinding(clusterResourcePattern, ace)).asJava)
-    } finally {
-      authorizer.close()
-    }
-  }
 
   override def setUpSasl(): Unit = {
     SslAdminIntegrationTest.semaphore = None
@@ -133,32 +113,6 @@ class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
 
     adminClients.foreach(_.close())
     super.tearDown()
-  }
-
-  override def addClusterAcl(permissionType: PermissionType, operation: Operation): Unit = {
-    val ace = clusterAcl(permissionType.toJava, operation.toJava)
-    val aclBinding = new AclBinding(clusterResourcePattern, ace)
-    val authorizer = servers.head.dataPlaneRequestProcessor.authorizer.get
-    val prevAcls = authorizer.acls(new AclBindingFilter(clusterResourcePattern.toFilter, AccessControlEntryFilter.ANY))
-      .asScala.map(_.entry).toSet
-    authorizer.createAcls(null, Collections.singletonList(aclBinding))
-    TestUtils.waitAndVerifyAcls(prevAcls ++ Set(ace), authorizer, clusterResourcePattern)
-  }
-
-  override def removeClusterAcl(permissionType: PermissionType, operation: Operation): Unit = {
-    val ace = clusterAcl(permissionType.toJava, operation.toJava)
-    val authorizer = servers.head.dataPlaneRequestProcessor.authorizer.get
-    val clusterFilter = new AclBindingFilter(clusterResourcePattern.toFilter, AccessControlEntryFilter.ANY)
-    val prevAcls = authorizer.acls(clusterFilter).asScala.map(_.entry).toSet
-    val deleteFilter = new AclBindingFilter(clusterResourcePattern.toFilter, ace.toFilter)
-    Assert.assertFalse(authorizer.deleteAcls(null, Collections.singletonList(deleteFilter))
-      .get(0).toCompletableFuture.get.aclBindingDeleteResults().asScala.head.exception.isPresent)
-    TestUtils.waitAndVerifyAcls(prevAcls -- Set(ace), authorizer, clusterResourcePattern)
-  }
-
-  private def clusterAcl(permissionType: AclPermissionType, operation: AclOperation): AccessControlEntry = {
-    new AccessControlEntry(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "*").toString,
-      WildcardHost, operation, permissionType)
   }
 
   @Test
@@ -314,5 +268,55 @@ class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
     }.values.toList
     assertTrue(s"Unable to find metric $name: allMetrics: ${allMetrics.keySet.map(_.getMBeanName)}", metrics.nonEmpty)
     metrics.map(_.asInstanceOf[Gauge[Int]].value).sum
+  }
+
+  class AclAuthorizationAdmin extends AuthorizationAdmin {
+
+    override def authorizerClassName: String = classOf[SslAdminIntegrationTest.TestableAclAuthorizer].getName
+
+    override def initializeAcls(): Unit = {
+      val authorizer = CoreUtils.createObject[Authorizer](classOf[AclAuthorizer].getName)
+      try {
+        authorizer.configure(configs.head.originals())
+        val ace = new AccessControlEntry(WildcardPrincipalString, WildcardHost, ALL, ALLOW)
+        authorizer.createAcls(null, List(new AclBinding(new ResourcePattern(TOPIC, "*", LITERAL), ace)).asJava)
+        authorizer.createAcls(null, List(new AclBinding(new ResourcePattern(GROUP, "*", LITERAL), ace)).asJava)
+
+        authorizer.createAcls(null, List(clusterAcl(ALLOW, CREATE),
+          clusterAcl(ALLOW, DELETE),
+          clusterAcl(ALLOW, CLUSTER_ACTION),
+          clusterAcl(ALLOW, ALTER_CONFIGS),
+          clusterAcl(ALLOW, ALTER))
+          .map(ace => new AclBinding(clusterResourcePattern, ace)).asJava)
+      } finally {
+        authorizer.close()
+      }
+    }
+
+    override def addClusterAcl(permissionType: AclPermissionType, operation: AclOperation): Unit = {
+      val ace = clusterAcl(permissionType, operation)
+      val aclBinding = new AclBinding(clusterResourcePattern, ace)
+      val authorizer = servers.head.dataPlaneRequestProcessor.authorizer.get
+      val prevAcls = authorizer.acls(new AclBindingFilter(clusterResourcePattern.toFilter, AccessControlEntryFilter.ANY))
+        .asScala.map(_.entry).toSet
+      authorizer.createAcls(null, Collections.singletonList(aclBinding))
+      TestUtils.waitAndVerifyAcls(prevAcls ++ Set(ace), authorizer, clusterResourcePattern)
+    }
+
+    override def removeClusterAcl(permissionType: AclPermissionType, operation: AclOperation): Unit = {
+      val ace = clusterAcl(permissionType, operation)
+      val authorizer = servers.head.dataPlaneRequestProcessor.authorizer.get
+      val clusterFilter = new AclBindingFilter(clusterResourcePattern.toFilter, AccessControlEntryFilter.ANY)
+      val prevAcls = authorizer.acls(clusterFilter).asScala.map(_.entry).toSet
+      val deleteFilter = new AclBindingFilter(clusterResourcePattern.toFilter, ace.toFilter)
+      Assert.assertFalse(authorizer.deleteAcls(null, Collections.singletonList(deleteFilter))
+        .get(0).toCompletableFuture.get.aclBindingDeleteResults().asScala.head.exception.isPresent)
+      TestUtils.waitAndVerifyAcls(prevAcls -- Set(ace), authorizer, clusterResourcePattern)
+    }
+
+    private def clusterAcl(permissionType: AclPermissionType, operation: AclOperation): AccessControlEntry = {
+      new AccessControlEntry(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "*").toString,
+        WildcardHost, operation, permissionType)
+    }
   }
 }

--- a/core/src/test/scala/kafka/security/auth/ResourceTest.scala
+++ b/core/src/test/scala/kafka/security/auth/ResourceTest.scala
@@ -22,6 +22,7 @@ import org.apache.kafka.common.resource.PatternType.{LITERAL, PREFIXED}
 import org.junit.Test
 import org.junit.Assert._
 
+@deprecated("Use org.apache.kafka.common.resource.ResourcePattern", "Since 2.5")
 class ResourceTest {
   @Test(expected = classOf[KafkaException])
   def shouldThrowOnTwoPartStringWithUnknownResourceType(): Unit = {

--- a/core/src/test/scala/kafka/zk/ExtendedAclStoreTest.scala
+++ b/core/src/test/scala/kafka/zk/ExtendedAclStoreTest.scala
@@ -17,20 +17,21 @@
 
 package kafka.zk
 
-import kafka.security.auth.{Resource, Topic}
 import org.apache.kafka.common.resource.PatternType.{LITERAL, PREFIXED}
+import org.apache.kafka.common.resource.ResourcePattern
+import org.apache.kafka.common.resource.ResourceType.TOPIC
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ExtendedAclStoreTest {
-  private val literalResource = Resource(Topic, "some-topic", LITERAL)
-  private val prefixedResource = Resource(Topic, "some-topic", PREFIXED)
+  private val literalResource = new ResourcePattern(TOPIC, "some-topic", LITERAL)
+  private val prefixedResource = new ResourcePattern(TOPIC, "some-topic", PREFIXED)
   private val store = new ExtendedAclStore(PREFIXED)
 
   @Test
   def shouldHaveCorrectPaths(): Unit = {
     assertEquals("/kafka-acl-extended/prefixed", store.aclPath)
-    assertEquals("/kafka-acl-extended/prefixed/Topic", store.path(Topic))
+    assertEquals("/kafka-acl-extended/prefixed/Topic", store.path(TOPIC))
     assertEquals("/kafka-acl-extended-changes", store.changeStore.aclChangePath)
   }
 

--- a/core/src/test/scala/kafka/zk/LiteralAclStoreTest.scala
+++ b/core/src/test/scala/kafka/zk/LiteralAclStoreTest.scala
@@ -19,20 +19,22 @@ package kafka.zk
 
 import java.nio.charset.StandardCharsets.UTF_8
 
-import kafka.security.auth.{Group, Resource, Topic}
+import kafka.security.authorizer.AclEntry
 import org.apache.kafka.common.resource.PatternType.{LITERAL, PREFIXED}
+import org.apache.kafka.common.resource.ResourcePattern
+import org.apache.kafka.common.resource.ResourceType.{GROUP, TOPIC}
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class LiteralAclStoreTest {
-  private val literalResource = Resource(Topic, "some-topic", LITERAL)
-  private val prefixedResource = Resource(Topic, "some-topic", PREFIXED)
+  private val literalResource = new ResourcePattern(TOPIC, "some-topic", LITERAL)
+  private val prefixedResource = new ResourcePattern(TOPIC, "some-topic", PREFIXED)
   private val store = LiteralAclStore
 
   @Test
   def shouldHaveCorrectPaths(): Unit = {
     assertEquals("/kafka-acl", store.aclPath)
-    assertEquals("/kafka-acl/Topic", store.path(Topic))
+    assertEquals("/kafka-acl/Topic", store.path(TOPIC))
     assertEquals("/kafka-acl-changes", store.changeStore.aclChangePath)
   }
 
@@ -64,8 +66,8 @@ class LiteralAclStoreTest {
 
   @Test
   def shouldDecodeResourceUsingTwoPartLogic(): Unit = {
-    val resource = Resource(Group, "PREFIXED:this, including the PREFIXED part, is a valid two part group name", LITERAL)
-    val encoded = (resource.resourceType +  Resource.Separator + resource.name).getBytes(UTF_8)
+    val resource = new ResourcePattern(GROUP, "PREFIXED:this, including the PREFIXED part, is a valid two part group name", LITERAL)
+    val encoded = (resource.resourceType +  AclEntry.ResourceSeparator + resource.name).getBytes(UTF_8)
 
     val actual = store.changeStore.decode(encoded)
 

--- a/core/src/test/scala/unit/kafka/admin/LeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LeaderElectionCommandTest.scala
@@ -314,10 +314,7 @@ object LeaderElectionCommandTest {
   }
 
   def bootstrapServers(servers: Seq[KafkaServer]): String = {
-    servers.map { server =>
-      val port = server.socketServer.boundPort(ListenerName.normalised("PLAINTEXT"))
-      s"localhost:$port"
-    }.headOption.mkString(",")
+    TestUtils.bootstrapServers(servers, new ListenerName("PLAINTEXT"))
   }
 
   def tempTopicPartitionFile(partitions: Set[TopicPartition]): Path = {

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -1,0 +1,319 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.cluster
+
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent._
+
+import kafka.api.{ApiVersion, LeaderAndIsr}
+import kafka.log._
+import kafka.server._
+import kafka.server.checkpoints.OffsetCheckpoints
+import kafka.utils._
+import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
+import org.apache.kafka.common.utils.Utils
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+import org.junit.{After, Before, Test}
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.{mock, when}
+
+import scala.collection.JavaConverters._
+
+/**
+ * Verifies that slow appends to log don't block request threads processing replica fetch requests.
+ *
+ * Test simulates:
+ *   1) Produce request handling by performing append to log as leader.
+ *   2) Replica fetch request handling by processing update of ISR and HW based on log read result.
+ *   3) Some tests also simulate a scheduler thread that checks or updates ISRs when replica falls out of ISR
+ */
+class PartitionLockTest extends Logging {
+
+  val numReplicaFetchers = 2
+  val numProducers = 3
+  val numRecordsPerProducer = 5
+
+  val mockTime = new MockTime() // Used for check to shrink ISR
+  val tmpDir = TestUtils.tempDir()
+  val logDir = TestUtils.randomPartitionLogDir(tmpDir)
+  val executorService = Executors.newFixedThreadPool(numReplicaFetchers + numProducers + 1)
+  val appendSemaphore = new Semaphore(0)
+  val shrinkIsrSemaphore = new Semaphore(0)
+  val followerQueues = (0 until numReplicaFetchers).map(_ => new ArrayBlockingQueue[MemoryRecords](2))
+
+  var logManager: LogManager = _
+  var partition: Partition = _
+
+  @Before
+  def setUp(): Unit = {
+    val logConfig = new LogConfig(new Properties)
+    logManager = TestUtils.createLogManager(Seq(logDir), logConfig, CleanerConfig(enableCleaner = false), mockTime)
+    partition = setupPartitionWithMocks(logManager, logConfig)
+  }
+
+  @After
+  def tearDown(): Unit = {
+    executorService.shutdownNow()
+    logManager.liveLogDirs.foreach(Utils.delete)
+    Utils.delete(tmpDir)
+  }
+
+  /**
+   * Verifies that delays in appending to leader while processing produce requests has no impact on timing
+   * of update of log read result when processing replica fetch request if no ISR update is required.
+   */
+  @Test
+  def testNoLockContentionWithoutIsrUpdate(): Unit = {
+    concurrentProduceFetchWithReadLockOnly()
+  }
+
+  /**
+   * Verifies that delays in appending to leader while processing produce requests has no impact on timing
+   * of update of log read result when processing replica fetch request even if a scheduler thread is checking
+   * for ISR shrink conditions if no ISR update is required.
+   */
+  @Test
+  def testAppendReplicaFetchWithSchedulerCheckForShrinkIsr(): Unit = {
+    val active = new AtomicBoolean(true)
+
+    val future = scheduleShrinkIsr(active, mockTimeSleepMs = 0)
+    concurrentProduceFetchWithReadLockOnly()
+    active.set(false)
+    future.get(15, TimeUnit.SECONDS)
+  }
+
+  /**
+   * Verifies concurrent produce and replica fetch log read result update with ISR updates. This
+   * can result in delays in processing produce and replica fetch requets since write lock is obtained,
+   * but it should complete without any failures.
+   */
+  @Test
+  def testAppendReplicaFetchWithUpdateIsr(): Unit = {
+    val active = new AtomicBoolean(true)
+
+    val future = scheduleShrinkIsr(active, mockTimeSleepMs = 10000)
+    TestUtils.waitUntilTrue(() => shrinkIsrSemaphore.hasQueuedThreads, "shrinkIsr not invoked")
+    concurrentProduceFetchWithWriteLock()
+    active.set(false)
+    future.get(15, TimeUnit.SECONDS)
+  }
+
+  /**
+   * Perform concurrent appends and replica fetch requests that don't require write lock to
+   * update follower state. Release sufficient append permits to complete all except one append.
+   * Verify that follower state updates complete even though an append holding read lock is in progress.
+   * Then release the permit for the final append and verify that all appends and follower updates complete.
+   */
+  private def concurrentProduceFetchWithReadLockOnly(): Unit = {
+    val appendFutures = scheduleAppends()
+    val stateUpdateFutures = scheduleUpdateFollowers(numProducers * numRecordsPerProducer - 1)
+
+    appendSemaphore.release(numProducers * numRecordsPerProducer - 1)
+    stateUpdateFutures.foreach(_.get(15, TimeUnit.SECONDS))
+
+    appendSemaphore.release(1)
+    scheduleUpdateFollowers(1).foreach(_.get(15, TimeUnit.SECONDS)) // just to make sure follower state update still works
+    appendFutures.foreach(_.get(15, TimeUnit.SECONDS))
+  }
+
+  /**
+   * Perform concurrent appends and replica fetch requests that may require write lock to update
+   * follower state. Threads waiting for write lock to update follower state while append thread is
+   * holding read lock will prevent other threads acquiring the read or write lock. So release sufficient
+   * permits for all appends to complete before verifying state updates.
+   */
+  private def concurrentProduceFetchWithWriteLock(): Unit = {
+
+    val appendFutures = scheduleAppends()
+    val stateUpdateFutures = scheduleUpdateFollowers(numProducers * numRecordsPerProducer)
+
+    assertFalse(stateUpdateFutures.exists(_.isDone))
+    appendSemaphore.release(numProducers * numRecordsPerProducer)
+    assertFalse(appendFutures.exists(_.isDone))
+
+    shrinkIsrSemaphore.release()
+    stateUpdateFutures.foreach(_.get(15, TimeUnit.SECONDS))
+    appendFutures.foreach(_.get(15, TimeUnit.SECONDS))
+  }
+
+  private def scheduleAppends(): Seq[Future[_]] = {
+    (0 until numProducers).map { _ =>
+      executorService.submit(new Runnable {
+        override def run(): Unit = {
+          try {
+            append(partition, numRecordsPerProducer, followerQueues)
+          } catch {
+            case e: Throwable =>
+              error("Exception during append", e)
+              throw e
+          }
+        }
+      })
+    }
+  }
+
+  private def scheduleUpdateFollowers(numRecords: Int): Seq[Future[_]] = {
+    (1 to numReplicaFetchers).map { index =>
+      executorService.submit(new Runnable {
+        override def run(): Unit = {
+          try {
+            updateFollowerFetchState(partition, index, numRecords, followerQueues(index - 1))
+          } catch {
+            case e: Throwable =>
+              error("Exception during updateFollowerFetchState", e)
+              throw e
+          }
+        }
+      })
+    }
+  }
+
+  private def scheduleShrinkIsr(activeFlag: AtomicBoolean, mockTimeSleepMs: Long): Future[_] = {
+    executorService.submit(new Runnable {
+      override def run(): Unit = {
+        while (activeFlag.get) {
+          if (mockTimeSleepMs > 0)
+            mockTime.sleep(mockTimeSleepMs)
+          partition.maybeShrinkIsr()
+          Thread.sleep(1) // just to avoid tight loop
+        }
+      }
+    })
+  }
+
+  private def setupPartitionWithMocks(logManager: LogManager, logConfig: LogConfig): Partition = {
+    val leaderEpoch = 1
+    val brokerId = 0
+    val topicPartition = new TopicPartition("test-topic", 0)
+    val stateStore: PartitionStateStore = mock(classOf[PartitionStateStore])
+    val delayedOperations: DelayedOperations = mock(classOf[DelayedOperations])
+    val metadataCache: MetadataCache = mock(classOf[MetadataCache])
+    val offsetCheckpoints: OffsetCheckpoints = mock(classOf[OffsetCheckpoints])
+
+    logManager.startup()
+    val partition = new Partition(topicPartition,
+      replicaLagTimeMaxMs = kafka.server.Defaults.ReplicaLagTimeMaxMs,
+      interBrokerProtocolVersion = ApiVersion.latestVersion,
+      localBrokerId = brokerId,
+      mockTime,
+      stateStore,
+      delayedOperations,
+      metadataCache,
+      logManager) {
+
+      override def shrinkIsr(newIsr: Set[Int]): Unit = {
+        shrinkIsrSemaphore.acquire()
+        try {
+          super.shrinkIsr(newIsr)
+        } finally {
+          shrinkIsrSemaphore.release()
+        }
+      }
+
+      override def createLog(replicaId: Int, isNew: Boolean, isFutureReplica: Boolean, offsetCheckpoints: OffsetCheckpoints): Log = {
+        val log = super.createLog(replicaId, isNew, isFutureReplica, offsetCheckpoints)
+        new SlowLog(log, mockTime, appendSemaphore)
+      }
+    }
+    when(stateStore.fetchTopicConfig()).thenReturn(createLogProperties(Map.empty))
+    when(offsetCheckpoints.fetch(ArgumentMatchers.anyString, ArgumentMatchers.eq(topicPartition)))
+      .thenReturn(None)
+    when(stateStore.shrinkIsr(ArgumentMatchers.anyInt, ArgumentMatchers.any[LeaderAndIsr]))
+      .thenReturn(Some(2))
+    when(stateStore.expandIsr(ArgumentMatchers.anyInt, ArgumentMatchers.any[LeaderAndIsr]))
+      .thenReturn(Some(2))
+
+    partition.createLogIfNotExists(brokerId, isNew = false, isFutureReplica = false, offsetCheckpoints)
+
+    val controllerId = 0
+    val controllerEpoch = 0
+    val replicas = (0 to numReplicaFetchers).map(i => Integer.valueOf(brokerId + i)).toList.asJava
+    val isr = replicas
+
+    assertTrue("Expected become leader transition to succeed", partition.makeLeader(controllerId, new LeaderAndIsrPartitionState()
+      .setControllerEpoch(controllerEpoch)
+      .setLeader(brokerId)
+      .setLeaderEpoch(leaderEpoch)
+      .setIsr(isr)
+      .setZkVersion(1)
+      .setReplicas(replicas)
+      .setIsNew(true), 0, offsetCheckpoints))
+
+    partition
+  }
+
+  private def createLogProperties(overrides: Map[String, String]): Properties = {
+    val logProps = new Properties()
+    logProps.put(LogConfig.SegmentBytesProp, 512: java.lang.Integer)
+    logProps.put(LogConfig.SegmentIndexBytesProp, 1000: java.lang.Integer)
+    logProps.put(LogConfig.RetentionMsProp, 999: java.lang.Integer)
+    overrides.foreach { case (k, v) => logProps.put(k, v) }
+    logProps
+  }
+
+  private def append(partition: Partition, numRecords: Int, followerQueues: Seq[ArrayBlockingQueue[MemoryRecords]]): Unit = {
+    (0 until numRecords).foreach { _ =>
+      val batch = TestUtils.records(records = List(new SimpleRecord("k1".getBytes, "v1".getBytes),
+        new SimpleRecord("k2".getBytes, "v2".getBytes)))
+      partition.appendRecordsToLeader(batch, origin = AppendOrigin.Client, requiredAcks = 0)
+      followerQueues.foreach(_.put(batch))
+    }
+  }
+
+  private def updateFollowerFetchState(partition: Partition, followerId: Int, numRecords: Int, followerQueue: ArrayBlockingQueue[MemoryRecords]): Unit = {
+    (1 to numRecords).foreach { i =>
+      val batch = followerQueue.poll(15, TimeUnit.SECONDS)
+      if (batch == null)
+        throw new RuntimeException(s"Timed out waiting for next batch $i")
+      val batches = batch.batches.iterator.asScala.toList
+      assertEquals(1, batches.size)
+      val recordBatch = batches.head
+      partition.updateFollowerFetchState(
+        followerId,
+        followerFetchOffsetMetadata = LogOffsetMetadata(recordBatch.lastOffset + 1),
+        followerStartOffset = 0L,
+        followerFetchTimeMs = mockTime.milliseconds(),
+        leaderEndOffset = partition.localLogOrException.logEndOffset,
+        lastSentHighwatermark = partition.localLogOrException.highWatermark)
+    }
+  }
+
+  private class SlowLog(log: Log, mockTime: MockTime, appendSemaphore: Semaphore) extends Log(
+    log.dir,
+    log.config,
+    log.logStartOffset,
+    log.recoveryPoint,
+    mockTime.scheduler,
+    new BrokerTopicStats,
+    log.time,
+    log.maxProducerIdExpirationMs,
+    log.producerIdExpirationCheckIntervalMs,
+    log.topicPartition,
+    log.producerStateManager,
+    new LogDirFailureChannel(1)) {
+
+    override def appendAsLeader(records: MemoryRecords, leaderEpoch: Int, origin: AppendOrigin, interBrokerProtocolVersion: ApiVersion): LogAppendInfo = {
+      val appendInfo = super.appendAsLeader(records, leaderEpoch, origin, interBrokerProtocolVersion)
+      appendSemaphore.acquire()
+      appendInfo
+    }
+  }
+}

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
@@ -240,8 +240,9 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
           offsetsPartitions.map(_.partition).toSet, isCommit = random.nextBoolean)
         responseCallback(errors)
       }
-      groupCoordinator.handleTxnCommitOffsets(member.group.groupId,
-          producerId, producerEpoch, offsets, callbackWithTxnCompletion)
+      groupCoordinator.handleTxnCommitOffsets(member.group.groupId, producerId, producerEpoch,
+        JoinGroupRequest.UNKNOWN_MEMBER_ID, Option.empty, JoinGroupRequest.UNKNOWN_GENERATION_ID,
+        offsets, callbackWithTxnCompletion)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -601,6 +601,27 @@ class GroupMetadataTest {
     assertFalse(member.isAwaitingSync)
   }
 
+  @Test
+  def testHasPendingNonTxnOffsets(): Unit = {
+    val partition = new TopicPartition("foo", 0)
+    val offset = offsetAndMetadata(37)
+
+    group.prepareOffsetCommit(Map(partition -> offset))
+    assertTrue(group.hasPendingOffsetCommitsForTopicPartition(partition))
+  }
+
+  @Test
+  def testHasPendingTxnOffsets(): Unit = {
+    val txnPartition = new TopicPartition("foo", 1)
+    val offset = offsetAndMetadata(37)
+    val producerId = 5
+
+    group.prepareTxnOffsetCommit(producerId, Map(txnPartition -> offset))
+    assertTrue(group.hasPendingOffsetCommitsForTopicPartition(txnPartition))
+
+    assertFalse(group.hasPendingOffsetCommitsForTopicPartition(new TopicPartition("non-exist", 0)))
+  }
+
   private def assertState(group: GroupMetadata, targetState: GroupState): Unit = {
     val states: Set[GroupState] = Set(Stable, PreparingRebalance, CompletingRebalance, Dead)
     val otherStates = states - targetState

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -179,7 +179,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
     bumpProducerId = true
     transactions.foreach { txn =>
       val txnMetadata = prepareExhaustedEpochTxnMetadata(txn)
-      txnStateManager.putTransactionStateIfNotExists(txn.transactionalId, txnMetadata)
+      txnStateManager.putTransactionStateIfNotExists(txnMetadata)
 
       // Test simultaneous requests from an existing producer trying to bump the epoch and a new producer initializing
       val newProducerOp1 = new InitProducerIdOperation()
@@ -296,7 +296,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
     bumpProducerId = true
     transactions.foreach { txn =>
       val txnMetadata = prepareExhaustedEpochTxnMetadata(txn)
-      txnStateManager.putTransactionStateIfNotExists(txn.transactionalId, txnMetadata)
+      txnStateManager.putTransactionStateIfNotExists(txnMetadata)
 
       // Test simultaneous requests from an existing producer attempting to bump the epoch and a new producer initializing
       val bumpEpochOp = new InitProducerIdOperation(Some(new ProducerIdAndEpoch(producerId, (Short.MaxValue - 1).toShort)))
@@ -332,7 +332,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
     bumpProducerId = true
     transactions.foreach { txn =>
       val txnMetadata = prepareExhaustedEpochTxnMetadata(txn)
-      txnStateManager.putTransactionStateIfNotExists(txn.transactionalId, txnMetadata)
+      txnStateManager.putTransactionStateIfNotExists(txnMetadata)
 
       val bumpEpochReq = new InitProducerIdOperation(Some(new ProducerIdAndEpoch(producerId, (Short.MaxValue - 1).toShort)))
       bumpEpochReq.run(txn)
@@ -556,7 +556,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
 
   class LoadTxnPartitionAction(txnTopicPartitionId: Int) extends Action {
     override def run(): Unit = {
-      transactionCoordinator.handleTxnImmigration(txnTopicPartitionId, coordinatorEpoch)
+      transactionCoordinator.onElection(txnTopicPartitionId, coordinatorEpoch)
     }
     override def await(): Unit = {
       allTransactions.foreach { txn =>
@@ -570,7 +570,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
   class UnloadTxnPartitionAction(txnTopicPartitionId: Int) extends Action {
     val txnRecords: mutable.ArrayBuffer[SimpleRecord] = mutable.ArrayBuffer[SimpleRecord]()
     override def run(): Unit = {
-      transactionCoordinator.handleTxnEmigration(txnTopicPartitionId, coordinatorEpoch)
+      transactionCoordinator.onResignation(txnTopicPartitionId, Some(coordinatorEpoch))
     }
     override def await(): Unit = {
       allTransactions.foreach { txn =>

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -109,7 +109,7 @@ class TransactionCoordinatorTest {
       .andReturn(Right(None))
       .once()
 
-    EasyMock.expect(transactionManager.putTransactionStateIfNotExists(EasyMock.eq(transactionalId), EasyMock.capture(capturedTxn)))
+    EasyMock.expect(transactionManager.putTransactionStateIfNotExists(EasyMock.capture(capturedTxn)))
       .andAnswer(new IAnswer[Either[Errors, CoordinatorEpochAndTxnMetadata]] {
         override def answer(): Either[Errors, CoordinatorEpochAndTxnMetadata] = {
           assertTrue(capturedTxn.hasCaptured)
@@ -144,7 +144,7 @@ class TransactionCoordinatorTest {
       .andReturn(Right(None))
       .once()
 
-    EasyMock.expect(transactionManager.putTransactionStateIfNotExists(EasyMock.eq(transactionalId), EasyMock.capture(capturedTxn)))
+    EasyMock.expect(transactionManager.putTransactionStateIfNotExists(EasyMock.capture(capturedTxn)))
       .andAnswer(new IAnswer[Either[Errors, CoordinatorEpochAndTxnMetadata]] {
         override def answer(): Either[Errors, CoordinatorEpochAndTxnMetadata] = {
           assertTrue(capturedTxn.hasCaptured)
@@ -556,7 +556,7 @@ class TransactionCoordinatorTest {
     EasyMock.expect(transactionManager.validateTransactionTimeoutMs(EasyMock.anyInt()))
       .andReturn(true)
 
-    EasyMock.expect(transactionManager.putTransactionStateIfNotExists(EasyMock.eq(transactionalId), EasyMock.anyObject[TransactionMetadata]()))
+    EasyMock.expect(transactionManager.putTransactionStateIfNotExists(EasyMock.anyObject[TransactionMetadata]()))
       .andReturn(Right(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata)))
       .anyTimes()
 
@@ -595,7 +595,7 @@ class TransactionCoordinatorTest {
     EasyMock.expect(transactionManager.validateTransactionTimeoutMs(EasyMock.anyInt()))
       .andReturn(true)
 
-    EasyMock.expect(transactionManager.putTransactionStateIfNotExists(EasyMock.eq(transactionalId), EasyMock.anyObject[TransactionMetadata]()))
+    EasyMock.expect(transactionManager.putTransactionStateIfNotExists(EasyMock.anyObject[TransactionMetadata]()))
       .andReturn(Right(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata)))
       .anyTimes()
 
@@ -853,7 +853,7 @@ class TransactionCoordinatorTest {
     EasyMock.expect(transactionMarkerChannelManager.removeMarkersForTxnTopicPartition(0))
     EasyMock.replay(transactionManager, transactionMarkerChannelManager)
 
-    coordinator.handleTxnEmigration(0, coordinatorEpoch)
+    coordinator.onResignation(0, Some(coordinatorEpoch))
 
     EasyMock.verify(transactionManager, transactionMarkerChannelManager)
   }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -18,13 +18,14 @@ package kafka.coordinator.transaction
 
 import java.lang.management.ManagementFactory
 import java.nio.ByteBuffer
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.locks.ReentrantLock
 
 import javax.management.ObjectName
 import kafka.api.KAFKA_2_4_IV1
 import kafka.log.{AppendOrigin, Log}
 import kafka.server.{FetchDataInfo, FetchLogEnd, LogOffsetMetadata, ReplicaManager}
-import kafka.utils.{MockScheduler, Pool}
+import kafka.utils.{MockScheduler, Pool, TestUtils}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.internals.Topic.TRANSACTION_STATE_TOPIC_NAME
@@ -106,11 +107,104 @@ class TransactionStateManagerTest {
 
     assertEquals(Right(None), transactionManager.getTransactionState(transactionalId1))
     assertEquals(Right(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1)),
-      transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1))
+      transactionManager.putTransactionStateIfNotExists(txnMetadata1))
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))),
       transactionManager.getTransactionState(transactionalId1))
-    assertEquals(Right(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1)),
-      transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata2))
+    assertEquals(Right(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata2)),
+      transactionManager.putTransactionStateIfNotExists(txnMetadata2))
+  }
+
+  @Test
+  def testDeletePartition(): Unit = {
+    val metadata1 = transactionMetadata("b", 5L)
+    val metadata2 = transactionMetadata("a", 10L)
+
+    assertEquals(0, transactionManager.partitionFor(metadata1.transactionalId))
+    assertEquals(1, transactionManager.partitionFor(metadata2.transactionalId))
+
+    transactionManager.addLoadedTransactionsToCache(0, coordinatorEpoch, new Pool[String, TransactionMetadata]())
+    transactionManager.putTransactionStateIfNotExists(metadata1)
+
+    transactionManager.addLoadedTransactionsToCache(1, coordinatorEpoch, new Pool[String, TransactionMetadata]())
+    transactionManager.putTransactionStateIfNotExists(metadata2)
+
+    def cachedProducerEpoch(transactionalId: String): Option[Short] = {
+      transactionManager.getTransactionState(transactionalId).right.toOption.flatten
+        .map(_.transactionMetadata.producerEpoch)
+    }
+
+    assertEquals(Some(metadata1.producerEpoch), cachedProducerEpoch(metadata1.transactionalId))
+    assertEquals(Some(metadata2.producerEpoch), cachedProducerEpoch(metadata2.transactionalId))
+
+    transactionManager.removeTransactionsForTxnTopicPartition(0)
+
+    assertEquals(None, cachedProducerEpoch(metadata1.transactionalId))
+    assertEquals(Some(metadata2.producerEpoch), cachedProducerEpoch(metadata2.transactionalId))
+  }
+
+  @Test
+  def testDeleteLoadingPartition(): Unit = {
+    // Verify the handling of a call to delete state for a partition while it is in the
+    // process of being loaded. Basically should be treated as a no-op.
+
+    val startOffset = 0L
+    val endOffset = 1L
+
+    val fileRecordsMock = EasyMock.mock[FileRecords](classOf[FileRecords])
+    val logMock = EasyMock.mock[Log](classOf[Log])
+    EasyMock.expect(replicaManager.getLog(topicPartition)).andStubReturn(Some(logMock))
+    EasyMock.expect(logMock.logStartOffset).andStubReturn(startOffset)
+    EasyMock.expect(logMock.read(EasyMock.eq(startOffset),
+      maxLength = EasyMock.anyInt(),
+      isolation = EasyMock.eq(FetchLogEnd),
+      minOneMessage = EasyMock.eq(true))
+    ).andReturn(FetchDataInfo(LogOffsetMetadata(startOffset), fileRecordsMock))
+    EasyMock.expect(replicaManager.getLogEndOffset(topicPartition)).andStubReturn(Some(endOffset))
+
+    txnMetadata1.state = PrepareCommit
+    txnMetadata1.addPartitions(Set[TopicPartition](
+      new TopicPartition("topic1", 0),
+      new TopicPartition("topic1", 1)))
+    val records = MemoryRecords.withRecords(startOffset, CompressionType.NONE,
+      new SimpleRecord(txnMessageKeyBytes1, TransactionLog.valueToBytes(txnMetadata1.prepareNoTransit())))
+
+    // We create a latch which is awaited while the log is loading. This ensures that the deletion
+    // is triggered before the loading returns
+    val latch = new CountDownLatch(1)
+
+    EasyMock.expect(fileRecordsMock.sizeInBytes()).andStubReturn(records.sizeInBytes)
+    val bufferCapture = EasyMock.newCapture[ByteBuffer]
+    fileRecordsMock.readInto(EasyMock.capture(bufferCapture), EasyMock.anyInt())
+    EasyMock.expectLastCall().andAnswer(new IAnswer[Unit] {
+      override def answer: Unit = {
+        latch.await()
+        val buffer = bufferCapture.getValue
+        buffer.put(records.buffer.duplicate)
+        buffer.flip()
+      }
+    })
+
+    EasyMock.replay(logMock, fileRecordsMock, replicaManager)
+
+    val coordinatorEpoch = 0
+    val partitionAndLeaderEpoch = TransactionPartitionAndLeaderEpoch(partitionId, coordinatorEpoch)
+
+    val loadingThread = new Thread(new Runnable {
+      override def run(): Unit =
+        transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch, (_, _, _, _, _) => ())
+    })
+    loadingThread.start()
+    TestUtils.waitUntilTrue(() => transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch),
+      "Timed out waiting for loading partition", pause = 10)
+
+    transactionManager.removeTransactionsForTxnTopicPartition(partitionId)
+    assertFalse(transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch))
+
+    latch.countDown()
+    loadingThread.join()
+
+    // Verify that transaction state was not loaded
+    assertEquals(Left(Errors.NOT_COORDINATOR), transactionManager.getTransactionState(txnMetadata1.transactionalId))
   }
 
   @Test
@@ -218,7 +312,7 @@ class TransactionStateManagerTest {
     transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
 
     // first insert the initial transaction metadata
-    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata1)
 
     prepareForTxnMessageAppend(Errors.NONE)
     expectedError = Errors.NONE
@@ -237,7 +331,7 @@ class TransactionStateManagerTest {
   @Test
   def testAppendFailToCoordinatorNotAvailableError(): Unit = {
     transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
-    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata1)
 
     expectedError = Errors.COORDINATOR_NOT_AVAILABLE
     var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
@@ -269,7 +363,7 @@ class TransactionStateManagerTest {
   @Test
   def testAppendFailToNotCoordinatorError(): Unit = {
     transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
-    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata1)
 
     expectedError = Errors.NOT_COORDINATOR
     var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
@@ -287,7 +381,7 @@ class TransactionStateManagerTest {
     prepareForTxnMessageAppend(Errors.NONE)
     transactionManager.removeTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch)
     transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch + 1, new Pool[String, TransactionMetadata]())
-    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata1)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
 
     prepareForTxnMessageAppend(Errors.NONE)
@@ -299,7 +393,7 @@ class TransactionStateManagerTest {
   @Test
   def testAppendFailToCoordinatorLoadingError(): Unit = {
     transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
-    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata1)
 
     expectedError = Errors.COORDINATOR_LOAD_IN_PROGRESS
     val failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
@@ -313,7 +407,7 @@ class TransactionStateManagerTest {
   @Test
   def testAppendFailToUnknownError(): Unit = {
     transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
-    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata1)
 
     expectedError = Errors.UNKNOWN_SERVER_ERROR
     var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
@@ -333,7 +427,7 @@ class TransactionStateManagerTest {
   @Test
   def testPendingStateNotResetOnRetryAppend(): Unit = {
     transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
-    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata1)
 
     expectedError = Errors.COORDINATOR_NOT_AVAILABLE
     val failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
@@ -349,7 +443,7 @@ class TransactionStateManagerTest {
     transactionManager.addLoadedTransactionsToCache(partitionId, 0, new Pool[String, TransactionMetadata]())
 
     // first insert the initial transaction metadata
-    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata1)
 
     prepareForTxnMessageAppend(Errors.NONE)
     expectedError = Errors.NOT_COORDINATOR
@@ -368,7 +462,7 @@ class TransactionStateManagerTest {
   def testAppendTransactionToLogWhilePendingStateChanged(): Unit = {
     // first insert the initial transaction metadata
     transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
-    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata1)
 
     prepareForTxnMessageAppend(Errors.NONE)
     expectedError = Errors.INVALID_PRODUCER_EPOCH
@@ -397,12 +491,12 @@ class TransactionStateManagerTest {
       transactionManager.addLoadedTransactionsToCache(partitionId, 0, new Pool[String, TransactionMetadata]())
     }
 
-    transactionManager.putTransactionStateIfNotExists("ongoing", transactionMetadata("ongoing", producerId = 0, state = Ongoing))
-    transactionManager.putTransactionStateIfNotExists("not-expiring", transactionMetadata("not-expiring", producerId = 1, state = Ongoing, txnTimeout = 10000))
-    transactionManager.putTransactionStateIfNotExists("prepare-commit", transactionMetadata("prepare-commit", producerId = 2, state = PrepareCommit))
-    transactionManager.putTransactionStateIfNotExists("prepare-abort", transactionMetadata("prepare-abort", producerId = 3, state = PrepareAbort))
-    transactionManager.putTransactionStateIfNotExists("complete-commit", transactionMetadata("complete-commit", producerId = 4, state = CompleteCommit))
-    transactionManager.putTransactionStateIfNotExists("complete-abort", transactionMetadata("complete-abort", producerId = 5, state = CompleteAbort))
+    transactionManager.putTransactionStateIfNotExists(transactionMetadata("ongoing", producerId = 0, state = Ongoing))
+    transactionManager.putTransactionStateIfNotExists(transactionMetadata("not-expiring", producerId = 1, state = Ongoing, txnTimeout = 10000))
+    transactionManager.putTransactionStateIfNotExists(transactionMetadata("prepare-commit", producerId = 2, state = PrepareCommit))
+    transactionManager.putTransactionStateIfNotExists(transactionMetadata("prepare-abort", producerId = 3, state = PrepareAbort))
+    transactionManager.putTransactionStateIfNotExists(transactionMetadata("complete-commit", producerId = 4, state = CompleteCommit))
+    transactionManager.putTransactionStateIfNotExists(transactionMetadata("complete-abort", producerId = 5, state = CompleteAbort))
 
     time.sleep(2000)
     val expiring = transactionManager.timedOutTransactions()
@@ -483,13 +577,11 @@ class TransactionStateManagerTest {
     // immigrate partition at epoch 0
     transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 0, (_, _, _, _, _) => ())
     assertEquals(0, transactionManager.loadingPartitions.size)
-    assertEquals(0, transactionManager.leavingPartitions.size)
 
     // Re-immigrate partition at epoch 1. This should be successful even though we didn't get to emigrate the partition.
     prepareTxnLog(topicPartition, 0, records)
     transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 1, (_, _, _, _, _) => ())
     assertEquals(0, transactionManager.loadingPartitions.size)
-    assertEquals(0, transactionManager.leavingPartitions.size)
     assertTrue(transactionManager.transactionMetadataCache.get(partitionId).isDefined)
     assertEquals(1, transactionManager.transactionMetadataCache.get(partitionId).get.coordinatorEpoch)
   }
@@ -580,10 +672,10 @@ class TransactionStateManagerTest {
 
     txnMetadata1.txnLastUpdateTimestamp = time.milliseconds() - txnConfig.transactionalIdExpirationMs
     txnMetadata1.state = txnState
-    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata1)
 
     txnMetadata2.txnLastUpdateTimestamp = time.milliseconds()
-    transactionManager.putTransactionStateIfNotExists(transactionalId2, txnMetadata2)
+    transactionManager.putTransactionStateIfNotExists(txnMetadata2)
 
     transactionManager.enableTransactionalIdExpiration()
     time.sleep(txnConfig.removeExpiredTransactionalIdsIntervalMs)

--- a/core/src/test/scala/unit/kafka/security/auth/OperationTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/OperationTest.scala
@@ -21,6 +21,7 @@ import org.apache.kafka.common.acl.AclOperation
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@deprecated("Scala Authorizer API classes gave been deprecated", "Since 2.5")
 class OperationTest {
   /**
     * Test round trip conversions between org.apache.kafka.common.acl.AclOperation and

--- a/core/src/test/scala/unit/kafka/security/auth/PermissionTypeTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/PermissionTypeTest.scala
@@ -22,6 +22,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.scalatest.Assertions.fail
 
+@deprecated("Scala Authorizer API classes gave been deprecated", "Since 2.5")
 class PermissionTypeTest {
 
   @Test

--- a/core/src/test/scala/unit/kafka/security/auth/ResourceTypeTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/ResourceTypeTest.scala
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.scalatest.Assertions.fail
 import org.apache.kafka.common.resource.{ResourceType => JResourceType}
 
+@deprecated("Scala Authorizer API classes gave been deprecated", "Since 2.5")
 class ResourceTypeTest {
 
   @Test

--- a/core/src/test/scala/unit/kafka/security/auth/SimpleAclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/SimpleAclAuthorizerTest.scala
@@ -313,12 +313,12 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
     //test remove all acls for resource
     simpleAclAuthorizer.removeAcls(resource)
     TestUtils.waitAndVerifyAcls(Set.empty[Acl], simpleAclAuthorizer, resource)
-    assertTrue(!zkClient.resourceExists(resource))
+    assertTrue(!zkClient.resourceExists(resource.toPattern))
 
     //test removing last acl also deletes ZooKeeper path
     acls = changeAclAndVerify(Set.empty[Acl], Set(acl1), Set.empty[Acl])
     changeAclAndVerify(acls, Set.empty[Acl], acls)
-    assertTrue(!zkClient.resourceExists(resource))
+    assertTrue(!zkClient.resourceExists(resource.toPattern))
   }
 
   @Test
@@ -639,7 +639,7 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
   def testWritesExtendedAclChangeEventIfInterBrokerProtocolNotSet(): Unit = {
     givenAuthorizerWithProtocolVersion(Option.empty)
     val resource = Resource(Topic, "z_other", PREFIXED)
-    val expected = new String(ZkAclStore(PREFIXED).changeStore.createChangeNode(resource).bytes, UTF_8)
+    val expected = new String(ZkAclStore(PREFIXED).changeStore.createChangeNode(resource.toPattern).bytes, UTF_8)
 
     simpleAclAuthorizer.addAcls(Set[Acl](denyReadAcl), resource)
 
@@ -652,7 +652,7 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
   def testWritesExtendedAclChangeEventWhenInterBrokerProtocolAtLeastKafkaV2(): Unit = {
     givenAuthorizerWithProtocolVersion(Option(KAFKA_2_0_IV1))
     val resource = Resource(Topic, "z_other", PREFIXED)
-    val expected = new String(ZkAclStore(PREFIXED).changeStore.createChangeNode(resource).bytes, UTF_8)
+    val expected = new String(ZkAclStore(PREFIXED).changeStore.createChangeNode(resource.toPattern).bytes, UTF_8)
 
     simpleAclAuthorizer.addAcls(Set[Acl](denyReadAcl), resource)
 
@@ -665,7 +665,7 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
   def testWritesLiteralWritesLiteralAclChangeEventWhenInterBrokerProtocolLessThanKafkaV2eralAclChangesForOlderProtocolVersions(): Unit = {
     givenAuthorizerWithProtocolVersion(Option(KAFKA_2_0_IV0))
     val resource = Resource(Topic, "z_other", LITERAL)
-    val expected = new String(ZkAclStore(LITERAL).changeStore.createChangeNode(resource).bytes, UTF_8)
+    val expected = new String(ZkAclStore(LITERAL).changeStore.createChangeNode(resource.toPattern).bytes, UTF_8)
 
     simpleAclAuthorizer.addAcls(Set[Acl](denyReadAcl), resource)
 
@@ -678,7 +678,7 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
   def testWritesLiteralAclChangeEventWhenInterBrokerProtocolIsKafkaV2(): Unit = {
     givenAuthorizerWithProtocolVersion(Option(KAFKA_2_0_IV1))
     val resource = Resource(Topic, "z_other", LITERAL)
-    val expected = new String(ZkAclStore(LITERAL).changeStore.createChangeNode(resource).bytes, UTF_8)
+    val expected = new String(ZkAclStore(LITERAL).changeStore.createChangeNode(resource.toPattern).bytes, UTF_8)
 
     simpleAclAuthorizer.addAcls(Set[Acl](denyReadAcl), resource)
 

--- a/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
@@ -22,8 +22,7 @@ import java.util.UUID
 import java.util.concurrent.{Executors, Semaphore, TimeUnit}
 
 import kafka.api.{ApiVersion, KAFKA_2_0_IV0, KAFKA_2_0_IV1}
-import kafka.security.auth.Resource
-import kafka.security.authorizer.AuthorizerUtils.{WildcardHost, WildcardPrincipal}
+import kafka.security.authorizer.AclEntry.{WildcardHost, WildcardPrincipalString}
 import kafka.server.KafkaConfig
 import kafka.utils.{CoreUtils, TestUtils}
 import kafka.zk.{ZkAclStore, ZooKeeperTestHarness}
@@ -37,6 +36,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.{RequestContext, RequestHeader}
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourcePatternFilter, ResourceType}
+import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
 import org.apache.kafka.common.resource.ResourcePattern.WILDCARD_RESOURCE
 import org.apache.kafka.common.resource.ResourceType._
 import org.apache.kafka.common.resource.PatternType.{LITERAL, MATCH, PREFIXED}
@@ -52,14 +52,14 @@ import scala.compat.java8.OptionConverters._
 
 class AclAuthorizerTest extends ZooKeeperTestHarness {
 
-  private val allowReadAcl = new AccessControlEntry(WildcardPrincipal, WildcardHost, READ, ALLOW)
-  private val allowWriteAcl = new AccessControlEntry(WildcardPrincipal, WildcardHost, WRITE, ALLOW)
-  private val denyReadAcl = new AccessControlEntry(WildcardPrincipal, WildcardHost, READ, DENY)
+  private val allowReadAcl = new AccessControlEntry(WildcardPrincipalString, WildcardHost, READ, ALLOW)
+  private val allowWriteAcl = new AccessControlEntry(WildcardPrincipalString, WildcardHost, WRITE, ALLOW)
+  private val denyReadAcl = new AccessControlEntry(WildcardPrincipalString, WildcardHost, READ, DENY)
 
   private val wildCardResource = new ResourcePattern(TOPIC, WILDCARD_RESOURCE, LITERAL)
   private val prefixedResource = new ResourcePattern(TOPIC, "foo", PREFIXED)
-  private val clusterResource = new ResourcePattern(CLUSTER, Resource.ClusterResourceName, LITERAL)
-  private val wildcardPrincipal = JSecurityUtils.parseKafkaPrincipal(WildcardPrincipal)
+  private val clusterResource = new ResourcePattern(CLUSTER, CLUSTER_NAME, LITERAL)
+  private val wildcardPrincipal = JSecurityUtils.parseKafkaPrincipal(WildcardPrincipalString)
 
   private val aclAuthorizer = new AclAuthorizer
   private val aclAuthorizer2 = new AclAuthorizer
@@ -205,7 +205,7 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
     val host = InetAddress.getByName("192.168.2.1")
     val session = newRequestContext(user, host)
 
-    val allowAll = new AccessControlEntry(WildcardPrincipal, WildcardHost, AclOperation.ALL, ALLOW)
+    val allowAll = new AccessControlEntry(WildcardPrincipalString, WildcardHost, AclOperation.ALL, ALLOW)
     val denyAcl = new AccessControlEntry(user.toString, host.getHostAddress, AclOperation.ALL, DENY)
     val acls = Set(allowAll, denyAcl)
 
@@ -216,7 +216,7 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
 
   @Test
   def testAllowAllAccess(): Unit = {
-    val allowAllAcl = new AccessControlEntry(WildcardPrincipal, WildcardHost, AclOperation.ALL, ALLOW)
+    val allowAllAcl = new AccessControlEntry(WildcardPrincipalString, WildcardHost, AclOperation.ALL, ALLOW)
 
     changeAclAndVerify(Set.empty, Set(allowAllAcl), Set.empty)
 
@@ -226,7 +226,7 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
 
   @Test
   def testSuperUserHasAccess(): Unit = {
-    val denyAllAcl = new AccessControlEntry(WildcardPrincipal, WildcardHost, AclOperation.ALL, DENY)
+    val denyAllAcl = new AccessControlEntry(WildcardPrincipalString, WildcardHost, AclOperation.ALL, DENY)
 
     changeAclAndVerify(Set.empty, Set(denyAllAcl), Set.empty)
 
@@ -242,7 +242,7 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
    */
   @Test
   def testSuperUserWithCustomPrincipalHasAccess(): Unit = {
-    val denyAllAcl = new AccessControlEntry(WildcardPrincipal, WildcardHost, AclOperation.ALL, DENY)
+    val denyAllAcl = new AccessControlEntry(WildcardPrincipalString, WildcardHost, AclOperation.ALL, DENY)
     changeAclAndVerify(Set.empty, Set(denyAllAcl), Set.empty)
 
     val session = newRequestContext(new CustomPrincipal(KafkaPrincipal.USER_TYPE, "superuser1"), InetAddress.getByName("192.0.4.4"))
@@ -338,12 +338,12 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
     //test remove all acls for resource
     removeAcls(aclAuthorizer, Set.empty, resource)
     TestUtils.waitAndVerifyAcls(Set.empty[AccessControlEntry], aclAuthorizer, resource)
-    assertTrue(!zkClient.resourceExists(AuthorizerUtils.convertToResource(resource)))
+    assertTrue(!zkClient.resourceExists(resource))
 
     //test removing last acl also deletes ZooKeeper path
     acls = changeAclAndVerify(Set.empty, Set(acl1), Set.empty)
     changeAclAndVerify(acls, Set.empty, acls)
-    assertTrue(!zkClient.resourceExists(AuthorizerUtils.convertToResource(resource)))
+    assertTrue(!zkClient.resourceExists(resource))
   }
 
   @Test
@@ -678,7 +678,7 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
       1, getAcls(aclAuthorizer, new KafkaPrincipal(principal.getPrincipalType, principal.getName)).size)
 
     removeAcls(aclAuthorizer, Set.empty, resource)
-    val aclOnWildcardPrincipal = new AccessControlEntry(WildcardPrincipal, WildcardHost, WRITE, ALLOW)
+    val aclOnWildcardPrincipal = new AccessControlEntry(WildcardPrincipalString, WildcardHost, WRITE, ALLOW)
     addAcls(aclAuthorizer, Set(aclOnWildcardPrincipal), resource)
 
     assertEquals("acl on wildcard should be returned for wildcard request",
@@ -734,7 +734,7 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
     givenAuthorizerWithProtocolVersion(Option.empty)
     val resource = new ResourcePattern(TOPIC, "z_other", PREFIXED)
     val expected = new String(ZkAclStore(PREFIXED).changeStore
-      .createChangeNode(AuthorizerUtils.convertToResource(resource)).bytes, UTF_8)
+      .createChangeNode(resource).bytes, UTF_8)
 
     addAcls(aclAuthorizer, Set(denyReadAcl), resource)
 
@@ -748,7 +748,7 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
     givenAuthorizerWithProtocolVersion(Option(KAFKA_2_0_IV1))
     val resource = new ResourcePattern(TOPIC, "z_other", PREFIXED)
     val expected = new String(ZkAclStore(PREFIXED).changeStore
-      .createChangeNode(AuthorizerUtils.convertToResource(resource)).bytes, UTF_8)
+      .createChangeNode(resource).bytes, UTF_8)
 
     addAcls(aclAuthorizer, Set(denyReadAcl), resource)
 
@@ -762,7 +762,7 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
     givenAuthorizerWithProtocolVersion(Option(KAFKA_2_0_IV0))
     val resource = new ResourcePattern(TOPIC, "z_other", LITERAL)
     val expected = new String(ZkAclStore(LITERAL).changeStore
-      .createChangeNode(AuthorizerUtils.convertToResource(resource)).bytes, UTF_8)
+      .createChangeNode(resource).bytes, UTF_8)
 
     addAcls(aclAuthorizer, Set(denyReadAcl), resource)
 
@@ -776,7 +776,7 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
     givenAuthorizerWithProtocolVersion(Option(KAFKA_2_0_IV1))
     val resource = new ResourcePattern(TOPIC, "z_other", LITERAL)
     val expected = new String(ZkAclStore(LITERAL).changeStore
-      .createChangeNode(AuthorizerUtils.convertToResource(resource)).bytes, UTF_8)
+      .createChangeNode(resource).bytes, UTF_8)
 
     addAcls(aclAuthorizer, Set(denyReadAcl), resource)
 

--- a/core/src/test/scala/unit/kafka/security/authorizer/AclEntryTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AclEntryTest.scala
@@ -14,17 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package kafka.security.auth
+package kafka.security.authorizer
 
 import java.nio.charset.StandardCharsets.UTF_8
 
 import kafka.utils.Json
+import org.apache.kafka.common.acl.AclOperation.READ
+import org.apache.kafka.common.acl.AclPermissionType.{ALLOW, DENY}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.junit.{Assert, Test}
 import org.scalatestplus.junit.JUnitSuite
+
 import scala.collection.JavaConverters._
 
-class AclTest extends JUnitSuite {
+class AclEntryTest extends JUnitSuite {
 
   val AclJson = "{\"version\": 1, \"acls\": [{\"host\": \"host1\",\"permissionType\": \"Deny\",\"operation\": \"READ\", \"principal\": \"User:alice\"  },  " +
     "{  \"host\":  \"*\" ,  \"permissionType\": \"Allow\",  \"operation\":  \"Read\", \"principal\": \"User:bob\"  },  " +
@@ -32,15 +35,15 @@ class AclTest extends JUnitSuite {
 
   @Test
   def testAclJsonConversion(): Unit = {
-    val acl1 = new Acl(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "alice"), Deny, "host1" , Read)
-    val acl2 = new Acl(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "bob"), Allow, "*", Read)
-    val acl3 = new Acl(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "bob"), Deny, "host1", Read)
+    val acl1 = AclEntry(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "alice"), DENY, "host1" , READ)
+    val acl2 = AclEntry(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "bob"), ALLOW, "*", READ)
+    val acl3 = AclEntry(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "bob"), DENY, "host1", READ)
 
-    val acls = Set[Acl](acl1, acl2, acl3)
-    val jsonAcls = Json.encodeAsBytes(Acl.toJsonCompatibleMap(acls).asJava)
+    val acls = Set[AclEntry](acl1, acl2, acl3)
+    val jsonAcls = Json.encodeAsBytes(AclEntry.toJsonCompatibleMap(acls).asJava)
 
-    Assert.assertEquals(acls, Acl.fromBytes(jsonAcls))
-    Assert.assertEquals(acls, Acl.fromBytes(AclJson.getBytes(UTF_8)))
+    Assert.assertEquals(acls, AclEntry.fromBytes(jsonAcls))
+    Assert.assertEquals(acls, AclEntry.fromBytes(AclJson.getBytes(UTF_8)))
   }
 
 }

--- a/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
@@ -22,8 +22,8 @@ import java.nio.ByteBuffer
 import java.util.{Base64, Properties}
 
 import kafka.network.RequestChannel.Session
-import kafka.security.auth.Acl.WildCardHost
 import kafka.security.authorizer.{AclAuthorizer, AuthorizerUtils}
+import kafka.security.authorizer.AclEntry.WildcardHost
 import kafka.server.{CreateTokenResult, Defaults, DelegationTokenManager, KafkaConfig}
 import kafka.utils.TestUtils
 import kafka.zk.{KafkaZkClient, ZooKeeperTestHarness}
@@ -287,7 +287,7 @@ class DelegationTokenManagerTest extends ZooKeeperTestHarness  {
 
     //get all tokens for multiple owners (owner1, renewer4) and with permission
     createAcl(new AclBinding(new ResourcePattern(DELEGATION_TOKEN, tokenId3, LITERAL),
-      new AccessControlEntry(owner1.toString, WildCardHost, DESCRIBE, ALLOW)))
+      new AccessControlEntry(owner1.toString, WildcardHost, DESCRIBE, ALLOW)))
     tokens = getTokens(tokenManager, aclAuthorizer, hostSession, owner1, List(owner1, renewer4))
     assert(tokens.size == 3)
 
@@ -302,7 +302,7 @@ class DelegationTokenManagerTest extends ZooKeeperTestHarness  {
     //get all tokens for multiple owners (renewer2, renewer3) which are token renewers principals and with permissions
     hostSession = Session(renewer2, InetAddress.getByName("192.168.1.1"))
     createAcl(new AclBinding(new ResourcePattern(DELEGATION_TOKEN, tokenId2, LITERAL),
-      new AccessControlEntry(renewer2.toString, WildCardHost, DESCRIBE, ALLOW)))
+      new AccessControlEntry(renewer2.toString, WildcardHost, DESCRIBE, ALLOW)))
     tokens = getTokens(tokenManager, aclAuthorizer, hostSession,  renewer2, List(renewer2, renewer3))
     assert(tokens.size == 2)
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -38,6 +38,7 @@ import kafka.utils.{MockTime, TestUtils}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.apache.kafka.common.errors.UnsupportedVersionException
+import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocol
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity
@@ -62,7 +63,7 @@ import org.junit.Assert.{assertArrayEquals, assertEquals, assertNull, assertTrue
 import org.junit.{After, Test}
 
 import scala.collection.JavaConverters._
-import scala.collection.{Map, Seq}
+import scala.collection.{Map, Seq, mutable}
 
 class KafkaApisTest {
 
@@ -317,6 +318,40 @@ class KafkaApisTest {
       .asInstanceOf[WriteTxnMarkersResponse]
     assertEquals(expectedErrors, markersResponse.errors(1))
     EasyMock.verify(replicaManager)
+  }
+
+  @Test
+  def shouldResignCoordinatorsIfStopReplicaReceivedWithDeleteFlag(): Unit = {
+    val controllerId = 0
+    val controllerEpoch = 5
+    val brokerEpoch = 230498320L
+
+    val groupMetadataPartition = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)
+    val txnStatePartition = new TopicPartition(Topic.TRANSACTION_STATE_TOPIC_NAME, 0)
+
+    val (_, request) = buildRequest(new StopReplicaRequest.Builder(
+      ApiKeys.STOP_REPLICA.latestVersion,
+      controllerId,
+      controllerEpoch,
+      brokerEpoch,
+      true,
+      Set(groupMetadataPartition, txnStatePartition).asJava))
+
+    EasyMock.expect(replicaManager.stopReplicas(anyObject())).andReturn(
+      (mutable.Map(groupMetadataPartition -> Errors.NONE, txnStatePartition -> Errors.NONE), Errors.NONE))
+    EasyMock.expect(controller.brokerEpoch).andStubReturn(brokerEpoch)
+
+    txnCoordinator.onResignation(txnStatePartition.partition, None)
+    EasyMock.expectLastCall()
+
+    groupCoordinator.onResignation(groupMetadataPartition.partition)
+    EasyMock.expectLastCall()
+
+    EasyMock.replay(controller, replicaManager, txnCoordinator, groupCoordinator)
+
+    createKafkaApis().handleStopReplicaRequest(request)
+
+    EasyMock.verify(txnCoordinator, groupCoordinator)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -292,7 +292,7 @@ class RequestQuotaTest extends BaseRequestTest {
               )
           )
         case ApiKeys.OFFSET_FETCH =>
-          new OffsetFetchRequest.Builder("test-group", List(tp).asJava)
+          new OffsetFetchRequest.Builder("test-group", false, List(tp).asJava)
 
         case ApiKeys.FIND_COORDINATOR =>
           new FindCoordinatorRequest.Builder(

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -33,7 +33,7 @@ import javax.net.ssl.X509TrustManager
 import kafka.api._
 import kafka.cluster.{Broker, EndPoint}
 import kafka.log._
-import kafka.security.auth.{Acl, Authorizer, Resource}
+import kafka.security.auth.{Acl, Authorizer => LegacyAuthorizer, Resource}
 import kafka.server._
 import kafka.server.checkpoints.OffsetCheckpointFile
 import Implicits._
@@ -59,7 +59,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, Deserializer, IntegerSerializer, Serializer}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.utils.Utils._
-import org.apache.kafka.server.authorizer.{Authorizer => JAuthorizer}
+import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
 import org.apache.zookeeper.KeeperException.SessionExpiredException
 import org.apache.zookeeper.ZooDefs._
@@ -1192,7 +1192,7 @@ object TestUtils extends Logging {
     trustManager
   }
 
-  def waitAndVerifyAcls(expected: Set[AccessControlEntry], authorizer: JAuthorizer, resource: ResourcePattern) = {
+  def waitAndVerifyAcls(expected: Set[AccessControlEntry], authorizer: Authorizer, resource: ResourcePattern) = {
     val newLine = scala.util.Properties.lineSeparator
 
     val filter = new AclBindingFilter(resource.toFilter, AccessControlEntryFilter.ANY)
@@ -1201,7 +1201,8 @@ object TestUtils extends Logging {
         s"but got:${authorizer.acls(filter).asScala.map(_.entry).mkString(newLine + "\t", newLine + "\t", newLine)}", waitTimeMs = JTestUtils.DEFAULT_MAX_WAIT_MS)
   }
 
-  def waitAndVerifyAcls(expected: Set[Acl], authorizer: Authorizer, resource: Resource) = {
+  @deprecated("Use org.apache.kafka.server.authorizer.Authorizer", "Since 2.5")
+  def waitAndVerifyAcls(expected: Set[Acl], authorizer: LegacyAuthorizer, resource: Resource) = {
     val newLine = scala.util.Properties.lineSeparator
 
     waitUntilTrue(() => authorizer.getAcls(resource) == expected,
@@ -1549,6 +1550,22 @@ object TestUtils extends Logging {
         brokerIds.subsetOf(isr)
       },
       s"Expected brokers $brokerIds to be in the ISR for $partition"
+    )
+  }
+
+  def waitForReplicasAssigned(client: Admin, partition: TopicPartition, brokerIds: Seq[Int]): Unit = {
+    TestUtils.waitUntilTrue(
+      () => {
+        val description = client.describeTopics(Set(partition.topic).asJava).all.get.asScala
+        val replicas = description
+          .values
+          .flatMap(_.partitions.asScala.flatMap(_.replicas.asScala))
+          .map(_.id)
+          .toSeq
+
+        brokerIds == replicas
+      },
+      s"Expected brokers $brokerIds to be the replicas for $partition"
     )
   }
 

--- a/docs/introduction.html
+++ b/docs/introduction.html
@@ -37,13 +37,14 @@
       <li>The Kafka cluster stores streams of <i>records</i> in categories called <i>topics</i>.
     <li>Each record consists of a key, a value, and a timestamp.
   </ul>
-  <p>Kafka has four core APIs:</p>
+  <p>Kafka has five core APIs:</p>
   <div style="overflow: hidden;">
       <ul style="float: left; width: 40%;">
       <li>The <a href="/documentation.html#producerapi">Producer API</a> allows an application to publish a stream of records to one or more Kafka topics.
       <li>The <a href="/documentation.html#consumerapi">Consumer API</a> allows an application to subscribe to one or more topics and process the stream of records produced to them.
     <li>The <a href="/documentation/streams">Streams API</a> allows an application to act as a <i>stream processor</i>, consuming an input stream from one or more topics and producing an output stream to one or more output topics, effectively transforming the input streams to output streams.
     <li>The <a href="/documentation.html#connect">Connector API</a> allows building and running reusable producers or consumers that connect Kafka topics to existing applications or data systems. For example, a connector to a relational database might capture every change to a table.
+    <li>The <a href="/documentation.html#adminapi">Admin API</a> allows managing and inspecting topics, brokers and other Kafka objects.
   </ul>
       <img src="/{{version}}/images/kafka-apis.png" style="float: right; width: 50%;">
       </div>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -30,6 +30,11 @@
         <code>zookeeper.session.timeout.ms</code> has been increased from 6s to 18s and
         <code>replica.lag.time.max.ms</code> from 10s to 30s.</li>
     <li>New DSL operator <code>cogroup()</code> has been added for aggregating multiple streams together at once.</li>
+    <li>All Scala classes from the package <code>kafka.security.auth</code> have been deprecated. See
+        <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-504+-+Add+new+Java+Authorizer+Interface">KIP-504</a>
+        for details of the new Java authorizer API added in 2.4.0.  Note that <code>kafka.security.auth.Authorizer</code>
+        and <code>kafka.security.auth.SimpleAclAuthorizer</code> were deprecated in 2.4.0.
+    </li>
 </ul>
 
 <h4><a id="upgrade_2_4_0" href="#upgrade_2_4_0">Upgrading from 0.8.x, 0.9.x, 0.10.0.x, 0.10.1.x, 0.10.2.x, 0.11.0.x, 1.0.x, 1.1.x, 2.0.x or 2.1.x or 2.2.x or 2.3.x to 2.4.0</a></h4>
@@ -152,6 +157,13 @@
         will also never be called when the set of revoked partitions is empty. The callback will generally be invoked only at the end of a rebalance, and only on the set of partitions that are being moved to another consumer. The
         <code>onPartitionsAssigned</code> callback will however always be called, even with an empty set of partitions, as a way to notify users of a rebalance event (this is true for both cooperative and eager). For details on
         the new callback semantics, see the <a href="https://kafka.apache.org/24/javadoc/index.html?org/apache/kafka/clients/consumer/ConsumerRebalanceListener.html">ConsumerRebalanceListener javadocs</a>.
+    </li>
+    <li>The Scala trait <code>kafka.security.auth.Authorizer</code> has been deprecated and replaced with a new Java API
+        <code>org.apache.kafka.server.authorizer.Authorizer</code>. The authorizer implementation class
+        <code>kafka.security.auth.SimpleAclAuthorizer</code> has also been deprecated and replaced with a new
+        implementation <code>kafka.security.authorizer.AclAuthorizer</code>. <code>AclAuthorizer</code> uses features
+        supported by the new API to improve authorization logging and is compatible with <code>SimpleAclAuthorizer</code>.
+        For more details, see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-504+-+Add+new+Java+Authorizer+Interface">KIP-504</a>.
     </li>
 </ul>
 

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -16,7 +16,14 @@
  */
 package org.apache.kafka.streams;
 
+import java.util.LinkedList;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -45,12 +52,15 @@ import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.GlobalStreamThread;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
+import org.apache.kafka.streams.processor.internals.StandbyTask;
 import org.apache.kafka.streams.processor.internals.StateDirectory;
+import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsMetadataState;
 import org.apache.kafka.streams.processor.internals.ThreadStateTransitionValidator;
@@ -61,7 +71,6 @@ import org.apache.kafka.streams.state.StreamsMetadata;
 import org.apache.kafka.streams.state.internals.GlobalStateStoreProvider;
 import org.apache.kafka.streams.state.internals.QueryableStoreProvider;
 import org.apache.kafka.streams.state.internals.RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter;
-import org.apache.kafka.streams.state.internals.StateStoreProvider;
 import org.apache.kafka.streams.state.internals.StreamThreadStateStoreProvider;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 import org.slf4j.Logger;
@@ -212,7 +221,7 @@ public class KafkaStreams implements AutoCloseable {
             this.validTransitions.addAll(Arrays.asList(validTransitions));
         }
 
-        public boolean isRunning() {
+        public boolean isRunningOrRebalancing() {
             return equals(RUNNING) || equals(REBALANCING);
         }
 
@@ -296,14 +305,14 @@ public class KafkaStreams implements AutoCloseable {
         return state;
     }
 
-    private boolean isRunning() {
+    private boolean isRunningOrRebalancing() {
         synchronized (stateLock) {
-            return state.isRunning();
+            return state.isRunningOrRebalancing();
         }
     }
 
-    private void validateIsRunning() {
-        if (!isRunning()) {
+    private void validateIsRunningOrRebalancing() {
+        if (!isRunningOrRebalancing()) {
             throw new IllegalStateException("KafkaStreams is not running. State is " + state + ".");
         }
     }
@@ -738,7 +747,7 @@ public class KafkaStreams implements AutoCloseable {
         adminClient = clientSupplier.getAdmin(config.getAdminConfigs(StreamThread.getSharedAdminClientId(clientId)));
 
         final Map<Long, StreamThread.State> threadState = new HashMap<>(threads.length);
-        final ArrayList<StateStoreProvider> storeProviders = new ArrayList<>();
+        final ArrayList<StreamThreadStateStoreProvider> storeProviders = new ArrayList<>();
         for (int i = 0; i < threads.length; i++) {
             threads[i] = StreamThread.create(
                 internalTopologyBuilder,
@@ -1003,7 +1012,7 @@ public class KafkaStreams implements AutoCloseable {
      * @throws StreamsException if cleanup failed
      */
     public void cleanUp() {
-        if (isRunning()) {
+        if (isRunningOrRebalancing()) {
             throw new IllegalStateException("Cannot clean up while running.");
         }
         stateDirectory.clean();
@@ -1019,7 +1028,7 @@ public class KafkaStreams implements AutoCloseable {
      * @return {@link StreamsMetadata} for each {@code KafkaStreams} instances of this application
      */
     public Collection<StreamsMetadata> allMetadata() {
-        validateIsRunning();
+        validateIsRunningOrRebalancing();
         return streamsMetadataState.getAllMetadata();
     }
 
@@ -1039,7 +1048,7 @@ public class KafkaStreams implements AutoCloseable {
      * this application
      */
     public Collection<StreamsMetadata> allMetadataForStore(final String storeName) {
-        validateIsRunning();
+        validateIsRunningOrRebalancing();
         return streamsMetadataState.getAllMetadataForStore(storeName);
     }
 
@@ -1073,13 +1082,15 @@ public class KafkaStreams implements AutoCloseable {
      * @param key           the key to find metadata for
      * @param keySerializer serializer for the key
      * @param <K>           key type
-     * @return {@link StreamsMetadata} for the {@code KafkaStreams} instance with the provide {@code storeName} and
+     * @return {@link StreamsMetadata} for the {@code KafkaStreams} instance with the provided {@code storeName} and
      * {@code key} of this application or {@link StreamsMetadata#NOT_AVAILABLE} if Kafka Streams is (re-)initializing
+     * @deprecated Since 2.5. Use {@link #queryMetadataForKey(String, Object, Serializer)} instead.
      */
+    @Deprecated
     public <K> StreamsMetadata metadataForKey(final String storeName,
                                               final K key,
                                               final Serializer<K> keySerializer) {
-        validateIsRunning();
+        validateIsRunningOrRebalancing();
         return streamsMetadataState.getMetadataWithKey(storeName, key, keySerializer);
     }
 
@@ -1104,20 +1115,59 @@ public class KafkaStreams implements AutoCloseable {
      * @param key         the key to find metadata for
      * @param partitioner the partitioner to be use to locate the host for the key
      * @param <K>         key type
-     * @return {@link StreamsMetadata} for the {@code KafkaStreams} instance with the provide {@code storeName} and
+     * @return {@link StreamsMetadata} for the {@code KafkaStreams} instance with the provided {@code storeName} and
      * {@code key} of this application or {@link StreamsMetadata#NOT_AVAILABLE} if Kafka Streams is (re-)initializing
+     * @deprecated Since 2.5. Use {@link #queryMetadataForKey(String, Object, StreamPartitioner)} instead.
      */
+    @Deprecated
     public <K> StreamsMetadata metadataForKey(final String storeName,
                                               final K key,
                                               final StreamPartitioner<? super K, ?> partitioner) {
-        validateIsRunning();
+        validateIsRunningOrRebalancing();
         return streamsMetadataState.getMetadataWithKey(storeName, key, partitioner);
+    }
+
+    /**
+     * Finds the metadata containing the active hosts and standby hosts where the key being queried would reside.
+     *
+     * @param storeName     the {@code storeName} to find metadata for
+     * @param key           the key to find metadata for
+     * @param keySerializer serializer for the key
+     * @param <K>           key type
+     * Returns {@link KeyQueryMetadata} containing all metadata about hosting the given key for the given store.
+     */
+    public <K> KeyQueryMetadata queryMetadataForKey(final String storeName,
+                                                    final K key,
+                                                    final Serializer<K> keySerializer) {
+        validateIsRunningOrRebalancing();
+        return streamsMetadataState.getKeyQueryMetadataForKey(storeName, key, keySerializer);
+    }
+
+    /**
+     * Finds the metadata containing the active hosts and standby hosts where the key being queried would reside.
+     *
+     * @param storeName     the {@code storeName} to find metadata for
+     * @param key           the key to find metadata for
+     * @param partitioner the partitioner to be use to locate the host for the key
+     * @param <K>           key type
+     * Returns {@link KeyQueryMetadata} containing all metadata about hosting the given key for the given store, using the
+     * the supplied partitioner
+     */
+    public <K> KeyQueryMetadata queryMetadataForKey(final String storeName,
+                                                    final K key,
+                                                    final StreamPartitioner<? super K, ?> partitioner) {
+        validateIsRunningOrRebalancing();
+        return streamsMetadataState.getKeyQueryMetadataForKey(storeName, key, partitioner);
     }
 
     /**
      * Get a facade wrapping the local {@link StateStore} instances with the provided {@code storeName} if the Store's
      * type is accepted by the provided {@link QueryableStoreType#accepts(StateStore) queryableStoreType}.
      * The returned object can be used to query the {@link StateStore} instances.
+     *
+     * Only permits queries on active replicas of the store (no standbys or restoring replicas).
+     * See {@link KafkaStreams#store(java.lang.String, org.apache.kafka.streams.state.QueryableStoreType, boolean)}
+     * for the option to set {@code includeStaleStores} to true and trade off consistency in favor of availability.
      *
      * @param storeName           name of the store to find
      * @param queryableStoreType  accept only stores that are accepted by {@link QueryableStoreType#accepts(StateStore)}
@@ -1127,8 +1177,30 @@ public class KafkaStreams implements AutoCloseable {
      * {@code queryableStoreType} doesn't exist
      */
     public <T> T store(final String storeName, final QueryableStoreType<T> queryableStoreType) {
-        validateIsRunning();
-        return queryableStoreProvider.getStore(storeName, queryableStoreType);
+        return store(storeName, queryableStoreType, false);
+    }
+
+    /**
+     * Get a facade wrapping the local {@link StateStore} instances with the provided {@code storeName} if the Store's
+     * type is accepted by the provided {@link QueryableStoreType#accepts(StateStore) queryableStoreType}.
+     * The returned object can be used to query the {@link StateStore} instances.
+     *
+     * @param storeName           name of the store to find
+     * @param queryableStoreType  accept only stores that are accepted by {@link QueryableStoreType#accepts(StateStore)}
+     * @param includeStaleStores      If false, only permit queries on the active replica for a partition, and only if the
+     *                            task for that partition is running. I.e., the state store is not a standby replica,
+     *                            and it is not restoring from the changelog.
+     *                            If true, allow queries on standbys and restoring replicas in addition to active ones.
+     * @param <T>                 return type
+     * @return A facade wrapping the local {@link StateStore} instances
+     * @throws InvalidStateStoreException if Kafka Streams is (re-)initializing or a store with {@code storeName} and
+     * {@code queryableStoreType} doesn't exist
+     */
+    public <T> T store(final String storeName,
+                       final QueryableStoreType<T> queryableStoreType,
+                       final boolean includeStaleStores) {
+        validateIsRunningOrRebalancing();
+        return queryableStoreProvider.getStore(storeName, queryableStoreType, includeStaleStores);
     }
 
     /**
@@ -1137,11 +1209,81 @@ public class KafkaStreams implements AutoCloseable {
      * @return the set of {@link ThreadMetadata}.
      */
     public Set<ThreadMetadata> localThreadsMetadata() {
-        validateIsRunning();
+        validateIsRunningOrRebalancing();
         final Set<ThreadMetadata> threadMetadata = new HashSet<>();
         for (final StreamThread thread : threads) {
             threadMetadata.add(thread.threadMetadata());
         }
         return threadMetadata;
+    }
+
+    /**
+     * Returns {@link LagInfo}, for all store partitions (active or standby) local to this Streams instance. Note that the
+     * values returned are just estimates and meant to be used for making soft decisions on whether the data in the store
+     * partition is fresh enough for querying.
+     *
+     * Note: Each invocation of this method issues a call to the Kafka brokers. Thus its advisable to limit the frequency
+     * of invocation to once every few seconds.
+     *
+     * @return map of store names to another map of partition to {@link LagInfo}s
+     */
+    public Map<String, Map<Integer, LagInfo>> allLocalStorePartitionLags() {
+        final long latestSentinel = -2L;
+        final Map<String, Map<Integer, LagInfo>> localStorePartitionLags = new TreeMap<>();
+
+        final Collection<TopicPartition> allPartitions = new LinkedList<>();
+        final Map<TopicPartition, Long> allChangelogPositions = new HashMap<>();
+
+        // Obtain the current positions, of all the active-restoring and standby tasks
+        for (final StreamThread streamThread : threads) {
+            for (final StandbyTask standbyTask : streamThread.allStandbyTasks()) {
+                allPartitions.addAll(standbyTask.changelogPartitions());
+                // Note that not all changelog partitions, will have positions; since some may not have started
+                allChangelogPositions.putAll(standbyTask.changelogPositions());
+            }
+
+            final Set<TaskId> restoringTaskIds = streamThread.restoringTaskIds();
+            for (final StreamTask activeTask : streamThread.allStreamsTasks()) {
+                final Collection<TopicPartition> taskChangelogPartitions = activeTask.changelogPartitions();
+                allPartitions.addAll(taskChangelogPartitions);
+
+                final boolean isRestoring = restoringTaskIds.contains(activeTask.id());
+                final Map<TopicPartition, Long> restoredOffsets = activeTask.restoredOffsets();
+                for (final TopicPartition topicPartition : taskChangelogPartitions) {
+                    if (isRestoring && restoredOffsets.containsKey(topicPartition)) {
+                        allChangelogPositions.put(topicPartition, restoredOffsets.get(topicPartition));
+                    } else {
+                        allChangelogPositions.put(topicPartition, latestSentinel);
+                    }
+                }
+            }
+        }
+
+        log.debug("Current changelog positions: {}", allChangelogPositions);
+        final Map<TopicPartition, ListOffsetsResultInfo> allEndOffsets;
+        try {
+            allEndOffsets = adminClient.listOffsets(
+                allPartitions.stream()
+                    .collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()))
+            ).all().get();
+        } catch (final RuntimeException | InterruptedException | ExecutionException e) {
+            throw new StreamsException("Unable to obtain end offsets from kafka", e);
+        }
+        log.debug("Current end offsets :{}", allEndOffsets);
+        for (final Map.Entry<TopicPartition, ListOffsetsResultInfo> entry : allEndOffsets.entrySet()) {
+            // Avoiding an extra admin API lookup by computing lags for not-yet-started restorations
+            // from zero instead of the real "earliest offset" for the changelog.
+            // This will yield the correct relative order of lagginess for the tasks in the cluster,
+            // but it is an over-estimate of how much work remains to restore the task from scratch.
+            final long earliestOffset = 0L;
+            final long changelogPosition = allChangelogPositions.getOrDefault(entry.getKey(), earliestOffset);
+            final long latestOffset = entry.getValue().offset();
+            final LagInfo lagInfo = new LagInfo(changelogPosition == latestSentinel ? latestOffset : changelogPosition, latestOffset);
+            final String storeName = streamsMetadataState.getStoreForChangelogTopic(entry.getKey().topic());
+            localStorePartitionLags.computeIfAbsent(storeName, ignored -> new TreeMap<>())
+                .put(entry.getKey().partition(), lagInfo);
+        }
+
+        return Collections.unmodifiableMap(localStorePartitionLags);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import org.apache.kafka.streams.state.HostInfo;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents all the metadata related to a key, where a particular key resides in a {@link KafkaStreams} application.
+ * It contains the active {@link HostInfo} and a set of standby {@link HostInfo}s, denoting the instances where the key resides.
+ * It also contains the partition number where the key belongs, which could be useful when used in conjunction with other APIs.
+ * e.g: Relating with lags for that store partition.
+ * NOTE: This is a point in time view. It may change as rebalances happen.
+ */
+public class KeyQueryMetadata {
+    /**
+     * Sentinel to indicate that the KeyQueryMetadata is currently unavailable. This can occur during rebalance
+     * operations.
+     */
+    public static final KeyQueryMetadata NOT_AVAILABLE = new KeyQueryMetadata(new HostInfo("unavailable", -1),
+            Collections.emptySet(),
+            -1);
+
+    private final HostInfo activeHost;
+
+    private final Set<HostInfo> standbyHosts;
+
+    private final int partition;
+
+    public KeyQueryMetadata(final HostInfo activeHost, final Set<HostInfo> standbyHosts, final int partition) {
+        this.activeHost = activeHost;
+        this.standbyHosts = standbyHosts;
+        this.partition = partition;
+    }
+
+    /**
+     * Get the Active streams instance for given key
+     *
+     * @return active instance's {@link HostInfo}
+     */
+    public HostInfo getActiveHost() {
+        return activeHost;
+    }
+
+    /**
+     * Get the Streams instances that host the key as standbys
+     *
+     * @return set of standby {@link HostInfo} or a empty set, if no standbys are configured
+     */
+    public Set<HostInfo> getStandbyHosts() {
+        return standbyHosts;
+    }
+
+    /**
+     * Get the Store partition corresponding to the key.
+     *
+     * @return store partition number
+     */
+    public int getPartition() {
+        return partition;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (!(obj instanceof KeyQueryMetadata)) {
+            return false;
+        }
+        final KeyQueryMetadata keyQueryMetadata = (KeyQueryMetadata) obj;
+        return Objects.equals(keyQueryMetadata.activeHost, activeHost)
+            && Objects.equals(keyQueryMetadata.standbyHosts, standbyHosts)
+            && Objects.equals(keyQueryMetadata.partition, partition);
+    }
+
+    @Override
+    public String toString() {
+        return "KeyQueryMetadata {" +
+                "activeHost=" + activeHost +
+                ", standbyHosts=" + standbyHosts +
+                ", partition=" + partition +
+                '}';
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(activeHost, standbyHosts, partition);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/LagInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/LagInfo.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import java.util.Objects;
+
+/**
+ * Encapsulates information about lag, at a store partition replica (active or standby). This information is constantly changing as the
+ * tasks process records and thus, they should be treated as simply instantaenous measure of lag.
+ */
+public class LagInfo {
+
+    private final long currentOffsetPosition;
+
+    private final long endOffsetPosition;
+
+    private final long offsetLag;
+
+    LagInfo(final long currentOffsetPosition, final long endOffsetPosition) {
+        this.currentOffsetPosition = currentOffsetPosition;
+        this.endOffsetPosition = endOffsetPosition;
+        this.offsetLag = Math.max(0, endOffsetPosition - currentOffsetPosition);
+    }
+
+    /**
+     * Get the current maximum offset on the store partition's changelog topic, that has been successfully written into
+     * the store partition's state store.
+     *
+     * @return current consume offset for standby/restoring store partitions & simply endoffset for active store partition replicas
+     */
+    public long currentOffsetPosition() {
+        return this.currentOffsetPosition;
+    }
+
+    /**
+     * Get the end offset position for this store partition's changelog topic on the Kafka brokers.
+     *
+     * @return last offset written to the changelog topic partition
+     */
+    public long endOffsetPosition() {
+        return this.endOffsetPosition;
+    }
+
+    /**
+     * Get the measured lag between current and end offset positions, for this store partition replica
+     *
+     * @return lag as measured by message offsets
+     */
+    public long offsetLag() {
+        return this.offsetLag;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (!(obj instanceof LagInfo)) {
+            return false;
+        }
+        final LagInfo other = (LagInfo) obj;
+        return currentOffsetPosition == other.currentOffsetPosition
+            && endOffsetPosition == other.endOffsetPosition
+            && this.offsetLag == other.offsetLag;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currentOffsetPosition, endOffsetPosition, offsetLag);
+    }
+
+    @Override
+    public String toString() {
+        return "LagInfo {" +
+            " currentOffsetPosition=" + currentOffsetPosition +
+            ", endOffsetPosition=" + endOffsetPosition +
+            ", offsetLag=" + offsetLag +
+            '}';
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -302,10 +302,10 @@ public class StreamsConfig extends AbstractConfig {
     public static final String APPLICATION_ID_CONFIG = "application.id";
     private static final String APPLICATION_ID_DOC = "An identifier for the stream processing application. Must be unique within the Kafka cluster. It is used as 1) the default client-id prefix, 2) the group-id for membership management, 3) the changelog topic prefix.";
 
-    /**{@code user.endpoint} */
+    /**{@code application.server} */
     @SuppressWarnings("WeakerAccess")
     public static final String APPLICATION_SERVER_CONFIG = "application.server";
-    private static final String APPLICATION_SERVER_DOC = "A host:port pair pointing to an embedded user defined endpoint that can be used for discovering the locations of state stores within a single KafkaStreams application";
+    private static final String APPLICATION_SERVER_DOC = "A host:port pair pointing to a user-defined endpoint that can be used for state store discovery and interactive queries on this KafkaStreams instance.";
 
     /** {@code bootstrap.servers} */
     @SuppressWarnings("WeakerAccess")

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -601,30 +601,30 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> selector) {
-        return groupBy(selector, Grouped.with(null, valSerde));
+    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> keySelector) {
+        return groupBy(keySelector, Grouped.with(null, valSerde));
     }
 
     @Override
     @Deprecated
-    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> selector,
+    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> keySelector,
                                               final org.apache.kafka.streams.kstream.Serialized<KR, V> serialized) {
-        Objects.requireNonNull(selector, "selector can't be null");
+        Objects.requireNonNull(keySelector, "keySelector can't be null");
         Objects.requireNonNull(serialized, "serialized can't be null");
 
         final SerializedInternal<KR, V> serializedInternal = new SerializedInternal<>(serialized);
 
-        return groupBy(selector, Grouped.with(serializedInternal.keySerde(), serializedInternal.valueSerde()));
+        return groupBy(keySelector, Grouped.with(serializedInternal.keySerde(), serializedInternal.valueSerde()));
     }
 
     @Override
-    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> selector,
+    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> keySelector,
                                               final Grouped<KR, V> grouped) {
-        Objects.requireNonNull(selector, "selector can't be null");
+        Objects.requireNonNull(keySelector, "keySelector can't be null");
         Objects.requireNonNull(grouped, "grouped can't be null");
 
         final GroupedInternal<KR, V> groupedInternal = new GroupedInternal<>(grouped);
-        final ProcessorGraphNode<K, V> selectKeyMapNode = internalSelectKey(selector, new NamedInternal(groupedInternal.name()));
+        final ProcessorGraphNode<K, V> selectKeyMapNode = internalSelectKey(keySelector, new NamedInternal(groupedInternal.name()));
         selectKeyMapNode.keyChangingOperation(true);
 
         builder.addGraphNode(streamsGraphNode, selectKeyMapNode);
@@ -646,12 +646,16 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     @Override
     @Deprecated
     public KGroupedStream<K, V> groupByKey(final org.apache.kafka.streams.kstream.Serialized<K, V> serialized) {
+        Objects.requireNonNull(serialized, "serialized can't be null");
+
         final SerializedInternal<K, V> serializedInternal = new SerializedInternal<>(serialized);
         return groupByKey(Grouped.with(serializedInternal.keySerde(), serializedInternal.valueSerde()));
     }
 
     @Override
     public KGroupedStream<K, V> groupByKey(final Grouped<K, V> grouped) {
+        Objects.requireNonNull(grouped, "grouped can't be null");
+
         final GroupedInternal<K, V> groupedInternal = new GroupedInternal<>(grouped);
 
         return new KGroupedStreamImpl<>(
@@ -664,10 +668,10 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public <VO, VR> KStream<K, VR> join(final KStream<K, VO> other,
+    public <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
                                         final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                         final JoinWindows windows) {
-        return join(other, joiner, windows, Joined.with(null, null, null));
+        return join(otherStream, joiner, windows, Joined.with(null, null, null));
     }
 
     @Override
@@ -705,19 +709,19 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> other,
-                                             final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                             final JoinWindows windows) {
-        return outerJoin(other, joiner, windows, Joined.with(null, null, null));
+    public <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                            final JoinWindows windows) {
+        return leftJoin(otherStream, joiner, windows, Joined.with(null, null, null));
     }
 
     @Override
     @Deprecated
-    public <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> other,
-                                             final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                             final JoinWindows windows,
-                                             final Joined<K, V, VO> joined) {
-        Objects.requireNonNull(joined, "Joined can't be null");
+    public <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                            final JoinWindows windows,
+                                            final Joined<K, V, VO> joined) {
+        Objects.requireNonNull(joined, "joined can't be null");
 
         final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
         final StreamJoined<K, V, VO> streamJoined = StreamJoined
@@ -727,30 +731,69 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                 joinedInternal.otherValueSerde())
             .withName(joinedInternal.name());
 
-        return outerJoin(other, joiner, windows, streamJoined);
+        return leftJoin(otherStream, joiner, windows, streamJoined);
     }
 
     @Override
-    public <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> other,
+    public <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                            final JoinWindows windows,
+                                            final StreamJoined<K, V, VO> streamJoined) {
+        return doJoin(
+            otherStream,
+            joiner,
+            windows,
+            streamJoined,
+            new KStreamImplJoin(builder, true, false));
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
+                                             final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                             final JoinWindows windows) {
+        return outerJoin(otherStream, joiner, windows, Joined.with(null, null, null));
+    }
+
+    @Override
+    @Deprecated
+    public <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
+                                             final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                             final JoinWindows windows,
+                                             final Joined<K, V, VO> joined) {
+        Objects.requireNonNull(joined, "joined can't be null");
+
+        final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
+        final StreamJoined<K, V, VO> streamJoined = StreamJoined
+            .with(
+                joinedInternal.keySerde(),
+                joinedInternal.valueSerde(),
+                joinedInternal.otherValueSerde())
+            .withName(joinedInternal.name());
+
+        return outerJoin(otherStream, joiner, windows, streamJoined);
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
                                              final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                              final JoinWindows windows,
                                              final StreamJoined<K, V, VO> streamJoined) {
 
-        return doJoin(other, joiner, windows, streamJoined, new KStreamImplJoin(builder, true, true));
+        return doJoin(otherStream, joiner, windows, streamJoined, new KStreamImplJoin(builder, true, true));
     }
 
-    private <VO, VR> KStream<K, VR> doJoin(final KStream<K, VO> other,
+    private <VO, VR> KStream<K, VR> doJoin(final KStream<K, VO> otherStream,
                                            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                            final JoinWindows windows,
                                            final StreamJoined<K, V, VO> streamJoined,
                                            final KStreamImplJoin join) {
-        Objects.requireNonNull(other, "other KStream can't be null");
+        Objects.requireNonNull(otherStream, "otherStream can't be null");
         Objects.requireNonNull(joiner, "joiner can't be null");
         Objects.requireNonNull(windows, "windows can't be null");
         Objects.requireNonNull(streamJoined, "streamJoined can't be null");
 
         KStreamImpl<K, V> joinThis = this;
-        KStreamImpl<K, VO> joinOther = (KStreamImpl<K, VO>) other;
+        KStreamImpl<K, VO> joinOther = (KStreamImpl<K, VO>) otherStream;
 
         final StreamJoinedInternal<K, V, VO> streamJoinedInternal = new StreamJoinedInternal<>(streamJoined);
         final NamedInternal name = new NamedInternal(streamJoinedInternal.name());
@@ -857,55 +900,16 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> other,
-                                            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                            final JoinWindows windows) {
-        return leftJoin(other, joiner, windows, Joined.with(null, null, null));
-    }
-
-    @Override
-    @Deprecated
-    public <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> other,
-                                            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                            final JoinWindows windows,
-                                            final Joined<K, V, VO> joined) {
-        Objects.requireNonNull(joined, "Joined can't be null");
-
-        final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
-        final StreamJoined<K, V, VO> streamJoined = StreamJoined
-            .with(
-                joinedInternal.keySerde(),
-                joinedInternal.valueSerde(),
-                joinedInternal.otherValueSerde())
-            .withName(joinedInternal.name());
-
-        return leftJoin(other, joiner, windows, streamJoined);
-    }
-
-    @Override
-    public <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> other,
-                                            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                            final JoinWindows windows,
-                                            final StreamJoined<K, V, VO> streamJoined) {
-        return doJoin(
-            other,
-            joiner,
-            windows,
-            streamJoined,
-            new KStreamImplJoin(builder, true, false));
-    }
-
-    @Override
-    public <VO, VR> KStream<K, VR> join(final KTable<K, VO> other,
+    public <VO, VR> KStream<K, VR> join(final KTable<K, VO> table,
                                         final ValueJoiner<? super V, ? super VO, ? extends VR> joiner) {
-        return join(other, joiner, Joined.with(null, null, null));
+        return join(table, joiner, Joined.with(null, null, null));
     }
 
     @Override
-    public <VO, VR> KStream<K, VR> join(final KTable<K, VO> other,
+    public <VO, VR> KStream<K, VR> join(final KTable<K, VO> table,
                                         final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                         final Joined<K, V, VO> joined) {
-        Objects.requireNonNull(other, "other can't be null");
+        Objects.requireNonNull(table, "table can't be null");
         Objects.requireNonNull(joiner, "joiner can't be null");
         Objects.requireNonNull(joined, "joined can't be null");
 
@@ -918,22 +922,22 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                 joined.keySerde(),
                 joined.valueSerde()
             );
-            return thisStreamRepartitioned.doStreamTableJoin(other, joiner, joined, false);
+            return thisStreamRepartitioned.doStreamTableJoin(table, joiner, joined, false);
         } else {
-            return doStreamTableJoin(other, joiner, joined, false);
+            return doStreamTableJoin(table, joiner, joined, false);
         }
     }
 
     @Override
-    public <VO, VR> KStream<K, VR> leftJoin(final KTable<K, VO> other, final ValueJoiner<? super V, ? super VO, ? extends VR> joiner) {
-        return leftJoin(other, joiner, Joined.with(null, null, null));
+    public <VO, VR> KStream<K, VR> leftJoin(final KTable<K, VO> table, final ValueJoiner<? super V, ? super VO, ? extends VR> joiner) {
+        return leftJoin(table, joiner, Joined.with(null, null, null));
     }
 
     @Override
-    public <VO, VR> KStream<K, VR> leftJoin(final KTable<K, VO> other,
+    public <VO, VR> KStream<K, VR> leftJoin(final KTable<K, VO> table,
                                             final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                             final Joined<K, V, VO> joined) {
-        Objects.requireNonNull(other, "other can't be null");
+        Objects.requireNonNull(table, "table can't be null");
         Objects.requireNonNull(joiner, "joiner can't be null");
         Objects.requireNonNull(joined, "joined can't be null");
 
@@ -946,49 +950,49 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                 joined.keySerde(),
                 joined.valueSerde()
             );
-            return thisStreamRepartitioned.doStreamTableJoin(other, joiner, joined, true);
+            return thisStreamRepartitioned.doStreamTableJoin(table, joiner, joined, true);
         } else {
-            return doStreamTableJoin(other, joiner, joined, true);
+            return doStreamTableJoin(table, joiner, joined, true);
         }
     }
 
     @Override
     public <KG, VG, VR> KStream<K, VR> join(final GlobalKTable<KG, VG> globalTable,
-                                            final KeyValueMapper<? super K, ? super V, ? extends KG> keyMapper,
+                                            final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
                                             final ValueJoiner<? super V, ? super VG, ? extends VR> joiner) {
-        return globalTableJoin(globalTable, keyMapper, joiner, false, NamedInternal.empty());
+        return globalTableJoin(globalTable, keySelector, joiner, false, NamedInternal.empty());
     }
 
     @Override
     public <KG, VG, VR> KStream<K, VR> join(final GlobalKTable<KG, VG> globalTable,
-                                            final KeyValueMapper<? super K, ? super V, ? extends KG> keyMapper,
+                                            final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
                                             final ValueJoiner<? super V, ? super VG, ? extends VR> joiner,
                                             final Named named) {
-        return globalTableJoin(globalTable, keyMapper, joiner, false, named);
+        return globalTableJoin(globalTable, keySelector, joiner, false, named);
     }
 
     @Override
     public <KG, VG, VR> KStream<K, VR> leftJoin(final GlobalKTable<KG, VG> globalTable,
-                                                final KeyValueMapper<? super K, ? super V, ? extends KG> keyMapper,
+                                                final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
                                                 final ValueJoiner<? super V, ? super VG, ? extends VR> joiner) {
-        return globalTableJoin(globalTable, keyMapper, joiner, true, NamedInternal.empty());
+        return globalTableJoin(globalTable, keySelector, joiner, true, NamedInternal.empty());
     }
 
     @Override
     public <KG, VG, VR> KStream<K, VR> leftJoin(final GlobalKTable<KG, VG> globalTable,
-                                                final KeyValueMapper<? super K, ? super V, ? extends KG> keyMapper,
+                                                final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
                                                 final ValueJoiner<? super V, ? super VG, ? extends VR> joiner,
                                                 final Named named) {
-        return globalTableJoin(globalTable, keyMapper, joiner, true, named);
+        return globalTableJoin(globalTable, keySelector, joiner, true, named);
     }
 
     private <KG, VG, VR> KStream<K, VR> globalTableJoin(final GlobalKTable<KG, VG> globalTable,
-                                                        final KeyValueMapper<? super K, ? super V, ? extends KG> keyMapper,
+                                                        final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
                                                         final ValueJoiner<? super V, ? super VG, ? extends VR> joiner,
                                                         final boolean leftJoin,
                                                         final Named named) {
         Objects.requireNonNull(globalTable, "globalTable can't be null");
-        Objects.requireNonNull(keyMapper, "keyMapper can't be null");
+        Objects.requireNonNull(keySelector, "keySelector can't be null");
         Objects.requireNonNull(joiner, "joiner can't be null");
         Objects.requireNonNull(named, "named can't be null");
 
@@ -998,7 +1002,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final ProcessorSupplier<K, V> processorSupplier = new KStreamGlobalKTableJoin<>(
             valueGetterSupplier,
             joiner,
-            keyMapper,
+            keySelector,
             leftJoin);
         final ProcessorParameters<K, V> processorParameters = new ProcessorParameters<>(processorSupplier, name);
         final StreamTableJoinNode<K, V> streamTableJoinNode =
@@ -1018,21 +1022,21 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @SuppressWarnings("unchecked")
-    private <VO, VR> KStream<K, VR> doStreamTableJoin(final KTable<K, VO> other,
+    private <VO, VR> KStream<K, VR> doStreamTableJoin(final KTable<K, VO> table,
                                                       final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                                       final Joined<K, V, VO> joined,
                                                       final boolean leftJoin) {
-        Objects.requireNonNull(other, "other KTable can't be null");
+        Objects.requireNonNull(table, "table can't be null");
         Objects.requireNonNull(joiner, "joiner can't be null");
 
-        final Set<String> allSourceNodes = ensureCopartitionWith(Collections.singleton((AbstractStream<K, VO>) other));
+        final Set<String> allSourceNodes = ensureCopartitionWith(Collections.singleton((AbstractStream<K, VO>) table));
 
         final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
         final NamedInternal renamed = new NamedInternal(joinedInternal.name());
 
         final String name = renamed.orElseGenerateWithPrefix(builder, leftJoin ? LEFTJOIN_NAME : JOIN_NAME);
         final ProcessorSupplier<K, V> processorSupplier = new KStreamKTableJoin<>(
-            ((KTableImpl<K, ?, VO>) other).valueGetterSupplier(),
+            ((KTableImpl<K, ?, VO>) table).valueGetterSupplier(),
             joiner,
             leftJoin);
 
@@ -1040,7 +1044,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final StreamTableJoinNode<K, V> streamTableJoinNode = new StreamTableJoinNode<>(
             name,
             processorParameters,
-            ((KTableImpl<K, ?, VO>) other).valueGetterSupplier().storeNames(),
+            ((KTableImpl<K, ?, VO>) table).valueGetterSupplier().storeNames(),
             this.name
         );
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -254,5 +254,4 @@ public abstract class AbstractTask implements Task {
     public Collection<TopicPartition> changelogPartitions() {
         return stateMgr.changelogPartitions();
     }
-
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
@@ -34,8 +35,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements RestoringTasks {
-    private final Map<TaskId, StreamTask> suspended = new HashMap<>();
-    private final Map<TaskId, StreamTask> restoring = new HashMap<>();
+    private final Map<TaskId, StreamTask> suspended = new ConcurrentHashMap<>();
+    private final Map<TaskId, StreamTask> restoring = new ConcurrentHashMap<>();
     private final Set<TopicPartition> restoredPartitions = new HashSet<>();
     private final Map<TopicPartition, StreamTask> restoringByPartition = new HashMap<>();
     private final Set<TaskId> prevActiveTasks = new HashSet<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
 abstract class AssignedTasks<T extends Task> {
     final Logger log;
     final String taskTypeName;
-    final Map<TaskId, T> created = new HashMap<>();
+    final Map<TaskId, T> created = new ConcurrentHashMap<>();
 
     // IQ may access this map.
     final Map<TaskId, T> running = new ConcurrentHashMap<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -102,6 +102,9 @@ public class InternalTopologyBuilder {
     // map from state store names to this state store's corresponding changelog topic if possible
     private final Map<String, String> storeToChangelogTopic = new HashMap<>();
 
+    // map from changelog topic name to its corresponding state store.
+    private final Map<String, String> changelogTopicToStore = new HashMap<>();
+
     // all global topics
     private final Set<String> globalTopics = new HashSet<>();
 
@@ -599,12 +602,17 @@ public class InternalTopologyBuilder {
         nodeGroups = null;
     }
 
+    public Map<String, String> getChangelogTopicToStore() {
+        return changelogTopicToStore;
+    }
+
     public void connectSourceStoreAndTopic(final String sourceStoreName,
                                             final String topic) {
         if (storeToChangelogTopic.containsKey(sourceStoreName)) {
             throw new TopologyException("Source store " + sourceStoreName + " is already added.");
         }
         storeToChangelogTopic.put(sourceStoreName, topic);
+        changelogTopicToStore.put(topic, sourceStoreName);
     }
 
     public final void addInternalTopic(final String topicName) {
@@ -940,6 +948,7 @@ public class InternalTopologyBuilder {
                     if (stateStoreFactory.loggingEnabled() && !storeToChangelogTopic.containsKey(stateStoreName)) {
                         final String changelogTopic = ProcessorStateManager.storeChangelogTopic(applicationId, stateStoreName);
                         storeToChangelogTopic.put(stateStoreName, changelogTopic);
+                        changelogTopicToStore.put(changelogTopic, stateStoreName);
                     }
                     stateStoreMap.put(stateStoreName, stateStoreFactory.build());
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.FixedOrderMap;
@@ -100,9 +102,9 @@ public class ProcessorStateManager implements StateManager {
             partitionForTopic.put(source.topic(), source);
         }
         offsetLimits = new HashMap<>();
-        standbyRestoredOffsets = new HashMap<>();
+        standbyRestoredOffsets = new ConcurrentHashMap<>();
         this.isStandby = isStandby;
-        restoreCallbacks = isStandby ? new HashMap<>() : null;
+        restoreCallbacks = isStandby ? new ConcurrentHashMap<>() : null;
         recordConverters = isStandby ? new HashMap<>() : null;
         this.storeToChangelogTopic = new HashMap<>(storeToChangelogTopic);
 
@@ -255,6 +257,10 @@ public class ProcessorStateManager implements StateManager {
     private long offsetLimit(final TopicPartition partition) {
         final Long limit = offsetLimits.get(partition);
         return limit != null ? limit : Long.MAX_VALUE;
+    }
+
+    ChangelogReader changelogReader() {
+        return changelogReader;
     }
 
     @Override
@@ -451,5 +457,9 @@ public class ProcessorStateManager implements StateManager {
         }
 
         return result;
+    }
+
+    Map<TopicPartition, Long> standbyRestoredOffsets() {
+        return Collections.unmodifiableMap(standbyRestoredOffsets);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -199,6 +199,12 @@ public class StandbyTask extends AbstractTask {
         return Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 
+    public Map<TopicPartition, Long> changelogPositions() {
+        // this maintains the most upto date value of the latest offset for a record consumed off
+        // the changelog topic, that is also within the offsetLimit tracked.
+        return stateMgr.standbyRestoredOffsets();
+    }
+
     private long updateOffsetLimits(final TopicPartition partition) {
         if (!offsetLimits.containsKey(partition)) {
             throw new IllegalArgumentException("Topic is not both a source and a changelog: " + partition);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -46,7 +47,7 @@ public class StoreChangelogReader implements ChangelogReader {
     private final StateRestoreListener userStateRestoreListener;
     private final Map<TopicPartition, Long> restoreToOffsets = new HashMap<>();
     private final Map<String, List<PartitionInfo>> partitionInfo = new HashMap<>();
-    private final Map<TopicPartition, StateRestorer> stateRestorers = new HashMap<>();
+    private final Map<TopicPartition, StateRestorer> stateRestorers = new ConcurrentHashMap<>();
     private final Set<TopicPartition> needsRestoring = new HashSet<>();
     private final Set<TopicPartition> needsInitializing = new HashSet<>();
     private final Set<TopicPartition> completedRestorers = new HashSet<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -962,4 +962,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         }
         return partitionTimes;
     }
+
+    public Map<TopicPartition, Long> restoredOffsets() {
+        return stateMgr.changelogReader().restoredOffsets();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -59,6 +59,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -147,7 +148,7 @@ public class StreamThread extends Thread {
             this.validTransitions.addAll(Arrays.asList(validTransitions));
         }
 
-        public boolean isRunning() {
+        public boolean isAlive() {
             return equals(RUNNING) || equals(STARTING) || equals(PARTITIONS_REVOKED) || equals(PARTITIONS_ASSIGNED);
         }
 
@@ -235,14 +236,9 @@ public class StreamThread extends Thread {
         return oldState;
     }
 
-    public boolean isRunningAndNotRebalancing() {
-        // we do not need to grab stateLock since it is a single read
-        return state == State.RUNNING;
-    }
-
     public boolean isRunning() {
         synchronized (stateLock) {
-            return state.isRunning();
+            return state.isAlive();
         }
     }
 
@@ -1191,8 +1187,27 @@ public class StreamThread extends Thread {
             standbyTasksMetadata);
     }
 
-    public Map<TaskId, StreamTask> tasks() {
+    public Map<TaskId, StreamTask> activeTasks() {
         return taskManager.activeTasks();
+    }
+
+    public List<StreamTask> allStreamsTasks() {
+        return taskManager.allStreamsTasks();
+    }
+
+    public List<StandbyTask> allStandbyTasks() {
+        return taskManager.allStandbyTasks();
+    }
+
+    public Set<TaskId> restoringTaskIds() {
+        return taskManager.restoringTaskIds();
+    }
+
+    public Map<TaskId, Task> allTasks() {
+        final Map<TaskId, Task> result = new TreeMap<>();
+        result.putAll(taskManager.standbyTasks());
+        result.putAll(taskManager.activeTasks());
+        return result;
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -283,6 +283,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                         Collections.emptyList(),
                         Collections.emptyMap(),
                         Collections.emptyMap(),
+                        Collections.emptyMap(),
                         errorCode).encode()
                 ));
             }
@@ -620,7 +621,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // ---------------- Step Three ---------------- //
 
         // construct the global partition assignment per host map
-        final Map<HostInfo, Set<TopicPartition>> partitionsByHostState = new HashMap<>();
+        final Map<HostInfo, Set<TopicPartition>> partitionsByHost = new HashMap<>();
+        final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost = new HashMap<>();
         if (minReceivedMetadataVersion >= 2) {
             for (final Map.Entry<UUID, ClientMetadata> entry : clientMetadataMap.entrySet()) {
                 final HostInfo hostInfo = entry.getValue().hostInfo;
@@ -628,24 +630,31 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 // if application server is configured, also include host state map
                 if (hostInfo != null) {
                     final Set<TopicPartition> topicPartitions = new HashSet<>();
+                    final Set<TopicPartition> standbyPartitions = new HashSet<>();
                     final ClientState state = entry.getValue().state;
 
                     for (final TaskId id : state.activeTasks()) {
                         topicPartitions.addAll(partitionsForTask.get(id));
                     }
 
-                    partitionsByHostState.put(hostInfo, topicPartitions);
+                    for (final TaskId id : state.standbyTasks()) {
+                        standbyPartitions.addAll(partitionsForTask.get(id));
+                    }
+
+                    partitionsByHost.put(hostInfo, topicPartitions);
+                    standbyPartitionsByHost.put(hostInfo, standbyPartitions);
                 }
             }
         }
-        taskManager.setPartitionsByHostState(partitionsByHostState);
+        taskManager.setHostPartitionMappings(partitionsByHost, standbyPartitionsByHost);
 
         final Map<String, Assignment> assignment;
         if (versionProbing) {
             assignment = versionProbingAssignment(
                 clientMetadataMap,
                 partitionsForTask,
-                partitionsByHostState,
+                partitionsByHost,
+                standbyPartitionsByHost,
                 allOwnedPartitions,
                 minReceivedMetadataVersion,
                 minSupportedMetadataVersion
@@ -654,7 +663,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             assignment = computeNewAssignment(
                 clientMetadataMap,
                 partitionsForTask,
-                partitionsByHostState,
+                partitionsByHost,
+                standbyPartitionsByHost,
                 allOwnedPartitions,
                 minReceivedMetadataVersion,
                 minSupportedMetadataVersion
@@ -667,6 +677,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     private Map<String, Assignment> computeNewAssignment(final Map<UUID, ClientMetadata> clientsMetadata,
                                                          final Map<TaskId, Set<TopicPartition>> partitionsForTask,
                                                          final Map<HostInfo, Set<TopicPartition>> partitionsByHostState,
+                                                         final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                                                          final Set<TopicPartition> allOwnedPartitions,
                                                          final int minUserMetadataVersion,
                                                          final int minSupportedMetadataVersion) {
@@ -700,6 +711,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 clientMetadata,
                 partitionsForTask,
                 partitionsByHostState,
+                standbyPartitionsByHost,
                 allOwnedPartitions,
                 activeTaskAssignments,
                 interleavedStandby,
@@ -712,7 +724,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     private Map<String, Assignment> versionProbingAssignment(final Map<UUID, ClientMetadata> clientsMetadata,
                                                              final Map<TaskId, Set<TopicPartition>> partitionsForTask,
-                                                             final Map<HostInfo, Set<TopicPartition>> partitionsByHostState,
+                                                             final Map<HostInfo, Set<TopicPartition>> partitionsByHost,
+                                                             final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                                                              final Set<TopicPartition> allOwnedPartitions,
                                                              final int minUserMetadataVersion,
                                                              final int minSupportedMetadataVersion) {
@@ -734,7 +747,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 assignment,
                 clientMetadata,
                 partitionsForTask,
-                partitionsByHostState,
+                partitionsByHost,
+                standbyPartitionsByHost,
                 allOwnedPartitions,
                 interleavedActive,
                 interleavedStandby,
@@ -749,6 +763,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                                       final ClientMetadata clientMetadata,
                                       final Map<TaskId, Set<TopicPartition>> partitionsForTask,
                                       final Map<HostInfo, Set<TopicPartition>> partitionsByHostState,
+                                      final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                                       final Set<TopicPartition> allOwnedPartitions,
                                       final Map<String, List<TaskId>> activeTaskAssignments,
                                       final Map<String, List<TaskId>> standbyTaskAssignments,
@@ -785,6 +800,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                         assignedActiveList,
                         standbyTaskMap,
                         partitionsByHostState,
+                        standbyPartitionsByHost,
                         AssignorError.NONE.code()
                     ).encode()
                 )
@@ -1113,6 +1129,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // version 2 fields
         final Map<TopicPartition, PartitionInfo> topicToPartitionInfo = new HashMap<>();
         final Map<HostInfo, Set<TopicPartition>> partitionsByHost;
+        final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost;
 
         final Map<TopicPartition, TaskId> partitionsToTaskId = new HashMap<>();
 
@@ -1120,6 +1137,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             case 1:
                 processVersionOneAssignment(logPrefix, info, partitions, activeTasks, partitionsToTaskId);
                 partitionsByHost = Collections.emptyMap();
+                standbyPartitionsByHost = Collections.emptyMap();
                 break;
             case 2:
             case 3:
@@ -1127,6 +1145,12 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             case 5:
                 processVersionTwoAssignment(logPrefix, info, partitions, activeTasks, topicToPartitionInfo, partitionsToTaskId);
                 partitionsByHost = info.partitionsByHost();
+                standbyPartitionsByHost = Collections.emptyMap();
+                break;
+            case 6:
+                processVersionTwoAssignment(logPrefix, info, partitions, activeTasks, topicToPartitionInfo, partitionsToTaskId);
+                partitionsByHost = info.partitionsByHost();
+                standbyPartitionsByHost = info.standbyPartitionByHost();
                 break;
             default:
                 throw new IllegalStateException(
@@ -1136,7 +1160,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         }
 
         taskManager.setClusterMetadata(Cluster.empty().withPartitions(topicToPartitionInfo));
-        taskManager.setPartitionsByHostState(partitionsByHost);
+        taskManager.setHostPartitionMappings(partitionsByHost, standbyPartitionsByHost);
         taskManager.setPartitionsToTaskId(partitionsToTaskId);
         taskManager.setAssignmentMetadata(activeTasks, info.standbyTasks());
         taskManager.updateSubscriptionsFromAssignment(partitions);
@@ -1235,7 +1259,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     }
 
     private int updateMinReceivedVersion(final int usedVersion, final int minReceivedMetadataVersion) {
-        return usedVersion < minReceivedMetadataVersion ? usedVersion : minReceivedMetadataVersion;
+        return Math.min(usedVersion, minReceivedMetadataVersion);
     }
 
     private int updateMinSupportedVersion(final int supportedVersion, final int minSupportedMetadataVersion) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -377,6 +377,18 @@ public class TaskManager {
         consumer.pause(consumer.assignment());
     }
 
+    List<StreamTask> allStreamsTasks() {
+        return active.allTasks();
+    }
+
+    Set<TaskId> restoringTaskIds() {
+        return active.restoringTaskIds();
+    }
+
+    List<StandbyTask> allStandbyTasks() {
+        return standby.allTasks();
+    }
+
     /**
      * @throws IllegalStateException If store gets registered after initialized is already finished
      * @throws StreamsException if the store's change log does not contain the partition
@@ -440,8 +452,9 @@ public class TaskManager {
         this.cluster = cluster;
     }
 
-    public void setPartitionsByHostState(final Map<HostInfo, Set<TopicPartition>> partitionsByHostState) {
-        this.streamsMetadataState.onChange(partitionsByHostState, cluster);
+    public void setHostPartitionMappings(final Map<HostInfo, Set<TopicPartition>> partitionsByHost,
+                                         final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost) {
+        this.streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, cluster);
     }
 
     public void setPartitionsToTaskId(final Map<TopicPartition, TaskId> partitionsToTaskId) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -30,12 +30,15 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
@@ -49,24 +52,27 @@ public class AssignmentInfo {
     private List<TaskId> activeTasks;
     private Map<TaskId, Set<TopicPartition>> standbyTasks;
     private Map<HostInfo, Set<TopicPartition>> partitionsByHost;
+    private Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost;
 
     // used for decoding and "future consumer" assignments during version probing
     public AssignmentInfo(final int version,
                           final int commonlySupportedVersion) {
         this(version,
-            commonlySupportedVersion,
-            Collections.emptyList(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            0);
+             commonlySupportedVersion,
+             Collections.emptyList(),
+             Collections.emptyMap(),
+             Collections.emptyMap(),
+             Collections.emptyMap(),
+             0);
     }
 
     public AssignmentInfo(final int version,
                           final List<TaskId> activeTasks,
                           final Map<TaskId, Set<TopicPartition>> standbyTasks,
                           final Map<HostInfo, Set<TopicPartition>> partitionsByHost,
+                          final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                           final int errCode) {
-        this(version, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, partitionsByHost, errCode);
+        this(version, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, partitionsByHost, standbyPartitionsByHost, errCode);
     }
 
     public AssignmentInfo(final int version,
@@ -74,12 +80,14 @@ public class AssignmentInfo {
                           final List<TaskId> activeTasks,
                           final Map<TaskId, Set<TopicPartition>> standbyTasks,
                           final Map<HostInfo, Set<TopicPartition>> partitionsByHost,
+                          final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                           final int errCode) {
         this.usedVersion = version;
         this.commonlySupportedVersion = commonlySupportedVersion;
         this.activeTasks = activeTasks;
         this.standbyTasks = standbyTasks;
         this.partitionsByHost = partitionsByHost;
+        this.standbyPartitionsByHost = standbyPartitionsByHost;
         this.errCode = errCode;
 
         if (version < 1 || version > LATEST_SUPPORTED_VERSION) {
@@ -110,6 +118,10 @@ public class AssignmentInfo {
 
     public Map<HostInfo, Set<TopicPartition>> partitionsByHost() {
         return partitionsByHost;
+    }
+
+    public Map<HostInfo, Set<TopicPartition>> standbyPartitionByHost() {
+        return standbyPartitionsByHost;
     }
 
     /**
@@ -150,9 +162,16 @@ public class AssignmentInfo {
                     encodePartitionsByHostAsDictionary(out);
                     out.writeInt(errCode);
                     break;
+                case 6:
+                    out.writeInt(usedVersion);
+                    out.writeInt(commonlySupportedVersion);
+                    encodeActiveAndStandbyTaskAssignment(out);
+                    encodeActiveAndStandbyHostPartitions(out);
+                    out.writeInt(errCode);
+                    break;
                 default:
                     throw new IllegalStateException("Unknown metadata version: " + usedVersion
-                        + "; latest commonly supported version: " + commonlySupportedVersion);
+                            + "; latest commonly supported version: " + commonlySupportedVersion);
             }
 
             out.flush();
@@ -191,16 +210,31 @@ public class AssignmentInfo {
         }
     }
 
-    private void encodePartitionsByHostAsDictionary(final DataOutputStream out) throws IOException {
+    private void encodeHostPartitionMapUsingDictionary(final DataOutputStream out,
+                                                       final Map<String, Integer> topicNameDict,
+                                                       final Map<HostInfo, Set<TopicPartition>> hostPartitionMap) throws IOException {
+        // encode partitions by host
+        out.writeInt(hostPartitionMap.size());
 
+        // Write the topic index, partition
+        for (final Map.Entry<HostInfo, Set<TopicPartition>> entry : hostPartitionMap.entrySet()) {
+            writeHostInfo(out, entry.getKey());
+            out.writeInt(entry.getValue().size());
+            for (final TopicPartition partition : entry.getValue()) {
+                out.writeInt(topicNameDict.get(partition.topic()));
+                out.writeInt(partition.partition());
+            }
+        }
+    }
+
+    private Map<String, Integer> encodeTopicDictionaryAndGet(final DataOutputStream out,
+                                                             final Set<TopicPartition> topicPartitions) throws IOException {
         // Build a dictionary to encode topicNames
         int topicIndex = 0;
         final Map<String, Integer> topicNameDict = new HashMap<>();
-        for (final Map.Entry<HostInfo, Set<TopicPartition>> entry : partitionsByHost.entrySet()) {
-            for (final TopicPartition topicPartition : entry.getValue()) {
-                if (!topicNameDict.containsKey(topicPartition.topic())) {
-                    topicNameDict.put(topicPartition.topic(), topicIndex++);
-                }
+        for (final TopicPartition topicPartition : topicPartitions) {
+            if (!topicNameDict.containsKey(topicPartition.topic())) {
+                topicNameDict.put(topicPartition.topic(), topicIndex++);
             }
         }
 
@@ -211,18 +245,23 @@ public class AssignmentInfo {
             out.writeUTF(entry.getKey());
         }
 
-        // encode partitions by host
-        out.writeInt(partitionsByHost.size());
+        return topicNameDict;
+    }
 
-        // Write the topic index, partition
-        for (final Map.Entry<HostInfo, Set<TopicPartition>> entry : partitionsByHost.entrySet()) {
-            writeHostInfo(out, entry.getKey());
-            out.writeInt(entry.getValue().size());
-            for (final TopicPartition partition : entry.getValue()) {
-                out.writeInt(topicNameDict.get(partition.topic()));
-                out.writeInt(partition.partition());
-            }
-        }
+    private void encodePartitionsByHostAsDictionary(final DataOutputStream out) throws IOException {
+        final Set<TopicPartition> allTopicPartitions = partitionsByHost.values().stream()
+            .flatMap(Collection::stream).collect(Collectors.toSet());
+        final Map<String, Integer> topicNameDict = encodeTopicDictionaryAndGet(out, allTopicPartitions);
+        encodeHostPartitionMapUsingDictionary(out, topicNameDict, partitionsByHost);
+    }
+
+    private void encodeActiveAndStandbyHostPartitions(final DataOutputStream out) throws IOException {
+        final Set<TopicPartition> allTopicPartitions = Stream
+            .concat(partitionsByHost.values().stream(), standbyPartitionsByHost.values().stream())
+            .flatMap(Collection::stream).collect(Collectors.toSet());
+        final Map<String, Integer> topicNameDict = encodeTopicDictionaryAndGet(out, allTopicPartitions);
+        encodeHostPartitionMapUsingDictionary(out, topicNameDict, partitionsByHost);
+        encodeHostPartitionMapUsingDictionary(out, topicNameDict, standbyPartitionsByHost);
     }
 
     private void writeHostInfo(final DataOutputStream out, final HostInfo hostInfo) throws IOException {
@@ -287,6 +326,14 @@ public class AssignmentInfo {
                     decodePartitionsByHostUsingDictionary(assignmentInfo, in);
                     assignmentInfo.errCode = in.readInt();
                     break;
+                case 6:
+                    commonlySupportedVersion = in.readInt();
+                    assignmentInfo = new AssignmentInfo(usedVersion, commonlySupportedVersion);
+                    decodeActiveTasks(assignmentInfo, in);
+                    decodeStandbyTasks(assignmentInfo, in);
+                    decodeActiveAndStandbyHostPartitions(assignmentInfo, in);
+                    assignmentInfo.errCode = in.readInt();
+                    break;
                 default:
                     final TaskAssignmentException fatalException = new TaskAssignmentException("Unable to decode assignment data: " +
                         "used version: " + usedVersion + "; latest supported version: " + LATEST_SUPPORTED_VERSION);
@@ -320,7 +367,7 @@ public class AssignmentInfo {
     }
 
     private static void decodePartitionsByHost(final AssignmentInfo assignmentInfo,
-                                                   final DataInputStream in) throws IOException {
+                                               final DataInputStream in) throws IOException {
         assignmentInfo.partitionsByHost = new HashMap<>();
         final int numEntries = in.readInt();
         for (int i = 0; i < numEntries; i++) {
@@ -338,24 +385,41 @@ public class AssignmentInfo {
         return partitions;
     }
 
-    private static void decodePartitionsByHostUsingDictionary(final AssignmentInfo assignmentInfo,
-        final DataInputStream in) throws IOException {
-        assignmentInfo.partitionsByHost = new HashMap<>();
+    private static Map<Integer, String> decodeTopicIndexAndGet(final DataInputStream in) throws IOException {
         final int dictSize = in.readInt();
         final Map<Integer, String> topicIndexDict = new HashMap<>(dictSize);
         for (int i = 0; i < dictSize; i++) {
             topicIndexDict.put(in.readInt(), in.readUTF());
         }
+        return topicIndexDict;
+    }
 
+    private static Map<HostInfo, Set<TopicPartition>> decodeHostPartitionMapUsingDictionary(final DataInputStream in,
+                                                                                            final Map<Integer, String> topicIndexDict) throws IOException {
+        final Map<HostInfo, Set<TopicPartition>> hostPartitionMap = new HashMap<>();
         final int numEntries = in.readInt();
         for (int i = 0; i < numEntries; i++) {
             final HostInfo hostInfo = new HostInfo(in.readUTF(), in.readInt());
-            assignmentInfo.partitionsByHost.put(hostInfo, readTopicPartitions(in, topicIndexDict));
+            hostPartitionMap.put(hostInfo, readTopicPartitions(in, topicIndexDict));
         }
+        return hostPartitionMap;
+    }
+
+    private static void decodePartitionsByHostUsingDictionary(final AssignmentInfo assignmentInfo,
+                                                              final DataInputStream in) throws IOException {
+        final Map<Integer, String> topicIndexDict = decodeTopicIndexAndGet(in);
+        assignmentInfo.partitionsByHost = decodeHostPartitionMapUsingDictionary(in, topicIndexDict);
+    }
+
+    private static void decodeActiveAndStandbyHostPartitions(final AssignmentInfo assignmentInfo,
+                                                             final DataInputStream in) throws IOException {
+        final Map<Integer, String> topicIndexDict = decodeTopicIndexAndGet(in);
+        assignmentInfo.partitionsByHost = decodeHostPartitionMapUsingDictionary(in, topicIndexDict);
+        assignmentInfo.standbyPartitionsByHost = decodeHostPartitionMapUsingDictionary(in, topicIndexDict);
     }
 
     private static Set<TopicPartition> readTopicPartitions(final DataInputStream in,
-        final Map<Integer, String> topicIndexDict) throws IOException {
+                                                           final Map<Integer, String> topicIndexDict) throws IOException {
         final int numPartitions = in.readInt();
         final Set<TopicPartition> partitions = new HashSet<>(numPartitions);
         for (int j = 0; j < numPartitions; j++) {
@@ -366,8 +430,9 @@ public class AssignmentInfo {
 
     @Override
     public int hashCode() {
+        final int hostMapHashCode = partitionsByHost.hashCode() ^ standbyPartitionsByHost.hashCode();
         return usedVersion ^ commonlySupportedVersion ^ activeTasks.hashCode() ^ standbyTasks.hashCode()
-            ^ partitionsByHost.hashCode() ^ errCode;
+                ^ hostMapHashCode ^ errCode;
     }
 
     @Override
@@ -375,11 +440,12 @@ public class AssignmentInfo {
         if (o instanceof AssignmentInfo) {
             final AssignmentInfo other = (AssignmentInfo) o;
             return usedVersion == other.usedVersion &&
-                    commonlySupportedVersion == other.commonlySupportedVersion &&
-                    errCode == other.errCode &&
-                    activeTasks.equals(other.activeTasks) &&
-                    standbyTasks.equals(other.standbyTasks) &&
-                    partitionsByHost.equals(other.partitionsByHost);
+                   commonlySupportedVersion == other.commonlySupportedVersion &&
+                   errCode == other.errCode &&
+                   activeTasks.equals(other.activeTasks) &&
+                   standbyTasks.equals(other.standbyTasks) &&
+                   partitionsByHost.equals(other.partitionsByHost) &&
+                   standbyPartitionsByHost.equals(other.standbyPartitionsByHost);
         } else {
             return false;
         }
@@ -391,6 +457,8 @@ public class AssignmentInfo {
             + ", supported version=" + commonlySupportedVersion
             + ", active tasks=" + activeTasks
             + ", standby tasks=" + standbyTasks
-            + ", partitions by host=" + partitionsByHost + "]";
+            + ", partitions by host=" + partitionsByHost
+            + ", standbyPartitions by host=" + standbyPartitionsByHost
+            + "]";
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StreamsAssignmentProtocolVersions.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StreamsAssignmentProtocolVersions.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.processor.internals.assignment;
 public final class StreamsAssignmentProtocolVersions {
     public static final int UNKNOWN = -1;
     public static final int EARLIEST_PROBEABLE_VERSION = 3;
-    public static final int LATEST_SUPPORTED_VERSION = 5;
+    public static final int LATEST_SUPPORTED_VERSION = 6;
 
     private StreamsAssignmentProtocolVersions() {}
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state;
 
+import java.util.Objects;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.KafkaStreams;
 
@@ -36,31 +37,77 @@ public class StreamsMetadata {
      */
     public final static StreamsMetadata NOT_AVAILABLE = new StreamsMetadata(new HostInfo("unavailable", -1),
                                                                             Collections.emptySet(),
+                                                                            Collections.emptySet(),
+                                                                            Collections.emptySet(),
                                                                             Collections.emptySet());
 
     private final HostInfo hostInfo;
+
     private final Set<String> stateStoreNames;
+
     private final Set<TopicPartition> topicPartitions;
+
+    private final Set<String> standbyStateStoreNames;
+
+    private final Set<TopicPartition> standbyTopicPartitions;
 
     public StreamsMetadata(final HostInfo hostInfo,
                            final Set<String> stateStoreNames,
-                           final Set<TopicPartition> topicPartitions) {
+                           final Set<TopicPartition> topicPartitions,
+                           final Set<String> standbyStateStoreNames,
+                           final Set<TopicPartition> standbyTopicPartitions) {
 
         this.hostInfo = hostInfo;
         this.stateStoreNames = stateStoreNames;
         this.topicPartitions = topicPartitions;
+        this.standbyTopicPartitions = standbyTopicPartitions;
+        this.standbyStateStoreNames = standbyStateStoreNames;
     }
 
+    /**
+     * The value of {@link org.apache.kafka.streams.StreamsConfig#APPLICATION_SERVER_CONFIG} configured for the streams
+     * instance, which is typically host/port
+     *
+     * @return {@link HostInfo} corresponding to the streams instance
+     */
     public HostInfo hostInfo() {
         return hostInfo;
     }
 
+    /**
+     * State stores owned by the instance as an active replica
+     *
+     * @return set of active state store names
+     */
     public Set<String> stateStoreNames() {
         return stateStoreNames;
     }
 
+    /**
+     * Topic partitions consumed by the instance as an active replica
+     *
+     * @return set of active topic partitions
+     */
     public Set<TopicPartition> topicPartitions() {
         return topicPartitions;
+    }
+
+    /**
+     * (Source) Topic partitions for which the instance acts as standby.
+     *
+     * @return set of standby topic partitions
+     */
+    public Set<TopicPartition> standbyTopicPartitions() {
+        return standbyTopicPartitions;
+    }
+
+    /**
+     * State stores owned by the instance as a standby replica
+     *
+     * @return set of standby state store names
+     */
+    public Set<String> standbyStateStoreNames() {
+        return standbyStateStoreNames;
     }
 
     public String host() {
@@ -80,31 +127,28 @@ public class StreamsMetadata {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final StreamsMetadata that = (StreamsMetadata) o;
-        if (!hostInfo.equals(that.hostInfo)) {
-            return false;
-        }
-        if (!stateStoreNames.equals(that.stateStoreNames)) {
-            return false;
-        }
-        return topicPartitions.equals(that.topicPartitions);
 
+        final StreamsMetadata that = (StreamsMetadata) o;
+        return Objects.equals(hostInfo, that.hostInfo)
+            && Objects.equals(stateStoreNames, that.stateStoreNames)
+            && Objects.equals(topicPartitions, that.topicPartitions)
+            && Objects.equals(standbyStateStoreNames, that.standbyStateStoreNames)
+            && Objects.equals(standbyTopicPartitions, that.standbyTopicPartitions);
     }
 
     @Override
     public int hashCode() {
-        int result = hostInfo.hashCode();
-        result = 31 * result + stateStoreNames.hashCode();
-        result = 31 * result + topicPartitions.hashCode();
-        return result;
+        return Objects.hash(hostInfo, stateStoreNames, topicPartitions, standbyStateStoreNames, standbyTopicPartitions);
     }
 
     @Override
     public String toString() {
-        return "StreamsMetadata{" +
+        return "StreamsMetadata {" +
                 "hostInfo=" + hostInfo +
                 ", stateStoreNames=" + stateStoreNames +
                 ", topicPartitions=" + topicPartitions +
+                ", standbyStateStoreNames=" + standbyStateStoreNames +
+                ", standbyTopicPartitions=" + standbyTopicPartitions +
                 '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -23,17 +23,15 @@ import org.apache.kafka.streams.state.QueryableStoreType;
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.Collections.singletonList;
-
 /**
  * A wrapper over all of the {@link StateStoreProvider}s in a Topology
  */
 public class QueryableStoreProvider {
 
-    private final List<StateStoreProvider> storeProviders;
+    private final List<StreamThreadStateStoreProvider> storeProviders;
     private final GlobalStateStoreProvider globalStoreProvider;
 
-    public QueryableStoreProvider(final List<StateStoreProvider> storeProviders,
+    public QueryableStoreProvider(final List<StreamThreadStateStoreProvider> storeProviders,
                                   final GlobalStateStoreProvider globalStateStoreProvider) {
         this.storeProviders = new ArrayList<>(storeProviders);
         this.globalStoreProvider = globalStateStoreProvider;
@@ -45,24 +43,28 @@ public class QueryableStoreProvider {
      *
      * @param storeName          name of the store
      * @param queryableStoreType accept stores passing {@link QueryableStoreType#accepts(StateStore)}
+     * @param includeStaleStores     if true, include standbys and recovering stores;
+     *                                        if false, only include running actives.
      * @param <T>                The expected type of the returned store
      * @return A composite object that wraps the store instances.
      */
     public <T> T getStore(final String storeName,
-                          final QueryableStoreType<T> queryableStoreType) {
+                          final QueryableStoreType<T> queryableStoreType,
+                          final boolean includeStaleStores) {
         final List<T> globalStore = globalStoreProvider.stores(storeName, queryableStoreType);
         if (!globalStore.isEmpty()) {
-            return queryableStoreType.create(new WrappingStoreProvider(singletonList(globalStoreProvider)), storeName);
+            return queryableStoreType.create(globalStoreProvider, storeName);
         }
         final List<T> allStores = new ArrayList<>();
-        for (final StateStoreProvider storeProvider : storeProviders) {
-            allStores.addAll(storeProvider.stores(storeName, queryableStoreType));
+        for (final StreamThreadStateStoreProvider storeProvider : storeProviders) {
+            allStores.addAll(storeProvider.stores(storeName, queryableStoreType, includeStaleStores));
         }
         if (allStores.isEmpty()) {
             throw new InvalidStateStoreException("The state store, " + storeName + ", may have migrated to another instance.");
         }
         return queryableStoreType.create(
-                new WrappingStoreProvider(storeProviders),
-                storeName);
+            new WrappingStoreProvider(storeProviders, includeStaleStores),
+            storeName
+        );
     }
 }

--- a/streams/src/main/resources/common/message/SubscriptionInfo.json
+++ b/streams/src/main/resources/common/message/SubscriptionInfo.json
@@ -15,7 +15,7 @@
 
 {
   "name": "SubscriptionInfo",
-  "validVersions": "1-5",
+  "validVersions": "1-6",
   "fields": [
     {
       "name": "version",

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -17,9 +17,14 @@
 package org.apache.kafka.streams;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
@@ -313,6 +318,10 @@ public class KafkaStreamsTest {
                 Thread.sleep(50L);
                 return null;
             }).anyTimes();
+
+        EasyMock.expect(thread.allStandbyTasks()).andStubReturn(Collections.emptyList());
+        EasyMock.expect(thread.restoringTaskIds()).andStubReturn(Collections.emptySet());
+        EasyMock.expect(thread.allStreamsTasks()).andStubReturn(Collections.emptyList());
     }
 
     @Test
@@ -659,15 +668,43 @@ public class KafkaStreamsTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void shouldNotGetTaskWithKeyAndSerializerWhenNotRunning() {
+    public void shouldNotGetQueryMetadataWithSerializerWhenNotRunningOrRebalancing() {
         final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
-        streams.metadataForKey("store", "key", Serdes.String().serializer());
+        streams.queryMetadataForKey("store", "key", Serdes.String().serializer());
+    }
+
+    @Test
+    public void shouldGetQueryMetadataWithSerializerWhenRunningOrRebalancing() {
+        final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
+        streams.start();
+        assertEquals(KeyQueryMetadata.NOT_AVAILABLE, streams.queryMetadataForKey("store", "key", Serdes.String().serializer()));
     }
 
     @Test(expected = IllegalStateException.class)
-    public void shouldNotGetTaskWithKeyAndPartitionerWhenNotRunning() {
+    public void shouldNotGetQueryMetadataWithPartitionerWhenNotRunningOrRebalancing() {
         final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
-        streams.metadataForKey("store", "key", (topic, key, value, numPartitions) -> 0);
+        streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> 0);
+    }
+
+    @Test
+    public void shouldReturnEmptyLocalStorePartitionLags() {
+        // Mock all calls made to compute the offset lags,
+        final ListOffsetsResult result = EasyMock.mock(ListOffsetsResult.class);
+        final KafkaFutureImpl<Map<TopicPartition, ListOffsetsResultInfo>> allFuture = new KafkaFutureImpl<>();
+        allFuture.complete(Collections.emptyMap());
+
+        EasyMock.expect(result.all()).andReturn(allFuture);
+        final MockAdminClient mockAdminClient = EasyMock.partialMockBuilder(MockAdminClient.class)
+            .addMockedMethod("listOffsets", Map.class).createMock();
+        EasyMock.expect(mockAdminClient.listOffsets(anyObject())).andStubReturn(result);
+        final MockClientSupplier mockClientSupplier = EasyMock.partialMockBuilder(MockClientSupplier.class)
+            .addMockedMethod("getAdmin").createMock();
+        EasyMock.expect(mockClientSupplier.getAdmin(anyObject())).andReturn(mockAdminClient);
+        EasyMock.replay(result, mockAdminClient, mockClientSupplier);
+
+        final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, mockClientSupplier, time);
+        streams.start();
+        assertEquals(0, streams.allLocalStorePartitionLags().size());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import kafka.utils.MockTime;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreamsWrapper;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.LagInfo;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.streams.processor.internals.StreamThread;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+@Category({IntegrationTest.class})
+public class LagFetchIntegrationTest {
+
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+
+    private static final long CONSUMER_TIMEOUT_MS = 60000;
+
+    private final MockTime mockTime = CLUSTER.time;
+    private Properties streamsConfiguration;
+    private Properties consumerConfiguration;
+    private String inputTopicName;
+    private String outputTopicName;
+    private String stateStoreName;
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Before
+    public void before() {
+        inputTopicName = "input-topic-" + name.getMethodName();
+        outputTopicName = "output-topic-" + name.getMethodName();
+        stateStoreName = "lagfetch-test-store" + name.getMethodName();
+
+        streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "lag-fetch-" + name.getMethodName());
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+
+        consumerConfiguration = new Properties();
+        consumerConfiguration.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        consumerConfiguration.setProperty(ConsumerConfig.GROUP_ID_CONFIG, name.getMethodName() + "-consumer");
+        consumerConfiguration.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerConfiguration.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerConfiguration.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class.getName());
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
+    }
+
+    private void shouldFetchLagsDuringRebalancing(final String optimization) throws Exception {
+        final CountDownLatch latchTillActiveIsRunning = new CountDownLatch(1);
+        final CountDownLatch latchTillStandbyIsRunning = new CountDownLatch(1);
+        final CountDownLatch latchTillStandbyHasPartitionsAssigned = new CountDownLatch(1);
+        final CyclicBarrier lagCheckBarrier = new CyclicBarrier(2);
+        final List<KafkaStreamsWrapper> streamsList = new ArrayList<>();
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+            inputTopicName,
+            mkSet(new KeyValue<>("k1", 1L), new KeyValue<>("k2", 2L), new KeyValue<>("k3", 3L), new KeyValue<>("k4", 4L), new KeyValue<>("k5", 5L)),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                LongSerializer.class,
+                new Properties()),
+            mockTime);
+
+        // create stream threads
+        for (int i = 0; i < 2; i++) {
+            final Properties props = (Properties) streamsConfiguration.clone();
+            props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + i);
+            props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-" + i);
+            props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, optimization);
+            props.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+            props.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(stateStoreName + i).getAbsolutePath());
+
+            final StreamsBuilder builder = new StreamsBuilder();
+            final KTable<String, Long> t1 = builder.table(inputTopicName, Materialized.as(stateStoreName));
+            t1.toStream().to(outputTopicName);
+            final KafkaStreamsWrapper streams = new KafkaStreamsWrapper(builder.build(props), props);
+            streamsList.add(streams);
+        }
+
+        final KafkaStreamsWrapper activeStreams = streamsList.get(0);
+        final KafkaStreamsWrapper standbyStreams = streamsList.get(1);
+        activeStreams.setStreamThreadStateListener((thread, newState, oldState) -> {
+            if (newState == StreamThread.State.RUNNING) {
+                latchTillActiveIsRunning.countDown();
+            }
+        });
+        standbyStreams.setStreamThreadStateListener((thread, newState, oldState) -> {
+            if (oldState == StreamThread.State.PARTITIONS_ASSIGNED && newState == StreamThread.State.RUNNING) {
+                latchTillStandbyHasPartitionsAssigned.countDown();
+                try {
+                    lagCheckBarrier.await(60, TimeUnit.SECONDS);
+                } catch (final Exception e) {
+                    throw new RuntimeException(e);
+                }
+            } else if (newState == StreamThread.State.RUNNING) {
+                latchTillStandbyIsRunning.countDown();
+            }
+        });
+
+        try {
+            // First start up the active.
+            Map<String, Map<Integer, LagInfo>> offsetLagInfoMap = activeStreams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(0));
+            activeStreams.start();
+            latchTillActiveIsRunning.await(60, TimeUnit.SECONDS);
+
+            IntegrationTestUtils.waitUntilMinValuesRecordsReceived(
+                consumerConfiguration,
+                outputTopicName,
+                5,
+                CONSUMER_TIMEOUT_MS);
+            // Check the active reports proper lag values.
+            offsetLagInfoMap = activeStreams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(1));
+            assertThat(offsetLagInfoMap.keySet(), equalTo(mkSet(stateStoreName)));
+            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            LagInfo lagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
+            assertThat(lagInfo.currentOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.offsetLag(), equalTo(0L));
+
+            // start up the standby & make it pause right after it has partition assigned
+            standbyStreams.start();
+            latchTillStandbyHasPartitionsAssigned.await(60, TimeUnit.SECONDS);
+            offsetLagInfoMap = standbyStreams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(1));
+            assertThat(offsetLagInfoMap.keySet(), equalTo(mkSet(stateStoreName)));
+            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            lagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
+            assertThat(lagInfo.currentOffsetPosition(), equalTo(0L));
+            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.offsetLag(), equalTo(5L));
+            // standby thread wont proceed to RUNNING before this barrier is crossed
+            lagCheckBarrier.await(60, TimeUnit.SECONDS);
+
+            // wait till the lag goes down to 0, on the standby
+            TestUtils.waitForCondition(() -> standbyStreams.allLocalStorePartitionLags().get(stateStoreName).get(0).offsetLag() == 0,
+                "Standby should eventually catchup and have zero lag.");
+        } finally {
+            for (final KafkaStreams streams : streamsList) {
+                streams.close();
+            }
+        }
+    }
+
+    @Test
+    public void shouldFetchLagsDuringRebalancingWithOptimization() throws Exception {
+        shouldFetchLagsDuringRebalancing(StreamsConfig.OPTIMIZE);
+    }
+
+    @Test
+    public void shouldFetchLagsDuringRebalancingWithNoOptimization() throws Exception {
+        shouldFetchLagsDuringRebalancing(StreamsConfig.NO_OPTIMIZATION);
+    }
+
+    @Test
+    public void shouldFetchLagsDuringRestoration() throws Exception {
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+            inputTopicName,
+            mkSet(new KeyValue<>("k1", 1L), new KeyValue<>("k2", 2L), new KeyValue<>("k3", 3L), new KeyValue<>("k4", 4L), new KeyValue<>("k5", 5L)),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                LongSerializer.class,
+                new Properties()),
+            mockTime);
+
+        // create stream threads
+        final Properties props = (Properties) streamsConfiguration.clone();
+        final File stateDir = TestUtils.tempDirectory(stateStoreName + "0");
+        props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:0");
+        props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-0");
+        props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KTable<String, Long> t1 = builder.table(inputTopicName, Materialized.as(stateStoreName));
+        t1.toStream().to(outputTopicName);
+        final KafkaStreams streams = new KafkaStreams(builder.build(), props);
+
+        try {
+            // First start up the active.
+            Map<String, Map<Integer, LagInfo>> offsetLagInfoMap = streams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(0));
+
+            // Get the instance to fully catch up and reach RUNNING state
+            startApplicationAndWaitUntilRunning(Collections.singletonList(streams), Duration.ofSeconds(60));
+            IntegrationTestUtils.waitUntilMinValuesRecordsReceived(
+                consumerConfiguration,
+                outputTopicName,
+                5,
+                CONSUMER_TIMEOUT_MS);
+
+            // check for proper lag values.
+            offsetLagInfoMap = streams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(1));
+            assertThat(offsetLagInfoMap.keySet(), equalTo(mkSet(stateStoreName)));
+            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            final LagInfo zeroLagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
+            assertThat(zeroLagInfo.currentOffsetPosition(), equalTo(5L));
+            assertThat(zeroLagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(zeroLagInfo.offsetLag(), equalTo(0L));
+
+            // Kill instance, delete state to force restoration.
+            assertThat("Streams instance did not close within timeout", streams.close(Duration.ofSeconds(60)));
+            IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
+            Files.walk(stateDir.toPath()).sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(f -> assertTrue("Some state " + f + " could not be deleted", f.delete()));
+
+            // wait till the lag goes down to 0
+            final KafkaStreams restartedStreams = new KafkaStreams(builder.build(), props);
+            // set a state restoration listener to track progress of restoration
+            final Map<String, Map<Integer, LagInfo>> restoreStartLagInfo = new HashMap<>();
+            final Map<String, Map<Integer, LagInfo>> restoreEndLagInfo = new HashMap<>();
+            restartedStreams.setGlobalStateRestoreListener(new StateRestoreListener() {
+                @Override
+                public void onRestoreStart(final TopicPartition topicPartition, final String storeName, final long startingOffset, final long endingOffset) {
+                    restoreStartLagInfo.putAll(restartedStreams.allLocalStorePartitionLags());
+                }
+
+                @Override
+                public void onBatchRestored(final TopicPartition topicPartition, final String storeName, final long batchEndOffset, final long numRestored) {
+                }
+
+                @Override
+                public void onRestoreEnd(final TopicPartition topicPartition, final String storeName, final long totalRestored) {
+                    restoreEndLagInfo.putAll(restartedStreams.allLocalStorePartitionLags());
+                }
+            });
+
+            restartedStreams.start();
+            TestUtils.waitForCondition(() -> restartedStreams.allLocalStorePartitionLags().get(stateStoreName).get(0).offsetLag() == 0,
+                "Standby should eventually catchup and have zero lag.");
+            final LagInfo fullLagInfo = restoreStartLagInfo.get(stateStoreName).get(0);
+            assertThat(fullLagInfo.currentOffsetPosition(), equalTo(0L));
+            assertThat(fullLagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(fullLagInfo.offsetLag(), equalTo(5L));
+
+            assertThat(zeroLagInfo, equalTo(restoreEndLagInfo.get(stateStoreName).get(0)));
+        } finally {
+            streams.close();
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -49,6 +49,7 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -64,7 +65,7 @@ import org.junit.experimental.categories.Category;
 @Category(IntegrationTest.class)
 public class OptimizedKTableIntegrationTest {
     private static final int NUM_BROKERS = 1;
-
+    private static int port = 0;
     private static final String INPUT_TOPIC_NAME = "input-topic";
     private static final String TABLE_NAME = "source-table";
 
@@ -157,7 +158,9 @@ public class OptimizedKTableIntegrationTest {
             .store(TABLE_NAME, QueryableStoreTypes.keyValueStore());
 
         final boolean kafkaStreams1WasFirstActive;
-        if (store1.get(key) != null) {
+        final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
+
+        if ((keyQueryMetadata.getActiveHost().port() % 2) == 1) {
             kafkaStreams1WasFirstActive = true;
         } else {
             // Assert that data from the job was sent to the store
@@ -254,6 +257,7 @@ public class OptimizedKTableIntegrationTest {
         final Properties config = new Properties();
         config.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
         config.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        config.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + String.valueOf(++port));
         config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(applicationId).getPath());
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQuerySuite.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQuerySuite.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.streams.state.internals.CompositeReadOnlyKeyValueStoreTest;
+import org.apache.kafka.streams.state.internals.CompositeReadOnlySessionStoreTest;
+import org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStoreTest;
+import org.apache.kafka.streams.state.internals.GlobalStateStoreProviderTest;
+import org.apache.kafka.streams.state.internals.StreamThreadStateStoreProviderTest;
+import org.apache.kafka.streams.state.internals.WrappingStoreProviderTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * This suite runs all the tests related to querying StateStores (IQ).
+ *
+ * It can be used from an IDE to selectively just run these tests.
+ *
+ * Tests ending in the word "Suite" are excluded from the gradle build because it
+ * already runs the component tests individually.
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+                        CompositeReadOnlyKeyValueStoreTest.class,
+                        CompositeReadOnlyWindowStoreTest.class,
+                        CompositeReadOnlySessionStoreTest.class,
+                        GlobalStateStoreProviderTest.class,
+                        StreamThreadStateStoreProviderTest.class,
+                        WrappingStoreProviderTest.class,
+                        QueryableStateIntegrationTest.class,
+                    })
+public class StoreQuerySuite {
+}
+
+

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
@@ -36,6 +36,7 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
+import static org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -87,9 +88,9 @@ public class StreamsUpgradeTestIntegrationTest {
         final AtomicInteger usedVersion6 = new AtomicInteger();
         final KafkaStreams kafkaStreams6 = buildFutureStreams(usedVersion6);
         startSync(kafkaStreams6);
-        assertThat(usedVersion6.get(), is(LATEST_SUPPORTED_VERSION + 1));
-        assertThat(usedVersion5.get(), is(LATEST_SUPPORTED_VERSION + 1));
-        assertThat(usedVersion4.get(), is(LATEST_SUPPORTED_VERSION + 1));
+        retryOnExceptionWithTimeout(() -> assertThat(usedVersion6.get(), is(LATEST_SUPPORTED_VERSION + 1)));
+        retryOnExceptionWithTimeout(() -> assertThat(usedVersion5.get(), is(LATEST_SUPPORTED_VERSION + 1)));
+        retryOnExceptionWithTimeout(() -> assertThat(usedVersion4.get(), is(LATEST_SUPPORTED_VERSION + 1)));
 
         kafkaStreams4.close(Duration.ZERO);
         kafkaStreams5.close(Duration.ZERO);
@@ -99,14 +100,14 @@ public class StreamsUpgradeTestIntegrationTest {
         kafkaStreams6.close();
     }
 
-    public static KafkaStreams buildFutureStreams(final AtomicInteger usedVersion4) {
+    private static KafkaStreams buildFutureStreams(final AtomicInteger usedVersion4) {
         final Properties properties = new Properties();
         properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         properties.put("test.future.metadata", usedVersion4);
         return StreamsUpgradeTest.buildStreams(properties);
     }
 
-    public static void startSync(final KafkaStreams... kafkaStreams) throws InterruptedException {
+    private static void startSync(final KafkaStreams... kafkaStreams) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(kafkaStreams.length);
         for (final KafkaStreams streams : kafkaStreams) {
             streams.setStateListener((newState, oldState) -> {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
@@ -343,7 +343,7 @@ public class SuppressionIntegrationTest {
     }
 
     private static void verifyErrorShutdown(final KafkaStreams driver) throws InterruptedException {
-        waitForCondition(() -> !driver.state().isRunning(), DEFAULT_TIMEOUT, "Streams didn't shut down.");
+        waitForCondition(() -> !driver.state().isRunningOrRebalancing(), DEFAULT_TIMEOUT, "Streams didn't shut down.");
         assertThat(driver.state(), is(KafkaStreams.State.ERROR));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -22,18 +22,14 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TopologyWrapper;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.kstream.Predicate;
-import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.state.HostInfo;
-import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StreamsMetadata;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +41,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -60,7 +59,8 @@ public class StreamsMetadataStateTest {
     private TopicPartition topic1P0;
     private TopicPartition topic2P0;
     private TopicPartition topic3P0;
-    private Map<HostInfo, Set<TopicPartition>> hostToPartitions;
+    private Map<HostInfo, Set<TopicPartition>> hostToActivePartitions;
+    private Map<HostInfo, Set<TopicPartition>> hostToStandbyPartitions;
     private StreamsBuilder builder;
     private TopicPartition topic1P1;
     private TopicPartition topic2P1;
@@ -68,32 +68,28 @@ public class StreamsMetadataStateTest {
     private Cluster cluster;
     private final String globalTable = "global-table";
     private StreamPartitioner<String, Object> partitioner;
+    private Set<String> storeNames;
 
     @Before
     public void before() {
         builder = new StreamsBuilder();
         final KStream<Object, Object> one = builder.stream("topic-one");
-        one.groupByKey().count(Materialized.<Object, Long, KeyValueStore<Bytes, byte[]>>as("table-one"));
+        one.groupByKey().count(Materialized.as("table-one"));
 
         final KStream<Object, Object> two = builder.stream("topic-two");
-        two.groupByKey().count(Materialized.<Object, Long, KeyValueStore<Bytes, byte[]>>as("table-two"));
+        two.groupByKey().count(Materialized.as("table-two"));
 
         builder.stream("topic-three")
                 .groupByKey()
-                .count(Materialized.<Object, Long, KeyValueStore<Bytes, byte[]>>as("table-three"));
+                .count(Materialized.as("table-three"));
 
-        one.merge(two).groupByKey().count(Materialized.<Object, Long, KeyValueStore<Bytes, byte[]>>as("merged-table"));
+        one.merge(two).groupByKey().count(Materialized.as("merged-table"));
 
-        builder.stream("topic-four").mapValues(new ValueMapper<Object, Object>() {
-            @Override
-            public Object apply(final Object value) {
-                return value;
-            }
-        });
+        builder.stream("topic-four").mapValues(value -> value);
 
         builder.globalTable("global-topic",
                             Consumed.with(null, null),
-                            Materialized.<Object, Object, KeyValueStore<Bytes, byte[]>>as(globalTable));
+                            Materialized.as(globalTable));
 
         TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("appId");
 
@@ -107,10 +103,14 @@ public class StreamsMetadataStateTest {
         hostOne = new HostInfo("host-one", 8080);
         hostTwo = new HostInfo("host-two", 9090);
         hostThree = new HostInfo("host-three", 7070);
-        hostToPartitions = new HashMap<>();
-        hostToPartitions.put(hostOne, Utils.mkSet(topic1P0, topic2P1, topic4P0));
-        hostToPartitions.put(hostTwo, Utils.mkSet(topic2P0, topic1P1));
-        hostToPartitions.put(hostThree, Collections.singleton(topic3P0));
+        hostToActivePartitions = new HashMap<>();
+        hostToActivePartitions.put(hostOne, mkSet(topic1P0, topic2P1, topic4P0));
+        hostToActivePartitions.put(hostTwo, mkSet(topic2P0, topic1P1));
+        hostToActivePartitions.put(hostThree, Collections.singleton(topic3P0));
+        hostToStandbyPartitions = new HashMap<>();
+        hostToStandbyPartitions.put(hostThree, mkSet(topic1P0, topic2P1, topic4P0));
+        hostToStandbyPartitions.put(hostOne, mkSet(topic2P0, topic1P1));
+        hostToStandbyPartitions.put(hostTwo, Collections.singleton(topic3P0));
 
         final List<PartitionInfo> partitionInfos = Arrays.asList(
                 new PartitionInfo("topic-one", 0, null, null, null),
@@ -122,28 +122,35 @@ public class StreamsMetadataStateTest {
 
         cluster = new Cluster(null, Collections.<Node>emptyList(), partitionInfos, Collections.<String>emptySet(), Collections.<String>emptySet());
         metadataState = new StreamsMetadataState(TopologyWrapper.getInternalTopologyBuilder(builder.build()), hostOne);
-        metadataState.onChange(hostToPartitions, cluster);
-        partitioner = new StreamPartitioner<String, Object>() {
-            @Override
-            public Integer partition(final String topic, final String key, final Object value, final int numPartitions) {
-                return 1;
-            }
-        };
+        metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions, cluster);
+        partitioner = (topic, key, value, numPartitions) -> 1;
+        storeNames = mkSet("table-one", "table-two", "merged-table", globalTable);
     }
 
     @Test
-    public void shouldNotThrowNPEWhenOnChangeNotCalled() {
-        new StreamsMetadataState(TopologyWrapper.getInternalTopologyBuilder(builder.build()), hostOne).getAllMetadataForStore("store");
+    public void shouldNotThrowExceptionWhenOnChangeNotCalled() {
+        final Collection<StreamsMetadata> metadata = new StreamsMetadataState(
+            TopologyWrapper.getInternalTopologyBuilder(builder.build()), hostOne).getAllMetadataForStore("store");
+        assertEquals(0, metadata.size());
     }
 
     @Test
     public void shouldGetAllStreamInstances() {
-        final StreamsMetadata one = new StreamsMetadata(hostOne, Utils.mkSet(globalTable, "table-one", "table-two", "merged-table"),
-                Utils.mkSet(topic1P0, topic2P1, topic4P0));
-        final StreamsMetadata two = new StreamsMetadata(hostTwo, Utils.mkSet(globalTable, "table-two", "table-one", "merged-table"),
-                Utils.mkSet(topic2P0, topic1P1));
-        final StreamsMetadata three = new StreamsMetadata(hostThree, Utils.mkSet(globalTable, "table-three"),
-                Collections.singleton(topic3P0));
+        final StreamsMetadata one = new StreamsMetadata(hostOne,
+            mkSet(globalTable, "table-one", "table-two", "merged-table"),
+            mkSet(topic1P0, topic2P1, topic4P0),
+            mkSet("table-one", "table-two", "merged-table"),
+            mkSet(topic2P0, topic1P1));
+        final StreamsMetadata two = new StreamsMetadata(hostTwo,
+            mkSet(globalTable, "table-two", "table-one", "merged-table"),
+            mkSet(topic2P0, topic1P1),
+            mkSet("table-three"),
+            mkSet(topic3P0));
+        final StreamsMetadata three = new StreamsMetadata(hostThree,
+            mkSet(globalTable, "table-three"),
+            Collections.singleton(topic3P0),
+            mkSet("table-one", "table-two", "merged-table"),
+            mkSet(topic1P0, topic2P1, topic4P0));
 
         final Collection<StreamsMetadata> actual = metadataState.getAllMetadata();
         assertEquals(3, actual.size());
@@ -154,35 +161,41 @@ public class StreamsMetadataStateTest {
 
     @Test
     public void shouldGetAllStreamsInstancesWithNoStores() {
-        builder.stream("topic-five").filter(new Predicate<Object, Object>() {
-            @Override
-            public boolean test(final Object key, final Object value) {
-                return true;
-            }
-        }).to("some-other-topic");
+        builder.stream("topic-five").filter((key, value) -> true).to("some-other-topic");
 
         final TopicPartition tp5 = new TopicPartition("topic-five", 1);
         final HostInfo hostFour = new HostInfo("host-four", 8080);
-        hostToPartitions.put(hostFour, Utils.mkSet(tp5));
+        hostToActivePartitions.put(hostFour, mkSet(tp5));
 
-        metadataState.onChange(hostToPartitions, cluster.withPartitions(Collections.singletonMap(tp5, new PartitionInfo("topic-five", 1, null, null, null))));
+        metadataState.onChange(hostToActivePartitions, Collections.emptyMap(),
+            cluster.withPartitions(Collections.singletonMap(tp5, new PartitionInfo("topic-five", 1, null, null, null))));
 
         final StreamsMetadata expected = new StreamsMetadata(hostFour, Collections.singleton(globalTable),
-                Collections.singleton(tp5));
+                Collections.singleton(tp5), Collections.emptySet(), Collections.emptySet());
         final Collection<StreamsMetadata> actual = metadataState.getAllMetadata();
         assertTrue("expected " + actual + " to contain " + expected, actual.contains(expected));
     }
 
     @Test
     public void shouldGetInstancesForStoreName() {
-        final StreamsMetadata one = new StreamsMetadata(hostOne, Utils.mkSet(globalTable, "table-one", "table-two", "merged-table"),
-                Utils.mkSet(topic1P0, topic2P1, topic4P0));
-        final StreamsMetadata two = new StreamsMetadata(hostTwo, Utils.mkSet(globalTable, "table-two", "table-one", "merged-table"),
-                Utils.mkSet(topic2P0, topic1P1));
+        final StreamsMetadata one = new StreamsMetadata(hostOne,
+            mkSet(globalTable, "table-one", "table-two", "merged-table"),
+            mkSet(topic1P0, topic2P1, topic4P0),
+            mkSet("table-one", "table-two", "merged-table"),
+            mkSet(topic2P0, topic1P1));
+        final StreamsMetadata two = new StreamsMetadata(hostTwo,
+            mkSet(globalTable, "table-two", "table-one", "merged-table"),
+            mkSet(topic2P0, topic1P1),
+            mkSet("table-three"),
+            mkSet(topic3P0));
         final Collection<StreamsMetadata> actual = metadataState.getAllMetadataForStore("table-one");
-        assertEquals(2, actual.size());
+        final Map<HostInfo, StreamsMetadata> actualAsMap = actual.stream()
+            .collect(Collectors.toMap(StreamsMetadata::hostInfo, Function.identity()));
+        assertEquals(3, actual.size());
         assertTrue("expected " + actual + " to contain " + one, actual.contains(one));
         assertTrue("expected " + actual + " to contain " + two, actual.contains(two));
+        assertTrue("expected " + hostThree + " to contain as standby",
+            actualAsMap.get(hostThree).standbyStateStoreNames().contains("table-one"));
     }
 
     @Test(expected = NullPointerException.class)
@@ -199,64 +212,61 @@ public class StreamsMetadataStateTest {
     @Test
     public void shouldGetInstanceWithKey() {
         final TopicPartition tp4 = new TopicPartition("topic-three", 1);
-        hostToPartitions.put(hostTwo, Utils.mkSet(topic2P0, tp4));
+        hostToActivePartitions.put(hostTwo, mkSet(topic2P0, tp4));
 
-        metadataState.onChange(hostToPartitions, cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
+        metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions,
+            cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
 
-        final StreamsMetadata expected = new StreamsMetadata(hostThree, Utils.mkSet(globalTable, "table-three"),
-                Collections.singleton(topic3P0));
-
-        final StreamsMetadata actual = metadataState.getMetadataWithKey("table-three",
+        final KeyQueryMetadata expected = new KeyQueryMetadata(hostThree, mkSet(hostTwo), 0);
+        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("table-three",
                                                                     "the-key",
                                                                     Serdes.String().serializer());
-
         assertEquals(expected, actual);
     }
 
     @Test
     public void shouldGetInstanceWithKeyAndCustomPartitioner() {
         final TopicPartition tp4 = new TopicPartition("topic-three", 1);
-        hostToPartitions.put(hostTwo, Utils.mkSet(topic2P0, tp4));
+        hostToActivePartitions.put(hostTwo, mkSet(topic2P0, tp4));
 
-        metadataState.onChange(hostToPartitions, cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
+        metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions,
+            cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
 
-        final StreamsMetadata expected = new StreamsMetadata(hostTwo, Utils.mkSet(globalTable, "table-two", "table-three", "merged-table"),
-                Utils.mkSet(topic2P0, tp4));
+        final KeyQueryMetadata expected = new KeyQueryMetadata(hostTwo, Collections.emptySet(), 1);
 
-        final StreamsMetadata actual = metadataState.getMetadataWithKey("table-three", "the-key", partitioner);
+        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("table-three",
+                "the-key",
+                partitioner);
         assertEquals(expected, actual);
+        assertEquals(1, actual.getPartition());
     }
 
     @Test
     public void shouldReturnNotAvailableWhenClusterIsEmpty() {
-        metadataState.onChange(Collections.<HostInfo, Set<TopicPartition>>emptyMap(), Cluster.empty());
-        final StreamsMetadata result = metadataState.getMetadataWithKey("table-one", "a", Serdes.String().serializer());
-        assertEquals(StreamsMetadata.NOT_AVAILABLE, result);
+        metadataState.onChange(Collections.emptyMap(), Collections.emptyMap(), Cluster.empty());
+        final KeyQueryMetadata result = metadataState.getKeyQueryMetadataForKey("table-one", "a", Serdes.String().serializer());
+        assertEquals(KeyQueryMetadata.NOT_AVAILABLE, result);
     }
 
     @Test
     public void shouldGetInstanceWithKeyWithMergedStreams() {
         final TopicPartition topic2P2 = new TopicPartition("topic-two", 2);
-        hostToPartitions.put(hostTwo, Utils.mkSet(topic2P0, topic1P1, topic2P2));
-        metadataState.onChange(hostToPartitions, cluster.withPartitions(Collections.singletonMap(topic2P2, new PartitionInfo("topic-two", 2, null, null, null))));
+        hostToActivePartitions.put(hostTwo, mkSet(topic2P0, topic1P1, topic2P2));
+        hostToStandbyPartitions.put(hostOne, mkSet(topic2P0, topic1P1, topic2P2));
+        metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions,
+                cluster.withPartitions(Collections.singletonMap(topic2P2, new PartitionInfo("topic-two", 2, null, null, null))));
 
-        final StreamsMetadata expected = new StreamsMetadata(hostTwo, Utils.mkSet("global-table", "table-two", "table-one", "merged-table"),
-                Utils.mkSet(topic2P0, topic1P1, topic2P2));
+        final KeyQueryMetadata expected = new KeyQueryMetadata(hostTwo, mkSet(hostOne), 2);
 
-        final StreamsMetadata actual = metadataState.getMetadataWithKey("merged-table", "123", new StreamPartitioner<String, Object>() {
-            @Override
-            public Integer partition(final String topic, final String key, final Object value, final int numPartitions) {
-                return 2;
-            }
-        });
+        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("merged-table",  "the-key",
+            (topic, key, value, numPartitions) -> 2);
 
         assertEquals(expected, actual);
-
     }
 
     @Test
     public void shouldReturnNullOnGetWithKeyWhenStoreDoesntExist() {
-        final StreamsMetadata actual = metadataState.getMetadataWithKey("not-a-store",
+        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("not-a-store",
                 "key",
                 Serdes.String().serializer());
         assertNull(actual);
@@ -264,23 +274,23 @@ public class StreamsMetadataStateTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenKeyIsNull() {
-        metadataState.getMetadataWithKey("table-three", null, Serdes.String().serializer());
+        metadataState.getKeyQueryMetadataForKey("table-three", null, Serdes.String().serializer());
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenSerializerIsNull() {
-        metadataState.getMetadataWithKey("table-three", "key", (Serializer<Object>) null);
+        metadataState.getKeyQueryMetadataForKey("table-three", "key", (Serializer<Object>) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowIfStoreNameIsNull() {
-        metadataState.getMetadataWithKey(null, "key", Serdes.String().serializer());
+        metadataState.getKeyQueryMetadataForKey(null, "key", Serdes.String().serializer());
     }
 
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void shouldThrowIfStreamPartitionerIsNull() {
-        metadataState.getMetadataWithKey(null, "key", (StreamPartitioner) null);
+        metadataState.getKeyQueryMetadataForKey(null, "key", (StreamPartitioner) null);
     }
 
     @Test
@@ -293,30 +303,40 @@ public class StreamsMetadataStateTest {
     }
 
     @Test
-    public void shouldGetMyMetadataForGlobalStoreWithKey() {
-        final StreamsMetadata metadata = metadataState.getMetadataWithKey(globalTable, "key", Serdes.String().serializer());
-        assertEquals(hostOne, metadata.hostInfo());
+    public void shouldGetLocalMetadataWithRightActiveStandbyInfo() {
+        assertEquals(hostOne, metadataState.getLocalMetadata().hostInfo());
+        assertEquals(hostToActivePartitions.get(hostOne), metadataState.getLocalMetadata().topicPartitions());
+        assertEquals(hostToStandbyPartitions.get(hostOne), metadataState.getLocalMetadata().standbyTopicPartitions());
+        assertEquals(storeNames, metadataState.getLocalMetadata().stateStoreNames());
+        assertEquals(storeNames.stream().filter(s -> !s.equals(globalTable)).collect(Collectors.toSet()),
+            metadataState.getLocalMetadata().standbyStateStoreNames());
+    }
+
+    @Test
+    public void shouldGetQueryMetadataForGlobalStoreWithKey() {
+        final KeyQueryMetadata metadata = metadataState.getKeyQueryMetadataForKey(globalTable, "key", Serdes.String().serializer());
+        assertEquals(hostOne, metadata.getActiveHost());
+        assertTrue(metadata.getStandbyHosts().isEmpty());
     }
 
     @Test
     public void shouldGetAnyHostForGlobalStoreByKeyIfMyHostUnknown() {
         final StreamsMetadataState streamsMetadataState = new StreamsMetadataState(TopologyWrapper.getInternalTopologyBuilder(builder.build()), StreamsMetadataState.UNKNOWN_HOST);
-        streamsMetadataState.onChange(hostToPartitions, cluster);
-        assertNotNull(streamsMetadataState.getMetadataWithKey(globalTable, "key", Serdes.String().serializer()));
+        streamsMetadataState.onChange(hostToActivePartitions, hostToStandbyPartitions, cluster);
+        assertNotNull(streamsMetadataState.getKeyQueryMetadataForKey(globalTable, "key", Serdes.String().serializer()));
     }
 
     @Test
-    public void shouldGetMyMetadataForGlobalStoreWithKeyAndPartitioner() {
-        final StreamsMetadata metadata = metadataState.getMetadataWithKey(globalTable, "key", partitioner);
-        assertEquals(hostOne, metadata.hostInfo());
+    public void shouldGetQueryMetadataForGlobalStoreWithKeyAndPartitioner() {
+        final KeyQueryMetadata metadata = metadataState.getKeyQueryMetadataForKey(globalTable, "key", partitioner);
+        assertEquals(hostOne, metadata.getActiveHost());
+        assertTrue(metadata.getStandbyHosts().isEmpty());
     }
 
     @Test
     public void shouldGetAnyHostForGlobalStoreByKeyAndPartitionerIfMyHostUnknown() {
         final StreamsMetadataState streamsMetadataState = new StreamsMetadataState(TopologyWrapper.getInternalTopologyBuilder(builder.build()), StreamsMetadataState.UNKNOWN_HOST);
-        streamsMetadataState.onChange(hostToPartitions, cluster);
-        assertNotNull(streamsMetadataState.getMetadataWithKey(globalTable, "key", partitioner));
+        streamsMetadataState.onChange(hostToActivePartitions, hostToStandbyPartitions, cluster);
+        assertNotNull(streamsMetadataState.getKeyQueryMetadataForKey(globalTable, "key", partitioner));
     }
-
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
@@ -17,18 +17,19 @@
 package org.apache.kafka.streams.processor.internals.assignment;
 
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.state.HostInfo;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
 import static org.junit.Assert.assertEquals;
@@ -36,71 +37,94 @@ import static org.junit.Assert.assertEquals;
 public class AssignmentInfoTest {
     private final List<TaskId> activeTasks = Arrays.asList(
         new TaskId(0, 0),
-        new TaskId(0, 0),
-        new TaskId(0, 1), new TaskId(1, 0));
-    private final Map<TaskId, Set<TopicPartition>> standbyTasks = new HashMap<TaskId, Set<TopicPartition>>() {
-        {
-            put(new TaskId(1, 1),
-                Utils.mkSet(new TopicPartition("t1", 1), new TopicPartition("t2", 1)));
-            put(new TaskId(2, 0),
-                Utils.mkSet(new TopicPartition("t3", 0), new TopicPartition("t3", 0)));
-        }
-    };
-    private final Map<HostInfo, Set<TopicPartition>> globalAssignment = new HashMap<HostInfo, Set<TopicPartition>>() {
-        {
-            put(new HostInfo("localhost", 80),
-                Utils.mkSet(new TopicPartition("t1", 1), new TopicPartition("t3", 3)));
-        }
-    };
+        new TaskId(0, 1),
+        new TaskId(1, 0),
+        new TaskId(1, 1));
+
+    private final Map<TaskId, Set<TopicPartition>> standbyTasks = mkMap(
+        mkEntry(new TaskId(1, 0), mkSet(new TopicPartition("t1", 0), new TopicPartition("t2", 0))),
+        mkEntry(new TaskId(1, 1), mkSet(new TopicPartition("t1", 1), new TopicPartition("t2", 1)))
+    );
+
+    private final Map<HostInfo, Set<TopicPartition>> activeAssignment = mkMap(
+        mkEntry(new HostInfo("localhost", 8088),
+            mkSet(new TopicPartition("t0", 0),
+                new TopicPartition("t1", 0),
+                new TopicPartition("t2", 0))),
+        mkEntry(new HostInfo("localhost", 8089),
+            mkSet(new TopicPartition("t0", 1),
+                new TopicPartition("t1", 1),
+                new TopicPartition("t2", 1)))
+    );
+
+    private final Map<HostInfo, Set<TopicPartition>> standbyAssignment = mkMap(
+        mkEntry(new HostInfo("localhost", 8088),
+            mkSet(new TopicPartition("t1", 0),
+                new TopicPartition("t2", 0))),
+        mkEntry(new HostInfo("localhost", 8089),
+            mkSet(new TopicPartition("t1", 1),
+                new TopicPartition("t2", 1)))
+    );
 
     @Test
     public void shouldUseLatestSupportedVersionByDefault() {
-        final AssignmentInfo info = new AssignmentInfo(LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, 0);
+        final AssignmentInfo info = new AssignmentInfo(LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 0);
         assertEquals(LATEST_SUPPORTED_VERSION, info.version());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion1() {
-        new AssignmentInfo(0, activeTasks, standbyTasks, globalAssignment, 0);
+        new AssignmentInfo(0, activeTasks, standbyTasks, activeAssignment, Collections.emptyMap(), 0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion2() {
-        new AssignmentInfo(LATEST_SUPPORTED_VERSION + 1, activeTasks, standbyTasks, globalAssignment, 0);
+        new AssignmentInfo(LATEST_SUPPORTED_VERSION + 1, activeTasks, standbyTasks, activeAssignment, Collections.emptyMap(), 0);
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion1() {
-        final AssignmentInfo info = new AssignmentInfo(1, activeTasks, standbyTasks, globalAssignment, 0);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(1, UNKNOWN, activeTasks, standbyTasks, Collections.<HostInfo, Set<TopicPartition>>emptyMap(), 0);
+        final AssignmentInfo info = new AssignmentInfo(1, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 0);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(1, UNKNOWN, activeTasks, standbyTasks, Collections.emptyMap(), Collections.emptyMap(), 0);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion2() {
-        final AssignmentInfo info = new AssignmentInfo(2, activeTasks, standbyTasks, globalAssignment, 0);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(2, UNKNOWN, activeTasks, standbyTasks, globalAssignment, 0);
+        final AssignmentInfo info = new AssignmentInfo(2, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 0);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(2, UNKNOWN, activeTasks, standbyTasks, activeAssignment, Collections.emptyMap(), 0);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion3() {
-        final AssignmentInfo info = new AssignmentInfo(3, activeTasks, standbyTasks, globalAssignment, 0);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(3, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, 0);
+        final AssignmentInfo info = new AssignmentInfo(3, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 0);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(3, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks,
+            activeAssignment, Collections.emptyMap(), 0);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion4() {
-        final AssignmentInfo info = new AssignmentInfo(4, activeTasks, standbyTasks, globalAssignment, 2);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(4, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, 2);
+        final AssignmentInfo info = new AssignmentInfo(4, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(4, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks,
+            activeAssignment, Collections.emptyMap(), 2);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion5() {
-        final AssignmentInfo info = new AssignmentInfo(5, activeTasks, standbyTasks, globalAssignment, 2);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(5, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, 2);
+        final AssignmentInfo info = new AssignmentInfo(5, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(5, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks,
+            activeAssignment, Collections.emptyMap(), 2);
+        assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeVersion6() {
+        final AssignmentInfo info = new AssignmentInfo(6, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(6, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks,
+            activeAssignment, standbyAssignment, 2);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
@@ -108,8 +132,10 @@ public class AssignmentInfoTest {
     public void shouldEncodeAndDecodeSmallerCommonlySupportedVersion() {
         final int usedVersion = LATEST_SUPPORTED_VERSION - 1;
         final int commonlySupportedVersion = LATEST_SUPPORTED_VERSION - 1;
-        final AssignmentInfo info = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks, globalAssignment, 2);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks, globalAssignment, 2);
+        final AssignmentInfo info = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks,
+            activeAssignment, standbyAssignment, 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks,
+            activeAssignment, Collections.emptyMap(), 2);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/LegacySubscriptionInfoSerde.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/LegacySubscriptionInfoSerde.java
@@ -32,7 +32,7 @@ public class LegacySubscriptionInfoSerde {
 
     private static final Logger log = LoggerFactory.getLogger(LegacySubscriptionInfoSerde.class);
 
-    public static final int LATEST_SUPPORTED_VERSION = 5;
+    public static final int LATEST_SUPPORTED_VERSION = 6;
     static final int UNKNOWN = -1;
 
     private final int usedVersion;
@@ -95,7 +95,7 @@ public class LegacySubscriptionInfoSerde {
      * @throws TaskAssignmentException if method fails to encode the data
      */
     public ByteBuffer encode() {
-        if (usedVersion == 3 || usedVersion == 4 || usedVersion == 5) {
+        if (usedVersion == 3 || usedVersion == 4 || usedVersion == 5 || usedVersion == 6) {
             final byte[] endPointBytes = prepareUserEndPoint(this.userEndPoint);
 
             final ByteBuffer buf = ByteBuffer.allocate(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -233,8 +233,8 @@ public class SubscriptionInfoTest {
     }
 
     @Test
-    public void generatedVersion3To5ShouldDecodeLegacyFormat() {
-        for (int version = 3; version <= 5; version++) {
+    public void generatedVersion3To6ShouldDecodeLegacyFormat() {
+        for (int version = 3; version <= 6; version++) {
             final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
                 version,
                 LATEST_SUPPORTED_VERSION,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
@@ -32,11 +32,11 @@ import org.apache.kafka.test.StateStoreProviderStub;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.apache.kafka.test.StreamsTestUtils.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -63,9 +63,10 @@ public class CompositeReadOnlyKeyValueStoreTest {
         stubProviderOne.addStore("other-store", otherUnderlyingStore);
 
         theStore = new CompositeReadOnlyKeyValueStore<>(
-            new WrappingStoreProvider(Arrays.<StateStoreProvider>asList(stubProviderOne, stubProviderTwo)),
-                                        QueryableStoreTypes.<String, String>keyValueStore(),
-                                        storeName);
+            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), false),
+            QueryableStoreTypes.keyValueStore(),
+            storeName
+        );
     }
 
     private KeyValueStore<String, String> newStoreInstance() {
@@ -293,8 +294,11 @@ public class CompositeReadOnlyKeyValueStoreTest {
     }
 
     private CompositeReadOnlyKeyValueStore<Object, Object> rebalancing() {
-        return new CompositeReadOnlyKeyValueStore<>(new WrappingStoreProvider(Collections.<StateStoreProvider>singletonList(new StateStoreProviderStub(true))),
-                QueryableStoreTypes.keyValueStore(), storeName);
+        return new CompositeReadOnlyKeyValueStore<>(
+            new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), false),
+            QueryableStoreTypes.keyValueStore(),
+            storeName
+        );
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
@@ -29,9 +29,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
 import static org.apache.kafka.test.StreamsTestUtils.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -55,8 +55,8 @@ public class CompositeReadOnlySessionStoreTest {
 
 
         sessionStore = new CompositeReadOnlySessionStore<>(
-                new WrappingStoreProvider(Arrays.<StateStoreProvider>asList(stubProviderOne, stubProviderTwo)),
-                QueryableStoreTypes.<String, Long>sessionStore(), storeName);
+            new WrappingStoreProvider(Arrays.asList(stubProviderOne, stubProviderTwo), false),
+            QueryableStoreTypes.sessionStore(), storeName);
     }
 
     @Test
@@ -90,8 +90,8 @@ public class CompositeReadOnlySessionStoreTest {
         final List<KeyValue<Windowed<String>, Long>> keyOneResults = toList(sessionStore.fetch("key-one"));
         final List<KeyValue<Windowed<String>, Long>> keyTwoResults = toList(sessionStore.fetch("key-two"));
 
-        assertEquals(Collections.singletonList(KeyValue.pair(keyOne, 0L)), keyOneResults);
-        assertEquals(Collections.singletonList(KeyValue.pair(keyTwo, 10L)), keyTwoResults);
+        assertEquals(singletonList(KeyValue.pair(keyOne, 0L)), keyOneResults);
+        assertEquals(singletonList(KeyValue.pair(keyTwo, 10L)), keyTwoResults);
     }
 
     @Test
@@ -109,9 +109,10 @@ public class CompositeReadOnlySessionStoreTest {
     public void shouldThrowInvalidStateStoreExceptionOnRebalance() {
         final CompositeReadOnlySessionStore<String, String> store =
             new CompositeReadOnlySessionStore<>(
-                new StateStoreProviderStub(true),
+                new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), false),
                 QueryableStoreTypes.sessionStore(),
-                "whateva");
+                "whateva"
+            );
 
         store.fetch("a");
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -46,43 +46,45 @@ public class QueryableStoreProviderTest {
         globalStateStores = new HashMap<>();
         storeProvider =
             new QueryableStoreProvider(
-                    Collections.<StateStoreProvider>singletonList(theStoreProvider), new GlobalStateStoreProvider(globalStateStores));
+                Collections.singletonList(theStoreProvider),
+                new GlobalStateStoreProvider(globalStateStores)
+            );
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionIfKVStoreDoesntExist() {
-        storeProvider.getStore("not-a-store", QueryableStoreTypes.keyValueStore());
+        storeProvider.getStore("not-a-store", QueryableStoreTypes.keyValueStore(), false);
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionIfWindowStoreDoesntExist() {
-        storeProvider.getStore("not-a-store", QueryableStoreTypes.windowStore());
+        storeProvider.getStore("not-a-store", QueryableStoreTypes.windowStore(), false);
     }
 
     @Test
     public void shouldReturnKVStoreWhenItExists() {
-        assertNotNull(storeProvider.getStore(keyValueStore, QueryableStoreTypes.keyValueStore()));
+        assertNotNull(storeProvider.getStore(keyValueStore, QueryableStoreTypes.keyValueStore(), false));
     }
 
     @Test
     public void shouldReturnWindowStoreWhenItExists() {
-        assertNotNull(storeProvider.getStore(windowStore, QueryableStoreTypes.windowStore()));
+        assertNotNull(storeProvider.getStore(windowStore, QueryableStoreTypes.windowStore(), false));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionWhenLookingForWindowStoreWithDifferentType() {
-        storeProvider.getStore(windowStore, QueryableStoreTypes.keyValueStore());
+        storeProvider.getStore(windowStore, QueryableStoreTypes.keyValueStore(), false);
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionWhenLookingForKVStoreWithDifferentType() {
-        storeProvider.getStore(keyValueStore, QueryableStoreTypes.windowStore());
+        storeProvider.getStore(keyValueStore, QueryableStoreTypes.windowStore(), false);
     }
 
     @Test
     public void shouldFindGlobalStores() {
         globalStateStores.put("global", new NoOpReadOnlyStore<>());
-        assertNotNull(storeProvider.getStore("global", QueryableStoreTypes.keyValueStore()));
+        assertNotNull(storeProvider.getStore("global", QueryableStoreTypes.keyValueStore(), false));
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -60,8 +60,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.apache.kafka.streams.state.QueryableStoreTypes.timestampedWindowStore;
-import static org.apache.kafka.streams.state.QueryableStoreTypes.windowStore;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -162,7 +160,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, String>> kvStores =
-            provider.stores("kv-store", QueryableStoreTypes.keyValueStore());
+            provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), false);
         assertEquals(2, kvStores.size());
         for (final ReadOnlyKeyValueStore<String, String> store: kvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -174,7 +172,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-            provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore());
+            provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore(), false);
         assertEquals(2, tkvStores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store: tkvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -186,7 +184,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldNotFindKeyValueStoresAsTimestampedStore() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-            provider.stores("kv-store", QueryableStoreTypes.timestampedKeyValueStore());
+            provider.stores("kv-store", QueryableStoreTypes.timestampedKeyValueStore(), false);
         assertEquals(0, tkvStores.size());
     }
 
@@ -194,7 +192,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedKeyValueStoresAsKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-            provider.stores("timestamped-kv-store", QueryableStoreTypes.keyValueStore());
+            provider.stores("timestamped-kv-store", QueryableStoreTypes.keyValueStore(), false);
         assertEquals(2, tkvStores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store: tkvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -206,7 +204,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindWindowStores() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, String>> windowStores =
-            provider.stores("window-store", windowStore());
+            provider.stores("window-store", QueryableStoreTypes.windowStore(), false);
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, String> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -218,7 +216,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedWindowStores() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores("timestamped-window-store", timestampedWindowStore());
+            provider.stores("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore(), false);
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -230,7 +228,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldNotFindWindowStoresAsTimestampedStore() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores("window-store", timestampedWindowStore());
+            provider.stores("window-store", QueryableStoreTypes.timestampedWindowStore(), false);
         assertEquals(0, windowStores.size());
     }
 
@@ -238,7 +236,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedWindowStoresAsWindowStore() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores("timestamped-window-store", windowStore());
+            provider.stores("timestamped-window-store", QueryableStoreTypes.windowStore(), false);
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -250,28 +248,28 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldThrowInvalidStoreExceptionIfKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("kv-store").close();
-        provider.stores("kv-store", QueryableStoreTypes.keyValueStore());
+        provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), false);
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfTsKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-kv-store").close();
-        provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore());
+        provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore(), false);
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("window-store").close();
-        provider.stores("window-store", QueryableStoreTypes.windowStore());
+        provider.stores("window-store", QueryableStoreTypes.windowStore(), false);
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfTsWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-window-store").close();
-        provider.stores("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore());
+        provider.stores("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore(), false);
     }
 
     @Test
@@ -279,7 +277,7 @@ public class StreamThreadStateStoreProviderTest {
         mockThread(true);
         assertEquals(
             Collections.emptyList(),
-            provider.stores("not-a-store", QueryableStoreTypes.keyValueStore()));
+            provider.stores("not-a-store", QueryableStoreTypes.keyValueStore(), false));
     }
 
     @Test
@@ -287,14 +285,14 @@ public class StreamThreadStateStoreProviderTest {
         mockThread(true);
         assertEquals(
             Collections.emptyList(),
-            provider.stores("window-store", QueryableStoreTypes.keyValueStore())
+            provider.stores("window-store", QueryableStoreTypes.keyValueStore(), false)
         );
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfNotAllStoresAvailable() {
         mockThread(false);
-        provider.stores("kv-store", QueryableStoreTypes.keyValueStore());
+        provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), false);
     }
 
     private StreamTask createStreamsTask(final StreamsConfig streamsConfig,
@@ -321,8 +319,11 @@ public class StreamThreadStateStoreProviderTest {
     }
 
     private void mockThread(final boolean initialized) {
-        EasyMock.expect(threadMock.isRunningAndNotRebalancing()).andReturn(initialized);
-        EasyMock.expect(threadMock.tasks()).andStubReturn(tasks);
+        EasyMock.expect(threadMock.isRunning()).andReturn(initialized);
+        EasyMock.expect(threadMock.activeTasks()).andStubReturn(tasks);
+        EasyMock.expect(threadMock.state()).andReturn(
+            initialized ? StreamThread.State.RUNNING : StreamThread.State.PARTITIONS_ASSIGNED
+        ).anyTimes();
         EasyMock.replay(threadMock);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
@@ -56,7 +56,9 @@ public class WrappingStoreProviderTest {
         stubProviderTwo.addStore("window", new NoOpWindowStore());
 
         wrappingStoreProvider = new WrappingStoreProvider(
-                Arrays.<StateStoreProvider>asList(stubProviderOne, stubProviderTwo));
+            Arrays.asList(stubProviderOne, stubProviderTwo),
+            false
+        );
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -225,7 +225,7 @@ public class StreamsUpgradeTest {
 
             final TaskManager taskManager = taskManger();
             taskManager.setClusterMetadata(Cluster.empty().withPartitions(topicToPartitionInfo));
-            taskManager.setPartitionsByHostState(partitionsByHost);
+            taskManager.setHostPartitionMappings(partitionsByHost, info.standbyPartitionByHost());
             taskManager.setPartitionsToTaskId(partitionsToTaskId);
             taskManager.setAssignmentMetadata(activeTasks, info.standbyTasks());
             taskManager.updateSubscriptionsFromAssignment(partitions);

--- a/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
@@ -19,26 +19,28 @@ package org.apache.kafka.test;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
-import org.apache.kafka.streams.state.internals.StateStoreProvider;
+import org.apache.kafka.streams.state.internals.StreamThreadStateStoreProvider;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class StateStoreProviderStub implements StateStoreProvider {
+public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
 
     private final Map<String, StateStore> stores = new HashMap<>();
     private final boolean throwException;
 
     public StateStoreProviderStub(final boolean throwException) {
-
+        super(null);
         this.throwException = throwException;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> List<T> stores(final String storeName, final QueryableStoreType<T> queryableStoreType) {
+    public <T> List<T> stores(final String storeName,
+                              final QueryableStoreType<T> queryableStoreType,
+                              final boolean includeStaleStores) {
         if (throwException) {
             throw new InvalidStateStoreException("store is unavailable");
         }

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -525,19 +525,19 @@ class StreamsUpgradeTest(Test):
                     monitors[second_other_processor] = second_other_monitor
 
                     if len(self.old_processors) > 0:
-                        log_monitor.wait_until("Sent a version 6 subscription and got version 5 assignment back (successful version probing). Downgrade subscription metadata to commonly supported version 5 and trigger new rebalance.",
+                        log_monitor.wait_until("Sent a version 7 subscription and got version 6 assignment back (successful version probing). Downgrade subscription metadata to commonly supported version 6 and trigger new rebalance.",
                                                timeout_sec=60,
                                                err_msg="Could not detect 'successful version probing' at upgrading node " + str(node.account))
                     else:
-                        log_monitor.wait_until("Sent a version 6 subscription and got version 5 assignment back (successful version probing). Downgrade subscription metadata to commonly supported version 6 and trigger new rebalance.",
+                        log_monitor.wait_until("Sent a version 7 subscription and got version 6 assignment back (successful version probing). Downgrade subscription metadata to commonly supported version 7 and trigger new rebalance.",
                                                timeout_sec=60,
                                                err_msg="Could not detect 'successful version probing with upgraded leader' at upgrading node " + str(node.account))
-                        first_other_monitor.wait_until("Sent a version 5 subscription and group.s latest commonly supported version is 6 (successful version probing and end of rolling upgrade). Upgrading subscription metadata version to 6 for next rebalance.",
+                        first_other_monitor.wait_until("Sent a version 6 subscription and group.s latest commonly supported version is 7 (successful version probing and end of rolling upgrade). Upgrading subscription metadata version to 7 for next rebalance.",
                                                        timeout_sec=60,
-                                                       err_msg="Never saw output 'Upgrade metadata to version 6' on" + str(first_other_node.account))
-                        second_other_monitor.wait_until("Sent a version 5 subscription and group.s latest commonly supported version is 6 (successful version probing and end of rolling upgrade). Upgrading subscription metadata version to 6 for next rebalance.",
+                                                       err_msg="Never saw output 'Upgrade metadata to version 7' on" + str(first_other_node.account))
+                        second_other_monitor.wait_until("Sent a version 6 subscription and group.s latest commonly supported version is 7 (successful version probing and end of rolling upgrade). Upgrading subscription metadata version to 7 for next rebalance.",
                                                         timeout_sec=60,
-                                                        err_msg="Never saw output 'Upgrade metadata to version 6' on" + str(second_other_node.account))
+                                                        err_msg="Never saw output 'Upgrade metadata to version 7' on" + str(second_other_node.account))
 
                     log_monitor.wait_until("Version probing detected. Triggering new rebalance.",
                                            timeout_sec=60,
@@ -584,9 +584,9 @@ class StreamsUpgradeTest(Test):
 
     def verify_metadata_no_upgraded_yet(self):
         for p in self.processors:
-            found = list(p.node.account.ssh_capture("grep \"Sent a version 5 subscription and group.s latest commonly supported version is 6 (successful version probing and end of rolling upgrade). Upgrading subscription metadata version to 6 for next rebalance.\" " + p.LOG_FILE, allow_fail=True))
+            found = list(p.node.account.ssh_capture("grep \"Sent a version 6 subscription and group.s latest commonly supported version is 7 (successful version probing and end of rolling upgrade). Upgrading subscription metadata version to 7 for next rebalance.\" " + p.LOG_FILE, allow_fail=True))
             if len(found) > 0:
-                raise Exception("Kafka Streams failed with 'group member upgraded to metadata 6 too early'")
+                raise Exception("Kafka Streams failed with 'group member upgraded to metadata 7 too early'")
 
     def confirm_topics_on_all_brokers(self, expected_topic_set):
         for node in self.kafka.nodes:


### PR DESCRIPTION
Conflicts due to the fact that we temporarily reverted the commit
that removes Scala 2.11 support:

* AclCommand.scala: take upstream changes.
* AclCommandTest.scala: take upstream changes.
* TransactionCoordinatorTest.scala: don't use SAMs, but adjust
mock call to putTransactionStateIfNotExists given new signature.
* TransactionStateManagerTest: use Runnable instead of SAMs.
* PartitionLockTest: use Runnable instead of SAMs.
* upgrade.html: take upstream changes excluding line that
states that Scala 2.11 support has been removed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
