### PR TITLE
MINOR: cp-downstream-builds failures should be treated as UNSTABLE

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,29 +66,34 @@ def job = {
         downstreamBuildsStepName: {
             echo "Building cp-downstream-builds"
             if (config.isPrJob) {
-                def muckrakeBranch = kafkaMuckrakeVersionMap[env.CHANGE_TARGET]
-                def forkRepo = "${env.CHANGE_FORK ?: "confluentinc"}/kafka.git"
-                def forkBranch = env.CHANGE_BRANCH
-                echo "Schedule test-cp-downstream-builds with :"
-                echo "Muckrake branch : ${muckrakeBranch}"
-                echo "PR fork repo : ${forkRepo}"
-                echo "PR fork branch : ${forkBranch}"
-                buildResult = build job: 'test-cp-downstream-builds', parameters: [
-                        [$class: 'StringParameterValue', name: 'BRANCH', value: muckrakeBranch],
-                        [$class: 'StringParameterValue', name: 'TEST_PATH', value: "muckrake/tests/dummy_test.py"],
-                        [$class: 'StringParameterValue', name: 'KAFKA_REPO', value: forkRepo],
-                        [$class: 'StringParameterValue', name: 'KAFKA_BRANCH', value: forkBranch]],
-                        propagate: true, wait: true
-                return ", downstream build result: " + buildResult.getResult();
+                try {
+                    def muckrakeBranch = kafkaMuckrakeVersionMap[env.CHANGE_TARGET]
+                    def forkRepo = "${env.CHANGE_FORK ?: "confluentinc"}/kafka.git"
+                    def forkBranch = env.CHANGE_BRANCH
+                    echo "Schedule test-cp-downstream-builds with :"
+                    echo "Muckrake branch : ${muckrakeBranch}"
+                    echo "PR fork repo : ${forkRepo}"
+                    echo "PR fork branch : ${forkBranch}"
+                    buildResult = build job: 'test-cp-downstream-builds', parameters: [
+                            [$class: 'StringParameterValue', name: 'BRANCH', value: muckrakeBranch],
+                            [$class: 'StringParameterValue', name: 'TEST_PATH', value: "muckrake/tests/dummy_test.py"],
+                            [$class: 'StringParameterValue', name: 'KAFKA_REPO', value: forkRepo],
+                            [$class: 'StringParameterValue', name: 'KAFKA_BRANCH', value: forkBranch]],
+                            propagate: true, wait: true
+                    return "cp-downstream-builds SUCCESS";
+                } catch (ignored) {
+                    currentBuild.result = 'UNSTABLE'
+                    return "cp-downstream-builds FAILURE";
+                }
             } else {
-                return ""
+                return "";
             }
          }
         ]
 
         result = parallel testTargets
         // combine results of the two targets into one result string
-        return result.runTestsStepName + result.downstreamBuildsStepName
+        return result.runTestsStepName + "\n" + result.downstreamBuildsStepName
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,8 +83,11 @@ def job = {
                     downstreamBuildFailureOutput = "cp-downstream-builds result: " + buildResult.getResult();
                     return downstreamBuildFailureOutput
                 } catch (ignored) {
-                    downstreamBuildFailureOutput = "cp-downstream-builds result: " + e.getMessage()
                     currentBuild.result = 'UNSTABLE'
+                    downstreamBuildFailureOutput = "cp-downstream-builds result: " + e.getMessage()
+                    writeFile file: "downstream/downstream-build-result.txt", text: downstreamBuildFailureOutput
+                    archiveArtifacts artifacts: 'downstream/*.txt'
+
                     return downstreamBuildFailureOutput
                 }
             } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ def job = {
                     return "cp-downstream-builds FAILURE";
                 }
             } else {
-                return "";
+                return ""
             }
          }
         ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,10 +80,12 @@ def job = {
                             [$class: 'StringParameterValue', name: 'KAFKA_REPO', value: forkRepo],
                             [$class: 'StringParameterValue', name: 'KAFKA_BRANCH', value: forkBranch]],
                             propagate: true, wait: true
-                    return "cp-downstream-builds SUCCESS";
+                    downstreamBuildFailureOutput = "cp-downstream-builds result: " + buildResult.getResult();
+                    return downstreamBuildFailureOutput
                 } catch (ignored) {
+                    downstreamBuildFailureOutput = "cp-downstream-builds result: " + e.getMessage()
                     currentBuild.result = 'UNSTABLE'
-                    return "cp-downstream-builds FAILURE";
+                    return downstreamBuildFailureOutput
                 }
             } else {
                 return ""
@@ -98,3 +100,4 @@ def job = {
 }
 
 runJob config, job
+echo downstreamBuildFailureOutput

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ def job = {
                 } catch (ignored) {
                     currentBuild.result = 'UNSTABLE'
                     downstreamBuildFailureOutput = "cp-downstream-builds result: " + e.getMessage()
-                    writeFile file: "downstream/downstream-build-result.txt", text: downstreamBuildFailureOutput
+                    writeFile file: "downstream/cp-downstream-build-failure.txt", text: downstreamBuildFailureOutput
                     archiveArtifacts artifacts: 'downstream/*.txt'
 
                     return downstreamBuildFailureOutput


### PR DESCRIPTION
This PR changes the way jenkins works to make cp-downstream-builds failures mark the build as unstable (yellow) rather than failed (red). We have previously seen committers treating red/failed builds as successful due to a lack of test failures, even though code may have failed to compile or jenkins workers may have exited with non-zero status codes.

We now also capture a text file with the downstream build number in it as a jenkins artifact.