### PR TITLE
MINOR: Fix Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ def job = {
                 echo "Muckrake branch : ${muckrakeBranch}"
                 echo "PR fork repo : ${forkRepo}"
                 echo "PR fork branch : ${forkBranch}"
-                buildResult = build job: 'test-cp-downstream-builds', parameters: [
+                buildResult = build job: 'test-cp-downstream-builds-jdk7', parameters: [
                         [$class: 'StringParameterValue', name: 'BRANCH', value: muckrakeBranch],
                         [$class: 'StringParameterValue', name: 'TEST_PATH', value: "muckrake/tests/dummy_test.py"],
                         [$class: 'StringParameterValue', name: 'KAFKA_REPO', value: forkRepo],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ def job = {
     ]
 
     stage("Compile and validate") {
-        sh "./gradlew clean assemble spotlessScalaCheck checkstyleMain checkstyleTest " +
+        sh "gradle && ./gradlew clean assemble checkstyleMain checkstyleTest " +
                 "--no-daemon --stacktrace --continue"
     }
 


### PR DESCRIPTION
1st change: The Kafka job for the 1.0 Branch has been failing on `./gradlew: not found` - 1.0 and 1.1 do not contain the wrapper script, so call gradle to do an initial "bootstrap" - this is the failing job:

https://jenkins.confluent.io/job/confluentinc/job/kafka/job/1.0/

This change seemed to make it work on my replay:

https://jenkins.confluent.io/job/confluentinc/job/kafka/job/1.0/42/replay/diff

2nd change: Use `test-cp-downstream-builds-jdk7` as the 4.0.x and 4.1.x versions use JDK7.

I will merge this into 1.1 as well since it too is suffering from the same failure.

Other notes:

> Why am I removing `spotlessScalaCheck`? 

That doesn't seem to be a valid target for 1.0:

https://jenkins.confluent.io/job/confluentinc/job/kafka/job/1.0/40/console