### PR TITLE
CONFLUENT: Remove support metrics exclusion from spotbugs-exclude.xml

### DIFF
--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -431,10 +431,4 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
         <!-- Suppress warnings related to jmh generated code -->
         <Package name="org.apache.kafka.jmh.acl.generated"/>
     </Match>
-
-    <Match>
-        <Package name="io.confluent.support.metrics.collectors"/>
-        <Source name="CollectorFactory.java"/>
-        <Bug pattern="IS2_INCONSISTENT_SYNC"/>
-    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
The support metrics code has been deleted.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
