### PR TITLE
Minimal raft server implementation for more interesting testing

### DIFF
--- a/bin/raft-server-start.sh
+++ b/bin/raft-server-start.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ $# -lt 1 ];
+then
+	echo "USAGE: $0 [-daemon] server.properties [--override property=value]*"
+	exit 1
+fi
+base_dir=$(dirname $0)
+
+if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
+    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/raft-log4j.properties"
+fi
+
+if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
+    export KAFKA_HEAP_OPTS="-Xmx1G -Xms1G"
+fi
+
+EXTRA_ARGS=${EXTRA_ARGS-'-name kafkaServer -loggc'}
+
+COMMAND=$1
+case $COMMAND in
+  -daemon)
+    EXTRA_ARGS="-daemon "$EXTRA_ARGS
+    shift
+    ;;
+  *)
+    ;;
+esac
+
+exec $base_dir/kafka-run-class.sh $EXTRA_ARGS kafka.server.RaftServer "$@"

--- a/config/raft-log4j.properties
+++ b/config/raft-log4j.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log4j.rootLogger=INFO, stderr
+
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.stderr.Target=System.err

--- a/config/raft.properties
+++ b/config/raft.properties
@@ -1,0 +1,6 @@
+broker.id=0
+listeners=PLAINTEXT://localhost:9092
+quorum.bootstrap.servers=localhost:9092
+quorum.bootstrap.voters=0
+log.dirs=/tmp/raft-logs
+zookeeper.connect=localhost:2181 

--- a/config/raft.properties
+++ b/config/raft.properties
@@ -3,4 +3,6 @@ listeners=PLAINTEXT://localhost:9092
 quorum.bootstrap.servers=localhost:9092
 quorum.bootstrap.voters=0
 log.dirs=/tmp/raft-logs
