### PR TITLE
Publish preview jobs with preview release settings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,11 @@ def retryFlagsString(jobConfig) {
 }
 
 def downstreamBuildFailureOutput = ""
+def publishStep(String configSettings) {
+  configFileProvider([configFile(fileId: configSettings, variable: 'GRADLE_NEXUS_SETTINGS')]) {
+          sh "./gradlew --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchivesAll"
+  }
+}
 def job = {
     // https://github.com/confluentinc/common-tools/blob/master/confluent/config/dev/versions.json
     def kafkaMuckrakeVersionMap = [
@@ -47,18 +52,14 @@ def job = {
                 "--no-daemon --stacktrace --continue -PxmlSpotBugsReport=true"
     }
 
-    if (config.publish && config.isDevJob) {
-      configFileProvider([configFile(fileId: 'Gradle-Artifactory-Settings', variable: 'GRADLE_NEXUS_SETTINGS')]) {
-          stage("Publish to artifactory") {
-              sh "./gradlew --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchivesAll"
-          }
-      }
-    } else if (config.publish && config.isPreviewJob) {
-        configFileProvider([configFile(fileId: 'Gradle-Artifactory-Preview-Release-Settings', variable: 'GRADLE_NEXUS_SETTINGS')]) {
-            stage("Publish to artifactory") {
-                sh "./gradlew --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchivesAll"
-            }
+    if (config.publish) {
+      stage("Publish to artifactory") {
+        if (config.isDevJob) {
+          publishStep('Gradle-Artifactory-Settings')
+        } else if (config.isPreviewJob) {
+          publishStep('Gradle-Artifactory-Preview-Release-Settings')
         }
+      }
     }
 
     stage("Run Tests and build cp-downstream-builds") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,12 @@ def job = {
               sh "./gradlew --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchivesAll"
           }
       }
+    } else if (config.publish && config.isPreviewJob) {
+        configFileProvider([configFile(fileId: 'Gradle-Artifactory-Preview-Release-Settings', variable: 'GRADLE_NEXUS_SETTINGS')]) {
+            stage("Publish to artifactory") {
+                sh "./gradlew --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchivesAll"
+            }
+        }
     }
 
     stage("Run Tests and build cp-downstream-builds") {

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ ext {
   userMaxTestRetryFailures = project.hasProperty('maxTestRetryFailures') ? maxTestRetryFailures.toInteger() : 0
 
   skipSigning = project.hasProperty('skipSigning') && skipSigning.toBoolean()
-  shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && project.gradle.startParameter.taskNames.any { it.contains("upload") }
+  shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && !version.endsWith("-alpha") && project.gradle.startParameter.taskNames.any { it.contains("upload") }
 
   mavenUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : ''
   mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : ''

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ ext {
   userMaxTestRetryFailures = project.hasProperty('maxTestRetryFailures') ? maxTestRetryFailures.toInteger() : 0
 
   skipSigning = project.hasProperty('skipSigning') && skipSigning.toBoolean()
-  shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && !version.endsWith("-alpha") && project.gradle.startParameter.taskNames.any { it.contains("upload") }
+  shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && !version.contains("-alpha") && project.gradle.startParameter.taskNames.any { it.contains("upload") }
 
   mavenUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : ''
   mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : ''


### PR DESCRIPTION
**Context:** Preview release artifacts (in particular jars for 6.0.0-ccs-alpha1) were not getting published to Artifactory. As a result, 6.0.x-alpha1 branches in `common` and other PLATFORM repos were not able to build successfully.

**Changes:** This commit updates the Jenkinsfile to handle preview release jobs. It checks if the job is a preview job (denoted by -alpha in the branch name), and use specific preview release settings for publishing to `maven-releases-preview` in Artifactory if so.
This was tested with replay option on [this 6.0.x-alpha1 job](https://jenkins.confluent.io/job/confluentinc/job/kafka/job/6.0.x-alpha1/17/) and it ran successfully, publishing artifacts to Artifactory and allowing platform repos to build (e.g. [successful build in common](https://jenkins.confluent.io/job/confluentinc/job/common/job/6.0.x-alpha1/10/)).