### PR TITLE
Porting scala 2.11 compatible from 2.5  to 2.4

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
@@ -35,6 +35,8 @@ import org.easymock.{Capture, CaptureType, EasyMock, IAnswer, IExpectationSetter
 import org.junit.Assert._
 import org.junit.Test
 import org.mockito.Mockito.{doNothing, when}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mockito}
 
 import scala.collection.{Map, Seq}
@@ -243,9 +245,9 @@ class ReplicaAlterLogDirsThreadTest {
       responseCallback = callbackCaptor.capture(),
       isolationLevel = ArgumentMatchers.eq(IsolationLevel.READ_UNCOMMITTED),
       clientMetadata = ArgumentMatchers.eq(None)
-    )).thenAnswer(_ => {
-      callbackCaptor.getValue.apply(Seq((topicPartition, responseData)))
-    })
+    )) thenAnswer new Answer[Unit] {
+      override def answer(invocation: InvocationOnMock): Unit = callbackCaptor.getValue.apply(Seq((topicPartition, responseData)))
+    }
   }
 
   @Test


### PR DESCRIPTION
Partial cherry-pick of changes from 2.5 leave documentation changes.