-zookeeper.connect=localhost:2181 
+
+# Below is not used, but is currently required by `KafkaConfig`
+zookeeper.connect=localhost:2181

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1464,7 +1464,8 @@ class Log(@volatile private var _dir: File,
            isolation: FetchIsolation,
            minOneMessage: Boolean): FetchDataInfo = {
     maybeHandleIOException(s"Exception while reading from $topicPartition in dir ${dir.getParent}") {
-      trace(s"Reading $maxLength bytes from offset $startOffset of length $size bytes")
+      trace(s"Reading maximum $maxLength bytes at offset $startOffset from log with " +
+        s"total length $size bytes")
 
       val includeAbortedTxns = isolation == FetchTxnCommitted
 

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -19,7 +19,7 @@ package kafka.raft
 import java.lang
 import java.util.{Optional, OptionalLong}
 
-import kafka.log.Log
+import kafka.log.{AppendOrigin, Log}
 import kafka.server.{FetchHighWatermark, FetchLogEnd}
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.record.{MemoryRecords, Records}
@@ -45,7 +45,9 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
   }
 
   override def appendAsLeader(records: Records, epoch: Int): lang.Long = {
-    val appendInfo = log.appendAsLeader(records.asInstanceOf[MemoryRecords], leaderEpoch = epoch)
+    val appendInfo = log.appendAsLeader(records.asInstanceOf[MemoryRecords],
+      leaderEpoch = epoch,
+      origin = AppendOrigin.Coordinator)
     appendInfo.firstOffset.getOrElse {
       throw new KafkaException("Append failed unexpectedly")
     }

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -30,8 +30,8 @@ import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{KafkaException, Node}
 import org.apache.kafka.raft.{NetworkChannel, RaftMessage, RaftRequest, RaftResponse, RaftUtil}
 
-import scala.jdk.CollectionConverters._
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
 object KafkaNetworkChannel {
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -108,7 +108,8 @@ class KafkaApis(val requestChannel: RequestChannel,
                 brokerTopicStats: BrokerTopicStats,
                 val clusterId: String,
                 time: Time,
-                val tokenManager: DelegationTokenManager) extends Logging {
+                val tokenManager: DelegationTokenManager)
+  extends ApiRequestHandler with Logging {
 
   type FetchResponseStats = Map[TopicPartition, RecordConversionStats]
   this.logIdent = "[KafkaApi-%d] ".format(brokerId)
@@ -123,7 +124,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   /**
    * Top-level method that handles all requests and multiplexes to the right api
    */
-  def handle(request: RequestChannel.Request): Unit = {
+  override def handle(request: RequestChannel.Request): Unit = {
     try {
       trace(s"Handling request:${request.requestDesc(true)} from connection ${request.context.connectionId};" +
         s"securityProtocol:${request.context.securityProtocol},principal:${request.context.principal}")

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -30,6 +30,10 @@ import org.apache.kafka.common.utils.{KafkaThread, Time}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
+trait ApiRequestHandler {
+  def handle(request: RequestChannel.Request): Unit
+}
+
 /**
  * A thread that answers kafka requests.
  */
@@ -38,7 +42,7 @@ class KafkaRequestHandler(id: Int,
                           val aggregateIdleMeter: Meter,
                           val totalHandlerThreads: AtomicInteger,
                           val requestChannel: RequestChannel,
-                          apis: KafkaApis,
+                          apis: ApiRequestHandler,
                           time: Time) extends Runnable with Logging {
   this.logIdent = "[Kafka Request Handler " + id + " on Broker " + brokerId + "], "
   private val shutdownComplete = new CountDownLatch(1)
@@ -95,7 +99,7 @@ class KafkaRequestHandler(id: Int,
 
 class KafkaRequestHandlerPool(val brokerId: Int,
                               val requestChannel: RequestChannel,
-                              val apis: KafkaApis,
+                              val apis: ApiRequestHandler,
                               time: Time,
                               numThreads: Int,
                               requestHandlerAvgIdleMetricName: String,

--- a/core/src/main/scala/kafka/server/RaftRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/RaftRequestHandler.scala
@@ -20,7 +20,6 @@ package kafka.server
 import kafka.network.RequestChannel
 import kafka.raft.KafkaNetworkChannel
 import kafka.utils.Logging
-import org.apache.kafka.common.errors.UnsupportedVersionException
 import org.apache.kafka.common.internals.FatalExitError
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse}

--- a/core/src/main/scala/kafka/server/RaftRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/RaftRequestHandler.scala
@@ -49,7 +49,7 @@ class RaftRequestHandler(networkChannel: KafkaNetworkChannel,
             requestBody,
             response => sendResponse(request, Some(response)))
 
-        case _ => throw new UnsupportedVersionException(s"Unsupported api key: ${request.header.apiKey}")
+        case _ => throw new IllegalArgumentException(s"Unsupported api key: ${request.header.apiKey}")
       }
     } catch {
       case e: FatalExitError => throw e

--- a/core/src/main/scala/kafka/server/RaftRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/RaftRequestHandler.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.network.RequestChannel
+import kafka.raft.KafkaNetworkChannel
+import kafka.utils.Logging
+import org.apache.kafka.common.errors.UnsupportedVersionException
+import org.apache.kafka.common.internals.FatalExitError
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse}
+import org.apache.kafka.common.utils.Time
+
+import scala.jdk.CollectionConverters._
+
+class RaftRequestHandler(networkChannel: KafkaNetworkChannel,
+                         requestChannel: RequestChannel,
+                         time: Time)
+  extends ApiRequestHandler with Logging {
+
+  override def handle(request: RequestChannel.Request): Unit = {
+    try {
+      trace(s"Handling request:${request.requestDesc(true)} from connection ${request.context.connectionId};" +
+        s"securityProtocol:${request.context.securityProtocol},principal:${request.context.principal}")
+      request.header.apiKey match {
+        case ApiKeys.VOTE
+             | ApiKeys.BEGIN_QUORUM_EPOCH
+             | ApiKeys.END_QUORUM_EPOCH
+             | ApiKeys.FETCH_QUORUM_RECORDS
+             | ApiKeys.FIND_QUORUM =>
+          val requestBody = request.body[AbstractRequest]
+          networkChannel.postInboundRequest(
+            request.header,
+            requestBody,
+            response => sendResponse(request, Some(response)))
+
+        case _ => throw new UnsupportedVersionException(s"Unsupported api key: ${request.header.apiKey}")
+      }
+    } catch {
+      case e: FatalExitError => throw e
+      case e: Throwable => handleError(request, e)
+    } finally {
+      // The local completion time may be set while processing the request. Only record it if it's unset.
+      if (request.apiLocalCompleteTimeNanos < 0)
+        request.apiLocalCompleteTimeNanos = time.nanoseconds
+    }
+  }
+
+  private def handleError(request: RequestChannel.Request, err: Throwable): Unit = {
+    error("Error when handling request: " +
+      s"clientId=${request.header.clientId}, " +
+      s"correlationId=${request.header.correlationId}, " +
+      s"api=${request.header.apiKey}, " +
+      s"version=${request.header.apiVersion}, " +
+      s"body=${request.body[AbstractRequest]}", err)
+
+    val requestBody = request.body[AbstractRequest]
+    val response = requestBody.getErrorResponse(0, err)
+    if (response == null)
+      closeConnection(request, requestBody.errorCounts(err))
+    else
+      sendResponse(request, Some(response))
+  }
+
+  private def closeConnection(request: RequestChannel.Request, errorCounts: java.util.Map[Errors, Integer]): Unit = {
+    // This case is used when the request handler has encountered an error, but the client
+    // does not expect a response (e.g. when produce request has acks set to 0)
+    requestChannel.updateErrorMetrics(request.header.apiKey, errorCounts.asScala)
+    requestChannel.sendResponse(new RequestChannel.CloseConnectionResponse(request))
+  }
+
+  private def sendResponse(request: RequestChannel.Request,
+                           responseOpt: Option[AbstractResponse]): Unit = {
+    // Update error metrics for each error code in the response including Errors.NONE
+    responseOpt.foreach(response => requestChannel.updateErrorMetrics(request.header.apiKey, response.errorCounts.asScala))
+
+    val response = responseOpt match {
+      case Some(response) =>
+        val responseSend = request.context.buildResponse(response)
+        val responseString =
+          if (RequestChannel.isRequestLoggingEnabled) Some(response.toString(request.context.apiVersion))
+          else None
+        new RequestChannel.SendResponse(request, responseSend, responseString, None)
+      case None =>
+        new RequestChannel.NoOpResponse(request)
+    }
+    sendResponse(response)
+  }
+
+  private def sendResponse(response: RequestChannel.Response): Unit = {
+    requestChannel.sendResponse(response)
+  }
+
+}

--- a/core/src/main/scala/kafka/server/RaftServer.scala
+++ b/core/src/main/scala/kafka/server/RaftServer.scala
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.io.File
+import java.net.{InetAddress, InetSocketAddress}
+import java.nio.file.Files
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicBoolean
+
+import joptsimple.OptionParser
+import kafka.log.{Log, LogConfig, LogManager}
+import kafka.network.SocketServer
+import kafka.raft.{KafkaMetadataLog, KafkaNetworkChannel, KafkaRequestPurgatory}
+import kafka.security.CredentialProvider
+import kafka.utils.timer.SystemTimer
+import kafka.utils.{CommandLineUtils, Exit, KafkaScheduler, Logging}
+import org.apache.kafka.clients.{ApiVersions, ClientDnsLookup, ManualMetadataUpdater, NetworkClient}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.ConfigException
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network.{ChannelBuilders, NetworkReceive, Selectable, Selector}
+import org.apache.kafka.common.security.JaasContext
+import org.apache.kafka.common.security.scram.internals.ScramMechanism
+import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
+import org.apache.kafka.common.utils.{LogContext, Time, Utils}
+import org.apache.kafka.raft.{ReplicatedCounter, FileBasedStateStore, KafkaRaftClient, QuorumState, RaftConfig}
+
+import scala.jdk.CollectionConverters._
+
+class RaftServer(val config: KafkaConfig) extends Logging {
+
+  private val partition = new TopicPartition("__cluster_metadata", 0)
+  private val time = Time.SYSTEM
+
+  var socketServer: SocketServer = _
+  var credentialProvider: CredentialProvider = _
+  var tokenCache: DelegationTokenCache = _
+  var dataPlaneRequestHandlerPool: KafkaRequestHandlerPool = _
+  var scheduler: KafkaScheduler = _
+  var metrics: Metrics = _
+
+  def startup(): Unit = {
+    metrics = new Metrics()
+    scheduler = new KafkaScheduler(threads = 1)
+
+    scheduler.startup()
+
+    tokenCache = new DelegationTokenCache(ScramMechanism.mechanismNames)
+    credentialProvider = new CredentialProvider(ScramMechanism.mechanismNames, tokenCache)
+
+    socketServer = new SocketServer(config, metrics, time, credentialProvider)
+    socketServer.startup(startProcessingRequests = false)
+
+    val logDirName = Log.logDirName(partition)
+    val logDir = createLogDirectory(new File(config.logDirs.head), logDirName)
+
+    val raftConfig = new RaftConfig(config.originals)
+    val logContext = new LogContext(s"[Raft id=${config.brokerId}] ")
+    val metadataLog = buildMetadataLog(logDir)
+    val networkChannel = buildNetworkChannel(raftConfig, logContext)
+
+    val requestHandler = new RaftRequestHandler(
+      networkChannel,
+      socketServer.dataPlaneRequestChannel,
+      time
+    )
+
+    val raftClient = buildRaftClient(
+      raftConfig,
+      metadataLog,
+      networkChannel,
+      logContext,
+      logDir
+    )
+
+    dataPlaneRequestHandlerPool = new KafkaRequestHandlerPool(
+      config.brokerId,
+      socketServer.dataPlaneRequestChannel,
+      requestHandler,
+      time,
+      config.numIoThreads,
+      s"${SocketServer.DataPlaneMetricPrefix}RequestHandlerAvgIdlePercent",
+      SocketServer.DataPlaneThreadPrefix
+    )
+
+    socketServer.startProcessingRequests(Map.empty)
+
+    val shutdown = new AtomicBoolean(false)
+    try {
+      val counter = new ReplicatedCounter(raftClient, logContext, true)
+      val incrementThread = new Thread() {
+        override def run(): Unit = {
+          while (!shutdown.get()) {
+            if (counter.isLeader) {
+              counter.increment()
+              Thread.sleep(500)
+            }
+          }
+        }
+      }
+
+      raftClient.initialize(counter)
+      incrementThread.start()
+
+      while (true) {
+        raftClient.poll()
+      }
+    } finally {
+      shutdown.set(true)
+      raftClient.shutdown(5000)
+    }
+  }
+
+  private def buildNetworkChannel(raftConfig: RaftConfig,
+                                  logContext: LogContext): KafkaNetworkChannel = {
+    val netClient = buildNetworkClient(raftConfig, logContext)
+    val clientId = s"Raft-${config.brokerId}"
+    new KafkaNetworkChannel(time, netClient, clientId,
+      raftConfig.retryBackoffMs, raftConfig.requestTimeoutMs)
+  }
+
+  private def buildMetadataLog(logDir: File): KafkaMetadataLog = {
+    if (config.logDirs.size != 1) {
+      throw new ConfigException("There must be exactly one configured log dir")
+    }
+
+    val defaultProps = KafkaServer.copyKafkaConfigToLog(config)
+    LogConfig.validateValues(defaultProps)
+    val defaultLogConfig = LogConfig(defaultProps)
+
+    val log = Log(
+      dir = logDir,
+      config = defaultLogConfig,
+      logStartOffset = 0L,
+      recoveryPoint = 0L,
+      scheduler = scheduler,
+      brokerTopicStats = new BrokerTopicStats,
+      time = time,
+      maxProducerIdExpirationMs = config.transactionalIdExpirationMs,
+      producerIdExpirationCheckIntervalMs = LogManager.ProducerIdExpirationCheckIntervalMs,
+      logDirFailureChannel = new LogDirFailureChannel(5)
+    )
+    new KafkaMetadataLog(time, log)
+  }
+
+  private def createLogDirectory(logDir: File, logDirName: String): File = {
+    val logDirPath = logDir.getAbsolutePath
+    val dir = new File(logDirPath, logDirName)
+    Files.createDirectories(dir.toPath)
+    dir
+  }
+
+  private def buildRaftClient(raftConfig: RaftConfig,
+                              metadataLog: KafkaMetadataLog,
+                              networkChannel: KafkaNetworkChannel,
+                              logContext: LogContext,
+                              logDir: File): KafkaRaftClient = {
+    val quorumState = new QuorumState(
+      config.brokerId,
+      raftConfig.bootstrapVoters,
+      new FileBasedStateStore(new File(logDir, "quorum-state")),
+      logContext
+    )
+
+    val purgatory = new KafkaRequestPurgatory(
+      config.brokerId,
+      new SystemTimer("raft-purgatory-reaper"),
+      reaperEnabled = true)
+
+    new KafkaRaftClient(
+      raftConfig,
+      networkChannel,
+      metadataLog,
+      quorumState,
+      time,
+      purgatory,
+      advertisedListener,
+      logContext
+    )
+  }
+
+  private def buildNetworkClient(raftConfig: RaftConfig,
+                                 logContext: LogContext): NetworkClient = {
+    val channelBuilder = ChannelBuilders.clientChannelBuilder(
+      config.interBrokerSecurityProtocol,
+      JaasContext.Type.SERVER,
+      config,
+      config.interBrokerListenerName,
+      config.saslMechanismInterBrokerProtocol,
+      time,
+      config.saslInterBrokerHandshakeRequestEnable,
+      logContext
+    )
+    val selector = new Selector(
+      NetworkReceive.UNLIMITED,
+      config.connectionsMaxIdleMs,
+      metrics,
+      time,
+      "raft-channel",
+      Map.empty[String, String].asJava,
+      false,
+      channelBuilder,
+      logContext
+    )
+    new NetworkClient(
+      selector,
+      new ManualMetadataUpdater(),
+      s"broker-${config.brokerId}-raft-client",
+      1,
+      50,
+      50,
+      Selectable.USE_DEFAULT_BUFFER_SIZE,
+      config.socketReceiveBufferBytes,
+      raftConfig.requestTimeoutMs,
+      ClientDnsLookup.USE_ALL_DNS_IPS,
+      time,
+      false,
+      new ApiVersions,
+      logContext
+    )
+  }
+
+  private def advertisedListener: InetSocketAddress = {
+    val host = Option(config.advertisedListeners
+      .find(_.listenerName == config.interBrokerListenerName).head.host)
+      .getOrElse(InetAddress.getLocalHost.getCanonicalHostName)
+    val port = socketServer.boundPort(config.interBrokerListenerName)
+    new InetSocketAddress(host, port)
+  }
+
+}
+
+object RaftServer extends Logging {
+  import kafka.utils.Implicits._
+
+  def getPropsFromArgs(args: Array[String]): Properties = {
+    val optionParser = new OptionParser(false)
+    val overrideOpt = optionParser.accepts("override", "Optional property that should override values set in server.properties file")
+      .withRequiredArg()
+      .ofType(classOf[String])
+    // This is just to make the parameter show up in the help output, we are not actually using this due the
+    // fact that this class ignores the first parameter which is interpreted as positional and mandatory
+    // but would not be mandatory if --version is specified
+    // This is a bit of an ugly crutch till we get a chance to rework the entire command line parsing
+    optionParser.accepts("version", "Print version information and exit.")
+
+    if (args.length == 0 || args.contains("--help")) {
+      CommandLineUtils.printUsageAndDie(optionParser, "USAGE: java [options] %s server.properties [--override property=value]*".format(classOf[RaftServer].getSimpleName()))
+    }
+
+    if (args.contains("--version")) {
+      CommandLineUtils.printVersionAndDie()
+    }
+
+    val props = Utils.loadProps(args(0))
+
+    if (args.length > 1) {
+      val options = optionParser.parse(args.slice(1, args.length): _*)
+
+      if (options.nonOptionArguments().size() > 0) {
+        CommandLineUtils.printUsageAndDie(optionParser, "Found non argument parameters: " + options.nonOptionArguments().toArray.mkString(","))
+      }
+
+      props ++= CommandLineUtils.parseKeyValueArgs(options.valuesOf(overrideOpt).asScala)
+    }
+    props
+  }
+
+  def main(args: Array[String]): Unit = {
+    try {
+      val serverProps = getPropsFromArgs(args)
+      val config = KafkaConfig.fromProps(serverProps, false)
+      val server = new RaftServer(config)
+      server.startup()
+    }
+    catch {
+      case e: Throwable =>
+        fatal("Exiting Kafka due to fatal exception", e)
+        Exit.exit(1)
+    }
+    Exit.exit(0)
+  }
+}

--- a/core/src/test/scala/unit/kafka/raft/KafkaFuturePurgatoryTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaFuturePurgatoryTest.scala
@@ -34,15 +34,15 @@ class KafkaFuturePurgatoryTest {
     val purgatory = new KafkaFuturePurgatory(brokerId, timer, reaperEnabled = false)
     assertEquals(0, purgatory.numWaiting())
 
-    val future1 = new CompletableFuture[Unit]()
+    val future1 = new CompletableFuture[Void]()
     purgatory.await(future1, 500)
     assertEquals(1, purgatory.numWaiting())
 
-    val future2 = new CompletableFuture[Unit]()
+    val future2 = new CompletableFuture[Void]()
     purgatory.await(future2, 500)
     assertEquals(2, purgatory.numWaiting())
 
-    val future3 = new CompletableFuture[Unit]()
+    val future3 = new CompletableFuture[Void]()
     purgatory.await(future3, 1000)
     assertEquals(3, purgatory.numWaiting())
 
@@ -63,19 +63,19 @@ class KafkaFuturePurgatoryTest {
     val purgatory = new KafkaFuturePurgatory(brokerId, timer, reaperEnabled = false)
     assertEquals(0, purgatory.numWaiting())
 
-    val future1 = new CompletableFuture[Unit]()
+    val future1 = new CompletableFuture[Void]()
     purgatory.await(future1, 500)
     assertEquals(1, purgatory.numWaiting())
 
-    val future2 = new CompletableFuture[Unit]()
+    val future2 = new CompletableFuture[Void]()
     purgatory.await(future2, 500)
     assertEquals(2, purgatory.numWaiting())
 
-    val future3 = new CompletableFuture[Unit]()
+    val future3 = new CompletableFuture[Void]()
     purgatory.await(future3, 1000)
     assertEquals(3, purgatory.numWaiting())
 
-    purgatory.completeAll(())
+    purgatory.completeAll(null)
     assertTrue(future1.isDone)
     assertEquals((), future1.get())
 

--- a/raft/src/main/java/org/apache/kafka/raft/ConnectionCache.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ConnectionCache.java
@@ -54,7 +54,7 @@ public class ConnectionCache {
         // Mimic logic in `Cluster.bootstrap` until we think of something smarter
         int nodeId = -1;
         for (InetSocketAddress address : bootstrapServers) {
-            ConnectionState connection = new BootstrapConnectionState(nodeId);
+            ConnectionState connection = new ConnectionState(nodeId);
             connection.maybeUpdate(new HostInfo(address, 0L));
             bootstrapConnections.put(nodeId, connection);
             bootstrapServerIds.add(nodeId);
@@ -151,19 +151,6 @@ public class ConnectionCache {
         BACKING_OFF,
         READY
     }
-
-    private class BootstrapConnectionState extends ConnectionState {
-
-        public BootstrapConnectionState(long id) {
-            super(id);
-        }
-
-        @Override
-        void onResponseReceived(long requestId, long timeMs) {
-            onResponseError(requestId, timeMs);
-        }
-    }
-
 
     public class ConnectionState {
         private final long id;

--- a/raft/src/main/java/org/apache/kafka/raft/ElectionState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ElectionState.java
@@ -41,12 +41,16 @@ public class ElectionState {
     public static ElectionState withVotedCandidate(int epoch, int votedId, Set<Integer> voters) {
         if (votedId < 0)
             throw new IllegalArgumentException("Illegal voted Id " + votedId + ": must be non-negative");
+        if (!voters.contains(votedId))
+            throw new IllegalArgumentException("Voted candidate with id " + votedId + " is not among the valid voters");
         return new ElectionState(epoch, OptionalInt.empty(), OptionalInt.of(votedId), voters);
     }
 
     public static ElectionState withElectedLeader(int epoch, int leaderId, Set<Integer> voters) {
         if (leaderId < 0)
             throw new IllegalArgumentException("Illegal leader Id " + leaderId + ": must be non-negative");
+        if (!voters.contains(leaderId))
+            throw new IllegalArgumentException("Leader with id " + leaderId + " is not among the valid voters");
         return new ElectionState(epoch, OptionalInt.of(leaderId), OptionalInt.empty(), voters);
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumStateStore.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumStateStore.java
@@ -30,7 +30,7 @@ public interface QuorumStateStore {
     /**
      * Read the latest election state.
      *
-     * @return The latest written election state or `ElectionState.withUnknownLeader(0)` if there is none.
+     * @return The latest written election state or `null` if there is none
      * @throws IOException For any error encountered reading from the storage
      */
     ElectionState readElectionState() throws IOException;

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -105,7 +105,7 @@ public class RaftConfig extends AbstractConfig {
                 QUORUM_ELECTION_TIMEOUT_MS_DOC)
             .define(QUORUM_ELECTION_JITTER_MAX_MS_CONFIG,
                 ConfigDef.Type.INT,
-                100,
+                5000,
                 atLeast(0),
                 ConfigDef.Importance.HIGH,
                 QUORUM_ELECTION_JITTER_MAX_MS_DOC)

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -16,16 +16,20 @@
  */
 package org.apache.kafka.raft;
 
+import org.apache.kafka.clients.ClientDnsLookup;
+import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
+import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
@@ -36,40 +40,42 @@ import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 public class RaftConfig extends AbstractConfig {
     private static final ConfigDef CONFIG;
 
-    public static final String QUORUM_VOTERS_CONFIG = "quorum.voters";
+    private static final String QUORUM_PREFIX = "quorum.";
+
+    public static final String QUORUM_VOTERS_CONFIG = QUORUM_PREFIX + "bootstrap.voters";
     private static final String QUORUM_VOTERS_DOC = "List of voters. This is only used the " +
         "first time a cluster is initialized.";
 
-    public static final String QUORUM_ELECTION_TIMEOUT_MS_CONFIG = "quorum.election.timeout.ms";
+    public static final String QUORUM_ELECTION_TIMEOUT_MS_CONFIG = QUORUM_PREFIX + "election.timeout.ms";
     private static final String QUORUM_ELECTION_TIMEOUT_MS_DOC = "Maximum time in milliseconds to wait " +
         "without being able to fetch from the leader before triggering a new election";
 
-    public static final String QUORUM_FETCH_TIMEOUT_MS_CONFIG = "quorum.fetch.timeout.ms";
+    public static final String QUORUM_FETCH_TIMEOUT_MS_CONFIG = QUORUM_PREFIX + "fetch.timeout.ms";
     private static final String QUORUM_FETCH_TIMEOUT_MS_DOC = "Maximum time without a successful fetch from " +
         "the current leader before becoming a candidate and triggering a election for voters; Maximum time without " +
         "receiving fetch from a majority of the quorum before asking around to see if there's a new epoch for leader";
 
-    public static final String QUORUM_ELECTION_JITTER_MAX_MS_CONFIG = "quorum.election.jitter.max.ms";
+    public static final String QUORUM_ELECTION_JITTER_MAX_MS_CONFIG = QUORUM_PREFIX + "election.jitter.max.ms";
     private static final String QUORUM_ELECTION_JITTER_MAX_MS_DOC = "Maximum jitter to delay new elections. " +
         "This helps prevent gridlocked elections";
 
     static {
         CONFIG = new ConfigDef()
-            .define(BOOTSTRAP_SERVERS_CONFIG,
+            .define(QUORUM_PREFIX + BOOTSTRAP_SERVERS_CONFIG,
                 ConfigDef.Type.LIST,
                 Collections.emptyList(),
                 new ConfigDef.NonNullValidator(),
                 ConfigDef.Importance.HIGH,
                 CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
-            .define(REQUEST_TIMEOUT_MS_CONFIG,
+            .define(QUORUM_PREFIX + REQUEST_TIMEOUT_MS_CONFIG,
                 ConfigDef.Type.INT,
                 20000,
                 atLeast(0),
                 ConfigDef.Importance.MEDIUM,
                 REQUEST_TIMEOUT_MS_DOC)
-            .define(RETRY_BACKOFF_MS_CONFIG,
-                ConfigDef.Type.LONG,
-                100L,
+            .define(QUORUM_PREFIX + RETRY_BACKOFF_MS_CONFIG,
+                ConfigDef.Type.INT,
+                100,
                 atLeast(0L),
                 ConfigDef.Importance.LOW,
                 CommonClientConfigs.RETRY_BACKOFF_MS_DOC)
@@ -93,8 +99,8 @@ public class RaftConfig extends AbstractConfig {
                 QUORUM_VOTERS_DOC)
             .define(QUORUM_ELECTION_TIMEOUT_MS_CONFIG,
                 ConfigDef.Type.INT,
-                30000,
-                atLeast(0),
+                5000,
+                atLeast(0L),
                 ConfigDef.Importance.HIGH,
                 QUORUM_ELECTION_TIMEOUT_MS_DOC)
             .define(QUORUM_ELECTION_JITTER_MAX_MS_CONFIG,
@@ -134,6 +140,35 @@ public class RaftConfig extends AbstractConfig {
 
     public static void main(String[] args) {
         System.out.println(CONFIG.toHtml());
+    }
+
+    public int requestTimeoutMs() {
+        return getInt(QUORUM_PREFIX + CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG);
+    }
+
+    public int retryBackoffMs() {
+        return getInt(QUORUM_PREFIX + CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG);
+    }
+
+    public int electionTimeoutMs() {
+        return getInt(QUORUM_ELECTION_TIMEOUT_MS_CONFIG);
+    }
+
+    public int electionJitterMaxMs() {
+        return getInt(QUORUM_ELECTION_JITTER_MAX_MS_CONFIG);
+    }
+
+    public int fetchTimeoutMs() {
+        return getInt(QUORUM_FETCH_TIMEOUT_MS_CONFIG);
+    }
+
+    public Set<Integer> bootstrapVoters() {
+        return getList(QUORUM_VOTERS_CONFIG).stream().map(Integer::valueOf).collect(Collectors.toSet());
+    }
+
+    public List<InetSocketAddress> bootstrapServers() {
+        return ClientUtils.parseAndValidateAddresses(getList(QUORUM_PREFIX + BOOTSTRAP_SERVERS_CONFIG),
+            ClientDnsLookup.USE_ALL_DNS_IPS);
     }
 
 }

--- a/raft/src/test/java/org/apache/kafka/raft/ConnectionCacheTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/ConnectionCacheTest.java
@@ -198,7 +198,7 @@ public class ConnectionCacheTest {
         long correlationId = 1;
         connectionState.onRequestSent(correlationId, time.milliseconds());
         assertFalse(connectionState.isReady(time.milliseconds()));
-        connectionState.onResponseReceived(correlationId);
+        connectionState.onResponseReceived(correlationId, time.milliseconds());
         assertTrue(connectionState.isReady(time.milliseconds()));
     }
 
@@ -225,7 +225,7 @@ public class ConnectionCacheTest {
         long correlationId = 1;
         connectionState.onRequestSent(correlationId, time.milliseconds());
         assertFalse(connectionState.isReady(time.milliseconds()));
-        connectionState.onResponseReceived(correlationId + 1);
+        connectionState.onResponseReceived(correlationId + 1, time.milliseconds());
         assertFalse(connectionState.isReady(time.milliseconds()));
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/MockQuorumStateStore.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockQuorumStateStore.java
@@ -17,10 +17,9 @@
 package org.apache.kafka.raft;
 
 import java.io.IOException;
-import java.util.Collections;
 
 public class MockQuorumStateStore implements QuorumStateStore {
-    private ElectionState current = ElectionState.withUnknownLeader(0, Collections.emptySet());
+    private ElectionState current;
 
     @Override
     public ElectionState readElectionState() throws IOException {
@@ -34,6 +33,6 @@ public class MockQuorumStateStore implements QuorumStateStore {
 
     @Override
     public void clear() {
-        current = ElectionState.withUnknownLeader(0, Collections.emptySet());
+        current = null;
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -38,7 +39,7 @@ public class QuorumStateTest {
     @Test
     public void testInitializePrimordialEpoch() throws IOException {
         Set<Integer> voters = Utils.mkSet(localId);
-        assertEquals(0, store.readElectionState().epoch);
+        assertNull(store.readElectionState());
 
         QuorumState state = initializeEmptyState(voters, store);
         assertTrue(state.isFollower());
@@ -127,7 +128,7 @@ public class QuorumStateTest {
     @Test
     public void testBecomeLeader() throws IOException {
         Set<Integer> voters = Utils.mkSet(localId);
-        assertEquals(0, store.readElectionState().epoch);
+        assertNull(store.readElectionState());
 
         QuorumState state = initializeEmptyState(voters, store);
         state.becomeCandidate();
@@ -142,7 +143,7 @@ public class QuorumStateTest {
     @Test
     public void testCannotBecomeLeaderIfAlreadyLeader() throws IOException {
         Set<Integer> voters = Utils.mkSet(localId);
-        assertEquals(0, store.readElectionState().epoch);
+        assertNull(store.readElectionState());
 
         store.writeElectionState(ElectionState.withUnknownLeader(1, voters));
 
@@ -158,7 +159,7 @@ public class QuorumStateTest {
     @Test
     public void testCannotBecomeFollowerOfSelf() throws IOException {
         Set<Integer> voters = Utils.mkSet(localId);
-        assertEquals(0, store.readElectionState().epoch);
+        assertNull(store.readElectionState());
         QuorumState state = initializeEmptyState(voters, store);
 
         assertThrows(IllegalArgumentException.class, () -> state.becomeFetchingFollower(0, localId));
@@ -180,8 +181,6 @@ public class QuorumStateTest {
     @Test
     public void testCannotBecomeCandidateIfCurrentlyLeading() throws IOException {
         Set<Integer> voters = Utils.mkSet(localId);
-        assertEquals(0, store.readElectionState().epoch);
-
         QuorumState state = initializeEmptyState(voters, store);
         state.becomeCandidate();
         state.becomeLeader(0L);
@@ -222,15 +221,8 @@ public class QuorumStateTest {
 
     private QuorumState initializeEmptyState(Set<Integer> voters,
                                              MockQuorumStateStore store) throws IOException {
-        return initializeEmptyState(voters, store, 0);
-    }
-
-    private QuorumState initializeEmptyState(Set<Integer> voters,
-                                             MockQuorumStateStore store,
-                                             int epoch) throws IOException {
         QuorumState state = new QuorumState(localId, voters, store, new LogContext());
-
-        store.writeElectionState(ElectionState.withUnknownLeader(epoch, voters));
+        store.writeElectionState(ElectionState.withUnknownLeader(0, voters));
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         return state;
     }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -676,7 +676,7 @@ public class RaftEventSimulationTest {
         }
 
         void initialize() {
-            this.counter = new ReplicatedCounter(nodeId, logContext);
+            this.counter = new ReplicatedCounter(nodeId, logContext, false);
             try {
                 client.initialize(counter);
             } catch (IOException e) {
@@ -767,12 +767,7 @@ public class RaftEventSimulationTest {
             this.cluster = cluster;
             for (Map.Entry<Integer, PersistentState> nodeStateEntry : cluster.nodes.entrySet()) {
                 Integer nodeId = nodeStateEntry.getKey();
-                PersistentState state = nodeStateEntry.getValue();
-                try {
-                    nodeEpochs.put(nodeId, state.store.readElectionState().epoch);
-                } catch (IOException e) {
-                    fail("Unexpected IO exception from state store read" + e);
-                }
+                nodeEpochs.put(nodeId, 0);
             }
         }
 


### PR DESCRIPTION
This patch adds the wiring to startup a dummy server which uses the `DistributedCounter` state machine. It more or less works after fixing a few minor bugs, but there are problems with the `FindQuorum` discovery logic.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
