### PR TITLE
Upgrade to Avro 1.9.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -63,7 +63,7 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  avro: "1.9.1",
+  avro: "1.9.2",
   avroPlugin: "0.17.0",
   bcpkix: "1.64",
   checkstyle: "8.20",


### PR DESCRIPTION
Upgrade to Avro 1.9.2, only for 2.5, not master

The Avro dependency has been removed from master