### PR TITLE
Changes to migrate to Artifactory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ def job = {
 
     if (config.publish && config.isDevJob) {
       configFileProvider([configFile(fileId: 'Gradle-Artifactory-Settings', variable: 'GRADLE_NEXUS_SETTINGS')]) {
-          stage("Publish to nexus") {
+          stage("Publish to artifactory") {
               sh "./gradlew --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchivesAll"
           }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ def job = {
     }
 
     if (config.publish && config.isDevJob) {
-      configFileProvider([configFile(fileId: 'Gradle Nexus Settings', variable: 'GRADLE_NEXUS_SETTINGS')]) {
+      configFileProvider([configFile(fileId: 'Gradle-Artifactory-Settings', variable: 'GRADLE_NEXUS_SETTINGS')]) {
           stage("Publish to nexus") {
               sh "./gradlew --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchivesAll"
           }


### PR DESCRIPTION
Move kafka build to Artifactory

Use Gradle Artifactory Credentials.

Kafka Team, please help cherry pick this into other branches once PR build passes and merged into master