### PR TITLE
CONFLUENT: Sync from apache/kafka (25 January 2020)

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -62,7 +62,7 @@
               files="(ConsumerCoordinator|Fetcher|Sender|KafkaProducer|BufferPool|ConfigDef|RecordAccumulator|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator).java"/>
 
     <suppress checks="JavaNCSS"
-              files="AbstractRequest.java|KerberosLogin.java|WorkerSinkTaskTest.java|TransactionManagerTest.java|SenderTest.java|KafkaAdminClient.java"/>
+              files="(AbstractRequest|KerberosLogin|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest).java"/>
 
     <suppress checks="NPathComplexity"
               files="(BufferPool|Fetcher|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest|KafkaProducer).java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1357,7 +1357,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
         private MetadataSnapshot(SubscriptionState subscription, Cluster cluster, int version) {
             Map<String, Integer> partitionsPerTopic = new HashMap<>();
-            for (String topic : subscription.groupSubscription()) {
+            for (String topic : subscription.metadataTopics()) {
                 Integer numPartitions = cluster.partitionCountForTopic(topic);
                 if (numPartitions != null)
                     partitionsPerTopic.put(topic, numPartitions);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
@@ -55,7 +55,7 @@ public class ConsumerMetadata extends Metadata {
         if (subscription.hasPatternSubscription())
             return MetadataRequest.Builder.allTopics();
         List<String> topics = new ArrayList<>();
-        topics.addAll(subscription.groupSubscription());
+        topics.addAll(subscription.metadataTopics());
         topics.addAll(transientTopics);
         return new MetadataRequest.Builder(topics, allowAutoTopicCreation);
     }
@@ -72,7 +72,7 @@ public class ConsumerMetadata extends Metadata {
 
     @Override
     protected synchronized boolean retainTopic(String topic, boolean isInternal, long nowMs) {
-        if (transientTopics.contains(topic) || subscription.isGroupSubscribed(topic))
+        if (transientTopics.contains(topic) || subscription.needsMetadata(topic))
             return true;
 
         if (isInternal && !includeInternalTopics)

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -21,7 +21,6 @@ import org.apache.kafka.clients.RequestCompletionHandler;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
@@ -59,6 +58,7 @@ import org.apache.kafka.common.requests.TxnOffsetCommitRequest.CommittedOffset;
 import org.apache.kafka.common.requests.TxnOffsetCommitResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.PrimitiveRef;
+import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -75,9 +75,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
-import static org.apache.kafka.common.record.RecordBatch.NO_PRODUCER_EPOCH;
-import static org.apache.kafka.common.record.RecordBatch.NO_PRODUCER_ID;
 
 /**
  * A class which maintains state for transactions. Also keeps the state necessary to ensure idempotent production.
@@ -217,6 +214,8 @@ public class TransactionManager {
 
         private boolean isTransitionValid(State source, State target) {
             switch (target) {
+                case UNINITIALIZED:
+                    return source == READY;
                 case INITIALIZING:
                     return source == UNINITIALIZED;
                 case READY:
@@ -256,7 +255,7 @@ public class TransactionManager {
     }
 
     public TransactionManager(LogContext logContext, String transactionalId, int transactionTimeoutMs, long retryBackoffMs) {
-        this.producerIdAndEpoch = new ProducerIdAndEpoch(NO_PRODUCER_ID, NO_PRODUCER_EPOCH);
+        this.producerIdAndEpoch = ProducerIdAndEpoch.NONE;
         this.transactionalId = transactionalId;
         this.log = logContext.logger(TransactionManager.class);
         this.transactionTimeoutMs = transactionTimeoutMs;
@@ -279,7 +278,6 @@ public class TransactionManager {
     public synchronized TransactionalRequestResult initializeTransactions() {
         return handleCachedTransactionRequestResult(() -> {
             transitionTo(State.INITIALIZING);
-            setProducerIdAndEpoch(ProducerIdAndEpoch.NONE);
             InitProducerIdRequestData requestData = new InitProducerIdRequestData()
                     .setTransactionalId(transactionalId)
                     .setTransactionTimeoutMs(transactionTimeoutMs);
@@ -418,6 +416,10 @@ public class TransactionManager {
 
     synchronized void transitionToFatalError(RuntimeException exception) {
         transitionTo(State.FATAL_ERROR, exception);
+
+        if (pendingResult != null) {
+            pendingResult.fail(exception);
+        }
     }
 
     // visible for testing
@@ -452,7 +454,7 @@ public class TransactionManager {
     /**
      * Set the producer id and epoch atomically.
      */
-    void setProducerIdAndEpoch(ProducerIdAndEpoch producerIdAndEpoch) {
+    private void setProducerIdAndEpoch(ProducerIdAndEpoch producerIdAndEpoch) {
         log.info("ProducerId set to {} with epoch {}", producerIdAndEpoch.producerId, producerIdAndEpoch.epoch);
         this.producerIdAndEpoch = producerIdAndEpoch;
     }
@@ -474,19 +476,32 @@ public class TransactionManager {
      * would not have any way of knowing this happened. So for the transactional producer, it's best to return the
      * produce error to the user and let them abort the transaction and close the producer explicitly.
      */
-    synchronized void resetProducerId() {
+    synchronized void resetIdempotentProducerId() {
         if (isTransactional())
             throw new IllegalStateException("Cannot reset producer state for a transactional producer. " +
                     "You must either abort the ongoing transaction or reinitialize the transactional producer instead");
         setProducerIdAndEpoch(ProducerIdAndEpoch.NONE);
         topicPartitionBookkeeper.reset();
         this.partitionsWithUnresolvedSequences.clear();
+        transitionTo(State.UNINITIALIZED);
     }
 
-    synchronized void resetProducerIdIfNeeded() {
-        if (shouldResetProducerStateAfterResolvingSequences())
-            // Check if the previous run expired batches which requires a reset of the producer state.
-            resetProducerId();
+    synchronized void resetIdempotentProducerIdIfNeeded() {
+        if (!isTransactional()) {
+            if (shouldResetProducerStateAfterResolvingSequences()) {
+                // Check if the previous run expired batches which requires a reset of the producer state.
+                resetIdempotentProducerId();
+            }
+
+            if (currentState != State.INITIALIZING && !hasProducerId()) {
+                transitionTo(State.INITIALIZING);
+                InitProducerIdRequestData requestData = new InitProducerIdRequestData()
+                        .setTransactionalId(null)
+                        .setTransactionTimeoutMs(Integer.MAX_VALUE);
+                InitProducerIdHandler handler = new InitProducerIdHandler(new InitProducerIdRequest.Builder(requestData));
+                enqueueRequest(handler);
+            }
+        }
     }
 
     /**
@@ -618,7 +633,7 @@ public class TransactionManager {
             // Reset the producerId since we have hit an irrecoverable exception and cannot make any guarantees
             // about the previously committed message. Note that this will discard the producer id and sequence
             // numbers for all existing partitions.
-            resetProducerId();
+            resetIdempotentProducerId();
         } else {
             removeInFlightBatch(batch);
             if (adjustSequenceNumbers)
@@ -694,9 +709,6 @@ public class TransactionManager {
     // Checks if there are any partitions with unresolved partitions which may now be resolved. Returns true if
     // the producer id needs a reset, false otherwise.
     private boolean shouldResetProducerStateAfterResolvingSequences() {
-        if (isTransactional())
-            // We should not reset producer state if we are transactional. We will transition to a fatal error instead.
-            return false;
         for (Iterator<TopicPartition> iter = partitionsWithUnresolvedSequences.iterator(); iter.hasNext(); ) {
             TopicPartition topicPartition = iter.next();
             if (!hasInflightBatches(topicPartition)) {
@@ -726,7 +738,7 @@ public class TransactionManager {
         topicPartitionBookkeeper.getPartition(topicPartition).nextSequence = sequence;
     }
 
-    synchronized TxnRequestHandler nextRequestHandler(boolean hasIncompleteBatches) {
+    synchronized TxnRequestHandler nextRequest(boolean hasIncompleteBatches) {
         if (!newPartitionsInTransaction.isEmpty())
             enqueueRequest(addPartitionsToTransactionHandler());
 
@@ -776,8 +788,7 @@ public class TransactionManager {
         pendingRequests.forEach(handler ->
                 handler.fatalError(shutdownException));
         if (pendingResult != null) {
-            pendingResult.setError(shutdownException);
-            pendingResult.done();
+            pendingResult.fail(shutdownException);
         }
     }
 
@@ -804,7 +815,7 @@ public class TransactionManager {
         inFlightRequestCorrelationId = NO_INFLIGHT_REQUEST_CORRELATION_ID;
     }
 
-    boolean hasInFlightTransactionalRequest() {
+    boolean hasInFlightRequest() {
         return inFlightRequestCorrelationId != NO_INFLIGHT_REQUEST_CORRELATION_ID;
     }
 
@@ -1036,20 +1047,17 @@ public class TransactionManager {
         }
 
         void fatalError(RuntimeException e) {
-            result.setError(e);
+            result.fail(e);
             transitionToFatalError(e);
-            result.done();
         }
 
         void abortableError(RuntimeException e) {
-            result.setError(e);
+            result.fail(e);
             transitionToAbortableError(e);
-            result.done();
         }
 
         void fail(RuntimeException e) {
-            result.setError(e);
-            result.done();
+            result.fail(e);
         }
 
         void reenqueue() {
@@ -1138,6 +1146,15 @@ public class TransactionManager {
         }
 
         @Override
+        FindCoordinatorRequest.CoordinatorType coordinatorType() {
+            if (isTransactional()) {
+                return FindCoordinatorRequest.CoordinatorType.TRANSACTION;
+            } else {
+                return null;
+            }
+        }
+
+        @Override
         public void handleResponse(AbstractResponse response) {
             InitProducerIdResponse initProducerIdResponse = (InitProducerIdResponse) response;
             Errors error = initProducerIdResponse.error();
@@ -1154,7 +1171,8 @@ public class TransactionManager {
                 reenqueue();
             } else if (error == Errors.COORDINATOR_LOAD_IN_PROGRESS || error == Errors.CONCURRENT_TRANSACTIONS) {
                 reenqueue();
-            } else if (error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED) {
+            } else if (error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED ||
+                    error == Errors.CLUSTER_AUTHORIZATION_FAILED) {
                 fatalError(error.exception());
             } else {
                 fatalError(new KafkaException("Unexpected error in InitProducerIdResponse; " + error.message()));

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionalRequestResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionalRequestResult.java
@@ -39,8 +39,9 @@ public final class TransactionalRequestResult {
         this.operation = operation;
     }
 
-    public void setError(RuntimeException error) {
+    public void fail(RuntimeException error) {
         this.error = error;
+        this.latch.countDown();
     }
 
     public void done() {

--- a/clients/src/main/java/org/apache/kafka/common/utils/Exit.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Exit.java
@@ -26,6 +26,10 @@ public class Exit {
         void execute(int statusCode, String message);
     }
 
+    public interface ShutdownHookAdder {
+        void addShutdownHook(String name, Runnable runnable);
+    }
+
     private static final Procedure DEFAULT_HALT_PROCEDURE = new Procedure() {
         @Override
         public void execute(int statusCode, String message) {
@@ -40,8 +44,19 @@ public class Exit {
         }
     };
 
+    private static final ShutdownHookAdder DEFAULT_SHUTDOWN_HOOK_ADDER = new ShutdownHookAdder() {
+        @Override
+        public void addShutdownHook(String name, Runnable runnable) {
+            if (name != null)
+                Runtime.getRuntime().addShutdownHook(KafkaThread.nonDaemon(name, runnable));
+            else
+                Runtime.getRuntime().addShutdownHook(new Thread(runnable));
+        }
+    };
+
     private volatile static Procedure exitProcedure = DEFAULT_EXIT_PROCEDURE;
     private volatile static Procedure haltProcedure = DEFAULT_HALT_PROCEDURE;
+    private volatile static ShutdownHookAdder shutdownHookAdder = DEFAULT_SHUTDOWN_HOOK_ADDER;
 
     public static void exit(int statusCode) {
         exit(statusCode, null);
@@ -59,12 +74,20 @@ public class Exit {
         haltProcedure.execute(statusCode, message);
     }
 
+    public static void addShutdownHook(String name, Runnable runnable) {
+        shutdownHookAdder.addShutdownHook(name, runnable);
+    }
+
     public static void setExitProcedure(Procedure procedure) {
         exitProcedure = procedure;
     }
 
     public static void setHaltProcedure(Procedure procedure) {
         haltProcedure = procedure;
+    }
+
+    public static void setShutdownHookAdder(ShutdownHookAdder shutdownHookAdder) {
+        Exit.shutdownHookAdder = shutdownHookAdder;
     }
 
     public static void resetExitProcedure() {
@@ -75,4 +98,7 @@ public class Exit {
         haltProcedure = DEFAULT_HALT_PROCEDURE;
     }
 
+    public static void resetShutdownHookAdder() {
+        shutdownHookAdder = DEFAULT_SHUTDOWN_HOOK_ADDER;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/ProducerIdAndEpoch.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ProducerIdAndEpoch.java
@@ -37,4 +37,23 @@ public class ProducerIdAndEpoch {
     public String toString() {
         return "(producerId=" + producerId + ", epoch=" + epoch + ")";
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ProducerIdAndEpoch that = (ProducerIdAndEpoch) o;
+
+        if (producerId != that.producerId) return false;
+        return epoch == that.epoch;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (producerId ^ (producerId >>> 32));
+        result = 31 * result + (int) epoch;
+        return result;
+    }
+
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
@@ -102,8 +102,11 @@ public class ConsumerMetadataTest {
     @Test
     public void testNormalSubscription() {
         subscription.subscribe(Utils.mkSet("foo", "bar", "__consumer_offsets"), new NoOpConsumerRebalanceListener());
-        subscription.groupSubscribe(Utils.mkSet("baz"));
+        subscription.groupSubscribe(Utils.mkSet("baz", "foo", "bar", "__consumer_offsets"));
         testBasicSubscription(Utils.mkSet("foo", "bar", "baz"), Utils.mkSet("__consumer_offsets"));
+
+        subscription.resetGroupSubscription();
+        testBasicSubscription(Utils.mkSet("foo", "bar"), Utils.mkSet("__consumer_offsets"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -1155,7 +1155,9 @@ public class SenderTest {
         Deque<ProducerBatch> batches = accumulator.batches().get(tp0);
         assertEquals(0, batches.size());
         assertTrue(transactionManager.hasProducerId(producerId));
+
         // We should now clear the old producerId and get a new one in a single run loop.
+        time.sleep(10);
         prepareAndReceiveInitProducerId(producerId + 1, Errors.NONE);
         assertTrue(transactionManager.hasProducerId(producerId + 1));
     }
@@ -1164,8 +1166,9 @@ public class SenderTest {
     public void testResetOfProducerStateShouldAllowQueuedBatchesToDrain() throws Exception {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         int maxRetries = 10;
         Metrics m = new Metrics();
@@ -1184,10 +1187,12 @@ public class SenderTest {
         responses.put(tp1, new OffsetAndError(-1, Errors.NOT_LEADER_FOR_PARTITION));
         responses.put(tp0, new OffsetAndError(-1, Errors.OUT_OF_ORDER_SEQUENCE_NUMBER));
         client.respond(produceResponse(responses));
+
         sender.runOnce();
         assertTrue(failedResponse.isDone());
         assertFalse("Expected transaction state to be reset upon receiving an OutOfOrderSequenceException", transactionManager.hasProducerId());
         prepareAndReceiveInitProducerId(producerId + 1, Errors.NONE); // also send request to tp1
+        sender.runOnce();
         assertEquals(producerId + 1, transactionManager.producerIdAndEpoch().producerId);
 
         assertFalse(successfulResponse.isDone());
@@ -1205,8 +1210,9 @@ public class SenderTest {
     public void testCloseWithProducerIdReset() throws Exception {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         Metrics m = new Metrics();
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
@@ -1242,8 +1248,9 @@ public class SenderTest {
     @Test
     public void testForceCloseWithProducerIdReset() throws Exception {
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(1L, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(1L, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         Metrics m = new Metrics();
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
@@ -1275,8 +1282,9 @@ public class SenderTest {
     public void testBatchesDrainedWithOldProducerIdShouldFailWithOutOfOrderSequenceOnSubsequentRetry() throws Exception {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         int maxRetries = 10;
         Metrics m = new Metrics();
@@ -1757,8 +1765,9 @@ public class SenderTest {
     public void testSequenceNumberIncrement() throws InterruptedException {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         int maxRetries = 10;
         Metrics m = new Metrics();
@@ -1800,8 +1809,9 @@ public class SenderTest {
     public void testAbortRetryWhenProducerIdChanges() throws InterruptedException {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         int maxRetries = 10;
         Metrics m = new Metrics();
@@ -1820,8 +1830,8 @@ public class SenderTest {
         assertEquals(0, client.inFlightRequestCount());
         assertFalse("Client ready status should be false", client.isReady(node, time.milliseconds()));
 
-        transactionManager.resetProducerId();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId + 1, (short) 0));
+        transactionManager.resetIdempotentProducerId();
+        prepareAndReceiveInitProducerId(producerId + 1, Errors.NONE);
         sender.runOnce(); // receive error
         sender.runOnce(); // reconnect
         sender.runOnce(); // nothing to do, since the pid has changed. We should check the metrics for errors.
@@ -1838,8 +1848,9 @@ public class SenderTest {
     public void testResetWhenOutOfOrderSequenceReceived() throws InterruptedException {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         int maxRetries = 10;
         Metrics m = new Metrics();
@@ -1868,7 +1879,9 @@ public class SenderTest {
         TopicPartition tp = new TopicPartition("testSplitBatchAndSend", 1);
         TransactionManager txnManager = new TransactionManager();
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
-        txnManager.setProducerIdAndEpoch(producerIdAndEpoch);
+        setupWithTransactionState(txnManager);
+        prepareAndReceiveInitProducerId(123456L, Errors.NONE);
+        assertTrue(txnManager.hasProducerId());
         testSplitBatchAndSend(txnManager, producerIdAndEpoch, tp);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -42,7 +42,6 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.message.EndTxnResponseData;
 import org.apache.kafka.common.message.InitProducerIdResponseData;
-import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
@@ -80,7 +79,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -89,6 +87,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -105,7 +105,6 @@ public class TransactionManagerTest {
     private static final int MAX_REQUEST_SIZE = 1024 * 1024;
     private static final short ACKS_ALL = -1;
     private static final int MAX_RETRIES = Integer.MAX_VALUE;
-    private static final String CLIENT_ID = "clientId";
     private static final int MAX_BLOCK_TIMEOUT = 1000;
     private static final int REQUEST_TIMEOUT = 1000;
     private static final long DEFAULT_RETRY_BACKOFF_MS = 100L;
@@ -113,42 +112,47 @@ public class TransactionManagerTest {
     private final int transactionTimeoutMs = 1121;
 
     private final String topic = "test";
-    private TopicPartition tp0 = new TopicPartition(topic, 0);
-    private TopicPartition tp1 = new TopicPartition(topic, 1);
-    private MockTime time = new MockTime();
-    private ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE, new LogContext(),
+    private final TopicPartition tp0 = new TopicPartition(topic, 0);
+    private final TopicPartition tp1 = new TopicPartition(topic, 1);
+    private final LogContext logContext = new LogContext();
+    private final MockTime time = new MockTime();
+    private final ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE, logContext,
             new ClusterResourceListeners(), time);
-    private MockClient client = new MockClient(time, metadata);
+    private final MockClient client = new MockClient(time, metadata);
+    private final ApiVersions apiVersions = new ApiVersions();
 
-    private ApiVersions apiVersions = new ApiVersions();
     private RecordAccumulator accumulator = null;
     private Sender sender = null;
     private TransactionManager transactionManager = null;
     private Node brokerNode = null;
-    private final LogContext logContext = new LogContext();
 
     @Before
     public void setup() {
-        Map<String, String> metricTags = new LinkedHashMap<>();
-        metricTags.put("client-id", CLIENT_ID);
+        this.metadata.add("test", time.milliseconds());
+        this.client.updateMetadata(TestUtils.metadataUpdateWith(1, singletonMap("test", 2)));
+        this.brokerNode = new Node(0, "localhost", 2211);
+
+        initializeTransactionManager(Optional.of(transactionalId));
+    }
+
+    private void initializeTransactionManager(Optional<String> transactionalId) {
+        Metrics metrics = new Metrics(time);
+
+        this.transactionManager = new TransactionManager(logContext, transactionalId.orElse(null),
+                transactionTimeoutMs, DEFAULT_RETRY_BACKOFF_MS);
+
         int batchSize = 16 * 1024;
         int deliveryTimeoutMs = 3000;
         long totalSize = 1024 * 1024;
         String metricGrpName = "producer-metrics";
-        MetricConfig metricConfig = new MetricConfig().tags(metricTags);
-        this.brokerNode = new Node(0, "localhost", 2211);
-        this.transactionManager = new TransactionManager(logContext, transactionalId, transactionTimeoutMs,
-                DEFAULT_RETRY_BACKOFF_MS);
-        Metrics metrics = new Metrics(metricConfig, time);
-        SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(metrics);
 
         this.accumulator = new RecordAccumulator(logContext, batchSize, CompressionType.NONE, 0, 0L,
                 deliveryTimeoutMs, metrics, metricGrpName, time, apiVersions, transactionManager,
                 new BufferPool(totalSize, batchSize, metrics, time, metricGrpName));
-        this.sender = new Sender(logContext, this.client, this.metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL,
-                MAX_RETRIES, senderMetrics, this.time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions);
-        this.metadata.add("test", time.milliseconds());
-        this.client.updateMetadata(TestUtils.metadataUpdateWith(1, singletonMap("test", 2)));
+
+        this.sender = new Sender(logContext, this.client, this.metadata, this.accumulator, true,
+                MAX_REQUEST_SIZE, ACKS_ALL, MAX_RETRIES, new SenderMetricsRegistry(metrics), this.time, REQUEST_TIMEOUT,
+                50, transactionManager, apiVersions);
     }
 
     @Test
@@ -164,17 +168,15 @@ public class TransactionManagerTest {
 
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
         prepareProduceResponse(Errors.NONE, pid, epoch);
+        runUntil(() -> !client.hasPendingResponses());
 
         sender.initiateClose();
         sender.runOnce();
-        TransactionalRequestResult result = transactionManager.beginCommit();
-        sender.runOnce();
-        prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.runOnce();
-        assertTrue(result.isCompleted());
-        sender.run();
 
-        assertTrue(sendFuture.isDone());
+        TransactionalRequestResult result = transactionManager.beginCommit();
+        prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
+        runUntil(result::isCompleted);
+        runUntil(sendFuture::isDone);
     }
 
     @Test
@@ -187,12 +189,11 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
-        sender.runOnce();
-        assertTrue(transactionManager.isPartitionAdded(tp0));
+        runUntil(() -> transactionManager.isPartitionAdded(tp0));
 
         transactionManager.beginCommit();
-        assertNull(transactionManager.nextRequestHandler(true));
-        assertTrue(transactionManager.nextRequestHandler(false).isEndTxn());
+        assertNull(transactionManager.nextRequest(true));
+        assertTrue(transactionManager.nextRequest(false).isEndTxn());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -202,15 +203,15 @@ public class TransactionManagerTest {
 
     @Test
     public void testFailIfNotReadyForSendIdempotentProducer() {
-        TransactionManager idempotentTransactionManager = new TransactionManager();
-        idempotentTransactionManager.failIfNotReadyForSend();
+        initializeTransactionManager(Optional.empty());
+        transactionManager.failIfNotReadyForSend();
     }
 
     @Test(expected = KafkaException.class)
     public void testFailIfNotReadyForSendIdempotentProducerFatalError() {
-        TransactionManager idempotentTransactionManager = new TransactionManager();
-        idempotentTransactionManager.transitionToFatalError(new KafkaException());
-        idempotentTransactionManager.failIfNotReadyForSend();
+        initializeTransactionManager(Optional.empty());
+        transactionManager.transitionToFatalError(new KafkaException());
+        transactionManager.failIfNotReadyForSend();
     }
 
     @Test(expected = IllegalStateException.class)
@@ -255,17 +256,16 @@ public class TransactionManagerTest {
 
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(partition);
-        assertTrue(transactionManager.hasOngoingTransaction());
+        runUntil(transactionManager::hasOngoingTransaction);
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.runOnce();
+        runUntil(() -> transactionManager.isPartitionAdded(partition));
 
         transactionManager.beginAbort();
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
-        sender.runOnce();
-        assertFalse(transactionManager.hasOngoingTransaction());
+        runUntil(() -> !transactionManager.hasOngoingTransaction());
     }
 
     @Test
@@ -286,14 +286,13 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.runOnce();
+        runUntil(() -> transactionManager.isPartitionAdded(partition));
 
         transactionManager.beginCommit();
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.runOnce();
-        assertFalse(transactionManager.hasOngoingTransaction());
+        runUntil(() -> !transactionManager.hasOngoingTransaction());
     }
 
     @Test
@@ -314,7 +313,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.runOnce();
+        runUntil(() -> transactionManager.isPartitionAdded(partition));
 
         transactionManager.transitionToAbortableError(new KafkaException());
         assertTrue(transactionManager.hasOngoingTransaction());
@@ -323,8 +322,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
-        sender.runOnce();
-        assertFalse(transactionManager.hasOngoingTransaction());
+        runUntil(() -> !transactionManager.hasOngoingTransaction());
     }
 
     @Test
@@ -345,7 +343,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.runOnce();
+        runUntil(() -> transactionManager.isPartitionAdded(partition));
 
         transactionManager.transitionToFatalError(new KafkaException());
         assertFalse(transactionManager.hasOngoingTransaction());
@@ -366,10 +364,10 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.isPartitionPendingAdd(partition));
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.runOnce();
+        assertTrue(transactionManager.hasPartitionsToAdd());
 
+        runUntil(() -> transactionManager.isPartitionAdded(partition));
         assertFalse(transactionManager.hasPartitionsToAdd());
-        assertTrue(transactionManager.isPartitionAdded(partition));
         assertFalse(transactionManager.isPartitionPendingAdd(partition));
 
         // adding the partition again should not have any effect
@@ -395,9 +393,9 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.isPartitionPendingAdd(partition));
 
         prepareAddPartitionsToTxn(partition, Errors.CONCURRENT_TRANSACTIONS);
-        sender.runOnce();
+        runUntil(() -> !client.hasPendingResponses());
 
-        TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
+        TransactionManager.TxnRequestHandler handler = transactionManager.nextRequest(false);
         assertNotNull(handler);
         assertEquals(20, handler.retryBackoffMs());
     }
@@ -417,9 +415,9 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.isPartitionPendingAdd(partition));
 
         prepareAddPartitionsToTxn(partition, Errors.COORDINATOR_NOT_AVAILABLE);
-        sender.runOnce();
+        runUntil(() -> !client.hasPendingResponses());
 
-        TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
+        TransactionManager.TxnRequestHandler handler = transactionManager.nextRequest(false);
         assertNotNull(handler);
         assertEquals(DEFAULT_RETRY_BACKOFF_MS, handler.retryBackoffMs());
     }
@@ -439,15 +437,14 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.isPartitionPendingAdd(partition));
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.runOnce();
-        assertTrue(transactionManager.isPartitionAdded(partition));
+        runUntil(() -> transactionManager.isPartitionAdded(partition));
 
         TopicPartition otherPartition = new TopicPartition("foo", 1);
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(otherPartition);
 
         prepareAddPartitionsToTxn(otherPartition, Errors.CONCURRENT_TRANSACTIONS);
-        TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
+        TransactionManager.TxnRequestHandler handler = transactionManager.nextRequest(false);
         assertNotNull(handler);
         assertEquals(DEFAULT_RETRY_BACKOFF_MS, handler.retryBackoffMs());
     }
@@ -516,7 +513,7 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
         // Send the AddPartitionsToTxn request and leave it in-flight
-        sender.runOnce();
+        runUntil(transactionManager::hasInFlightRequest);
         transactionManager.transitionToAbortableError(new KafkaException());
 
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
@@ -551,7 +548,7 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
         // Send the AddPartitionsToTxn request and leave it in-flight
-        sender.runOnce();
+        runUntil(transactionManager::hasInFlightRequest);
         transactionManager.transitionToFatalError(new KafkaException());
 
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
@@ -570,8 +567,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
-        sender.runOnce();
-        assertFalse(transactionManager.hasPartitionsToAdd());
+
+        runUntil(() -> !transactionManager.hasPartitionsToAdd());
         transactionManager.transitionToAbortableError(new KafkaException());
 
         assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
@@ -589,8 +586,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
-        sender.runOnce();
-        assertFalse(transactionManager.hasPartitionsToAdd());
+
+        runUntil(() -> !transactionManager.hasPartitionsToAdd());
         transactionManager.transitionToFatalError(new KafkaException());
 
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
@@ -608,7 +605,7 @@ public class TransactionManagerTest {
 
     @Test
     public void testDefaultSequenceNumber() {
-        TransactionManager transactionManager = new TransactionManager();
+        initializeTransactionManager(Optional.empty());
         assertEquals((int) transactionManager.sequenceNumber(tp0), 0);
         transactionManager.incrementSequenceNumber(tp0, 3);
         assertEquals((int) transactionManager.sequenceNumber(tp0), 3);
@@ -618,10 +615,9 @@ public class TransactionManagerTest {
     public void testResetSequenceNumbersAfterUnknownProducerId() {
         final long producerId = 13131L;
         final short epoch = 1;
-        ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(producerId, epoch);
 
-        TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(producerIdAndEpoch);
+        initializeTransactionManager(Optional.empty());
+        initializeIdempotentProducerId(producerId, epoch);
 
         ProducerBatch b1 = writeIdempotentBatchWithValue(transactionManager, tp0, "1");
         ProducerBatch b2 = writeIdempotentBatchWithValue(transactionManager, tp0, "2");
@@ -652,10 +648,9 @@ public class TransactionManagerTest {
     public void testAdjustSequenceNumbersAfterFatalError() {
         final long producerId = 13131L;
         final short epoch = 1;
-        ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(producerId, epoch);
 
-        TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(producerIdAndEpoch);
+        initializeTransactionManager(Optional.empty());
+        initializeIdempotentProducerId(producerId, epoch);
 
         ProducerBatch b1 = writeIdempotentBatchWithValue(transactionManager, tp0, "1");
         ProducerBatch b2 = writeIdempotentBatchWithValue(transactionManager, tp0, "2");
@@ -702,15 +697,14 @@ public class TransactionManagerTest {
 
         final long producerId = 13131L;
         final short epoch = 1;
-        ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(producerId, epoch);
-        TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(producerIdAndEpoch);
+
+        initializeTransactionManager(Optional.empty());
+        initializeIdempotentProducerId(producerId, epoch);
 
         ProducerBatch b1 = writeIdempotentBatchWithValue(transactionManager, tp0, "1");
 
-        ProducerIdAndEpoch updatedProducerIdAndEpoch = new ProducerIdAndEpoch(producerId + 1, epoch);
-        transactionManager.resetProducerId();
-        transactionManager.setProducerIdAndEpoch(updatedProducerIdAndEpoch);
+        transactionManager.resetIdempotentProducerId();
+        initializeIdempotentProducerId(producerId + 1, epoch);
 
         ProducerBatch b2 = writeIdempotentBatchWithValue(transactionManager, tp0, "2");
         assertEquals(1, transactionManager.sequenceNumber(tp0).intValue());
@@ -728,16 +722,15 @@ public class TransactionManagerTest {
     public void testBatchCompletedAfterProducerReset() {
         final long producerId = 13131L;
         final short epoch = 1;
-        ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(producerId, epoch);
-        TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(producerIdAndEpoch);
+
+        initializeTransactionManager(Optional.empty());
+        initializeIdempotentProducerId(producerId, epoch);
 
         ProducerBatch b1 = writeIdempotentBatchWithValue(transactionManager, tp0, "1");
 
         // The producerId might be reset due to a failure on another partition
-        ProducerIdAndEpoch updatedProducerIdAndEpoch = new ProducerIdAndEpoch(producerId + 1, epoch);
-        transactionManager.resetProducerId();
-        transactionManager.setProducerIdAndEpoch(updatedProducerIdAndEpoch);
+        transactionManager.resetIdempotentProducerId();
+        initializeIdempotentProducerId(producerId + 1, epoch);
 
         ProducerBatch b2 = writeIdempotentBatchWithValue(transactionManager, tp0, "2");
         assertEquals(1, transactionManager.sequenceNumber(tp0).intValue());
@@ -774,7 +767,7 @@ public class TransactionManagerTest {
 
     @Test
     public void testSequenceNumberOverflow() {
-        TransactionManager transactionManager = new TransactionManager();
+        initializeTransactionManager(Optional.empty());
         assertEquals((int) transactionManager.sequenceNumber(tp0), 0);
         transactionManager.incrementSequenceNumber(tp0, Integer.MAX_VALUE);
         assertEquals((int) transactionManager.sequenceNumber(tp0), Integer.MAX_VALUE);
@@ -786,11 +779,12 @@ public class TransactionManagerTest {
 
     @Test
     public void testProducerIdReset() {
-        TransactionManager transactionManager = new TransactionManager();
+        initializeTransactionManager(Optional.empty());
+        initializeIdempotentProducerId(15L, (short) 0);
         assertEquals((int) transactionManager.sequenceNumber(tp0), 0);
         transactionManager.incrementSequenceNumber(tp0, 3);
         assertEquals((int) transactionManager.sequenceNumber(tp0), 3);
-        transactionManager.resetProducerId();
+        transactionManager.resetIdempotentProducerId();
         assertEquals((int) transactionManager.sequenceNumber(tp0), 0);
     }
 
@@ -813,14 +807,10 @@ public class TransactionManagerTest {
         prepareProduceResponse(Errors.NONE, pid, epoch);
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
-        sender.runOnce();  // send addPartitions.
-        // Check that only addPartitions was sent.
-        assertTrue(transactionManager.transactionContainsPartition(tp0));
+        runUntil(() -> transactionManager.transactionContainsPartition(tp0));
         assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
         assertFalse(responseFuture.isDone());
-
-        sender.runOnce();  // send produce request.
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);
 
         Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
         offsets.put(tp1, new OffsetAndMetadata(1));
@@ -833,8 +823,7 @@ public class TransactionManagerTest {
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
 
-        sender.runOnce();  // Send AddOffsetsRequest
-        assertTrue(transactionManager.hasPendingOffsetCommits());  // We should now have created and queued the offset commit request.
+        runUntil(transactionManager::hasPendingOffsetCommits);
         assertFalse(addOffsetsResult.isCompleted()); // the result doesn't complete until TxnOffsetCommit returns
 
         Map<TopicPartition, Errors> txnOffsetCommitResponse = new HashMap<>();
@@ -844,21 +833,15 @@ public class TransactionManagerTest {
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, txnOffsetCommitResponse);
 
         assertNull(transactionManager.coordinator(CoordinatorType.GROUP));
-        sender.runOnce();  // try to send TxnOffsetCommitRequest, but find we don't have a group coordinator.
-        sender.runOnce();  // send find coordinator for group request
-        assertNotNull(transactionManager.coordinator(CoordinatorType.GROUP));
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.GROUP) != null);
         assertTrue(transactionManager.hasPendingOffsetCommits());
 
-        sender.runOnce();  // send TxnOffsetCommitRequest commit.
-
-        assertFalse(transactionManager.hasPendingOffsetCommits());
+        runUntil(() -> !transactionManager.hasPendingOffsetCommits());
         assertTrue(addOffsetsResult.isCompleted());  // We should only be done after both RPCs complete.
 
         transactionManager.beginCommit();
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.runOnce();  // commit.
-
-        assertFalse(transactionManager.hasOngoingTransaction());
+        runUntil(() -> !transactionManager.hasOngoingTransaction());
         assertFalse(transactionManager.isCompleting());
         assertFalse(transactionManager.transactionContainsPartition(tp0));
     }
@@ -869,12 +852,20 @@ public class TransactionManagerTest {
         // It finds the coordinator and then gets a PID.
         transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, true, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();  // find coordinator, connection lost.
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) == null);
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();  // find coordinator
-        sender.runOnce();
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
+    }
+
+    @Test
+    public void testInitializeTransactionsTwiceRaisesError() {
+        final long producerId = 13131L;
+        final short epoch = 1;
+        doInitTransactions(producerId, epoch);
+        assertTrue(transactionManager.hasProducerId());
+        assertThrows(KafkaException.class, () -> transactionManager.initializeTransactions());
     }
 
     @Test
@@ -887,8 +878,7 @@ public class TransactionManagerTest {
             return true;
         });
 
-        sender.runOnce(); // InitProducerRequest is queued
-        sender.runOnce(); // FindCoordinator is queued after peeking InitProducerRequest
+        runUntil(transactionManager::hasFatalError);
         assertTrue(transactionManager.hasFatalError());
         assertTrue(transactionManager.lastError() instanceof UnsupportedVersionException);
     }
@@ -897,11 +887,8 @@ public class TransactionManagerTest {
     public void testUnsupportedInitTransactions() {
         transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce(); // InitProducerRequest is queued
-        sender.runOnce(); // FindCoordinator is queued after peeking InitProducerRequest
-
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
         assertFalse(transactionManager.hasError());
-        assertNotNull(transactionManager.coordinator(CoordinatorType.TRANSACTION));
 
         client.prepareUnsupportedVersionResponse(body -> {
             InitProducerIdRequest initProducerIdRequest = (InitProducerIdRequest) body;
@@ -910,7 +897,7 @@ public class TransactionManagerTest {
             return true;
         });
 
-        sender.runOnce(); // InitProducerRequest is dequeued
+        runUntil(transactionManager::hasFatalError);
         assertTrue(transactionManager.hasFatalError());
         assertTrue(transactionManager.lastError() instanceof UnsupportedVersionException);
     }
@@ -929,16 +916,10 @@ public class TransactionManagerTest {
                 singletonMap(tp, new OffsetAndMetadata(39L)), new ConsumerGroupMetadata(consumerGroupId));
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.runOnce();  // FindCoordinator Enqueued
-
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.runOnce();  // FindCoordinator Returned
-
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, singletonMap(tp, Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT));
-        sender.runOnce();  // TxnOffsetCommit Handled
+        runUntil(transactionManager::hasError);
 
-        assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof UnsupportedForMessageFormatException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
@@ -965,11 +946,8 @@ public class TransactionManagerTest {
             new ConsumerGroupMetadata(consumerGroupId, 5, fencedMemberId, Optional.of(instanceId)));
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.runOnce();  // FindCoordinator Enqueued
-
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.runOnce();  // FindCoordinator Returned
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.GROUP) != null);
 
         client.prepareResponse(request -> {
             TxnOffsetCommitRequest txnOffsetCommitRequest = (TxnOffsetCommitRequest) request;
@@ -980,9 +958,7 @@ public class TransactionManagerTest {
                 && !txnOffsetCommitRequest.data.memberId().equals(memberId);
         }, new TxnOffsetCommitResponse(0, singletonMap(tp, Errors.FENCED_INSTANCE_ID)));
 
-        sender.runOnce();  // TxnOffsetCommit Handled
-
-        assertTrue(transactionManager.hasError());
+        runUntil(transactionManager::hasError);
         assertTrue(transactionManager.lastError() instanceof FencedInstanceIdException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
@@ -1008,11 +984,8 @@ public class TransactionManagerTest {
             new ConsumerGroupMetadata(consumerGroupId, 5, unknownMemberId, Optional.empty()));
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.runOnce();  // FindCoordinator Enqueued
-
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.runOnce();  // FindCoordinator Returned
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.GROUP) != null);
 
         client.prepareResponse(request -> {
             TxnOffsetCommitRequest txnOffsetCommitRequest = (TxnOffsetCommitRequest) request;
@@ -1023,7 +996,7 @@ public class TransactionManagerTest {
         }, new TxnOffsetCommitResponse(0, singletonMap(tp, Errors.UNKNOWN_MEMBER_ID)));
         sender.runOnce();  // TxnOffsetCommit Handled
 
-        assertTrue(transactionManager.hasError());
+        runUntil(transactionManager::hasError);
         assertTrue(transactionManager.lastError() instanceof CommitFailedException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
@@ -1050,11 +1023,8 @@ public class TransactionManagerTest {
                 Optional.empty()));
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.runOnce();  // FindCoordinator Enqueued
-
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.runOnce();  // FindCoordinator Returned
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.GROUP) != null);
 
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, singletonMap(tp, Errors.ILLEGAL_GENERATION));
         client.prepareResponse(request -> {
@@ -1066,7 +1036,7 @@ public class TransactionManagerTest {
         }, new TxnOffsetCommitResponse(0, singletonMap(tp, Errors.ILLEGAL_GENERATION)));
         sender.runOnce();  // TxnOffsetCommit Handled
 
-        assertTrue(transactionManager.hasError());
+        runUntil(transactionManager::hasError);
         assertTrue(transactionManager.lastError() instanceof CommitFailedException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
@@ -1082,24 +1052,25 @@ public class TransactionManagerTest {
         final short epoch = 1;
         TransactionalRequestResult initPidResult = transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();  // find coordinator
-        sender.runOnce();
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
+
         prepareInitPidResponse(Errors.NONE, true, pid, epoch);
         // send pid to coordinator, should get disconnected before receiving the response, and resend the
         // FindCoordinator and InitPid requests.
-        sender.runOnce();
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) == null);
 
         assertNull(transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         assertFalse(transactionManager.hasProducerId());
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
+
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         prepareInitPidResponse(Errors.NONE, false, pid, epoch);
-        sender.runOnce();  // get pid and epoch
+        runUntil(initPidResult::isCompleted);
 
         assertTrue(initPidResult.isCompleted()); // The future should only return after the second round of retries succeed.
         assertTrue(transactionManager.hasProducerId());
@@ -1115,29 +1086,26 @@ public class TransactionManagerTest {
         final short epoch = 1;
         TransactionalRequestResult initPidResult = transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();  // one loop to realize we need a coordinator.
-        sender.runOnce();  // next loop to find coordintor.
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
 
         client.disconnect(brokerNode.idString());
         client.blackout(brokerNode, 100);
         // send pid to coordinator. Should get disconnected before the send and resend the FindCoordinator
         // and InitPid requests.
-        sender.runOnce();
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) == null);
         time.sleep(110);  // waiting for the blackout period for the node to expire.
 
-        assertNull(transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         assertFalse(transactionManager.hasProducerId());
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         prepareInitPidResponse(Errors.NONE, false, pid, epoch);
-        sender.runOnce();  // get pid and epoch
 
-        assertTrue(initPidResult.isCompleted()); // The future should only return after the second round of retries succeed.
+        runUntil(initPidResult::isCompleted);
         assertTrue(transactionManager.hasProducerId());
         assertEquals(pid, transactionManager.producerIdAndEpoch().producerId);
         assertEquals(epoch, transactionManager.producerIdAndEpoch().epoch);
@@ -1151,25 +1119,22 @@ public class TransactionManagerTest {
         final short epoch = 1;
         TransactionalRequestResult initPidResult = transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();  // find coordinator
-        sender.runOnce();
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
 
         prepareInitPidResponse(Errors.NOT_COORDINATOR, false, pid, epoch);
-        sender.runOnce();  // send pid, get not coordinator. Should resend the FindCoordinator and InitPid requests
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) == null);
 
-        assertNull(transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         assertFalse(transactionManager.hasProducerId());
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         prepareInitPidResponse(Errors.NONE, false, pid, epoch);
-        sender.runOnce();  // get pid and epoch
 
-        assertTrue(initPidResult.isCompleted()); // The future should only return after the second round of retries succeed.
+        runUntil(initPidResult::isCompleted);
         assertTrue(transactionManager.hasProducerId());
         assertEquals(pid, transactionManager.producerIdAndEpoch().producerId);
         assertEquals(epoch, transactionManager.producerIdAndEpoch().epoch);
@@ -1180,17 +1145,13 @@ public class TransactionManagerTest {
         TransactionalRequestResult initPidResult = transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED, false,
                 CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();  // find coordinator
-        sender.runOnce();
 
-        assertTrue(transactionManager.hasError());
+        runUntil(transactionManager::hasError);
+
+        assertTrue(transactionManager.hasFatalError());
         assertTrue(transactionManager.lastError() instanceof TransactionalIdAuthorizationException);
-
-        sender.runOnce(); // one more run to fail the InitProducerId future
-        assertTrue(initPidResult.isCompleted());
         assertFalse(initPidResult.isSuccessful());
         assertTrue(initPidResult.error() instanceof TransactionalIdAuthorizationException);
-
         assertFatalError(TransactionalIdAuthorizationException.class);
     }
 
@@ -1199,14 +1160,11 @@ public class TransactionManagerTest {
         final long pid = 13131L;
         TransactionalRequestResult initPidResult = transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();  // find coordinator
-        sender.runOnce();
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
 
         prepareInitPidResponse(Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED, false, pid, RecordBatch.NO_PRODUCER_EPOCH);
-        sender.runOnce();
-
-        assertTrue(transactionManager.hasError());
+        runUntil(transactionManager::hasError);
         assertTrue(initPidResult.isCompleted());
         assertFalse(initPidResult.isSuccessful());
         assertTrue(initPidResult.error() instanceof TransactionalIdAuthorizationException);
@@ -1227,15 +1185,13 @@ public class TransactionManagerTest {
                 singletonMap(new TopicPartition("foo", 0), new OffsetAndMetadata(39L)), new ConsumerGroupMetadata(consumerGroupId));
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.runOnce();  // FindCoordinator Enqueued
+        runUntil(() -> !transactionManager.hasPartitionsToAdd());
 
         prepareFindCoordinatorResponse(Errors.GROUP_AUTHORIZATION_FAILED, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.runOnce();  // FindCoordinator Failed
-        sender.runOnce();  // TxnOffsetCommit Aborted
-        assertTrue(transactionManager.hasError());
+        runUntil(transactionManager::hasError);
         assertTrue(transactionManager.lastError() instanceof GroupAuthorizationException);
-        assertTrue(sendOffsetsResult.isCompleted());
+
+        runUntil(sendOffsetsResult::isCompleted);
         assertFalse(sendOffsetsResult.isSuccessful());
         assertTrue(sendOffsetsResult.error() instanceof GroupAuthorizationException);
 
@@ -1259,16 +1215,12 @@ public class TransactionManagerTest {
                 singletonMap(tp1, new OffsetAndMetadata(39L)), new ConsumerGroupMetadata(consumerGroupId));
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.runOnce();  // FindCoordinator Enqueued
+        runUntil(() -> !transactionManager.hasPartitionsToAdd());
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.runOnce();  // FindCoordinator Returned
-
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, singletonMap(tp1, Errors.GROUP_AUTHORIZATION_FAILED));
-        sender.runOnce();  // TxnOffsetCommit Handled
 
-        assertTrue(transactionManager.hasError());
+        runUntil(transactionManager::hasError);
         assertTrue(transactionManager.lastError() instanceof GroupAuthorizationException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
@@ -1295,9 +1247,7 @@ public class TransactionManagerTest {
                 singletonMap(tp, new OffsetAndMetadata(39L)), new ConsumerGroupMetadata(consumerGroupId));
 
         prepareAddOffsetsToTxnResponse(Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED, consumerGroupId, pid, epoch);
-        sender.runOnce();  // AddOffsetsToTxn Handled
-
-        assertTrue(transactionManager.hasError());
+        runUntil(transactionManager::hasError);
         assertTrue(transactionManager.lastError() instanceof TransactionalIdAuthorizationException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
@@ -1320,16 +1270,12 @@ public class TransactionManagerTest {
                 singletonMap(tp, new OffsetAndMetadata(39L)), new ConsumerGroupMetadata(consumerGroupId));
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.runOnce();  // FindCoordinator Enqueued
+        runUntil(() -> !transactionManager.hasPartitionsToAdd());
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.runOnce();  // FindCoordinator Returned
-
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, singletonMap(tp, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED));
-        sender.runOnce();  // TxnOffsetCommit Handled
+        runUntil(transactionManager::hasError);
 
-        assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof TransactionalIdAuthorizationException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
@@ -1361,9 +1307,8 @@ public class TransactionManagerTest {
         errors.put(tp1, Errors.OPERATION_NOT_ATTEMPTED);
 
         prepareAddPartitionsToTxn(errors);
-        sender.runOnce();
+        runUntil(transactionManager::hasError);
 
-        assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof TopicAuthorizationException);
         assertFalse(transactionManager.isPartitionPendingAdd(tp0));
         assertFalse(transactionManager.isPartitionPendingAdd(tp1));
@@ -1444,17 +1389,15 @@ public class TransactionManagerTest {
         Future<RecordMetadata> responseFuture = appendToAccumulator(unauthorizedPartition);
 
         prepareAddPartitionsToTxn(singletonMap(unauthorizedPartition, Errors.TOPIC_AUTHORIZATION_FAILED));
-        sender.runOnce();
+        runUntil(() -> !client.hasPendingResponses());
 
         assertTrue(transactionManager.hasAbortableError());
         transactionManager.beginAbort();
-        sender.runOnce();
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);
         assertFutureFailed(responseFuture);
 
         // No partitions added, so no need to prepare EndTxn response
-        sender.runOnce();
-        assertTrue(transactionManager.isReady());
+        runUntil(transactionManager::isReady);
         assertFalse(transactionManager.hasPartitionsToAdd());
         assertFalse(accumulator.hasIncomplete());
 
@@ -1467,21 +1410,16 @@ public class TransactionManagerTest {
         responseFuture = appendToAccumulator(tp0);
 
         prepareAddPartitionsToTxn(singletonMap(tp0, Errors.NONE));
-        sender.runOnce();
-        assertTrue(transactionManager.isPartitionAdded(tp0));
+        runUntil(() -> transactionManager.isPartitionAdded(tp0));
         assertFalse(transactionManager.hasPartitionsToAdd());
 
         transactionManager.beginCommit();
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.runOnce();
-
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);
         assertNotNull(responseFuture.get());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.runOnce();
-
-        assertTrue(transactionManager.isReady());
+        runUntil(transactionManager::isReady);
     }
 
     @Test
@@ -1498,15 +1436,13 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
 
         Future<RecordMetadata> authorizedTopicProduceFuture = appendToAccumulator(unauthorizedPartition);
-        sender.runOnce();
-        assertTrue(transactionManager.isPartitionAdded(tp0));
+        runUntil(() -> transactionManager.isPartitionAdded(tp0));
 
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(unauthorizedPartition);
         Future<RecordMetadata> unauthorizedTopicProduceFuture = appendToAccumulator(unauthorizedPartition);
         prepareAddPartitionsToTxn(singletonMap(unauthorizedPartition, Errors.TOPIC_AUTHORIZATION_FAILED));
-        sender.runOnce();
-        assertTrue(transactionManager.hasAbortableError());
+        runUntil(transactionManager::hasAbortableError);
         assertTrue(transactionManager.isPartitionAdded(tp0));
         assertFalse(transactionManager.isPartitionAdded(unauthorizedPartition));
         assertFalse(authorizedTopicProduceFuture.isDone());
@@ -1514,11 +1450,10 @@ public class TransactionManagerTest {
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
         transactionManager.beginAbort();
-        sender.runOnce();
+        runUntil(transactionManager::isReady);
         // neither produce request has been sent, so they should both be failed immediately
         assertFutureFailed(authorizedTopicProduceFuture);
         assertFutureFailed(unauthorizedTopicProduceFuture);
-        assertTrue(transactionManager.isReady());
         assertFalse(transactionManager.hasPartitionsToAdd());
         assertFalse(accumulator.hasIncomplete());
 
@@ -1531,21 +1466,16 @@ public class TransactionManagerTest {
         FutureRecordMetadata nextTransactionFuture = appendToAccumulator(tp0);
 
         prepareAddPartitionsToTxn(singletonMap(tp0, Errors.NONE));
-        sender.runOnce();
-        assertTrue(transactionManager.isPartitionAdded(tp0));
+        runUntil(() -> transactionManager.isPartitionAdded(tp0));
         assertFalse(transactionManager.hasPartitionsToAdd());
 
         transactionManager.beginCommit();
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.runOnce();
-
-        assertTrue(nextTransactionFuture.isDone());
+        runUntil(nextTransactionFuture::isDone);
         assertNotNull(nextTransactionFuture.get());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.runOnce();
-
-        assertTrue(transactionManager.isReady());
+        runUntil(transactionManager::isReady);
     }
 
     @Test
@@ -1562,12 +1492,11 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
 
         Future<RecordMetadata> authorizedTopicProduceFuture = appendToAccumulator(tp0);
-        sender.runOnce();
-        assertTrue(transactionManager.isPartitionAdded(tp0));
+        runUntil(() -> transactionManager.isPartitionAdded(tp0));
 
         accumulator.beginFlush();
         prepareProduceResponse(Errors.REQUEST_TIMED_OUT, pid, epoch);
-        sender.runOnce();
+        runUntil(() -> !client.hasPendingResponses());
         assertFalse(authorizedTopicProduceFuture.isDone());
         assertTrue(accumulator.hasIncomplete());
 
@@ -1575,22 +1504,21 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(unauthorizedPartition);
         Future<RecordMetadata> unauthorizedTopicProduceFuture = appendToAccumulator(unauthorizedPartition);
         prepareAddPartitionsToTxn(singletonMap(unauthorizedPartition, Errors.TOPIC_AUTHORIZATION_FAILED));
-        sender.runOnce();
-        assertTrue(transactionManager.hasAbortableError());
+        runUntil(transactionManager::hasAbortableError);
         assertTrue(transactionManager.isPartitionAdded(tp0));
         assertFalse(transactionManager.isPartitionAdded(unauthorizedPartition));
         assertFalse(authorizedTopicProduceFuture.isDone());
 
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.runOnce();
+        runUntil(authorizedTopicProduceFuture::isDone);
+
         assertFutureFailed(unauthorizedTopicProduceFuture);
-        assertTrue(authorizedTopicProduceFuture.isDone());
         assertNotNull(authorizedTopicProduceFuture.get());
         assertTrue(authorizedTopicProduceFuture.isDone());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
         transactionManager.beginAbort();
-        sender.runOnce();
+        runUntil(transactionManager::isReady);
         // neither produce request has been sent, so they should both be failed immediately
         assertTrue(transactionManager.isReady());
         assertFalse(transactionManager.hasPartitionsToAdd());
@@ -1605,21 +1533,16 @@ public class TransactionManagerTest {
         FutureRecordMetadata nextTransactionFuture = appendToAccumulator(tp0);
 
         prepareAddPartitionsToTxn(singletonMap(tp0, Errors.NONE));
-        sender.runOnce();
-        assertTrue(transactionManager.isPartitionAdded(tp0));
+        runUntil(() -> transactionManager.isPartitionAdded(tp0));
         assertFalse(transactionManager.hasPartitionsToAdd());
 
         transactionManager.beginCommit();
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.runOnce();
-
-        assertTrue(nextTransactionFuture.isDone());
+        runUntil(nextTransactionFuture::isDone);
         assertNotNull(nextTransactionFuture.get());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.runOnce();
-
-        assertTrue(transactionManager.isReady());
+        runUntil(transactionManager::isReady);
     }
 
     @Test
@@ -1635,9 +1558,7 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp);
 
         prepareAddPartitionsToTxn(tp, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED);
-        sender.runOnce();
-
-        assertTrue(transactionManager.hasError());
+        runUntil(transactionManager::hasError);
         assertTrue(transactionManager.lastError() instanceof TransactionalIdAuthorizationException);
 
         assertFatalError(TransactionalIdAuthorizationException.class);
@@ -1668,22 +1589,19 @@ public class TransactionManagerTest {
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
 
-        sender.runOnce();  // AddPartitions.
-        assertTrue(transactionManager.transactionContainsPartition(tp0));
+        runUntil(() -> transactionManager.transactionContainsPartition(tp0));
         assertFalse(responseFuture.isDone());
         assertFalse(commitResult.isCompleted());
 
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.runOnce();  // Produce.
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
         assertFalse(commitResult.isCompleted());
         assertTrue(transactionManager.hasOngoingTransaction());
         assertTrue(transactionManager.isCompleting());
 
-        sender.runOnce();
-        assertTrue(commitResult.isCompleted());
+        runUntil(commitResult::isCompleted);
         assertFalse(transactionManager.hasOngoingTransaction());
     }
 
@@ -1707,9 +1625,7 @@ public class TransactionManagerTest {
         assertFalse(transactionManager.transactionContainsPartition(tp0));
 
         // Sender flushes one add partitions. The produce goes next.
-        sender.runOnce();  // send addPartitions.
-        // Check that only addPartitions was sent.
-        assertTrue(transactionManager.transactionContainsPartition(tp0));
+        runUntil(() -> transactionManager.transactionContainsPartition(tp0));
 
         // In the mean time, the user does a second produce to a different partition
         transactionManager.failIfNotReadyForSend();
@@ -1725,16 +1641,13 @@ public class TransactionManagerTest {
         assertFalse(secondResponseFuture.isDone());
 
         // The second add partitions should go out here.
-        sender.runOnce();  // send second add partitions request
-        assertTrue(transactionManager.transactionContainsPartition(tp1));
+        runUntil(() -> transactionManager.transactionContainsPartition(tp1));
 
         assertFalse(responseFuture.isDone());
         assertFalse(secondResponseFuture.isDone());
 
         // Finally we get to the produce.
-        sender.runOnce();  // send produce request
-
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);
         assertTrue(secondResponseFuture.isDone());
     }
 
@@ -1754,11 +1667,8 @@ public class TransactionManagerTest {
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
         prepareProduceResponse(Errors.INVALID_PRODUCER_EPOCH, pid, epoch);
-        sender.runOnce(); // Add partitions.
 
-        sender.runOnce();  // send produce.
-
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);
         assertTrue(transactionManager.hasError());
 
         try {
@@ -1795,12 +1705,7 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
         prepareProduceResponse(Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, pid, epoch);
 
-        sender.runOnce();  // Send AddPartitionsRequest
-        assertFalse(commitResult.isCompleted());
-        sender.runOnce();  // Send Produce Request, returns OutOfOrderSequenceException.
-
-        sender.runOnce();  // try to commit.
-        assertTrue(commitResult.isCompleted());  // commit should be cancelled with exception without being sent.
+        runUntil(commitResult::isCompleted);  // commit should be cancelled with exception without being sent.
 
         try {
             commitResult.await();
@@ -1819,9 +1724,8 @@ public class TransactionManagerTest {
         // Commit is not allowed, so let's abort and try again.
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
-        sender.runOnce();  // Send abort request. It is valid to transition from ERROR to ABORT
 
-        assertTrue(abortResult.isCompleted());
+        runUntil(abortResult::isCompleted);
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
     }
@@ -1844,12 +1748,10 @@ public class TransactionManagerTest {
         prepareProduceResponse(Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, pid, epoch);
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
 
-        sender.runOnce();  // Send AddPartitionsRequest
-        sender.runOnce();  // Send Produce Request, returns OutOfOrderSequenceException.
-
+        runUntil(transactionManager::hasAbortableError);
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
-        sender.runOnce();  // try to abort
-        assertTrue(abortResult.isCompleted());
+
+        runUntil(abortResult::isCompleted);
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
     }
@@ -1869,9 +1771,7 @@ public class TransactionManagerTest {
 
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
-
-        sender.runOnce();  // Send AddPartitionsRequest
-        sender.runOnce();  // Send Produce Request
+        runUntil(() -> !accumulator.hasUndrained());
 
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
         assertTrue(transactionManager.isAborting());
@@ -1879,14 +1779,13 @@ public class TransactionManagerTest {
 
         sendProduceResponse(Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, pid, epoch);
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
-        sender.runOnce();  // receive the produce response
+        runUntil(responseFuture::isDone);
 
         // we do not transition to ABORTABLE_ERROR since we were already aborting
         assertTrue(transactionManager.isAborting());
         assertFalse(transactionManager.hasError());
 
-        sender.runOnce();  // handle the abort
-        assertTrue(abortResult.isCompleted());
+        runUntil(abortResult::isCompleted);
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
     }
@@ -1905,39 +1804,37 @@ public class TransactionManagerTest {
         Future<RecordMetadata> responseFuture = appendToAccumulator(tp0);
 
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
-        sender.runOnce();
+        runUntil(() -> !client.hasPendingResponses());
         assertTrue(accumulator.hasUndrained());
 
         // committing the transaction should cause the unsent batch to be flushed
         transactionManager.beginCommit();
-        sender.runOnce();
-        assertFalse(accumulator.hasUndrained());
+        runUntil(() -> !accumulator.hasUndrained());
         assertTrue(accumulator.hasIncomplete());
-        assertFalse(transactionManager.hasInFlightTransactionalRequest());
+        assertFalse(transactionManager.hasInFlightRequest());
         assertFalse(responseFuture.isDone());
 
         // until the produce future returns, we will not send EndTxn
-        sender.runOnce();
+        AtomicInteger numRuns = new AtomicInteger(0);
+        runUntil(() -> numRuns.incrementAndGet() >= 4);
         assertFalse(accumulator.hasUndrained());
         assertTrue(accumulator.hasIncomplete());
-        assertFalse(transactionManager.hasInFlightTransactionalRequest());
+        assertFalse(transactionManager.hasInFlightRequest());
         assertFalse(responseFuture.isDone());
 
         // now the produce response returns
         sendProduceResponse(Errors.NONE, pid, epoch);
-        sender.runOnce();
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);
         assertFalse(accumulator.hasUndrained());
         assertFalse(accumulator.hasIncomplete());
-        assertFalse(transactionManager.hasInFlightTransactionalRequest());
+        assertFalse(transactionManager.hasInFlightRequest());
 
         // now we send EndTxn
-        sender.runOnce();
-        assertTrue(transactionManager.hasInFlightTransactionalRequest());
+        runUntil(transactionManager::hasInFlightRequest);
         sendEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.runOnce();
-        assertFalse(transactionManager.hasInFlightTransactionalRequest());
-        assertTrue(transactionManager.isReady());
+
+        runUntil(transactionManager::isReady);
+        assertFalse(transactionManager.hasInFlightRequest());
     }
 
     @Test
@@ -1954,45 +1851,36 @@ public class TransactionManagerTest {
         Future<RecordMetadata> responseFuture = appendToAccumulator(tp0);
 
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
-        sender.runOnce();
+        runUntil(() -> !transactionManager.hasPartitionsToAdd());
         assertTrue(accumulator.hasUndrained());
 
         accumulator.beginFlush();
-        sender.runOnce();
+        runUntil(() -> !accumulator.hasUndrained());
         assertFalse(accumulator.hasUndrained());
         assertTrue(accumulator.hasIncomplete());
-        assertFalse(transactionManager.hasInFlightTransactionalRequest());
+        assertFalse(transactionManager.hasInFlightRequest());
 
         // now we begin the commit with the produce request still pending
         transactionManager.beginCommit();
-        sender.runOnce();
+        AtomicInteger numRuns = new AtomicInteger(0);
+        runUntil(() -> numRuns.incrementAndGet() >= 4);
         assertFalse(accumulator.hasUndrained());
         assertTrue(accumulator.hasIncomplete());
-        assertFalse(transactionManager.hasInFlightTransactionalRequest());
-        assertFalse(responseFuture.isDone());
-
-        // until the produce future returns, we will not send EndTxn
-        sender.runOnce();
-        assertFalse(accumulator.hasUndrained());
-        assertTrue(accumulator.hasIncomplete());
-        assertFalse(transactionManager.hasInFlightTransactionalRequest());
+        assertFalse(transactionManager.hasInFlightRequest());
         assertFalse(responseFuture.isDone());
 
         // now the produce response returns
         sendProduceResponse(Errors.NONE, pid, epoch);
-        sender.runOnce();
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);
         assertFalse(accumulator.hasUndrained());
         assertFalse(accumulator.hasIncomplete());
-        assertFalse(transactionManager.hasInFlightTransactionalRequest());
+        assertFalse(transactionManager.hasInFlightRequest());
 
         // now we send EndTxn
-        sender.runOnce();
-        assertTrue(transactionManager.hasInFlightTransactionalRequest());
+        runUntil(transactionManager::hasInFlightRequest);
         sendEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.runOnce();
-        assertFalse(transactionManager.hasInFlightTransactionalRequest());
-        assertTrue(transactionManager.isReady());
+        runUntil(transactionManager::isReady);
+        assertFalse(transactionManager.hasInFlightRequest());
     }
 
     @Test
@@ -2009,16 +1897,14 @@ public class TransactionManagerTest {
         Future<RecordMetadata> responseFuture = appendToAccumulator(tp0);
 
         assertFalse(responseFuture.isDone());
-        sender.runOnce();  // Send AddPartitionsRequest
+        runUntil(transactionManager::hasInFlightRequest);
 
         transactionManager.transitionToAbortableError(new KafkaException());
         sendAddPartitionsToTxnResponse(Errors.NOT_COORDINATOR, tp0, epoch, pid);
-        sender.runOnce(); // AddPartitions returns
-        assertTrue(transactionManager.hasAbortableError());
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) == null);
 
-        assertNull(transactionManager.coordinator(CoordinatorType.TRANSACTION));
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce(); // FindCoordinator handled
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertTrue(transactionManager.hasAbortableError());
     }
@@ -2041,8 +1927,7 @@ public class TransactionManagerTest {
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
         // note since no partitions were added to the transaction, no EndTxn will be sent
 
-        sender.runOnce();  // try to abort
-        assertTrue(abortResult.isCompleted());
+        runUntil(abortResult::isCompleted);
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
 
@@ -2068,7 +1953,7 @@ public class TransactionManagerTest {
 
         Future<RecordMetadata> responseFuture = appendToAccumulator(tp0);
 
-        sender.runOnce();  // Send AddPartitions and let it fail
+        runUntil(() -> !client.hasPendingResponses());
         assertFalse(responseFuture.isDone());
 
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
@@ -2077,10 +1962,7 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, producerEpoch, producerId);
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, producerId, producerEpoch);
 
-        sender.runOnce();  // Resend AddPartitions
-        sender.runOnce();  // Send EndTxn
-
-        assertTrue(abortResult.isCompleted());
+        runUntil(abortResult::isCompleted);
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
 
@@ -2107,9 +1989,7 @@ public class TransactionManagerTest {
 
         Future<RecordMetadata> responseFuture = appendToAccumulator(tp0);
 
-        sender.runOnce();  // Send AddPartitions
-        sender.runOnce();  // Send ProduceRequest and let it fail
-
+        runUntil(() -> !client.hasPendingResponses());
         assertFalse(responseFuture.isDone());
 
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
@@ -2118,10 +1998,7 @@ public class TransactionManagerTest {
         prepareProduceResponse(Errors.NONE, producerId, producerEpoch);
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, producerId, producerEpoch);
 
-        sender.runOnce();  // Resend ProduceRequest
-        sender.runOnce();  // Send EndTxn
-
-        assertTrue(abortResult.isCompleted());
+        runUntil(abortResult::isCompleted);
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
 
@@ -2145,16 +2022,13 @@ public class TransactionManagerTest {
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, tp0, epoch, pid);
 
-        sender.runOnce();  // Send AddPartitionsRequest
+        runUntil(() -> !client.hasPendingResponses());
         assertFalse(transactionManager.transactionContainsPartition(tp0));  // The partition should not yet be added.
 
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.runOnce();  // Send AddPartitionsRequest successfully.
-        assertTrue(transactionManager.transactionContainsPartition(tp0));
-
-        sender.runOnce();  // Send ProduceRequest.
-        assertTrue(responseFuture.isDone());
+        runUntil(() -> transactionManager.transactionContainsPartition(tp0));
+        runUntil(responseFuture::isDone);
     }
 
     @Test
@@ -2183,9 +2057,7 @@ public class TransactionManagerTest {
         TransactionalRequestResult addOffsetsResult = transactionManager.sendOffsetsToTransaction(
             offsets, new ConsumerGroupMetadata(consumerGroupId));
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-
-        sender.runOnce();  // send AddOffsetsToTxnResult
-
+        runUntil(() -> !client.hasPendingResponses());
         assertFalse(addOffsetsResult.isCompleted());  // The request should complete only after the TxnOffsetCommit completes.
 
         Map<TopicPartition, Errors> txnOffsetCommitResponse = new HashMap<>();
@@ -2196,21 +2068,15 @@ public class TransactionManagerTest {
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, txnOffsetCommitResponse);
 
         assertNull(transactionManager.coordinator(CoordinatorType.GROUP));
-        sender.runOnce();  // try to send TxnOffsetCommitRequest, but find we don't have a group coordinator.
-        sender.runOnce();  // send find coordinator for group request
-        assertNotNull(transactionManager.coordinator(CoordinatorType.GROUP));
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.GROUP) != null);
         assertTrue(transactionManager.hasPendingOffsetCommits());
 
-        sender.runOnce();  // send TxnOffsetCommitRequest request.
-
-        assertTrue(transactionManager.hasPendingOffsetCommits());  // The TxnOffsetCommit failed.
+        runUntil(transactionManager::hasPendingOffsetCommits);  // The TxnOffsetCommit failed.
         assertFalse(addOffsetsResult.isCompleted());  // We should only be done after both RPCs complete successfully.
 
         txnOffsetCommitResponse.put(tp1, Errors.NONE);
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, txnOffsetCommitResponse);
-        sender.runOnce();  // Send TxnOffsetCommitRequest again.
-
-        assertTrue(addOffsetsResult.isCompleted());
+        runUntil(addOffsetsResult::isCompleted);
         assertTrue(addOffsetsResult.isSuccessful());
     }
 
@@ -2231,13 +2097,12 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
         prepareAddPartitionsToTxnResponse(Errors.TOPIC_AUTHORIZATION_FAILED, tp0, epoch, pid);
-        sender.runOnce();  // Send AddPartitionsRequest
+        runUntil(() -> !client.hasPendingResponses());
 
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
         assertFalse(abortResult.isCompleted());
 
-        sender.runOnce();
-        assertTrue(abortResult.isCompleted());
+        runUntil(abortResult::isCompleted);
         assertTrue(abortResult.isSuccessful());
     }
 
@@ -2258,10 +2123,7 @@ public class TransactionManagerTest {
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
 
         prepareAddOffsetsToTxnResponse(Errors.GROUP_AUTHORIZATION_FAILED, consumerGroupId, pid, epoch);
-        sender.runOnce();  // Send AddOffsetsToTxnRequest
-        assertFalse(abortResult.isCompleted());
-
-        sender.runOnce();
+        runUntil(abortResult::isCompleted);
         assertTrue(transactionManager.isReady());
         assertTrue(abortResult.isCompleted());
         assertTrue(abortResult.isSuccessful());
@@ -2284,11 +2146,8 @@ public class TransactionManagerTest {
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
 
         prepareAddOffsetsToTxnResponse(Errors.UNKNOWN_SERVER_ERROR, consumerGroupId, pid, epoch);
-        sender.runOnce();  // Send AddOffsetsToTxnRequest
-        assertFalse(abortResult.isCompleted());
 
-        sender.runOnce();
-        assertTrue(abortResult.isCompleted());
+        runUntil(abortResult::isCompleted);
         assertFalse(abortResult.isSuccessful());
         assertTrue(transactionManager.hasFatalError());
     }
@@ -2389,16 +2248,12 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp1);
         prepareAddPartitionsToTxn(tp1, Errors.NONE);
-        sender.runOnce();  // Send AddPartitions, tp1 should be in the transaction now.
-
-        assertTrue(transactionManager.transactionContainsPartition(tp1));
+        runUntil(() -> transactionManager.transactionContainsPartition(tp1));
 
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxn(tp0, Errors.TOPIC_AUTHORIZATION_FAILED);
-        sender.runOnce();  // Send AddPartitions, should be in abortable state.
-
-        assertTrue(transactionManager.hasAbortableError());
+        runUntil(transactionManager::hasAbortableError);
         assertTrue(transactionManager.isSendToPartitionAllowed(tp1));
 
         // Try to drain a message destined for tp1, it should get drained.
@@ -2455,16 +2310,13 @@ public class TransactionManagerTest {
 
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
         prepareProduceResponse(Errors.NOT_LEADER_FOR_PARTITION, pid, epoch);
-        sender.runOnce(); // Add partitions
-        sender.runOnce(); // Produce
+        runUntil(() -> !client.hasPendingResponses());
 
         assertFalse(responseFuture.isDone());
 
         transactionManager.transitionToAbortableError(new KafkaException());
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.runOnce();
-
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);
         assertNotNull(responseFuture.get()); // should throw the exception which caused the transaction to be aborted.
     }
 
@@ -2487,9 +2339,8 @@ public class TransactionManagerTest {
 
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
-        sender.runOnce();  // send addPartitions.
         // Check that only addPartitions was sent.
-        assertTrue(transactionManager.transactionContainsPartition(tp0));
+        runUntil(() -> transactionManager.transactionContainsPartition(tp0));
         assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
         assertFalse(responseFuture.isDone());
 
@@ -2501,8 +2352,7 @@ public class TransactionManagerTest {
         client.disconnect(clusterNode.idString());
         client.blackout(clusterNode, 100);
 
-        sender.runOnce();  // We should try to flush the produce, but expire it instead without sending anything.
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);
 
         try {
             // make sure the produce was expired.
@@ -2540,9 +2390,8 @@ public class TransactionManagerTest {
 
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
-        sender.runOnce();  // send addPartitions.
         // Check that only addPartitions was sent.
-        assertTrue(transactionManager.transactionContainsPartition(tp0));
+        runUntil(() -> transactionManager.transactionContainsPartition(tp0));
         assertTrue(transactionManager.transactionContainsPartition(tp1));
         assertTrue(transactionManager.isSendToPartitionAllowed(tp1));
         assertTrue(transactionManager.isSendToPartitionAllowed(tp1));
@@ -2557,9 +2406,8 @@ public class TransactionManagerTest {
         client.disconnect(clusterNode.idString());
         client.blackout(clusterNode, 100);
 
-        sender.runOnce();  // We should try to flush the produce, but expire it instead without sending anything.
-        assertTrue(firstBatchResponse.isDone());
-        assertTrue(secondBatchResponse.isDone());
+        runUntil(firstBatchResponse::isDone);
+        runUntil(secondBatchResponse::isDone);
 
         try {
             // make sure the produce was expired.
@@ -2598,9 +2446,8 @@ public class TransactionManagerTest {
 
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
-        sender.runOnce();  // send addPartitions.
         // Check that only addPartitions was sent.
-        assertTrue(transactionManager.transactionContainsPartition(tp0));
+        runUntil(() -> transactionManager.transactionContainsPartition(tp0));
         assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
         assertFalse(responseFuture.isDone());
 
@@ -2613,8 +2460,7 @@ public class TransactionManagerTest {
         Node clusterNode = metadata.fetch().nodes().get(0);
         client.disconnect(clusterNode.idString());
 
-        sender.runOnce();  // We should try to flush the produce, but expire it instead without sending anything.
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);  // We should try to flush the produce, but expire it instead without sending anything.
 
         try {
             // make sure the produce was expired.
@@ -2623,9 +2469,7 @@ public class TransactionManagerTest {
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof  TimeoutException);
         }
-        sender.runOnce();  // the commit shouldn't be completed without being sent since the produce request failed.
-
-        assertTrue(commitResult.isCompleted());
+        runUntil(commitResult::isCompleted);  // the commit shouldn't be completed without being sent since the produce request failed.
         assertFalse(commitResult.isSuccessful());  // the commit shouldn't succeed since the produce request failed.
 
         assertTrue(transactionManager.hasAbortableError());
@@ -2636,10 +2480,7 @@ public class TransactionManagerTest {
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
-
-        sender.runOnce();  // send the abort.
-
-        assertTrue(abortResult.isCompleted());
+        runUntil(abortResult::isCompleted);
         assertTrue(abortResult.isSuccessful());
         assertFalse(transactionManager.hasOngoingTransaction());
         assertFalse(transactionManager.transactionContainsPartition(tp0));
@@ -2664,14 +2505,12 @@ public class TransactionManagerTest {
 
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
-        sender.runOnce();  // send addPartitions.
         // Check that only addPartitions was sent.
-        assertTrue(transactionManager.transactionContainsPartition(tp0));
+        runUntil(() -> transactionManager.transactionContainsPartition(tp0));
         assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
 
         prepareProduceResponse(Errors.NOT_LEADER_FOR_PARTITION, pid, epoch);
-        sender.runOnce();  // send the produce request.
-
+        runUntil(() -> !client.hasPendingResponses());
         assertFalse(responseFuture.isDone());
 
         TransactionalRequestResult commitResult = transactionManager.beginCommit();
@@ -2684,8 +2523,7 @@ public class TransactionManagerTest {
         client.disconnect(clusterNode.idString());
         client.blackout(clusterNode, 100);
 
-        sender.runOnce();  // We should try to flush the produce, but expire it instead without sending anything.
-        assertTrue(responseFuture.isDone());
+        runUntil(responseFuture::isDone);  // We should try to flush the produce, but expire it instead without sending anything.
 
         try {
             // make sure the produce was expired.
@@ -2694,10 +2532,7 @@ public class TransactionManagerTest {
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof  TimeoutException);
         }
-        sender.runOnce();  // Transition to fatal error since we have unresolved batches.
-        sender.runOnce();  // Fail the queued transactional requests
-
-        assertTrue(commitResult.isCompleted());
+        runUntil(commitResult::isCompleted);
         assertFalse(commitResult.isSuccessful());  // the commit should have been dropped.
 
         assertTrue(transactionManager.hasFatalError());
@@ -2706,140 +2541,137 @@ public class TransactionManagerTest {
 
     @Test
     public void testResetProducerIdAfterWithoutPendingInflightRequests() {
-        TransactionManager manager = new TransactionManager(logContext, null, transactionTimeoutMs,
-            DEFAULT_RETRY_BACKOFF_MS);
+        initializeTransactionManager(Optional.empty());
         long producerId = 15L;
         short epoch = 5;
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(producerId, epoch);
-        manager.setProducerIdAndEpoch(producerIdAndEpoch);
+        initializeIdempotentProducerId(producerId, epoch);
 
         // Nothing to resolve, so no reset is needed
-        manager.resetProducerIdIfNeeded();
-        assertEquals(producerIdAndEpoch, manager.producerIdAndEpoch());
+        transactionManager.resetIdempotentProducerIdIfNeeded();
+        assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
 
         TopicPartition tp0 = new TopicPartition("foo", 0);
-        assertEquals(Integer.valueOf(0), manager.sequenceNumber(tp0));
+        assertEquals(Integer.valueOf(0), transactionManager.sequenceNumber(tp0));
 
-        ProducerBatch b1 = writeIdempotentBatchWithValue(manager, tp0, "1");
-        assertEquals(Integer.valueOf(1), manager.sequenceNumber(tp0));
-        manager.handleCompletedBatch(b1, new ProduceResponse.PartitionResponse(
+        ProducerBatch b1 = writeIdempotentBatchWithValue(transactionManager, tp0, "1");
+        assertEquals(Integer.valueOf(1), transactionManager.sequenceNumber(tp0));
+        transactionManager.handleCompletedBatch(b1, new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, time.milliseconds(), 0L));
-        assertEquals(OptionalInt.of(0), manager.lastAckedSequence(tp0));
+        assertEquals(OptionalInt.of(0), transactionManager.lastAckedSequence(tp0));
 
         // Marking sequence numbers unresolved without inflight requests is basically a no-op.
-        manager.markSequenceUnresolved(tp0);
-        manager.resetProducerIdIfNeeded();
-        assertEquals(producerIdAndEpoch, manager.producerIdAndEpoch());
-        assertFalse(manager.hasUnresolvedSequences());
+        transactionManager.markSequenceUnresolved(tp0);
+        transactionManager.resetIdempotentProducerIdIfNeeded();
+        assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
+        assertFalse(transactionManager.hasUnresolvedSequences());
 
         // We have a new batch which fails with a timeout
-        ProducerBatch b2 = writeIdempotentBatchWithValue(manager, tp0, "2");
-        assertEquals(Integer.valueOf(2), manager.sequenceNumber(tp0));
-        manager.markSequenceUnresolved(tp0);
-        manager.handleFailedBatch(b2, new TimeoutException(), false);
-        assertTrue(manager.hasUnresolvedSequences());
+        ProducerBatch b2 = writeIdempotentBatchWithValue(transactionManager, tp0, "2");
+        assertEquals(Integer.valueOf(2), transactionManager.sequenceNumber(tp0));
+        transactionManager.markSequenceUnresolved(tp0);
+        transactionManager.handleFailedBatch(b2, new TimeoutException(), false);
+        assertTrue(transactionManager.hasUnresolvedSequences());
 
         // We only had one inflight batch, so we should be able to clear the unresolved status
         // and reset the producerId
-        manager.resetProducerIdIfNeeded();
-        assertFalse(manager.hasUnresolvedSequences());
-        assertFalse(manager.hasProducerId());
+        transactionManager.resetIdempotentProducerIdIfNeeded();
+        assertFalse(transactionManager.hasUnresolvedSequences());
+        assertFalse(transactionManager.hasProducerId());
     }
 
     @Test
     public void testNoProducerIdResetAfterLastInFlightBatchSucceeds() {
-        TransactionManager manager = new TransactionManager(logContext, null, transactionTimeoutMs,
-                DEFAULT_RETRY_BACKOFF_MS);
+        initializeTransactionManager(Optional.empty());
         long producerId = 15L;
         short epoch = 5;
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(producerId, epoch);
-        manager.setProducerIdAndEpoch(producerIdAndEpoch);
+        initializeIdempotentProducerId(producerId, epoch);
 
         TopicPartition tp0 = new TopicPartition("foo", 0);
-        ProducerBatch b1 = writeIdempotentBatchWithValue(manager, tp0, "1");
-        ProducerBatch b2 = writeIdempotentBatchWithValue(manager, tp0, "2");
-        ProducerBatch b3 = writeIdempotentBatchWithValue(manager, tp0, "3");
-        assertEquals(3, manager.sequenceNumber(tp0).intValue());
+        ProducerBatch b1 = writeIdempotentBatchWithValue(transactionManager, tp0, "1");
+        ProducerBatch b2 = writeIdempotentBatchWithValue(transactionManager, tp0, "2");
+        ProducerBatch b3 = writeIdempotentBatchWithValue(transactionManager, tp0, "3");
+        assertEquals(3, transactionManager.sequenceNumber(tp0).intValue());
 
         // The first batch fails with a timeout
-        manager.markSequenceUnresolved(tp0);
-        manager.handleFailedBatch(b1, new TimeoutException(), false);
-        assertTrue(manager.hasUnresolvedSequences());
+        transactionManager.markSequenceUnresolved(tp0);
+        transactionManager.handleFailedBatch(b1, new TimeoutException(), false);
+        assertTrue(transactionManager.hasUnresolvedSequences());
 
         // The reset should not occur until sequence numbers have been resolved
-        manager.resetProducerIdIfNeeded();
-        assertEquals(producerIdAndEpoch, manager.producerIdAndEpoch());
-        assertTrue(manager.hasUnresolvedSequences());
+        transactionManager.resetIdempotentProducerIdIfNeeded();
+        assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
+        assertTrue(transactionManager.hasUnresolvedSequences());
 
         // The second batch fails as well with a timeout
-        manager.handleFailedBatch(b2, new TimeoutException(), false);
-        manager.resetProducerIdIfNeeded();
-        assertEquals(producerIdAndEpoch, manager.producerIdAndEpoch());
-        assertTrue(manager.hasUnresolvedSequences());
+        transactionManager.handleFailedBatch(b2, new TimeoutException(), false);
+        transactionManager.resetIdempotentProducerIdIfNeeded();
+        assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
+        assertTrue(transactionManager.hasUnresolvedSequences());
 
         // The third batch succeeds, which should resolve the sequence number without
         // requiring a producerId reset.
-        manager.handleCompletedBatch(b3, new ProduceResponse.PartitionResponse(
+        transactionManager.handleCompletedBatch(b3, new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, time.milliseconds(), 0L));
-        manager.resetProducerIdIfNeeded();
-        assertEquals(producerIdAndEpoch, manager.producerIdAndEpoch());
-        assertFalse(manager.hasUnresolvedSequences());
-        assertEquals(3, manager.sequenceNumber(tp0).intValue());
+        transactionManager.resetIdempotentProducerIdIfNeeded();
+        assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
+        assertFalse(transactionManager.hasUnresolvedSequences());
+        assertEquals(3, transactionManager.sequenceNumber(tp0).intValue());
     }
 
     @Test
     public void testProducerIdResetAfterLastInFlightBatchFails() {
-        TransactionManager manager = new TransactionManager(logContext, null, transactionTimeoutMs,
-                DEFAULT_RETRY_BACKOFF_MS);
+        initializeTransactionManager(Optional.empty());
         long producerId = 15L;
         short epoch = 5;
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(producerId, epoch);
-        manager.setProducerIdAndEpoch(producerIdAndEpoch);
+        initializeIdempotentProducerId(producerId, epoch);
 
         TopicPartition tp0 = new TopicPartition("foo", 0);
-        ProducerBatch b1 = writeIdempotentBatchWithValue(manager, tp0, "1");
-        ProducerBatch b2 = writeIdempotentBatchWithValue(manager, tp0, "2");
-        ProducerBatch b3 = writeIdempotentBatchWithValue(manager, tp0, "3");
-        assertEquals(Integer.valueOf(3), manager.sequenceNumber(tp0));
+        ProducerBatch b1 = writeIdempotentBatchWithValue(transactionManager, tp0, "1");
+        ProducerBatch b2 = writeIdempotentBatchWithValue(transactionManager, tp0, "2");
+        ProducerBatch b3 = writeIdempotentBatchWithValue(transactionManager, tp0, "3");
+        assertEquals(Integer.valueOf(3), transactionManager.sequenceNumber(tp0));
 
         // The first batch fails with a timeout
-        manager.markSequenceUnresolved(tp0);
-        manager.handleFailedBatch(b1, new TimeoutException(), false);
-        assertTrue(manager.hasUnresolvedSequences());
+        transactionManager.markSequenceUnresolved(tp0);
+        transactionManager.handleFailedBatch(b1, new TimeoutException(), false);
+        assertTrue(transactionManager.hasUnresolvedSequences());
 
         // The second batch succeeds, but sequence numbers are still not resolved
-        manager.handleCompletedBatch(b2, new ProduceResponse.PartitionResponse(
+        transactionManager.handleCompletedBatch(b2, new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, time.milliseconds(), 0L));
-        manager.resetProducerIdIfNeeded();
-        assertEquals(producerIdAndEpoch, manager.producerIdAndEpoch());
-        assertTrue(manager.hasUnresolvedSequences());
+        transactionManager.resetIdempotentProducerIdIfNeeded();
+        assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
+        assertTrue(transactionManager.hasUnresolvedSequences());
 
         // When the last inflight batch fails, we have to reset the producerId
-        manager.handleFailedBatch(b3, new TimeoutException(), false);
-        manager.resetProducerIdIfNeeded();
-        assertFalse(manager.hasProducerId());
-        assertFalse(manager.hasUnresolvedSequences());
-        assertEquals(0, manager.sequenceNumber(tp0).intValue());
+        transactionManager.handleFailedBatch(b3, new TimeoutException(), false);
+        transactionManager.resetIdempotentProducerIdIfNeeded();
+        assertFalse(transactionManager.hasProducerId());
+        assertFalse(transactionManager.hasUnresolvedSequences());
+        assertEquals(0, transactionManager.sequenceNumber(tp0).intValue());
     }
 
     @Test
     public void testRetryAbortTransaction() throws InterruptedException {
-        verifyCommitOrAbortTranscationRetriable(TransactionResult.ABORT, TransactionResult.ABORT);
+        verifyCommitOrAbortTransactionRetriable(TransactionResult.ABORT, TransactionResult.ABORT);
     }
 
     @Test
     public void testRetryCommitTransaction() throws InterruptedException {
-        verifyCommitOrAbortTranscationRetriable(TransactionResult.COMMIT, TransactionResult.COMMIT);
+        verifyCommitOrAbortTransactionRetriable(TransactionResult.COMMIT, TransactionResult.COMMIT);
     }
 
     @Test(expected = KafkaException.class)
     public void testRetryAbortTransactionAfterCommitTimeout() throws InterruptedException {
-        verifyCommitOrAbortTranscationRetriable(TransactionResult.COMMIT, TransactionResult.ABORT);
+        verifyCommitOrAbortTransactionRetriable(TransactionResult.COMMIT, TransactionResult.ABORT);
     }
 
     @Test(expected = KafkaException.class)
     public void testRetryCommitTransactionAfterAbortTimeout() throws InterruptedException {
-        verifyCommitOrAbortTranscationRetriable(TransactionResult.ABORT, TransactionResult.COMMIT);
+        verifyCommitOrAbortTransactionRetriable(TransactionResult.ABORT, TransactionResult.COMMIT);
     }
 
     private FutureRecordMetadata appendToAccumulator(TopicPartition tp) throws InterruptedException {
@@ -2848,7 +2680,7 @@ public class TransactionManagerTest {
                 null, MAX_BLOCK_TIMEOUT, false, nowMs).future;
     }
 
-    private void verifyCommitOrAbortTranscationRetriable(TransactionResult firstTransactionResult,
+    private void verifyCommitOrAbortTransactionRetriable(TransactionResult firstTransactionResult,
                                                          TransactionResult retryTransactionResult)
             throws InterruptedException {
         final long pid = 13131L;
@@ -2863,15 +2695,13 @@ public class TransactionManagerTest {
         appendToAccumulator(tp0);
 
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
-
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.runOnce();  // send addPartitions.
-        sender.runOnce();  // send produce request.
+        runUntil(() -> !client.hasPendingResponses());
 
         TransactionalRequestResult result = firstTransactionResult == TransactionResult.COMMIT ?
                 transactionManager.beginCommit() : transactionManager.beginAbort();
         prepareEndTxnResponse(Errors.NONE, firstTransactionResult, pid, epoch, true);
-        sender.runOnce();
+        runUntil(() -> !client.hasPendingResponses());
         assertFalse(result.isCompleted());
 
         try {
@@ -2881,13 +2711,13 @@ public class TransactionManagerTest {
         }
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();
+        runUntil(() -> !client.hasPendingResponses());
         TransactionalRequestResult retryResult = retryTransactionResult == TransactionResult.COMMIT ?
                 transactionManager.beginCommit() : transactionManager.beginAbort();
         assertEquals(retryResult, result); // check if cached result is reused.
+
         prepareEndTxnResponse(Errors.NONE, retryTransactionResult, pid, epoch, false);
-        sender.runOnce();
-        assertTrue(retryResult.isCompleted());
+        runUntil(retryResult::isCompleted);
         assertFalse(transactionManager.hasOngoingTransaction());
     }
 
@@ -2904,8 +2734,7 @@ public class TransactionManagerTest {
         Future<RecordMetadata> responseFuture = appendToAccumulator(tp0);
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxn(tp0, error);
-        sender.runOnce();  // attempt send addPartitions.
-        assertTrue(transactionManager.hasError());
+        runUntil(transactionManager::hasError);
         assertFalse(transactionManager.transactionContainsPartition(tp0));
     }
 
@@ -2940,8 +2769,8 @@ public class TransactionManagerTest {
                 .setThrottleTimeMs(0);
         client.prepareResponse(body -> {
             InitProducerIdRequest initProducerIdRequest = (InitProducerIdRequest) body;
-            assertEquals(initProducerIdRequest.data.transactionalId(), transactionalId);
-            assertEquals(initProducerIdRequest.data.transactionTimeoutMs(), transactionTimeoutMs);
+            assertEquals(transactionalId, initProducerIdRequest.data.transactionalId());
+            assertEquals(transactionTimeoutMs, initProducerIdRequest.data.transactionTimeoutMs());
             return true;
         }, new InitProducerIdResponse(responseData), shouldDisconnect);
     }
@@ -3081,16 +2910,29 @@ public class TransactionManagerTest {
         return new ProduceResponse(partResp, throttleTimeMs);
     }
 
+    private void initializeIdempotentProducerId(long producerId, short epoch) {
+        InitProducerIdResponseData responseData = new InitProducerIdResponseData()
+                .setErrorCode(Errors.NONE.code())
+                .setProducerEpoch(epoch)
+                .setProducerId(producerId)
+                .setThrottleTimeMs(0);
+        client.prepareResponse(body -> {
+            InitProducerIdRequest initProducerIdRequest = (InitProducerIdRequest) body;
+            assertNull(initProducerIdRequest.data.transactionalId());
+            return true;
+        }, new InitProducerIdResponse(responseData), false);
+
+        runUntil(transactionManager::hasProducerId);
+    }
+
     private void doInitTransactions(long pid, short epoch) {
         transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.runOnce();  // find coordinator
-        sender.runOnce();
+        runUntil(() -> transactionManager.coordinator(CoordinatorType.TRANSACTION) != null);
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
 
         prepareInitPidResponse(Errors.NONE, false, pid, epoch);
-        sender.runOnce();  // get pid.
-        assertTrue(transactionManager.hasProducerId());
+        runUntil(transactionManager::hasProducerId);
     }
 
     private void assertAbortableError(Class<? extends RuntimeException> cause) {
@@ -3137,6 +2979,16 @@ public class TransactionManagerTest {
         } catch (ExecutionException e) {
             // expected
         }
+    }
+
+    private void runUntil(Supplier<Boolean> condition) {
+        for (int i = 0; i < 5; i++) {
+            if (condition.get())
+                break;
+            sender.runOnce();
+        }
+        if (!condition.get())
+            throw new AssertionError("Condition was not satisfied after multiple runs");
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ExitTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ExitTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExitTest {
+    @Test
+    public void shouldHaltImmediately() {
+        List<Object> list = new ArrayList<>();
+        Exit.setHaltProcedure((statusCode, message) -> {
+            list.add(statusCode);
+            list.add(message);
+        });
+        try {
+            int statusCode = 0;
+            String message = "mesaage";
+            Exit.halt(statusCode);
+            Exit.halt(statusCode, message);
+            assertEquals(Arrays.asList(statusCode, null, statusCode, message), list);
+        } finally {
+            Exit.resetHaltProcedure();
+        }
+    }
+
+    @Test
+    public void shouldExitImmediately() {
+        List<Object> list = new ArrayList<>();
+        Exit.setExitProcedure((statusCode, message) -> {
+            list.add(statusCode);
+            list.add(message);
+        });
+        try {
+            int statusCode = 0;
+            String message = "mesaage";
+            Exit.exit(statusCode);
+            Exit.exit(statusCode, message);
+            assertEquals(Arrays.asList(statusCode, null, statusCode, message), list);
+        } finally {
+            Exit.resetExitProcedure();
+        }
+    }
+
+    @Test
+    public void shouldAddShutdownHookImmediately() {
+        List<Object> list = new ArrayList<>();
+        Exit.setShutdownHookAdder((name, runnable) -> {
+            list.add(name);
+            list.add(runnable);
+        });
+        try {
+            Runnable runnable = () -> { };
+            String name = "name";
+            Exit.addShutdownHook(name, runnable);
+            assertEquals(Arrays.asList(name, runnable), list);
+        } finally {
+            Exit.resetShutdownHookAdder();
+        }
+    }
+
+    @Test
+    public void shouldNotInvokeShutdownHookImmediately() {
+        List<Object> list = new ArrayList<>();
+        Runnable runnable = () -> list.add(this);
+        Exit.addShutdownHook("message", runnable);
+        assertEquals(0, list.size());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -262,14 +263,11 @@ public class TestUtils {
         }
         file.deleteOnExit();
 
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                try {
-                    Utils.delete(file);
-                } catch (IOException e) {
-                    log.error("Error deleting {}", file.getAbsolutePath(), e);
-                }
+        Exit.addShutdownHook("delete-temp-file-shutdown-hook", () -> {
+            try {
+                Utils.delete(file);
+            } catch (IOException e) {
+                log.error("Error deleting {}", file.getAbsolutePath(), e);
             }
         });
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -164,7 +164,7 @@ public class MirrorMaker {
         }
         startLatch = new CountDownLatch(herders.size());
         stopLatch = new CountDownLatch(herders.size());
-        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        Exit.addShutdownHook("mirror-maker-shutdown-hook", shutdownHook);
         for (Herder herder : herders.values()) {
             try {
                 herder.start();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.connect.runtime.rest.RestServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,7 @@ public class Connect {
     public void start() {
         try {
             log.info("Kafka Connect starting");
-            Runtime.getRuntime().addShutdownHook(shutdownHook);
+            Exit.addShutdownHook("connect-shutdown-hook", shutdownHook);
 
             herder.start();
             rest.initializeResources(herder);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -699,7 +699,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     public Void call() throws Exception {
                         log.trace("Handling connector config request {}", connName);
                         if (!isLeader()) {
-                            callback.onCompletion(new NotLeaderException("Only the leader can set connector configs.", leaderUrl()), null);
+                            callback.onCompletion(new NotLeaderException("Only the leader can delete connector configs.", leaderUrl()), null);
                             return null;
                         }
 

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -77,9 +77,7 @@ object Kafka extends Logging {
       }
 
       // attach shutdown handler to catch terminating signals as well as normal termination
-      Runtime.getRuntime().addShutdownHook(new Thread("kafka-shutdown-hook") {
-        override def run(): Unit = kafkaServerStartable.shutdown()
-      })
+      Exit.addShutdownHook("kafka-shutdown-hook", kafkaServerStartable.shutdown)
 
       kafkaServerStartable.startup()
       kafkaServerStartable.awaitShutdown()

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -619,7 +619,7 @@ class DynamicLogConfig(logManager: LogManager, server: KafkaServer) extends Brok
       props ++= newBrokerDefaults
       props ++= log.config.originals.asScala.filterKeys(log.config.overriddenConfigs.contains)
 
-      val logConfig = LogConfig(props.asJava)
+      val logConfig = LogConfig(props.asJava, log.config.overriddenConfigs)
       log.updateConfig(logConfig)
     }
   }

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -28,7 +28,7 @@ import com.typesafe.scalalogging.LazyLogging
 import joptsimple._
 import kafka.common.MessageFormatter
 import kafka.utils.Implicits._
-import kafka.utils._
+import kafka.utils.{Exit, _}
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{AuthenticationException, TimeoutException, WakeupException}
@@ -85,8 +85,7 @@ object ConsoleConsumer extends Logging {
   }
 
   def addShutdownHook(consumer: ConsumerWrapper, conf: ConsumerConfig): Unit = {
-    Runtime.getRuntime.addShutdownHook(new Thread() {
-      override def run(): Unit = {
+    Exit.addShutdownHook("consumer-shutdown-hook", {
         consumer.wakeup()
 
         shutdownLatch.await()
@@ -94,7 +93,6 @@ object ConsoleConsumer extends Logging {
         if (conf.enableSystestEventsLogging) {
           System.out.println("shutdown_complete")
         }
-      }
     })
   }
 

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -44,11 +44,7 @@ object ConsoleProducer {
 
         val producer = new KafkaProducer[Array[Byte], Array[Byte]](producerProps(config))
 
-        Runtime.getRuntime.addShutdownHook(new Thread() {
-          override def run(): Unit = {
-            producer.close()
-          }
-        })
+    Exit.addShutdownHook("producer-shutdown-hook", producer.close)
 
         var record: ProducerRecord[Array[Byte], Array[Byte]] = null
         do {

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -519,11 +519,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       offsetCommitIntervalMs = options.valueOf(offsetCommitIntervalMsOpt).intValue()
       val numStreams = options.valueOf(numStreamsOpt).intValue()
 
-      Runtime.getRuntime.addShutdownHook(new Thread("MirrorMakerShutdownHook") {
-        override def run(): Unit = {
-          cleanShutdown()
-        }
-      })
+      Exit.addShutdownHook("MirrorMakerShutdownHook", cleanShutdown())
 
       // create producer
       val producerProps = Utils.loadProps(options.valueOf(producerConfigOpt))

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -200,11 +200,9 @@ object ReplicaVerificationTool extends Logging {
         fetcherId = counter.incrementAndGet())
     }
 
-    Runtime.getRuntime.addShutdownHook(new Thread() {
-      override def run(): Unit = {
+    Exit.addShutdownHook("ReplicaVerificationToolShutdownHook", {
         info("Stopping all fetchers")
         fetcherThreads.foreach(_.shutdown())
-      }
     })
     fetcherThreads.foreach(_.start())
     println(s"${ReplicaVerificationTool.getCurrentTimeString()}: verification process is started.")

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -505,6 +505,40 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
   }
 
   @Test
+  def testConsecutiveConfigChange(): Unit = {
+    val topic2 = "testtopic2"
+    val topicProps = new Properties
+    topicProps.put(KafkaConfig.MinInSyncReplicasProp, "2")
+    TestUtils.createTopic(zkClient, topic2, 1, replicationFactor = numServers, servers, topicProps)
+    var log = servers.head.logManager.getLog(new TopicPartition(topic2, 0)).getOrElse(throw new IllegalStateException("Log not found"))
+    assertTrue(log.config.overriddenConfigs.contains(KafkaConfig.MinInSyncReplicasProp))
+    assertEquals("2", log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString)
+
+    val props = new Properties
+    props.put(KafkaConfig.MinInSyncReplicasProp, "3")
+    // Make a broker-default config
+    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MinInSyncReplicasProp, "3"))
+    // Verify that all broker defaults have been updated again
+    servers.foreach { server =>
+      props.asScala.foreach { case (k, v) =>
+        assertEquals(s"Not reconfigured $k", v, server.config.originals.get(k).toString)
+      }
+    }
+
+    log = servers.head.logManager.getLog(new TopicPartition(topic2, 0)).getOrElse(throw new IllegalStateException("Log not found"))
+    assertTrue(log.config.overriddenConfigs.contains(KafkaConfig.MinInSyncReplicasProp))
+    assertEquals("2", log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString) // Verify topic-level config survives
+
+    // Make a second broker-default change
+    props.clear()
+    props.put(KafkaConfig.LogRetentionTimeMillisProp, "604800000")
+    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.LogRetentionTimeMillisProp, "604800000"))
+    log = servers.head.logManager.getLog(new TopicPartition(topic2, 0)).getOrElse(throw new IllegalStateException("Log not found"))
+    assertTrue(log.config.overriddenConfigs.contains(KafkaConfig.MinInSyncReplicasProp))
+    assertEquals("2", log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString) // Verify topic-level config still survives
+  }
+
+  @Test
   def testDefaultTopicConfig(): Unit = {
     val (producerThread, consumerThread) = startProduceConsume(retries = 0)
 
@@ -774,7 +808,7 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
     val partitions = (0 until numPartitions).map(i => new TopicPartition(topic, i)).filter { tp =>
       zkClient.getLeaderForPartition(tp).contains(leaderId)
     }
-    assertTrue(s"Partitons not found with leader $leaderId", partitions.nonEmpty)
+    assertTrue(s"Partitions not found with leader $leaderId", partitions.nonEmpty)
     partitions.foreach { tp =>
       (1 to 2).foreach { i =>
         val replicaFetcherManager = servers(i).replicaManager.replicaFetcherManager

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -370,7 +370,7 @@ object MiniKdc {
     }
   }
 
-  private def start(workDir: File, config: Properties, keytabFile: File, principals: Seq[String]): Unit = {
+  private[minikdc] def start(workDir: File, config: Properties, keytabFile: File, principals: Seq[String]): MiniKdc = {
     val miniKdc = new MiniKdc(config, workDir)
     miniKdc.start()
     miniKdc.createPrincipal(keytabFile, principals: _*)
@@ -390,9 +390,8 @@ object MiniKdc {
       |
     """.stripMargin
     println(infoMessage)
-    Runtime.getRuntime.addShutdownHook(CoreUtils.newThread("minikdc-shutdown-hook", daemon = false) {
-      miniKdc.stop()
-    })
+    Exit.addShutdownHook("minikdc-shutdown-hook", miniKdc.stop)
+    miniKdc
   }
 
   val OrgName = "org.name"

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdcTest.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdcTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.security.minikdc
+
+import java.util.Properties
+
+import kafka.utils.TestUtils
+import org.junit.Test
+import org.junit.Assert._
+
+class MiniKdcTest {
+  @Test
+  def shouldNotStopImmediatelyWhenStarted(): Unit = {
+    val config = new Properties()
+    config.setProperty("kdc.bind.address", "0.0.0.0")
+    config.setProperty("transport", "TCP");
+    config.setProperty("max.ticket.lifetime", "86400000")
+    config.setProperty("org.name", "Example")
+    config.setProperty("kdc.port", "0")
+    config.setProperty("org.domain", "COM")
+    config.setProperty("max.renewable.lifetime", "604800000")
+    config.setProperty("instance", "DefaultKrbServer")
+    val minikdc = MiniKdc.start(TestUtils.tempDir(), config, TestUtils.tempFile(), List("foo"))
+    val running = System.getProperty(MiniKdc.JavaSecurityKrb5Conf) != null
+    try {
+      assertTrue("MiniKdc stopped immediately; it should not have", running)
+    } finally {
+      if (running) minikdc.stop()
+    }
+  }
+}

--- a/core/src/test/scala/kafka/utils/ExitTest.scala
+++ b/core/src/test/scala/kafka/utils/ExitTest.scala
@@ -1,0 +1,122 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.utils
+
+import java.io.IOException
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.scalatest.Assertions.intercept
+
+class ExitTest {
+  @Test
+  def shouldHaltImmediately(): Unit = {
+    val array:Array[Any] = Array("a", "b")
+    def haltProcedure(exitStatus: Int, message: Option[String]) : Nothing = {
+      array(0) = exitStatus
+      array(1) = message
+      throw new IOException()
+    }
+    Exit.setHaltProcedure(haltProcedure)
+    val statusCode = 0
+    val message = Some("message")
+    try {
+      intercept[IOException] {Exit.halt(statusCode)}
+      assertEquals(statusCode, array(0))
+      assertEquals(None, array(1))
+
+      intercept[IOException] {Exit.halt(statusCode, message)}
+      assertEquals(statusCode, array(0))
+      assertEquals(message, array(1))
+    } finally {
+      Exit.resetHaltProcedure()
+    }
+  }
+
+  @Test
+  def shouldExitImmediately(): Unit = {
+    val array:Array[Any] = Array("a", "b")
+    def exitProcedure(exitStatus: Int, message: Option[String]) : Nothing = {
+      array(0) = exitStatus
+      array(1) = message
+      throw new IOException()
+    }
+    Exit.setExitProcedure(exitProcedure)
+    val statusCode = 0
+    val message = Some("message")
+    try {
+      intercept[IOException] {Exit.exit(statusCode)}
+      assertEquals(statusCode, array(0))
+      assertEquals(None, array(1))
+
+      intercept[IOException] {Exit.exit(statusCode, message)}
+      assertEquals(statusCode, array(0))
+      assertEquals(message, array(1))
+    } finally {
+      Exit.resetExitProcedure()
+    }
+  }
+
+  @Test
+  def shouldAddShutdownHookImmediately(): Unit = {
+    val name = "name"
+    val array:Array[Any] = Array("", 0)
+    // immediately invoke the shutdown hook to mutate the data when a hook is added
+    def shutdownHookAdder(name: String, shutdownHook: => Unit) : Unit = {
+      // mutate the first element
+      array(0) = array(0).toString + name
+      // invoke the shutdown hook (see below, it mutates the second element)
+      shutdownHook
+    }
+    Exit.setShutdownHookAdder(shutdownHookAdder)
+    def sideEffect(): Unit = {
+      // mutate the second element
+      array(1) = array(1).asInstanceOf[Int] + 1
+    }
+    try {
+      Exit.addShutdownHook(name, sideEffect) // by-name parameter, only invoked due to above shutdownHookAdder
+      assertEquals(1, array(1))
+      assertEquals(name * array(1).asInstanceOf[Int], array(0).toString)
+      Exit.addShutdownHook(name, array(1) = array(1).asInstanceOf[Int] + 1) // by-name parameter, only invoked due to above shutdownHookAdder
+      assertEquals(2, array(1))
+      assertEquals(name * array(1).asInstanceOf[Int], array(0).toString)
+    } finally {
+      Exit.resetShutdownHookAdder()
+    }
+  }
+
+  @Test
+  def shouldNotInvokeShutdownHookImmediately(): Unit = {
+    val name = "name"
+    val array:Array[String] = Array(name)
+
+    def sideEffect(): Unit = {
+      // mutate the first element
+      array(0) = array(0) + name
+    }
+    Exit.addShutdownHook(name, sideEffect) // by-name parameter, not invoked
+    // make sure the first element wasn't mutated
+    assertEquals(name, array(0))
+    Exit.addShutdownHook(name, sideEffect()) // by-name parameter, not invoked
+    // again make sure the first element wasn't mutated
+    assertEquals(name, array(0))
+    Exit.addShutdownHook(name, array(0) = array(0) + name) // by-name parameter, not invoked
+    // again make sure the first element wasn't mutated
+    assertEquals(name, array(0))
+  }
+}

--- a/core/src/test/scala/other/kafka/StressTestLog.scala
+++ b/core/src/test/scala/other/kafka/StressTestLog.scala
@@ -57,13 +57,11 @@ object StressTestLog {
     val reader = new ReaderThread(log)
     reader.start()
 
-    Runtime.getRuntime().addShutdownHook(new Thread() {
-      override def run() = {
+    Exit.addShutdownHook("stress-test-shutdown-hook", {
         running.set(false)
         writer.join()
         reader.join()
         Utils.delete(dir)
-      }
     })
 
     while(running.get) {

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1064,6 +1064,9 @@ public class StreamsConfig extends AbstractConfig {
         consumerProps.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, StreamsPartitionAssignor.class.getName());
         consumerProps.put(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, getLong(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG));
 
+        // disable auto topic creation
+        consumerProps.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
+
         // add admin retries configs for creating topics
         final AdminClientConfig adminClientDefaultConfig = new AdminClientConfig(getClientPropsWithPrefix(ADMIN_CLIENT_PREFIX, AdminClientConfig.configNames()));
         consumerProps.put(adminClientPrefix(AdminClientConfig.RETRIES_CONFIG), adminClientDefaultConfig.getInt(AdminClientConfig.RETRIES_CONFIG));

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
@@ -51,7 +51,7 @@ public class StreamSourceNode<K, V> extends StreamsGraphNode {
         this.consumedInternal = consumedInternal;
     }
 
-    public Collection<String> getTopicNames() {
+    public Collection<String> topicNames() {
         return new ArrayList<>(topicNames);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -81,7 +81,7 @@ public class TableSourceNode<K, V> extends StreamSourceNode<K, V> {
     @Override
     @SuppressWarnings("unchecked")
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
-        final String topicName = getTopicNames().iterator().next();
+        final String topicName = topicNames().iterator().next();
 
         // TODO: we assume source KTables can only be timestamped-key-value stores for now.
         // should be expanded for other types of stores as well.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -690,7 +690,7 @@ public class StreamThread extends Thread {
      * @throws StreamsException      if the store's change log does not contain the partition
      */
     private void runLoop() {
-        consumer.subscribe(builder.sourceTopicPattern(), rebalanceListener);
+        subscribeConsumer();
 
         while (isRunning()) {
             try {
@@ -713,7 +713,15 @@ public class StreamThread extends Thread {
 
     private void enforceRebalance() {
         consumer.unsubscribe();
-        consumer.subscribe(builder.sourceTopicPattern(), rebalanceListener);
+        subscribeConsumer();
+    }
+
+    private void subscribeConsumer() {
+        if (builder.usesPatternSubscription()) {
+            consumer.subscribe(builder.sourceTopicPattern(), rebalanceListener);
+        } else {
+            consumer.subscribe(builder.sourceTopicCollection(), rebalanceListener);
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -241,9 +241,9 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     }
 
     protected static Set<TaskId> prepareForSubscription(final TaskManager taskManager,
-        final Set<String> topics,
-        final Set<TaskId> standbyTasks,
-        final RebalanceProtocol rebalanceProtocol) {
+                                                        final Set<String> topics,
+                                                        final Set<TaskId> standbyTasks,
+                                                        final RebalanceProtocol rebalanceProtocol) {
         // Any tasks that are not yet running are counted as standby tasks for assignment purposes,
         // along with any old tasks for which we still found state on disk
         final Set<TaskId> activeTasks;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -517,7 +517,7 @@ public class TaskManager {
                 assignedTopics.add(topicPartition.topic());
             }
 
-            final Collection<String> existingTopics = builder().subscriptionUpdates().getUpdates();
+            final Collection<String> existingTopics = builder().subscriptionUpdates();
             if (!existingTopics.containsAll(assignedTopics)) {
                 assignedTopics.addAll(existingTopics);
                 builder().updateSubscribedTopics(assignedTopics, logPrefix);
@@ -527,7 +527,7 @@ public class TaskManager {
 
     public void updateSubscriptionsFromMetadata(final Set<String> topics) {
         if (builder().sourceTopicPattern() != null) {
-            final Collection<String> existingTopics = builder().subscriptionUpdates().getUpdates();
+            final Collection<String> existingTopics = builder().subscriptionUpdates();
             if (!existingTopics.equals(topics)) {
                 builder().updateSubscribedTopics(topics, logPrefix);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.Optional;
 
 public class StreamsMetricsImpl implements StreamsMetrics {
 
@@ -210,11 +211,12 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                           final Sensor... parents) {
         final String key = threadSensorPrefix(threadId);
         synchronized (threadLevelSensors) {
-            threadLevelSensors.putIfAbsent(key, new LinkedList<>());
             final String fullSensorName = key + SENSOR_NAME_DELIMITER + sensorName;
-            final Sensor sensor = metrics.sensor(fullSensorName, recordingLevel, parents);
-            threadLevelSensors.get(key).push(fullSensorName);
-            return sensor;
+            return Optional.ofNullable(metrics.getSensor(fullSensorName))
+                .orElseGet(() -> {
+                    threadLevelSensors.computeIfAbsent(key, ignored -> new LinkedList<>()).push(fullSensorName);
+                    return metrics.sensor(fullSensorName, recordingLevel, parents);
+                });
         }
     }
 
@@ -290,13 +292,12 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                         final Sensor... parents) {
         final String key = taskSensorPrefix(threadId, taskId);
         synchronized (taskLevelSensors) {
-            if (!taskLevelSensors.containsKey(key)) {
-                taskLevelSensors.put(key, new LinkedList<>());
-            }
             final String fullSensorName = key + SENSOR_NAME_DELIMITER + sensorName;
-            final Sensor sensor = metrics.sensor(fullSensorName, recordingLevel, parents);
-            taskLevelSensors.get(key).push(fullSensorName);
-            return sensor;
+            return Optional.ofNullable(metrics.getSensor(fullSensorName))
+                .orElseGet(() -> {
+                    taskLevelSensors.computeIfAbsent(key, ignored -> new LinkedList<>()).push(fullSensorName);
+                    return metrics.sensor(fullSensorName, recordingLevel, parents);
+                });
         }
     }
 
@@ -323,17 +324,12 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                   final Sensor... parents) {
         final String key = nodeSensorPrefix(threadId, taskId, processorNodeName);
         synchronized (nodeLevelSensors) {
-            if (!nodeLevelSensors.containsKey(key)) {
-                nodeLevelSensors.put(key, new LinkedList<>());
-            }
-
             final String fullSensorName = key + SENSOR_NAME_DELIMITER + sensorName;
-
-            final Sensor sensor = metrics.sensor(fullSensorName, recordingLevel, parents);
-
-            nodeLevelSensors.get(key).push(fullSensorName);
-
-            return sensor;
+            return Optional.ofNullable(metrics.getSensor(fullSensorName))
+                .orElseGet(() -> {
+                    nodeLevelSensors.computeIfAbsent(key, ignored -> new LinkedList<>()).push(fullSensorName);
+                    return metrics.sensor(fullSensorName, recordingLevel, parents);
+                });
         }
     }
 
@@ -362,17 +358,12 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                    final Sensor... parents) {
         final String key = cacheSensorPrefix(threadId, taskName, storeName);
         synchronized (cacheLevelSensors) {
-            if (!cacheLevelSensors.containsKey(key)) {
-                cacheLevelSensors.put(key, new LinkedList<>());
-            }
-
             final String fullSensorName = key + SENSOR_NAME_DELIMITER + sensorName;
-
-            final Sensor sensor = metrics.sensor(fullSensorName, recordingLevel, parents);
-
-            cacheLevelSensors.get(key).push(fullSensorName);
-
-            return sensor;
+            return Optional.ofNullable(metrics.getSensor(fullSensorName))
+                .orElseGet(() -> {
+                    cacheLevelSensors.computeIfAbsent(key, ignored -> new LinkedList<>()).push(fullSensorName);
+                    return metrics.sensor(fullSensorName, recordingLevel, parents);
+                });
         }
     }
 
@@ -413,15 +404,12 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                          final Sensor... parents) {
         final String key = storeSensorPrefix(threadId, taskId, storeName);
         synchronized (storeLevelSensors) {
-            if (!storeLevelSensors.containsKey(key)) {
-                storeLevelSensors.put(key, new LinkedList<>());
-            }
             final String fullSensorName = key + SENSOR_NAME_DELIMITER + sensorName;
-            final Sensor sensor = metrics.sensor(fullSensorName, recordingLevel, parents);
-
-            storeLevelSensors.get(key).push(fullSensorName);
-
-            return sensor;
+            return Optional.ofNullable(metrics.getSensor(fullSensorName))
+                .orElseGet(() -> {
+                    storeLevelSensors.computeIfAbsent(key, ignored -> new LinkedList<>()).push(fullSensorName);
+                    return metrics.sensor(fullSensorName, recordingLevel, parents);
+                });
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Arrays;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -34,7 +35,6 @@ import org.apache.kafka.test.MockTimestampExtractor;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Test;
 
-import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -231,7 +231,19 @@ public class InternalTopologyBuilderTest {
     }
 
     @Test
-    public void testSourceTopics() {
+    public void testOnlyTopicNameSourceTopics() {
+        builder.setApplicationId("X");
+        builder.addSource(null, "source-1", null, null, null, "topic-1");
+        builder.addSource(null, "source-2", null, null, null, "topic-2");
+        builder.addSource(null, "source-3", null, null, null, "topic-3");
+        builder.addInternalTopic("topic-3");
+
+        assertFalse(builder.usesPatternSubscription());
+        assertEquals(Arrays.asList("X-topic-3", "topic-1", "topic-2"), builder.sourceTopicCollection());
+    }
+
+    @Test
+    public void testPatternSourceTopics() {
         builder.setApplicationId("X");
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         builder.addSource(null, "source-2", null, null, null, "topic-2");
@@ -667,22 +679,18 @@ public class InternalTopologyBuilderTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldSetCorrectSourceNodesWithRegexUpdatedTopics() throws Exception {
+    public void shouldSetCorrectSourceNodesWithRegexUpdatedTopics() {
         builder.addSource(null, "source-1", null, null, null, "topic-foo");
         builder.addSource(null, "source-2", null, null, null, Pattern.compile("topic-[A-C]"));
         builder.addSource(null, "source-3", null, null, null, Pattern.compile("topic-\\d"));
 
-        final InternalTopologyBuilder.SubscriptionUpdates subscriptionUpdates = new InternalTopologyBuilder.SubscriptionUpdates();
-        final Field updatedTopicsField  = subscriptionUpdates.getClass().getDeclaredField("updatedTopicSubscriptions");
-        updatedTopicsField.setAccessible(true);
-
-        final Set<String> updatedTopics = (Set<String>) updatedTopicsField.get(subscriptionUpdates);
+        final Set<String> updatedTopics = new HashSet<>();
 
         updatedTopics.add("topic-B");
         updatedTopics.add("topic-3");
         updatedTopics.add("topic-A");
 
-        builder.updateSubscriptions(subscriptionUpdates, null);
+        builder.updateSubscribedTopics(updatedTopics, null);
         builder.setApplicationId("test-id");
 
         final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
@@ -690,7 +698,6 @@ public class InternalTopologyBuilderTest {
         assertTrue(topicGroups.get(1).sourceTopics.contains("topic-A"));
         assertTrue(topicGroups.get(1).sourceTopics.contains("topic-B"));
         assertTrue(topicGroups.get(2).sourceTopics.contains("topic-3"));
-
     }
 
     @Test
@@ -754,22 +761,18 @@ public class InternalTopologyBuilderTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldConnectRegexMatchedTopicsToStateStore() throws Exception {
+    public void shouldConnectRegexMatchedTopicsToStateStore() {
         builder.addSource(null, "ingest", null, null, null, Pattern.compile("topic-\\d+"));
         builder.addProcessor("my-processor", new MockProcessorSupplier(), "ingest");
         builder.addStateStore(storeBuilder, "my-processor");
 
-        final InternalTopologyBuilder.SubscriptionUpdates subscriptionUpdates = new InternalTopologyBuilder.SubscriptionUpdates();
-        final Field updatedTopicsField  = subscriptionUpdates.getClass().getDeclaredField("updatedTopicSubscriptions");
-        updatedTopicsField.setAccessible(true);
-
-        final Set<String> updatedTopics = (Set<String>) updatedTopicsField.get(subscriptionUpdates);
+        final Set<String> updatedTopics = new HashSet<>();
 
         updatedTopics.add("topic-2");
         updatedTopics.add("topic-3");
         updatedTopics.add("topic-A");
 
-        builder.updateSubscriptions(subscriptionUpdates, "test-thread");
+        builder.updateSubscribedTopics(updatedTopics, "test-thread");
         builder.setApplicationId("test-app");
 
         final Map<String, List<String>> stateStoreAndTopics = builder.stateStoreNameToSourceTopics();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -70,8 +70,7 @@ public class TaskManagerTest {
     private final Map<TaskId, Set<TopicPartition>> taskId0Assignment = Collections.singletonMap(taskId0, taskId0Partitions);
     private final Map<TopicPartition, TaskId> taskId0PartitionToTaskId = Collections.singletonMap(t1p0, taskId0);
 
-    @Mock(type = MockType.STRICT)
-    private InternalTopologyBuilder.SubscriptionUpdates subscriptionUpdates;
+
     @Mock(type = MockType.STRICT)
     private InternalTopologyBuilder topologyBuilder;
     @Mock(type = MockType.STRICT)
@@ -118,6 +117,7 @@ public class TaskManagerTest {
     private final Set<TaskId> revokedTasks = new HashSet<>();
     private final List<TopicPartition> revokedPartitions = new ArrayList<>();
     private final List<TopicPartition> revokedChangelogs = Collections.emptyList();
+    private Set<String> subscriptionUpdates = Collections.emptySet();
 
     @Rule
     public final TemporaryFolder testFolder = new TemporaryFolder();
@@ -152,69 +152,61 @@ public class TaskManagerTest {
     @Test
     public void shouldUpdateSubscriptionFromAssignment() {
         mockTopologyBuilder();
-        expect(subscriptionUpdates.getUpdates()).andReturn(Utils.mkSet(topic1));
+        expect(topologyBuilder.subscriptionUpdates()).andReturn(Utils.mkSet(topic1));
         topologyBuilder.updateSubscribedTopics(EasyMock.eq(Utils.mkSet(topic1, topic2)), EasyMock.anyString());
         expectLastCall().once();
 
         EasyMock.replay(activeTaskCreator,
-                        topologyBuilder,
-                        subscriptionUpdates);
+                        topologyBuilder);
 
         taskManager.updateSubscriptionsFromAssignment(asList(t1p1, t2p1));
 
         EasyMock.verify(activeTaskCreator,
-                        topologyBuilder,
-                        subscriptionUpdates);
+                        topologyBuilder);
     }
 
     @Test
     public void shouldNotUpdateSubscriptionFromAssignment() {
         mockTopologyBuilder();
-        expect(subscriptionUpdates.getUpdates()).andReturn(Utils.mkSet(topic1, topic2));
+        expect(topologyBuilder.subscriptionUpdates()).andReturn(Utils.mkSet(topic1, topic2));
 
         EasyMock.replay(activeTaskCreator,
-                        topologyBuilder,
-                        subscriptionUpdates);
+                        topologyBuilder);
 
         taskManager.updateSubscriptionsFromAssignment(asList(t1p1));
 
         EasyMock.verify(activeTaskCreator,
-                        topologyBuilder,
-                        subscriptionUpdates);
+                        topologyBuilder);
     }
 
     @Test
     public void shouldUpdateSubscriptionFromMetadata() {
         mockTopologyBuilder();
-        expect(subscriptionUpdates.getUpdates()).andReturn(Utils.mkSet(topic1));
+        expect(topologyBuilder.subscriptionUpdates()).andReturn(Utils.mkSet(topic1));
         topologyBuilder.updateSubscribedTopics(EasyMock.eq(Utils.mkSet(topic1, topic2)), EasyMock.anyString());
         expectLastCall().once();
 
         EasyMock.replay(activeTaskCreator,
-                topologyBuilder,
-                subscriptionUpdates);
+                        topologyBuilder);
 
         taskManager.updateSubscriptionsFromMetadata(Utils.mkSet(topic1, topic2));
 
         EasyMock.verify(activeTaskCreator,
-                topologyBuilder,
-                subscriptionUpdates);
+                        topologyBuilder);
     }
 
     @Test
     public void shouldNotUpdateSubscriptionFromMetadata() {
         mockTopologyBuilder();
-        expect(subscriptionUpdates.getUpdates()).andReturn(Utils.mkSet(topic1));
+        expect(topologyBuilder.subscriptionUpdates()).andReturn(Utils.mkSet(topic1));
 
         EasyMock.replay(activeTaskCreator,
-                topologyBuilder,
-                subscriptionUpdates);
+                        topologyBuilder);
 
         taskManager.updateSubscriptionsFromMetadata(Utils.mkSet(topic1));
 
         EasyMock.verify(activeTaskCreator,
-                topologyBuilder,
-                subscriptionUpdates);
+                        topologyBuilder);
     }
 
     @Test
@@ -677,7 +669,7 @@ public class TaskManagerTest {
     }
 
     private void mockSingleActiveTask() {
-        expect(activeTaskCreator.createTasks(EasyMock.<Consumer<byte[], byte[]>>anyObject(),
+        expect(activeTaskCreator.createTasks(EasyMock.anyObject(),
                                                   EasyMock.eq(taskId0Assignment)))
                 .andReturn(Collections.singletonList(streamTask));
 
@@ -685,7 +677,6 @@ public class TaskManagerTest {
 
     private void mockTopologyBuilder() {
         expect(activeTaskCreator.builder()).andReturn(topologyBuilder).anyTimes();
-        expect(topologyBuilder.sourceTopicPattern()).andReturn(Pattern.compile("abc"));
-        expect(topologyBuilder.subscriptionUpdates()).andReturn(subscriptionUpdates);
+        expect(topologyBuilder.sourceTopicPattern()).andReturn(Pattern.compile("abc")).anyTimes();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -193,14 +193,233 @@ public class StreamsMetricsImplTest {
         streamsMetrics.storeLevelSensor(THREAD_ID, TASK_ID, storeName, sensorName2, RecordingLevel.INFO);
     }
 
-    private void setupGetSensorTest(final Metrics metrics,
-                                    final String level,
-                                    final RecordingLevel recordingLevel) {
-        final String fullSensorName =
-            INTERNAL_PREFIX + SENSOR_PREFIX_DELIMITER + level + SENSOR_NAME_DELIMITER + sensorName1;
+    private void setupGetNewSensorTest(final Metrics metrics,
+                                       final String level,
+                                       final RecordingLevel recordingLevel) {
+        final String fullSensorName = fullSensorName(level);
+        expect(metrics.getSensor(fullSensorName)).andStubReturn(null);
         final Sensor[] parents = {};
         expect(metrics.sensor(fullSensorName, recordingLevel, parents)).andReturn(sensor);
         replay(metrics);
+    }
+
+    private void setupGetExistingSensorTest(final Metrics metrics,
+                                            final String level) {
+        final String fullSensorName = fullSensorName(level);
+        expect(metrics.getSensor(fullSensorName)).andStubReturn(sensor);
+        replay(metrics);
+    }
+
+    private String fullSensorName(final String level) {
+        return INTERNAL_PREFIX + SENSOR_PREFIX_DELIMITER + level + SENSOR_NAME_DELIMITER + sensorName1;
+    }
+
+    @Test
+    public void shouldGetNewThreadLevelSensor() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        setupGetNewSensorTest(metrics, THREAD_ID, recordingLevel);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.threadLevelSensor(
+            THREAD_ID,
+            sensorName1,
+            recordingLevel
+        );
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldGetExistingThreadLevelSensor() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        setupGetExistingSensorTest(metrics, THREAD_ID);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.threadLevelSensor(
+            THREAD_ID,
+            sensorName1,
+            recordingLevel
+        );
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldGetNewTaskLevelSensor() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        setupGetNewSensorTest(metrics, THREAD_ID + ".task." + TASK_ID, recordingLevel);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.taskLevelSensor(
+            THREAD_ID,
+            TASK_ID,
+            sensorName1,
+            recordingLevel
+        );
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldGetExistingTaskLevelSensor() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        setupGetExistingSensorTest(metrics, THREAD_ID + ".task." + TASK_ID);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.taskLevelSensor(
+            THREAD_ID,
+            TASK_ID,
+            sensorName1,
+            recordingLevel
+        );
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldGetNewStoreLevelSensor() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        setupGetNewSensorTest(
+            metrics,
+            THREAD_ID + ".task." + storeName + SENSOR_PREFIX_DELIMITER + storeName + SENSOR_PREFIX_DELIMITER
+                + TASK_ID,
+            recordingLevel
+        );
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.storeLevelSensor(
+            THREAD_ID,
+            storeName,
+            TASK_ID,
+            sensorName1,
+            recordingLevel
+        );
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldGetExistingStoreLevelSensor() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        setupGetExistingSensorTest(
+            metrics, THREAD_ID + ".task." + storeName + SENSOR_PREFIX_DELIMITER + storeName + SENSOR_PREFIX_DELIMITER
+                + TASK_ID
+        );
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.storeLevelSensor(
+            THREAD_ID,
+            storeName,
+            TASK_ID,
+            sensorName1,
+            recordingLevel
+        );
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldGetNewNodeLevelSensor() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        final String processorNodeName = "processorNodeName";
+        setupGetNewSensorTest(metrics, THREAD_ID + ".task." + TASK_ID + SENSOR_PREFIX_DELIMITER + "node"
+            + SENSOR_PREFIX_DELIMITER + processorNodeName,
+            recordingLevel
+        );
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.nodeLevelSensor(
+            THREAD_ID,
+            TASK_ID,
+            processorNodeName,
+            sensorName1,
+            recordingLevel
+        );
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldGetExistingNodeLevelSensor() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        final String processorNodeName = "processorNodeName";
+        setupGetExistingSensorTest(
+            metrics, THREAD_ID + ".task." + TASK_ID + SENSOR_PREFIX_DELIMITER
+            + "node" + SENSOR_PREFIX_DELIMITER + processorNodeName
+        );
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.nodeLevelSensor(
+            THREAD_ID,
+            TASK_ID,
+            processorNodeName,
+            sensorName1,
+            recordingLevel
+        );
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldGetNewCacheLevelSensor() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        final String processorCacheName = "processorNodeName";
+        setupGetNewSensorTest(
+            metrics, THREAD_ID + ".task." + TASK_ID + SENSOR_PREFIX_DELIMITER
+            + "cache" + SENSOR_PREFIX_DELIMITER + processorCacheName,
+            recordingLevel
+        );
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.cacheLevelSensor(
+            THREAD_ID,
+            TASK_ID,
+            processorCacheName,
+            sensorName1,
+            recordingLevel
+        );
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldGetExistingCacheLevelSensor() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        final String processorCacheName = "processorNodeName";
+        setupGetExistingSensorTest(
+            metrics, THREAD_ID + ".task." + TASK_ID + SENSOR_PREFIX_DELIMITER
+            + "cache" + SENSOR_PREFIX_DELIMITER + processorCacheName
+        );
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.cacheLevelSensor(
+            THREAD_ID, TASK_ID,
+            processorCacheName,
+            sensorName1,
+            recordingLevel
+        );
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
     }
 
     @Test
@@ -242,19 +461,6 @@ public class StreamsMetricsImplTest {
     public void shouldProvideCorrectStrings() {
         assertThat(LATENCY_SUFFIX, is("-latency"));
         assertThat(ROLLUP_VALUE, is("all"));
-    }
-
-    @Test
-    public void shouldGetThreadLevelSensor() {
-        final Metrics metrics = mock(Metrics.class);
-        final RecordingLevel recordingLevel = RecordingLevel.INFO;
-        setupGetSensorTest(metrics, THREAD_ID, recordingLevel);
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
-
-        final Sensor actualSensor = streamsMetrics.threadLevelSensor(THREAD_ID, sensorName1, recordingLevel);
-
-        verify(metrics);
-        assertThat(actualSensor, is(equalToObject(sensor)));
     }
 
     private void setupRemoveSensorsTest(final Metrics metrics,

--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
@@ -69,11 +69,11 @@ public class EosTestDriver extends SmokeTestUtil {
 
     static void generate(final String kafka) {
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook("streams-eos-test-driver-shutdown-hook", () -> {
             System.out.println("Terminating");
             System.out.flush();
             isRunning = false;
-        }));
+        });
 
         final Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, "EosTest");

--- a/streams/src/test/java/org/apache/kafka/streams/tests/ShutdownDeadlockTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/ShutdownDeadlockTest.java
@@ -62,12 +62,7 @@ public class ShutdownDeadlockTest {
             }
         });
 
-        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-            @Override
-            public void run() {
-                streams.close(Duration.ofSeconds(5));
-            }
-        }));
+        Exit.addShutdownHook("streams-shutdown-hook", () -> streams.close(Duration.ofSeconds(5)));
 
         final Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, "SmokeTest");

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -76,7 +77,7 @@ public class SmokeTestClient extends SmokeTestUtil {
             e.printStackTrace();
         });
 
-        Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+        Exit.addShutdownHook("streams-shutdown-hook", () -> close());
 
         thread = new Thread(() -> streams.start());
         thread.start();

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StaticMemberTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StaticMemberTestClient.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.tests;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -70,15 +71,12 @@ public class StaticMemberTestClient {
 
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                System.out.println("closing Kafka Streams instance");
-                System.out.flush();
-                streams.close();
-                System.out.println("Static membership test closed");
-                System.out.flush();
-            }
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
+            System.out.println("closing Kafka Streams instance");
+            System.out.flush();
+            streams.close();
+            System.out.println("Static membership test closed");
+            System.out.flush();
         });
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
@@ -114,12 +115,11 @@ public class StreamsBrokerDownResilienceTest {
         System.out.println("Start Kafka Streams");
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             streams.close(Duration.ofSeconds(30));
             System.out.println("Complete shutdown of streams resilience test app now");
             System.out.flush();
-        }
-        ));
+        });
     }
 
     private static boolean confirmCorrectConfigs(final Properties properties) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsNamedRepartitionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsNamedRepartitionTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.tests;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -110,12 +111,12 @@ public class StreamsNamedRepartitionTest {
 
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             System.out.println("closing Kafka Streams instance");
             System.out.flush();
             streams.close(Duration.ofMillis(5000));
             System.out.println("NAMED_REPARTITION_TEST Streams Stopped");
             System.out.flush();
-        }));
+        });
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.tests;
 
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -131,15 +132,12 @@ public class StreamsOptimizedTest {
 
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                System.out.println("closing Kafka Streams instance");
-                System.out.flush();
-                streams.close(Duration.ofMillis(5000));
-                System.out.println("OPTIMIZE_TEST Streams Stopped");
-                System.out.flush();
-            }
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
+            System.out.println("closing Kafka Streams instance");
+            System.out.flush();
+            streams.close(Duration.ofMillis(5000));
+            System.out.println("OPTIMIZE_TEST Streams Stopped");
+            System.out.flush();
         });
 
     }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStandByReplicaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStandByReplicaTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -147,10 +148,10 @@ public class StreamsStandByReplicaTest {
         System.out.println("Start Kafka Streams");
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             shutdown(streams);
             System.out.println("Shut down streams now");
-        }));
+        });
     }
 
     private static void shutdown(final KafkaStreams streams) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.ByteBufferInputStream;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
