### PR TITLE
CONFLUENCE: Enable rat gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ ext {
 
 apply from: file('wrapper.gradle')
 
-if (false) {
+if (file('.git').exists()) {
   apply from: file('gradle/rat.gradle')
   rat {
     // Exclude everything under the directory that git should be ignoring via .gitignore or that isn't checked in. These

--- a/build.gradle
+++ b/build.gradle
@@ -140,9 +140,6 @@ ext {
 
 apply from: file('wrapper.gradle')
 
-// The RAT check examines the license headers of files.  Because we have some
-// Confluent header files now, this check currently fails.  For now, we have
-// disabled the check. We would like to have a more permanent solution.
 if (false) {
   apply from: file('gradle/rat.gradle')
   rat {


### PR DESCRIPTION
This PR revert two commits that disable the RAT. 

`./gradlew rat` fails unless we have https://github.com/confluentinc/kafka/pull/282 too, in which case it passes. 

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
