### PR TITLE
KCORE-349: Add quorum-state file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ clients/src/generated-test
 jmh-benchmarks/generated
 jmh-benchmarks/src/main/generated
 streams/src/generated
+raft/src/generated

--- a/build.gradle
+++ b/build.gradle
@@ -1106,6 +1106,31 @@ project(':raft') {
     }
   }
 
+  task processMessages(type:JavaExec) {
+    main = "org.apache.kafka.message.MessageGenerator"
+    classpath = project(':generator').sourceSets.main.runtimeClasspath
+    args = [ "org.apache.kafka.raft.generated",
+             "src/generated/java/org/apache/kafka/raft/generated",
+             "src/main/resources/common/message" ]
+    inputs.dir("src/main/resources/common/message")
+    outputs.dir("src/generated/java/org/apache/kafka/raft/generated")
+  }
+
+  sourceSets {
+    main {
+      java {
+        srcDirs = ["src/generated/java", "src/main/java"]
+      }
+    }
+    test {
+      java {
+        srcDirs = ["src/generated/java", "src/test/java"]
+      }
+    }
+  }
+  
+  compileJava.dependsOn 'processMessages'
+
   jar {
     dependsOn createVersionFile
     from("$buildDir") {

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -310,6 +310,7 @@
     <allow pkg="org.apache.kafka.common.record" />
     <allow pkg="org.apache.kafka.common.protocol" />
     <allow pkg="org.apache.kafka.test"/>
+    <allow pkg="com.fasterxml.jackson" />
   </subpackage>
 
   <subpackage name="connect">

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -198,6 +198,8 @@
     <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS)"
               files="streams[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS)"
+              files="raft[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
     <!-- Streams tests -->
     <suppress checks="ClassFanOutComplexity"

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{KafkaException, Node}
 import org.apache.kafka.raft.{NetworkChannel, RaftMessage, RaftRequest, RaftResponse}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 object KafkaNetworkChannel {

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -120,8 +120,7 @@ class KafkaNetworkChannel(time: Time,
             val success = undelivered.offer(new RaftResponse.Inbound(
               request.correlationId, disconnectResponse, request.destinationId))
             if (!success) {
-              debug(s"Request to ${request.destinationId()} failed to add to undelivered queue, " +
-                s"because the queue was full.")
+              throw new KafkaException("Undelivered queue is full")
             }
           } else if (client.ready(node, currentTimeMs)) {
             pendingOutbound.poll()

--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -1,12 +1,12 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
+ * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -251,7 +251,7 @@ class AclAuthorizer extends Authorizer with Logging {
         } catch {
           case e: Exception =>
             resourceBindingsBeingDeleted.keys.foreach { binding =>
-                deleteExceptions.getOrElseUpdate(binding, apiException(e))
+              deleteExceptions.getOrElseUpdate(binding, apiException(e))
             }
         }
       }
@@ -266,15 +266,15 @@ class AclAuthorizer extends Authorizer with Logging {
 
   @nowarn("cat=optimizer")
   override def acls(filter: AclBindingFilter): lang.Iterable[AclBinding] = {
-      val aclBindings = new util.ArrayList[AclBinding]()
-      aclCache.foreach { case (resource, versionedAcls) =>
-        versionedAcls.acls.foreach { acl =>
-          val binding = new AclBinding(resource, acl.ace)
-          if (filter.matches(binding))
-            aclBindings.add(binding)
-        }
+    val aclBindings = new util.ArrayList[AclBinding]()
+    aclCache.foreach { case (resource, versionedAcls) =>
+      versionedAcls.acls.foreach { acl =>
+        val binding = new AclBinding(resource, acl.ace)
+        if (filter.matches(binding))
+          aclBindings.add(binding)
       }
-      aclBindings
+    }
+    aclBindings
   }
 
   override def close(): Unit = {
@@ -528,7 +528,7 @@ class AclAuthorizer extends Authorizer with Logging {
   }
 
   private def updateAclChangedFlag(resource: ResourcePattern): Unit = {
-      zkClient.createAclChangeNotification(resource)
+    zkClient.createAclChangeNotification(resource)
   }
 
   private def backoffTime = {

--- a/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.clients.MockClient.MockMetadataUpdater
 import org.apache.kafka.common.Node
 import org.apache.kafka.common.message.{BeginQuorumEpochRequestData, BeginQuorumEpochResponseData, EndQuorumEpochRequestData, EndQuorumEpochResponseData, FetchQuorumRecordsRequestData, FetchQuorumRecordsResponseData, FindQuorumRequestData, FindQuorumResponseData, VoteRequestData, VoteResponseData}
 import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
-import org.apache.kafka.common.requests.{AbstractResponse, BeginQuorumEpochResponse, EndQuorumEpochResponse, FetchQuorumRecordsResponse, FindQuorumResponse, RequestHeader, VoteResponse}
+import org.apache.kafka.common.requests.{AbstractResponse, RequestHeader}
 import org.apache.kafka.common.utils.{MockTime, Time}
 import org.apache.kafka.raft.{RaftRequest, RaftResponse}
 import org.junit.Assert._

--- a/raft/src/main/java/org/apache/kafka/raft/ElectionState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ElectionState.java
@@ -26,9 +26,9 @@ public class ElectionState {
     private final OptionalInt leaderIdOpt;
     private final OptionalInt votedIdOpt;
 
-    private ElectionState(int epoch,
-                          OptionalInt leaderIdOpt,
-                          OptionalInt votedIdOpt) {
+    ElectionState(int epoch,
+                  OptionalInt leaderIdOpt,
+                  OptionalInt votedIdOpt) {
         this.epoch = epoch;
         this.leaderIdOpt = leaderIdOpt;
         this.votedIdOpt = votedIdOpt;
@@ -60,10 +60,6 @@ public class ElectionState {
         if (nodeId < 0)
             throw new IllegalArgumentException("Invalid negative nodeId: " + nodeId);
         return votedIdOpt.orElse(-1) == nodeId;
-    }
-
-    public boolean isFollower(int nodeId) {
-        return !isLeader(nodeId) && !isCandidate(nodeId);
     }
 
     public int leaderId() {
@@ -114,5 +110,4 @@ public class ElectionState {
         result = 31 * result + votedIdOpt.hashCode();
         return result;
     }
-
 }

--- a/raft/src/main/java/org/apache/kafka/raft/FileBasedStateStore.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FileBasedStateStore.java
@@ -79,15 +79,15 @@ public class FileBasedStateStore implements QuorumStateStore {
             JsonNode readNode = objectMapper.readTree(line);
 
             if (!(readNode instanceof ObjectNode)) {
-                throw new IOException("Deserialized node " + readNode.toString() +
+                throw new IOException("Deserialized node " + readNode +
                     " is not an object node");
             }
             final ObjectNode dataObject = (ObjectNode) readNode;
 
             JsonNode dataVersionNode = dataObject.get(DATA_VERSION);
             if (dataVersionNode == null) {
-                throw new IOException("Deserialized node " + readNode.toString() +
-                    " does not have 'data_version' field");
+                throw new IOException("Deserialized node " + readNode +
+                    " does not have " + DATA_VERSION + " field");
             }
 
             final short dataVersion = dataVersionNode.shortValue();
@@ -151,6 +151,7 @@ public class FileBasedStateStore implements QuorumStateStore {
     @Override
     public void clear() throws IOException {
         Files.deleteIfExists(stateFile.toPath());
+        Files.deleteIfExists(new File(stateFile.getAbsolutePath() + ".tmp").toPath());
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/FileBasedStateStore.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FileBasedStateStore.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ShortNode;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.raft.generated.QuorumStateData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.util.OptionalInt;
+
+/**
+ * Local file based quorum state store. It takes the JSON format of {@link QuorumStateData}
+ * with an extra data version number as part of the data for easy deserialization.
+ *
+ * Example format:
+ * <pre>
+ * {"clusterId":"",
+ *   "leaderId":1,
+ *   "leaderEpoch":2,
+ *   "votedId":-1,
+ *   "appliedOffset":0,
+ *   "currentVoters":[],
+ *   "targetVoters":[],
+ *   "data_version":0}
+ * </pre>
+ * */
+public class FileBasedStateStore implements QuorumStateStore {
+    private static final Logger log = LoggerFactory.getLogger(FileBasedStateStore.class);
+
+    private final File stateFile;
+
+    static final String DATA_VERSION = "data_version";
+
+    public FileBasedStateStore(final File stateFile) {
+        this.stateFile = stateFile;
+    }
+
+    private QuorumStateData loadState(File file) throws IOException {
+        if (!file.exists()) {
+            throw new NoSuchFileException("State store file " + file.toPath() + " is not found");
+        }
+
+        try (final BufferedReader reader = Files.newBufferedReader(file.toPath())) {
+            final String line = reader.readLine();
+            if (line == null) {
+                throw new EOFException("File ended prematurely.");
+            }
+
+            final ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode readNode = objectMapper.readTree(line);
+
+            if (!(readNode instanceof ObjectNode)) {
+                throw new IOException("Deserialized node " + readNode.toString() +
+                    " is not an object node");
+            }
+            final ObjectNode dataObject = (ObjectNode) readNode;
+
+            JsonNode dataVersionNode = dataObject.get(DATA_VERSION);
+            if (dataVersionNode == null) {
+                throw new IOException("Deserialized node " + readNode.toString() +
+                    " does not have 'data_version' field");
+            }
+
+            final short dataVersion = dataVersionNode.shortValue();
+            QuorumStateData data = new QuorumStateData();
+            data.fromJson(dataObject, dataVersion);
+            return data;
+        }
+    }
+
+    /**
+     * Reads the election state from local file.
+     */
+    @Override
+    public ElectionState readElectionState() throws IOException {
+        QuorumStateData data = loadState(stateFile);
+
+        return new ElectionState(data.leaderEpoch(),
+            data.leaderId() == UNKNOWN_LEADER_ID ? OptionalInt.empty() :
+                OptionalInt.of(data.leaderId()),
+            data.votedId() == NOT_VOTED ? OptionalInt.empty() :
+                OptionalInt.of(data.votedId()));
+    }
+
+    @Override
+    public void writeElectionState(ElectionState latest) throws IOException {
+        QuorumStateData data = new QuorumStateData()
+            .setLeaderEpoch(latest.epoch)
+            .setVotedId(latest.hasVoted() ? latest.votedId() : NOT_VOTED)
+            .setLeaderId(latest.hasLeader() ? latest.leaderId() : UNKNOWN_LEADER_ID);
+        writeElectionStateToFile(stateFile, data);
+    }
+
+    private void writeElectionStateToFile(final File stateFile, QuorumStateData state) throws IOException  {
+        final File temp = new File(stateFile.getAbsolutePath() + ".tmp");
+        Files.deleteIfExists(temp.toPath());
+
+        log.trace("Writing tmp quorum state {}", temp.getAbsolutePath());
+
+        try (final FileOutputStream fileOutputStream = new FileOutputStream(temp);
+             final BufferedWriter writer = new BufferedWriter(
+                 new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8))) {
+            short version = state.highestSupportedVersion();
+
+            ObjectNode jsonState = (ObjectNode) state.toJson(version);
+            jsonState.set(DATA_VERSION, new ShortNode(version));
+            writer.write(jsonState.toString());
+            writer.flush();
+            fileOutputStream.getFD().sync();
+            Utils.atomicMoveWithFallback(temp.toPath(), stateFile.toPath());
+        } finally {
+            // cleanup the temp file when the write finishes (either success or fail).
+            Files.deleteIfExists(temp.toPath());
+        }
+    }
+
+    /**
+     * Clear state store by deleting the local quorum state file
+     *
+     * @throws IOException if there is any IO exception during delete
+     */
+    @Override
+    public void clear() throws IOException {
+        Files.deleteIfExists(stateFile.toPath());
+    }
+
+    @Override
+    public String toString() {
+        return "Quorum state filepath: " + stateFile.getAbsolutePath();
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -191,7 +191,7 @@ public class KafkaRaftClient implements RaftClient {
     @Override
     public void initialize(DistributedStateMachine stateMachine) throws IOException {
         this.stateMachine = stateMachine;
-        quorum.initialize(log.endOffset());
+        quorum.initialize(new OffsetAndEpoch(log.endOffset(), log.lastFetchedEpoch()));
 
         if (quorum.isLeader()) {
             electionTimer.reset(Long.MAX_VALUE);

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -34,13 +34,13 @@ import java.util.stream.Collectors;
 public class QuorumState {
     public final int localId;
     private final Logger log;
-    private final ElectionStore store;
+    private final QuorumStateStore store;
     private final Set<Integer> voters;
     private EpochState state;
 
     public QuorumState(int localId,
                        Set<Integer> voters,
-                       ElectionStore store,
+                       QuorumStateStore store,
                        LogContext logContext) {
         this.localId = localId;
         this.voters = new HashSet<>(voters);
@@ -48,14 +48,30 @@ public class QuorumState {
         this.log = logContext.logger(QuorumState.class);
     }
 
-    public void initialize(long endOffset) throws IOException {
+    public void initialize(OffsetAndEpoch logEndOffsetAndEpoch) throws IOException {
         // We initialize in whatever state we were in on shutdown. If we were a leader
         // or candidate, probably an election was held, but we will find out about it
         // when we send Vote or BeginEpoch requests.
 
-        ElectionState election = store.read();
-        if (election.isLeader(localId)) {
-            state = new LeaderState(localId, election.epoch, endOffset, voters);
+        ElectionState election;
+        try {
+            election = store.readElectionState();
+        } catch (final IOException e) {
+            // For exceptions during state file loading (missing or not readable),
+            // we could assume the file is corrupted already and should be cleaned up.
+            log.warn("Clear local quorum state store {}", store.toString(), e);
+            store.clear();
+
+            election = ElectionState.withUnknownLeader(0);
+        }
+
+        if (election.epoch < logEndOffsetAndEpoch.epoch) {
+            log.warn("Epoch from quorum-state file is {}, which is " +
+                "smaller than last written epoch {} in the log",
+                election.epoch, logEndOffsetAndEpoch.epoch);
+            becomeUnattachedFollower(logEndOffsetAndEpoch.epoch);
+        } else if (election.isLeader(localId)) {
+            state = new LeaderState(localId, election.epoch, logEndOffsetAndEpoch.offset, voters);
         } else if (election.isCandidate(localId)) {
             state = new CandidateState(localId, election.epoch, voters);
         } else {
@@ -166,7 +182,7 @@ public class QuorumState {
 
         FollowerState followerState = followerStateOrThrow();
         if (func.apply(followerState) || stateChanged) {
-            store.write(followerState.election());
+            store.writeElectionState(followerState.election());
             return true;
         }
         return false;
@@ -181,7 +197,7 @@ public class QuorumState {
         int newEpoch = epoch() + 1;
         log.info("Become candidate in epoch {}", newEpoch);
         CandidateState state = new CandidateState(localId, newEpoch, voters);
-        store.write(state.election());
+        store.writeElectionState(state.election());
         this.state = state;
         return state;
     }
@@ -196,7 +212,7 @@ public class QuorumState {
 
         log.info("Become leader in epoch {}", epoch());
         LeaderState state = new LeaderState(localId, epoch(), epochStartOffset, voters);
-        store.write(state.election());
+        store.writeElectionState(state.election());
         this.state = state;
         return state;
     }
@@ -218,5 +234,4 @@ public class QuorumState {
             return (CandidateState) state;
         throw new IllegalStateException("Expected to be a candidate, but current state is " + state);
     }
-
 }

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -63,6 +63,7 @@ public class QuorumState {
             store.clear();
 
             election = ElectionState.withUnknownLeader(0);
+            state = new FollowerState(election.epoch);
         }
 
         if (election.epoch < logEndOffsetAndEpoch.epoch) {

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumStateStore.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumStateStore.java
@@ -18,14 +18,22 @@ package org.apache.kafka.raft;
 
 import java.io.IOException;
 
-public interface ElectionStore {
+/**
+ *  Maintain the save and retrieval of quorum state information, so far only supports
+ *  read and write of election states.
+ */
+public interface QuorumStateStore {
+
+    int UNKNOWN_LEADER_ID = -1;
+    int NOT_VOTED = -1;
 
     /**
      * Read the latest election state.
+     *
      * @return The latest written election state or `ElectionState.withUnknownLeader(0)` if there is none.
      * @throws IOException For any error encountered reading from the storage
      */
-    ElectionState read() throws IOException;
+    ElectionState readElectionState() throws IOException;
 
     /**
      * Persist the updated election state. This must be atomic, both writing the full updated state
@@ -33,5 +41,12 @@ public interface ElectionStore {
      * @param latest The latest election state
      * @throws IOException For any error encountered while writing the updated state
      */
-    void write(ElectionState latest) throws IOException;
+    void writeElectionState(ElectionState latest) throws IOException;
+
+    /**
+     * Clear any state associated to the store for a fresh start
+     *
+     * @throws IOException For any error encountered while cleaning up the state
+     */
+    void clear() throws IOException;
 }

--- a/raft/src/main/resources/common/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
+++ b/raft/src/main/resources/common/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.common.config.provider.FileConfigProvider

--- a/raft/src/main/resources/common/message/QuorumState.json
+++ b/raft/src/main/resources/common/message/QuorumState.json
@@ -15,7 +15,7 @@
 
 {
   "type": "data",
-  "name": "QuorumState",
+  "name": "QuorumStateData",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/raft/src/main/resources/common/message/QuorumState.json
+++ b/raft/src/main/resources/common/message/QuorumState.json
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "type": "data",
+  "name": "QuorumState",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    {"name": "ClusterId", "type": "string", "versions": "0+"},
+    {"name": "LeaderId", "type": "int32", "versions": "0+", "default": "-1"},
+    {"name": "LeaderEpoch", "type": "int32", "versions": "0+", "default": "-1"},
+    {"name": "VotedId", "type": "int32", "versions": "0+", "default": "-1"},
+    {"name": "AppliedOffset", "type": "int64", "versions": "0+"},
+    {"name": "CurrentVoters", "type": "[]Voter", "versions": "0+", "nullableVersions": "0+"},
+    {"name": "TargetVoters", "type": "[]Voter", "versions": "0+", "nullableVersions": "0+"}
+  ],
+  "commonStructs": [
+    { "name": "Voter", "versions": "0+", "fields": [
+      {"name": "VoterId", "type": "int32", "versions": "0+"}
+    ]}
+  ]
+}

--- a/raft/src/test/java/org/apache/kafka/raft/FileBasedStateStoreTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/FileBasedStateStoreTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ShortNode;
+import org.apache.kafka.raft.generated.QuorumStateData;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.OptionalInt;
+
+import static org.apache.kafka.raft.FileBasedStateStore.DATA_VERSION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FileBasedStateStoreTest {
+
+    private FileBasedStateStore stateStore;
+
+    @Test
+    public void testReadElectionState() throws IOException {
+        final File stateFile = TestUtils.tempFile();
+        final FileOutputStream fileOutputStream = new FileOutputStream(stateFile);
+
+        final int leaderId = 1;
+        final int epoch = 2;
+
+        final QuorumStateData data = new QuorumStateData()
+            .setLeaderId(leaderId)
+            .setLeaderEpoch(epoch);
+
+        try (final BufferedWriter writer = new BufferedWriter(
+            new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8))) {
+            short version = data.highestSupportedVersion();
+
+            ObjectNode node = (ObjectNode) data.toJson(version);
+            node.set(DATA_VERSION, new ShortNode(version));
+
+            writer.write(node.toString());
+            writer.flush();
+            fileOutputStream.getFD().sync();
+
+            stateStore = new FileBasedStateStore(stateFile);
+            assertTrue(stateFile.exists());
+            assertEquals(ElectionState.withElectedLeader(epoch, leaderId), stateStore.readElectionState());
+        }
+    }
+
+    @Test
+    public void testWriteElectionState() throws IOException {
+        final File stateFile = TestUtils.tempFile();
+
+        stateStore = new FileBasedStateStore(stateFile);
+
+        // We initialized a state from the metadata log
+        assertTrue(stateFile.exists());
+
+        // The temp file should be removed
+        final File createdTempFile = new File(stateFile.getAbsolutePath() + ".tmp");
+        assertFalse(createdTempFile.exists());
+
+        final int epoch = 2;
+        final int leaderId = 1;
+        final int votedId = 5;
+
+        stateStore.writeElectionState(ElectionState.withElectedLeader(epoch, leaderId));
+
+        assertEquals(stateStore.readElectionState(), new ElectionState(epoch,
+            OptionalInt.of(leaderId), OptionalInt.empty()));
+
+        stateStore.writeElectionState(ElectionState.withVotedCandidate(epoch, votedId));
+
+        assertEquals(stateStore.readElectionState(), new ElectionState(epoch,
+            OptionalInt.empty(), OptionalInt.of(votedId)));
+
+        final FileBasedStateStore rebootStateStore = new FileBasedStateStore(stateFile);
+
+        assertEquals(rebootStateStore.readElectionState(), new ElectionState(epoch,
+            OptionalInt.empty(), OptionalInt.of(votedId)));
+
+        stateStore.clear();
+        assertFalse(stateFile.exists());
+    }
+
+    @After
+    public void cleanup() throws IOException {
+        if (stateStore != null) {
+            stateStore.clear();
+        }
+    }
+}

--- a/raft/src/test/java/org/apache/kafka/raft/FileBasedStateStoreTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/FileBasedStateStoreTest.java
@@ -42,9 +42,6 @@ public class FileBasedStateStoreTest {
 
     @Test
     public void testReadElectionState() throws IOException {
-        final File stateFile = TestUtils.tempFile();
-        final FileOutputStream fileOutputStream = new FileOutputStream(stateFile);
-
         final int leaderId = 1;
         final int epoch = 2;
 
@@ -52,8 +49,10 @@ public class FileBasedStateStoreTest {
             .setLeaderId(leaderId)
             .setLeaderEpoch(epoch);
 
-        try (final BufferedWriter writer = new BufferedWriter(
-            new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8))) {
+        final File stateFile = TestUtils.tempFile();
+        try (final FileOutputStream fileOutputStream = new FileOutputStream(stateFile);
+             final BufferedWriter writer = new BufferedWriter(
+                 new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8))) {
             short version = data.highestSupportedVersion();
 
             ObjectNode node = (ObjectNode) data.toJson(version);

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -44,7 +44,6 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.raft.generated.QuorumStateData;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -77,18 +76,11 @@ public class KafkaRaftClientTest {
     private final MockLog log = new MockLog();
     private final MockNetworkChannel channel = new MockNetworkChannel();
 
-    private QuorumStateStore quorumStateStore;
-
-    @Before
-    public void setUpStateStore() {
-        quorumStateStore = new MockQuorumStateStore();
-    }
+    private QuorumStateStore quorumStateStore = new MockQuorumStateStore();
 
     @After
     public void cleanUp() throws IOException {
-        if (quorumStateStore instanceof FileBasedStateStore) {
-            ((FileBasedStateStore) quorumStateStore).clear();
-        }
+        quorumStateStore.clear();
     }
 
     private InetSocketAddress mockAddress(int id) {

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -282,4 +282,11 @@ public class MockLog implements ReplicatedLog {
             this.startOffset = startOffset;
         }
     }
+
+    public void close() {
+        epochStartOffsets.clear();
+        log.clear();
+        highWatermark = 0L;
+    }
 }
+

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -283,7 +283,7 @@ public class MockLog implements ReplicatedLog {
         }
     }
 
-    public void close() {
+    public void clear() {
         epochStartOffsets.clear();
         log.clear();
         highWatermark = 0L;

--- a/raft/src/test/java/org/apache/kafka/raft/MockQuorumStateStore.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockQuorumStateStore.java
@@ -16,16 +16,21 @@
  */
 package org.apache.kafka.raft;
 
-public class MockElectionStore implements ElectionStore {
+public class MockQuorumStateStore implements QuorumStateStore {
     private ElectionState current = ElectionState.withUnknownLeader(0);
 
     @Override
-    public ElectionState read() {
+    public ElectionState readElectionState() {
         return current;
     }
 
     @Override
-    public void write(ElectionState update) {
+    public void writeElectionState(ElectionState update) {
         this.current = update;
+    }
+
+    @Override
+    public void clear() {
+        current = ElectionState.withUnknownLeader(0);
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/MockQuorumStateStore.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockQuorumStateStore.java
@@ -16,11 +16,13 @@
  */
 package org.apache.kafka.raft;
 
+import java.io.IOException;
+
 public class MockQuorumStateStore implements QuorumStateStore {
     private ElectionState current = ElectionState.withUnknownLeader(0);
 
     @Override
-    public ElectionState readElectionState() {
+    public ElectionState readElectionState() throws IOException {
         return current;
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -91,36 +91,42 @@ public class RaftEventSimulationTest {
             cluster.startAll();
             schedulePolling(scheduler, cluster, 3, 5);
             scheduler.schedule(router::deliverAll, 0, 2, 1);
-            scheduler.runUntil(cluster::hasConsistentLeader);
+            scheduler.runUntil(() -> {
+                try {
+                    return cluster.hasConsistentLeader();
+                } catch (IOException e) {
+                    return false;
+                }
+            });
         }
     }
 
     @Test
-    public void testReplicationNoLeaderChangeQuorumSizeOne() {
+    public void testReplicationNoLeaderChangeQuorumSizeOne() throws IOException {
         testReplicationNoLeaderChange(new QuorumConfig(1));
     }
 
     @Test
-    public void testReplicationNoLeaderChangeQuorumSizeTwo() {
+    public void testReplicationNoLeaderChangeQuorumSizeTwo() throws IOException {
         testReplicationNoLeaderChange(new QuorumConfig(2));
     }
 
     @Test
-    public void testReplicationNoLeaderChangeQuorumSizeThree() {
+    public void testReplicationNoLeaderChangeQuorumSizeThree() throws IOException {
         testReplicationNoLeaderChange(new QuorumConfig(3, 0));
     }
 
     @Test
-    public void testReplicationNoLeaderChangeQuorumSizeFour() {
+    public void testReplicationNoLeaderChangeQuorumSizeFour() throws IOException {
         testReplicationNoLeaderChange(new QuorumConfig(4));
     }
 
     @Test
-    public void testReplicationNoLeaderChangeQuorumSizeFive() {
+    public void testReplicationNoLeaderChangeQuorumSizeFive() throws IOException {
         testReplicationNoLeaderChange(new QuorumConfig(5));
     }
 
-    private void testReplicationNoLeaderChange(QuorumConfig config) {
+    private void testReplicationNoLeaderChange(QuorumConfig config) throws IOException {
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
             MessageRouter router = new MessageRouter(cluster);
@@ -139,36 +145,36 @@ public class RaftEventSimulationTest {
     }
 
     @Test
-    public void testElectionAfterLeaderFailureQuorumSizeThree() {
+    public void testElectionAfterLeaderFailureQuorumSizeThree() throws IOException {
         testElectionAfterLeaderFailure(new QuorumConfig(3, 0));
     }
 
     @Test
-    public void testElectionAfterLeaderFailureQuorumSizeThreeAndTwoObservers() {
+    public void testElectionAfterLeaderFailureQuorumSizeThreeAndTwoObservers() throws IOException {
         testElectionAfterLeaderFailure(new QuorumConfig(3, 2));
     }
 
     @Test
-    public void testElectionAfterLeaderFailureQuorumSizeFour() {
+    public void testElectionAfterLeaderFailureQuorumSizeFour() throws IOException {
         testElectionAfterLeaderFailure(new QuorumConfig(4, 0));
     }
 
     @Test
-    public void testElectionAfterLeaderFailureQuorumSizeFourAndTwoObservers() {
+    public void testElectionAfterLeaderFailureQuorumSizeFourAndTwoObservers() throws IOException {
         testElectionAfterLeaderFailure(new QuorumConfig(4, 2));
     }
 
     @Test
-    public void testElectionAfterLeaderFailureQuorumSizeFive() {
+    public void testElectionAfterLeaderFailureQuorumSizeFive() throws IOException {
         testElectionAfterLeaderFailure(new QuorumConfig(5, 0));
     }
 
     @Test
-    public void testElectionAfterLeaderFailureQuorumSizeFiveAndThreeObservers() {
+    public void testElectionAfterLeaderFailureQuorumSizeFiveAndThreeObservers() throws IOException {
         testElectionAfterLeaderFailure(new QuorumConfig(5, 3));
     }
 
-    private void testElectionAfterLeaderFailure(QuorumConfig config) {
+    private void testElectionAfterLeaderFailure(QuorumConfig config) throws IOException {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
 
@@ -196,36 +202,36 @@ public class RaftEventSimulationTest {
     }
 
     @Test
-    public void testElectionAfterLeaderNetworkPartitionQuorumSizeThree() {
+    public void testElectionAfterLeaderNetworkPartitionQuorumSizeThree() throws IOException {
         testElectionAfterLeaderNetworkPartition(new QuorumConfig(3));
     }
 
     @Test
-    public void testElectionAfterLeaderNetworkPartitionQuorumSizeThreeAndTwoObservers() {
+    public void testElectionAfterLeaderNetworkPartitionQuorumSizeThreeAndTwoObservers() throws IOException {
         testElectionAfterLeaderNetworkPartition(new QuorumConfig(3, 2));
     }
 
     @Test
-    public void testElectionAfterLeaderNetworkPartitionQuorumSizeFour() {
+    public void testElectionAfterLeaderNetworkPartitionQuorumSizeFour() throws IOException {
         testElectionAfterLeaderNetworkPartition(new QuorumConfig(4));
     }
 
     @Test
-    public void testElectionAfterLeaderNetworkPartitionQuorumSizeFourAndTwoObservers() {
+    public void testElectionAfterLeaderNetworkPartitionQuorumSizeFourAndTwoObservers() throws IOException {
         testElectionAfterLeaderNetworkPartition(new QuorumConfig(4, 2));
     }
 
     @Test
-    public void testElectionAfterLeaderNetworkPartitionQuorumSizeFive() {
+    public void testElectionAfterLeaderNetworkPartitionQuorumSizeFive() throws IOException {
         testElectionAfterLeaderNetworkPartition(new QuorumConfig(5));
     }
 
     @Test
-    public void testElectionAfterLeaderNetworkPartitionQuorumSizeFiveAndThreeObservers() {
+    public void testElectionAfterLeaderNetworkPartitionQuorumSizeFiveAndThreeObservers() throws IOException {
         testElectionAfterLeaderNetworkPartition(new QuorumConfig(5, 3));
     }
 
-    private void testElectionAfterLeaderNetworkPartition(QuorumConfig config) {
+    private void testElectionAfterLeaderNetworkPartition(QuorumConfig config) throws IOException {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
 
@@ -257,16 +263,16 @@ public class RaftEventSimulationTest {
     }
 
     @Test
-    public void testElectionAfterMultiNodeNetworkPartitionQuorumSizeFive() {
+    public void testElectionAfterMultiNodeNetworkPartitionQuorumSizeFive() throws IOException {
         testElectionAfterMultiNodeNetworkPartition(new QuorumConfig(5));
     }
 
     @Test
-    public void testElectionAfterMultiNodeNetworkPartitionQuorumSizeFiveAndTwoObservers() {
+    public void testElectionAfterMultiNodeNetworkPartitionQuorumSizeFiveAndTwoObservers() throws IOException {
         testElectionAfterMultiNodeNetworkPartition(new QuorumConfig(5, 2));
     }
 
-    private void testElectionAfterMultiNodeNetworkPartition(QuorumConfig config) {
+    private void testElectionAfterMultiNodeNetworkPartition(QuorumConfig config) throws IOException {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
 
@@ -533,7 +539,7 @@ public class RaftEventSimulationTest {
                 .allMatch(node -> node.quorum.highWatermark().orElse(0) > offset);
         }
 
-        boolean hasConsistentLeader() {
+        boolean hasConsistentLeader() throws IOException {
             Iterator<RaftNode> iter = running.values().iterator();
             if (!iter.hasNext())
                 return false;
@@ -753,7 +759,11 @@ public class RaftEventSimulationTest {
             for (Map.Entry<Integer, PersistentState> nodeStateEntry : cluster.nodes.entrySet()) {
                 Integer nodeId = nodeStateEntry.getKey();
                 PersistentState state = nodeStateEntry.getValue();
-                nodeEpochs.put(nodeId, state.store.readElectionState().epoch);
+                try {
+                    nodeEpochs.put(nodeId, state.store.readElectionState().epoch);
+                } catch (IOException e) {
+                    fail("Unexpected IO exception from state store read" + e);
+                }
             }
         }
 
@@ -763,7 +773,13 @@ public class RaftEventSimulationTest {
                 Integer nodeId = nodeStateEntry.getKey();
                 PersistentState state = nodeStateEntry.getValue();
                 Integer oldEpoch = nodeEpochs.get(nodeId);
-                Integer newEpoch = state.store.readElectionState().epoch;
+                final Integer newEpoch;
+                try {
+                    newEpoch = state.store.readElectionState().epoch;
+                } catch (IOException e) {
+                    fail("Unexpected IO exception from state store read" + e);
+                    break;
+                }
                 if (oldEpoch > newEpoch) {
                     fail("Non-monotonic update of high watermark detected: " +
                             oldEpoch + " -> " + newEpoch);

--- a/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
@@ -41,7 +41,7 @@ public class SimpleKeyValueStoreTest {
         int retryBackoffMs = 100;
         int requestTimeoutMs = 5000;
         Set<Integer> voters = Collections.singleton(localId);
-        ElectionStore store = new MockElectionStore();
+        QuorumStateStore store = new MockQuorumStateStore();
         Time time = new MockTime();
         ReplicatedLog log = new MockLog();
         NetworkChannel channel = new MockNetworkChannel();


### PR DESCRIPTION
This patch adds the auto generation framework to Raft package, create QuorumState as a data type, and use local file to materialize election state, etc. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
