### PR TITLE
Use correct versioning for alpha release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
-version=6.0.0-alpha1
+version=6.0.0-ccs-alpha1
 scalaVersion=2.12.10
 task=build
 org.gradle.jvmargs=-Xmx1024m -Xss2m


### PR DESCRIPTION
There was a mistake in the version bumping replacement (commit [here](https://github.com/confluentinc/kafka/commit/2a8712bc23efe2e215d54d87ee34a5756144af5f)), so -ccs was removed from the version when bumping for 6.0.x-alpha1, resulting in packaging builds to [fail](https://jenkins.confluent.io/job/confluentinc/job/packaging/job/6.0.x-alpha1/3/console). This commit fixes the version in kafka to include ccs in the versioning.
