### PR TITLE
MINOR: fix downstream build failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ def retryFlagsString(jobConfig) {
     else ""
 }
 
+def downstreamBuildFailureOutput = ""
 def job = {
     // https://github.com/confluentinc/common-tools/blob/master/confluent/config/dev/versions.json
     def kafkaMuckrakeVersionMap = [


### PR DESCRIPTION
Fixes groovy.lang.MissingPropertyException: No such property: downstreamBuildFailureOutput for class: WorkflowScript

This happened because we run things slightly differently on master compared to a PR.