@@ -81,13 +82,13 @@ public class StreamsUpgradeTest {
         final KafkaStreams streams = buildStreams(streamsProperties);
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             System.out.println("closing Kafka Streams instance");
             System.out.flush();
             streams.close();
             System.out.println("UPGRADE-TEST-CLIENT-CLOSED");
             System.out.flush();
-        }));
+        });
     }
 
     public static KafkaStreams buildStreams(final Properties streamsProperties) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeToCooperativeRebalanceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeToCooperativeRebalanceTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.tests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -108,11 +109,11 @@ public class StreamsUpgradeToCooperativeRebalanceTest {
 
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             streams.close();
             System.out.println(String.format("%sCOOPERATIVE-REBALANCE-TEST-CLIENT-CLOSED", upgradePhase));
             System.out.flush();
-        }));
+        });
     }
 
     private static void addTasksToBuilder(final List<String> tasks, final StringBuilder builder) {

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.utils.Exit;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -264,7 +265,7 @@ public class TransactionalMessageCopier {
         final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
         final AtomicLong remainingMessages = new AtomicLong(maxMessages);
         final AtomicLong numMessagesProcessed = new AtomicLong(0);
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook("transactional-message-copier-shutdown-hook", () -> {
             isShuttingDown.set(true);
             // Flush any remaining messages
             producer.close();
@@ -272,7 +273,7 @@ public class TransactionalMessageCopier {
                 consumer.close();
             }
             System.out.println(shutDownString(numMessagesProcessed.get(), remainingMessages.get(), transactionalId));
-        }));
+        });
 
         try {
             Random random = new Random();

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -644,7 +644,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
 
         try {
             final VerifiableConsumer consumer = createFromArgs(parser, args);
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> consumer.close()));
+            Exit.addShutdownHook("verifiable-consumer-shutdown-hook", () -> consumer.close());
 
             consumer.run();
         } catch (ArgumentParserException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
@@ -241,10 +241,8 @@ public class VerifiableLog4jAppender {
         final VerifiableLog4jAppender appender = createFromArgs(args);
         boolean infinite = appender.maxMessages < 0;
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Trigger main thread to stop producing messages
-            appender.stopLogging = true;
-        }));
+        // Trigger main thread to stop producing messages when shutting down
+        Exit.addShutdownHook("verifiable-log4j-appender-shutdown-hook", () -> appender.stopLogging = true);
 
         long maxMessages = infinite ? Long.MAX_VALUE : appender.maxMessages;
         for (long i = 0; i < maxMessages; i++) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -517,7 +517,7 @@ public class VerifiableProducer implements AutoCloseable {
             final long startMs = System.currentTimeMillis();
             ThroughputThrottler throttler = new ThroughputThrottler(producer.throughput, startMs);
 
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            Exit.addShutdownHook("verifiable-producer-shutdown-hook", () -> {
                 // Trigger main thread to stop producing messages
                 producer.stopProducing = true;
 
@@ -529,7 +529,7 @@ public class VerifiableProducer implements AutoCloseable {
                 double avgThroughput = 1000 * ((producer.numAcked) / (double) (stopMs - startMs));
 
                 producer.printJson(new ToolData(producer.numSent, producer.numAcked, producer.throughput, avgThroughput));
-            }));
+            });
 
             producer.run(throttler);
         } catch (ArgumentParserException e) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -249,7 +249,7 @@ public final class Agent {
         log.info("Starting agent process.");
         final Agent agent = new Agent(platform, Scheduler.SYSTEM, restServer, resource);
         restServer.start(resource);
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook("agent-shutdown-hook", () -> {
             log.warn("Running agent shutdown hook.");
             try {
                 agent.beginShutdown();
@@ -257,7 +257,7 @@ public final class Agent {
             } catch (Exception e) {
                 log.error("Got exception while running agent shutdown hook.", e);
             }
-        }));
+        });
         if (taskSpec != null) {
             TaskSpec spec = null;
             try {

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -171,7 +171,7 @@ public final class Coordinator {
         final Coordinator coordinator = new Coordinator(platform, Scheduler.SYSTEM,
             restServer, resource, ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE / 2));
         restServer.start(resource);
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook("coordinator-shutdown-hook", () -> {
             log.warn("Running coordinator shutdown hook.");
             try {
                 coordinator.beginShutdown(false);
@@ -179,7 +179,7 @@ public final class Coordinator {
             } catch (Exception e) {
                 log.error("Got exception while running coordinator shutdown hook.", e);
             }
-        }));
+        });
         coordinator.waitForShutdown();
     }
 };


### PR DESCRIPTION
Conflicts and/or compiler errors due to the fact that we
temporarily reverted the commit that removes
Scala 2.11 support:

* Exit.scala: replace SAMs with anonymous inner classes.
* MiniKdc.scala: take upstream changes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
