### PR TITLE
MINOR: allow retries for unitTest and integrationTest runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -347,6 +347,10 @@ subprojects {
       includeCategories 'org.apache.kafka.test.IntegrationTest'
     }
 
+    retry {
+      maxRetries = userMaxTestRetries
+      maxFailures = userMaxTestRetryFailures
+    }
   }
 
   task unitTest(type: Test, dependsOn: compileJava) {
@@ -367,6 +371,11 @@ subprojects {
       useJUnit {
         excludeCategories 'org.apache.kafka.test.IntegrationTest'
       }
+    }
+
+    retry {
+      maxRetries = userMaxTestRetries
+      maxFailures = userMaxTestRetryFailures
     }
   }
 


### PR DESCRIPTION
We will currently retry if you run gradle test, but not unitTest or integrationTest, which are used directly in Jenkins https://github.com/confluentinc/kafka/blob/master/Jenkinsfile#L65. This means that we have not been achieving the expected retry behavior in Jenkins.