### PR TITLE
MINOR: Address review comments and improve test coverage

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -487,6 +487,24 @@ public class MemoryRecordsBuilder implements AutoCloseable {
     }
 
     /**
+     * Append a control record at the given offset. The control record type must be known or
+     * this method will raise an error.
+     *
+     * @param offset The absolute offset of the record in the log buffer
+     * @param record The record to append
+     * @return CRC of the record or null if record-level CRC is not supported for the message format
+     */
+    public Long appendControlRecordWithOffset(long offset, SimpleRecord record) {
+        short typeId = ControlRecordType.parseTypeId(record.key());
+        ControlRecordType type = ControlRecordType.fromTypeId(typeId);
+        if (type == ControlRecordType.UNKNOWN)
+            throw new IllegalArgumentException("Cannot append record with unknown control record type " + typeId);
+
+        return appendWithOffset(offset, true, record.timestamp(),
+            record.key(), record.value(), record.headers());
+    }
+
+    /**
      * Append a new record at the next sequential offset.
      * @param timestamp The record timestamp
      * @param key The record key

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -75,7 +75,7 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
     log.logStartOffset
   }
 
-  override def truncateTo(offset: Long): Boolean = {
+  override def truncateTo(offset: Long): Unit = {
     log.truncateTo(offset)
   }
 

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -75,18 +75,18 @@ class KafkaNetworkChannel(time: Time,
 
   type ResponseHandler = AbstractResponse => Unit
 
-  private val requestIdCounter = new AtomicInteger(0)
+  private val correlationIdCounter = new AtomicInteger(0)
   private val pendingInbound = mutable.Map.empty[Long, ResponseHandler]
   private val undelivered = new ArrayBlockingQueue[RaftMessage](10)
   private val pendingOutbound = new ArrayBlockingQueue[RaftRequest.Outbound](10)
   private val endpoints = mutable.HashMap.empty[Int, Node]
 
-  override def newRequestId(): Int = requestIdCounter.getAndIncrement()
+  override def newCorrelationId(): Int = correlationIdCounter.getAndIncrement()
 
   private def buildClientRequest(req: RaftRequest.Outbound): ClientRequest = {
     val destination = req.destinationId.toString
     val request = buildRequest(req.data)
-    val correlationId = req.requestId
+    val correlationId = req.correlationId
     val createdTimeMs = req.createdTimeMs
     new ClientRequest(destination, request, correlationId, clientId, createdTimeMs, true,
       requestTimeoutMs, null)
@@ -99,7 +99,7 @@ class KafkaNetworkChannel(time: Time,
           throw new KafkaException("Pending outbound queue is full")
 
       case response: RaftResponse.Outbound =>
-        pendingInbound.remove(response.requestId).foreach { onResponseReceived: ResponseHandler =>
+        pendingInbound.remove(response.correlationId).foreach { onResponseReceived: ResponseHandler =>
           onResponseReceived(buildResponse(response.data))
         }
       case _ =>
@@ -117,7 +117,7 @@ class KafkaNetworkChannel(time: Time,
             val apiKey = ApiKeys.forId(request.data.apiKey)
             val disconnectResponse = errorResponseData(apiKey, Errors.BROKER_NOT_AVAILABLE)
             undelivered.offer(new RaftResponse.Inbound(
-              request.requestId, disconnectResponse, request.destinationId))
+              request.correlationId, disconnectResponse, request.destinationId))
           } else if (client.ready(node, currentTimeMs)) {
             pendingOutbound.poll()
             val clientRequest = buildClientRequest(request)
@@ -131,7 +131,7 @@ class KafkaNetworkChannel(time: Time,
           pendingOutbound.poll()
           val apiKey = ApiKeys.forId(request.data.apiKey)
           val responseData = errorResponseData(apiKey, Errors.BROKER_NOT_AVAILABLE)
-          val response = new RaftResponse.Inbound(request.requestId, responseData, request.destinationId)
+          val response = new RaftResponse.Inbound(request.correlationId, responseData, request.destinationId)
           if (!undelivered.offer(response))
             throw new KafkaException("Undelivered queue is full")
       }
@@ -238,9 +238,9 @@ class KafkaNetworkChannel(time: Time,
 
   def postInboundRequest(request: AbstractRequest, onResponseReceived: ResponseHandler): Unit = {
     val data = requestData(request)
-    val requestId = newRequestId()
-    val req = new RaftRequest.Inbound(requestId, data, time.milliseconds())
-    pendingInbound.put(requestId, onResponseReceived)
+    val correlationId = newCorrelationId()
+    val req = new RaftRequest.Inbound(correlationId, data, time.milliseconds())
+    pendingInbound.put(correlationId, onResponseReceived)
     if (!undelivered.offer(req))
       throw new KafkaException("Undelivered queue is full")
     wakeup()

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -236,9 +236,11 @@ class KafkaNetworkChannel(time: Time,
     endpoints.put(id, node)
   }
 
-  def postInboundRequest(request: AbstractRequest, onResponseReceived: ResponseHandler): Unit = {
+  def postInboundRequest(header: RequestHeader,
+                         request: AbstractRequest,
+                         onResponseReceived: ResponseHandler): Unit = {
     val data = requestData(request)
-    val correlationId = newCorrelationId()
+    val correlationId = header.correlationId
     val req = new RaftRequest.Inbound(correlationId, data, time.milliseconds())
     pendingInbound.put(correlationId, onResponseReceived)
     if (!undelivered.offer(req))

--- a/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
@@ -119,10 +119,10 @@ class KafkaNetworkChannelTest {
       assertEquals(1, inbound.size)
 
       val inboundRequest = inbound.head.asInstanceOf[RaftRequest.Inbound]
-      val requestId = inboundRequest.requestId()
+      val correlationId = inboundRequest.correlationId
 
       val errorResponse = buildTestErrorResponse(apiKey, Errors.INVALID_REQUEST)
-      val outboundResponse = new RaftResponse.Outbound(requestId, errorResponse)
+      val outboundResponse = new RaftResponse.Outbound(correlationId, errorResponse)
       channel.send(outboundResponse)
       channel.receive(1000)
 
@@ -134,10 +134,10 @@ class KafkaNetworkChannelTest {
   private def sendAndAssertErrorResponse(apiKey: ApiKeys,
                                          destinationId: Int,
                                          error: Errors): Unit = {
-    val requestId = channel.newRequestId()
+    val correlationId = channel.newCorrelationId()
     val createdTimeMs = time.milliseconds()
     val apiRequest = buildTestRequest(apiKey)
-    val request = new RaftRequest.Outbound(requestId, apiRequest, destinationId, createdTimeMs)
+    val request = new RaftRequest.Outbound(correlationId, apiRequest, destinationId, createdTimeMs)
 
     channel.send(request)
     val responses = channel.receive(1000).asScala
@@ -145,7 +145,7 @@ class KafkaNetworkChannelTest {
 
     val response = responses.head.asInstanceOf[RaftResponse.Inbound]
     assertEquals(destinationId, response.sourceId)
-    assertEquals(requestId, response.requestId)
+    assertEquals(correlationId, response.correlationId)
     assertEquals(apiKey, ApiKeys.forId(response.data.apiKey))
     assertEquals(error, extractError(response.data))
   }

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -167,14 +167,14 @@ public class KafkaRaftClient implements RaftClient {
             long newHighWatermark = Math.min(endOffset().offset, highWatermark);
             state.updateHighWatermark(OptionalLong.of(newHighWatermark));
             highWatermarkOpt.ifPresent(log::updateHighWatermark);
-            logger.info("Follower high watermark updated to {}", newHighWatermark);
+            logger.trace("Follower high watermark updated to {}", newHighWatermark);
             applyCommittedRecordsToStateMachine();
         });
     }
 
     private void updateLeaderEndOffset(LeaderState state) {
         if (state.updateLocalEndOffset(log.endOffset())) {
-            logger.info("Leader high watermark updated to {} after end offset updated to {}",
+            logger.trace("Leader high watermark updated to {} after end offset updated to {}",
                     state.highWatermark(), log.endOffset());
             applyCommittedRecordsToStateMachine();
         }

--- a/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
+++ b/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
@@ -53,7 +53,7 @@ public interface NetworkChannel {
     void wakeup();
 
     /**
-     * Update connection information for the  given id.
+     * Update connection information for the given id.
      */
     void updateEndpoint(int id, InetSocketAddress address);
 

--- a/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
+++ b/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
@@ -25,14 +25,36 @@ import java.util.List;
  */
 public interface NetworkChannel {
 
-    int newRequestId();
+    /**
+     * Generate a new and unique correlationId for a new request to be sent.
+     */
+    int newCorrelationId();
 
+    /**
+     * Send an outbound message. This could be either an outbound request
+     * (i.e. an instance of {@link org.apache.kafka.raft.RaftRequest.Outbound})
+     * or a response to a request that was received through {@link #receive(long)}
+     * (i.e. an instance of {@link org.apache.kafka.raft.RaftResponse.Outbound}).
+     */
     void send(RaftMessage message);
 
+    /**
+     * Receive inbound messages. These could contain either inbound requests
+     * (i.e. instances of {@link org.apache.kafka.raft.RaftRequest.Inbound})
+     * or responses to outbound requests sent through {@link #send(RaftMessage)}
+     * (i.e. instances of {@link org.apache.kafka.raft.RaftResponse.Inbound}).
+     */
     List<RaftMessage> receive(long timeoutMs);
 
+    /**
+     * Wakeup the channel if it is blocking in {@link #receive(long)}. This will cause
+     * the call to immediately return with whatever messages are available.
+     */
     void wakeup();
 
+    /**
+     * Update connection information for the  given id.
+     */
     void updateEndpoint(int id, InetSocketAddress address);
 
 }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftMessage.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftMessage.java
@@ -19,7 +19,7 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 public interface RaftMessage {
-    int requestId();
+    int correlationId();
 
     ApiMessage data();
 

--- a/raft/src/main/java/org/apache/kafka/raft/RaftRequest.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftRequest.java
@@ -19,19 +19,19 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 public abstract class RaftRequest implements RaftMessage {
-    protected final int requestId;
+    protected final int correlationId;
     protected final ApiMessage data;
     protected final long createdTimeMs;
 
-    public RaftRequest(int requestId, ApiMessage data, long createdTimeMs) {
-        this.requestId = requestId;
+    public RaftRequest(int correlationId, ApiMessage data, long createdTimeMs) {
+        this.correlationId = correlationId;
         this.data = data;
         this.createdTimeMs = createdTimeMs;
     }
 
     @Override
-    public int requestId() {
-        return requestId;
+    public int correlationId() {
+        return correlationId;
     }
 
     @Override
@@ -44,14 +44,14 @@ public abstract class RaftRequest implements RaftMessage {
     }
 
     public static class Inbound extends RaftRequest {
-        public Inbound(int requestId, ApiMessage data, long createdTimeMs) {
-            super(requestId, data, createdTimeMs);
+        public Inbound(int correlationId, ApiMessage data, long createdTimeMs) {
+            super(correlationId, data, createdTimeMs);
         }
 
         @Override
         public String toString() {
             return "InboundRequest(" +
-                    "requestId=" + requestId +
+                    "correlationId=" + correlationId +
                     ", data=" + data +
                     ", createdTimeMs=" + createdTimeMs +
                     ')';
@@ -61,8 +61,8 @@ public abstract class RaftRequest implements RaftMessage {
     public static class Outbound extends RaftRequest {
         private final int destinationId;
 
-        public Outbound(int requestId, ApiMessage data, int destinationId, long createdTimeMs) {
-            super(requestId, data, createdTimeMs);
+        public Outbound(int correlationId, ApiMessage data, int destinationId, long createdTimeMs) {
+            super(correlationId, data, createdTimeMs);
             this.destinationId = destinationId;
         }
 
@@ -73,7 +73,7 @@ public abstract class RaftRequest implements RaftMessage {
         @Override
         public String toString() {
             return "OutboundRequest(" +
-                    "requestId=" + requestId +
+                    "correlationId=" + correlationId +
                     ", data=" + data +
                     ", createdTimeMs=" + createdTimeMs +
                     ", destinationId=" + destinationId +

--- a/raft/src/main/java/org/apache/kafka/raft/RaftResponse.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftResponse.java
@@ -19,17 +19,17 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 public abstract class RaftResponse implements RaftMessage {
-    protected final int requestId;
+    protected final int correlationId;
     protected final ApiMessage data;
 
-    protected RaftResponse(int requestId, ApiMessage data) {
-        this.requestId = requestId;
+    protected RaftResponse(int correlationId, ApiMessage data) {
+        this.correlationId = correlationId;
         this.data = data;
     }
 
     @Override
-    public int requestId() {
-        return requestId;
+    public int correlationId() {
+        return correlationId;
     }
 
     @Override
@@ -40,8 +40,8 @@ public abstract class RaftResponse implements RaftMessage {
     public static class Inbound extends RaftResponse {
         private final int sourceId;
 
-        public Inbound(int requestId, ApiMessage data, int sourceId) {
-            super(requestId, data);
+        public Inbound(int correlationId, ApiMessage data, int sourceId) {
+            super(correlationId, data);
             this.sourceId = sourceId;
         }
 
@@ -52,7 +52,7 @@ public abstract class RaftResponse implements RaftMessage {
         @Override
         public String toString() {
             return "Inbound(" +
-                    "requestId=" + requestId +
+                    "correlationId=" + correlationId +
                     ", data=" + data +
                     ", sourceId=" + sourceId +
                     ')';
@@ -67,7 +67,7 @@ public abstract class RaftResponse implements RaftMessage {
         @Override
         public String toString() {
             return "OutboundResponse(" +
-                    "requestId=" + requestId +
+                    "correlationId=" + correlationId +
                     ", data=" + data +
                     ')';
         }

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
@@ -77,9 +77,12 @@ public interface ReplicatedLog {
     void assignEpochStartOffset(int epoch, long startOffset);
 
     /**
-     * Truncate the log to the given offset. Returns true iff targetOffset < logEndOffset.
+     * Truncate the log to the given offset. All records with offsets greater than or equal to
+     * the given offset will be removed.
+     *
+     * @param offset The offset to truncate to
      */
-    boolean truncateTo(long offset);
+    void truncateTo(long offset);
 
     void updateHighWatermark(long offset);
 

--- a/raft/src/test/java/org/apache/kafka/raft/ConnectionCacheTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/ConnectionCacheTest.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConnectionCacheTest {
+    private final MockTime time = new MockTime();
+    private final MockNetworkChannel networkChannel = new MockNetworkChannel();
+    private final LogContext logContext = new LogContext();
+    private final int requestTimeoutMs = 30000;
+    private final int retryBackoffMs = 100;
+
+    @Test
+    public void testMaybeUpdate() {
+        List<InetSocketAddress> bootstrapServers = Collections.singletonList(
+            new InetSocketAddress("127.0.0.1", 9092)
+        );
+
+        ConnectionCache cache = new ConnectionCache(networkChannel,
+            bootstrapServers,
+            retryBackoffMs,
+            requestTimeoutMs,
+            logContext);
+
+        ConnectionCache.HostInfo initialHostInfo = new ConnectionCache.HostInfo(
+            new InetSocketAddress("127.0.0.1", 9093),
+            1L
+        );
+
+        cache.maybeUpdate(1, initialHostInfo);
+        assertEquals(Optional.of(initialHostInfo), cache.getOrCreate(1).hostInfo());
+
+        ConnectionCache.HostInfo updatedHostInfo = new ConnectionCache.HostInfo(
+            new InetSocketAddress("127.0.0.1", 9093),
+            2L
+        );
+
+        cache.maybeUpdate(1, updatedHostInfo);
+        assertEquals(Optional.of(updatedHostInfo), cache.getOrCreate(1).hostInfo());
+
+        cache.maybeUpdate(1, initialHostInfo);
+        assertEquals(Optional.of(updatedHostInfo), cache.getOrCreate(1).hostInfo());
+    }
+
+    @Test
+    public void testResetConnectionStateAfterHostInfoUpdate() {
+        List<InetSocketAddress> bootstrapServers = Collections.singletonList(
+            new InetSocketAddress("127.0.0.1", 9092)
+        );
+
+        ConnectionCache cache = new ConnectionCache(networkChannel,
+            bootstrapServers,
+            retryBackoffMs,
+            requestTimeoutMs,
+            logContext);
+
+        ConnectionCache.HostInfo initialHostInfo = new ConnectionCache.HostInfo(
+            new InetSocketAddress("127.0.0.1", 9093),
+            1L
+        );
+
+        ConnectionCache.ConnectionState connectionState = cache.getOrCreate(1);
+        cache.maybeUpdate(1, initialHostInfo);
+
+        long correlationId = 1;
+        connectionState.onRequestSent(correlationId, time.milliseconds());
+        assertFalse(connectionState.isReady(time.milliseconds()));
+
+        ConnectionCache.HostInfo updatedHostInfo = new ConnectionCache.HostInfo(
+            new InetSocketAddress("127.0.0.1", 9093),
+            2L
+        );
+
+        cache.maybeUpdate(1, updatedHostInfo);
+        assertTrue(connectionState.isReady(time.milliseconds()));
+    }
+
+    @Test
+    public void testResetAllConnections() {
+        List<InetSocketAddress> bootstrapServers = Collections.singletonList(
+            new InetSocketAddress("127.0.0.1", 9092)
+        );
+
+        ConnectionCache cache = new ConnectionCache(networkChannel,
+            bootstrapServers,
+            retryBackoffMs,
+            requestTimeoutMs,
+            logContext);
+
+        cache.maybeUpdate(1, new ConnectionCache.HostInfo(
+            new InetSocketAddress("127.0.0.1", 9093),
+            1L
+        ));
+
+        cache.maybeUpdate(2, new ConnectionCache.HostInfo(
+            new InetSocketAddress("127.0.0.1", 9094),
+            1L
+        ));
+
+        // One host has an inflight request
+        ConnectionCache.ConnectionState connectionState1 = cache.getOrCreate(1);
+        connectionState1.onRequestSent(1, time.milliseconds());
+        assertFalse(connectionState1.isReady(time.milliseconds()));
+
+        // Another is backing off
+        ConnectionCache.ConnectionState connectionState2 = cache.getOrCreate(2);
+        connectionState2.onRequestSent(2, time.milliseconds());
+        connectionState2.onResponseError(2, time.milliseconds());
+        assertFalse(connectionState2.isReady(time.milliseconds()));
+
+        cache.resetAll();
+
+        // Now both should be ready
+        assertTrue(connectionState1.isReady(time.milliseconds()));
+        assertTrue(connectionState2.isReady(time.milliseconds()));
+    }
+
+    @Test
+    public void testBackoffAfterFailure() {
+        List<InetSocketAddress> bootstrapServers = Collections.singletonList(
+            new InetSocketAddress("127.0.0.1", 9092)
+        );
+
+        ConnectionCache cache = new ConnectionCache(networkChannel,
+            bootstrapServers,
+            retryBackoffMs,
+            requestTimeoutMs,
+            logContext);
+
+        ConnectionCache.HostInfo hostInfo = new ConnectionCache.HostInfo(
+            new InetSocketAddress("127.0.0.1", 9093),
+            1L
+        );
+
+        ConnectionCache.ConnectionState connectionState = cache.getOrCreate(1);
+        assertFalse(connectionState.isReady(time.milliseconds()));
+
+        cache.maybeUpdate(1, hostInfo);
+        assertTrue(connectionState.isReady(time.milliseconds()));
+
+        long correlationId = 1;
+        connectionState.onRequestSent(correlationId, time.milliseconds());
+        assertFalse(connectionState.isReady(time.milliseconds()));
+
+        connectionState.onResponseError(correlationId, time.milliseconds());
+        assertFalse(connectionState.isReady(time.milliseconds()));
+
+        time.sleep(retryBackoffMs);
+        assertTrue(connectionState.isReady(time.milliseconds()));
+    }
+
+    @Test
+    public void testSuccessfulResponse() {
+        List<InetSocketAddress> bootstrapServers = Collections.singletonList(
+            new InetSocketAddress("127.0.0.1", 9092)
+        );
+
+        ConnectionCache cache = new ConnectionCache(networkChannel,
+            bootstrapServers,
+            retryBackoffMs,
+            requestTimeoutMs,
+            logContext);
+
+        ConnectionCache.HostInfo hostInfo = new ConnectionCache.HostInfo(
+            new InetSocketAddress("127.0.0.1", 9093),
+            1L
+        );
+
+        ConnectionCache.ConnectionState connectionState = cache.getOrCreate(1);
+        cache.maybeUpdate(1, hostInfo);
+
+        long correlationId = 1;
+        connectionState.onRequestSent(correlationId, time.milliseconds());
+        connectionState.onResponseReceived(correlationId);
+        assertTrue(connectionState.isReady(time.milliseconds()));
+    }
+
+    @Test
+    public void testIgnoreUnexpectedResponse() {
+        List<InetSocketAddress> bootstrapServers = Collections.singletonList(
+            new InetSocketAddress("127.0.0.1", 9092)
+        );
+
+        ConnectionCache cache = new ConnectionCache(networkChannel,
+            bootstrapServers,
+            retryBackoffMs,
+            requestTimeoutMs,
+            logContext);
+
+        ConnectionCache.HostInfo hostInfo = new ConnectionCache.HostInfo(
+            new InetSocketAddress("127.0.0.1", 9093),
+            1L
+        );
+
+        ConnectionCache.ConnectionState connectionState = cache.getOrCreate(1);
+        cache.maybeUpdate(1, hostInfo);
+
+        long correlationId = 1;
+        connectionState.onRequestSent(correlationId, time.milliseconds());
+        connectionState.onResponseReceived(correlationId + 1);
+        assertFalse(connectionState.isReady(time.milliseconds()));
+    }
+
+    @Test
+    public void testRequestTimeout() {
+        List<InetSocketAddress> bootstrapServers = Collections.singletonList(
+            new InetSocketAddress("127.0.0.1", 9092)
+        );
+
+        ConnectionCache cache = new ConnectionCache(networkChannel,
+            bootstrapServers,
+            retryBackoffMs,
+            requestTimeoutMs,
+            logContext);
+
+        ConnectionCache.HostInfo hostInfo = new ConnectionCache.HostInfo(
+            new InetSocketAddress("127.0.0.1", 9093),
+            1L
+        );
+
+        ConnectionCache.ConnectionState connectionState = cache.getOrCreate(1);
+        cache.maybeUpdate(1, hostInfo);
+
+        long correlationId = 1;
+        connectionState.onRequestSent(correlationId, time.milliseconds());
+        assertFalse(connectionState.isReady(time.milliseconds()));
+
+        time.sleep(requestTimeoutMs - 1);
+        assertFalse(connectionState.isReady(time.milliseconds()));
+
+        time.sleep(1);
+        assertTrue(connectionState.isReady(time.milliseconds()));
+    }
+
+}

--- a/raft/src/test/java/org/apache/kafka/raft/ConnectionCacheTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/ConnectionCacheTest.java
@@ -197,6 +197,7 @@ public class ConnectionCacheTest {
 
         long correlationId = 1;
         connectionState.onRequestSent(correlationId, time.milliseconds());
+        assertFalse(connectionState.isReady(time.milliseconds()));
         connectionState.onResponseReceived(correlationId);
         assertTrue(connectionState.isReady(time.milliseconds()));
     }
@@ -223,6 +224,7 @@ public class ConnectionCacheTest {
 
         long correlationId = 1;
         connectionState.onRequestSent(correlationId, time.milliseconds());
+        assertFalse(connectionState.isReady(time.milliseconds()));
         connectionState.onResponseReceived(correlationId + 1);
         assertFalse(connectionState.isReady(time.milliseconds()));
     }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -106,15 +106,15 @@ public class KafkaRaftClientTest {
 
         pollUntilSend(client);
 
-        int findQuorumRequestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(findQuorumRequestId,
+        int findQuorumCorrelationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(findQuorumCorrelationId,
             findQuorumResponse(-1, 1, voters), -1));
 
         pollUntilSend(client);
 
-        int requestId = assertSentVoteRequest(1, 0, 0L);
+        int correlationId = assertSentVoteRequest(1, 0, 0L);
         VoteResponseData voteResponse = voteResponse(true, Optional.empty(), 1);
-        channel.mockReceive(new RaftResponse.Inbound(requestId, voteResponse, otherNodeId));
+        channel.mockReceive(new RaftResponse.Inbound(correlationId, voteResponse, otherNodeId));
 
         // Become leader after receiving the vote
         client.poll();
@@ -147,13 +147,13 @@ public class KafkaRaftClientTest {
 
         pollUntilSend(client);
 
-        int findQuorumRequestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(findQuorumRequestId,
+        int findQuorumCorrelationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(findQuorumCorrelationId,
             findQuorumResponse(localId, epoch, voters), -1));
 
         pollUntilSend(client);
 
-        int requestId = assertSentVoteRequest(epoch, 0, 0L);
+        int correlationId = assertSentVoteRequest(epoch, 0, 0L);
 
         time.sleep(requestTimeoutMs);
         client.poll();
@@ -162,7 +162,7 @@ public class KafkaRaftClientTest {
         // Even though we have resent the request, we should still accept the response to
         // the first request if it arrives late.
         VoteResponseData voteResponse = voteResponse(true, Optional.empty(), 1);
-        channel.mockReceive(new RaftResponse.Inbound(requestId, voteResponse, otherNodeId));
+        channel.mockReceive(new RaftResponse.Inbound(correlationId, voteResponse, otherNodeId));
         client.poll();
         assertEquals(ElectionState.withElectedLeader(epoch, localId), electionStore.read());
 
@@ -182,16 +182,16 @@ public class KafkaRaftClientTest {
 
         pollUntilSend(client);
 
-        int findQuorumRequestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(findQuorumRequestId,
+        int findQuorumCorrelationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(findQuorumCorrelationId,
             findQuorumResponse(-1, 1, voters), -1));
 
         pollUntilSend(client);
 
         // Quorum size is two. If the other member rejects, then we need to schedule a revote.
-        int requestId = assertSentVoteRequest(1, 0, 0L);
+        int correlationId = assertSentVoteRequest(1, 0, 0L);
         VoteResponseData voteResponse = voteResponse(false, Optional.empty(), 1);
-        channel.mockReceive(new RaftResponse.Inbound(requestId, voteResponse, otherNodeId));
+        channel.mockReceive(new RaftResponse.Inbound(correlationId, voteResponse, otherNodeId));
 
         client.poll();
         assertEquals(ElectionState.withUnknownLeader(1), electionStore.read());
@@ -218,8 +218,8 @@ public class KafkaRaftClientTest {
 
         pollUntilSend(client);
 
-        int findQuorumRequestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(findQuorumRequestId,
+        int findQuorumCorrelationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(findQuorumCorrelationId,
             findQuorumResponse(otherNodeId, epoch, voters), -1));
 
         pollUntilSend(client);
@@ -241,8 +241,8 @@ public class KafkaRaftClientTest {
 
         pollUntilSend(client);
 
-        int findQuorumRequestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(findQuorumRequestId,
+        int findQuorumCorrelationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(findQuorumCorrelationId,
             findQuorumResponse(otherNodeId, epoch, voters), -1));
 
         pollUntilSend(client);
@@ -264,8 +264,8 @@ public class KafkaRaftClientTest {
 
         pollUntilSend(client);
 
-        int findQuorumRequestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(findQuorumRequestId,
+        int findQuorumCorrelationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(findQuorumCorrelationId,
             findQuorumResponse(otherNodeId, epoch, voters), -1));
 
         pollUntilSend(client);
@@ -286,8 +286,8 @@ public class KafkaRaftClientTest {
         KafkaRaftClient client = buildClient(voters);
 
         client.poll();
-        int requestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(requestId,
+        int correlationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(correlationId,
             findQuorumResponse(leaderId, epoch, voters), -1));
 
         client.poll();
@@ -302,8 +302,8 @@ public class KafkaRaftClientTest {
         KafkaRaftClient client = buildClient(voters);
 
         client.poll();
-        int requestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(requestId, findQuorumFailure(Errors.UNKNOWN_SERVER_ERROR), -1));
+        int correlationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(correlationId, findQuorumFailure(Errors.UNKNOWN_SERVER_ERROR), -1));
 
         client.poll();
         assertEquals(0, channel.drainSendQueue().size());
@@ -327,8 +327,8 @@ public class KafkaRaftClientTest {
         KafkaRaftClient client = buildClient(voters);
 
         client.poll();
-        int requestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(requestId,
+        int correlationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(correlationId,
             findQuorumResponse(leaderId, epoch, voters), -1));
 
         client.poll();
@@ -348,19 +348,19 @@ public class KafkaRaftClientTest {
         KafkaRaftClient client = buildClient(voters);
 
         client.poll();
-        int requestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(requestId,
+        int correlationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(correlationId,
             findQuorumResponse(leaderId, epoch, voters), -1));
 
         client.poll();
         assertEquals(ElectionState.withElectedLeader(epoch, leaderId), electionStore.read());
 
         client.poll();
-        int fetchRequestId = assertSentFetchQuorumRecordsRequest(epoch, 0L, 0);
+        int fetchCorrelationId = assertSentFetchQuorumRecordsRequest(epoch, 0L, 0);
 
         FetchQuorumRecordsResponseData response = fetchRecordsResponse(epoch, leaderId, MemoryRecords.EMPTY, 0L,
                 Errors.BROKER_NOT_AVAILABLE);
-        channel.mockReceive(new RaftResponse.Inbound(fetchRequestId, response, leaderId));
+        channel.mockReceive(new RaftResponse.Inbound(fetchCorrelationId, response, leaderId));
         client.poll();
 
         assertEquals(ElectionState.withUnknownLeader(epoch), electionStore.read());
@@ -376,8 +376,8 @@ public class KafkaRaftClientTest {
         KafkaRaftClient client = buildClient(voters);
 
         client.poll();
-        int requestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(requestId,
+        int correlationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(correlationId,
             findQuorumResponse(leaderId, epoch, voters), -1));
 
         pollUntilSend(client);
@@ -399,7 +399,7 @@ public class KafkaRaftClientTest {
 
         int observerId = 1;
         FindQuorumRequestData request = new FindQuorumRequestData().setReplicaId(observerId);
-        channel.mockReceive(new RaftRequest.Inbound(channel.newRequestId(), request, time.milliseconds()));
+        channel.mockReceive(new RaftRequest.Inbound(channel.newCorrelationId(), request, time.milliseconds()));
 
         client.poll();
         assertSentFindQuorumResponse(1, Optional.of(localId));
@@ -416,15 +416,15 @@ public class KafkaRaftClientTest {
 
         pollUntilSend(client);
 
-        int findQuorumRequestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(findQuorumRequestId,
+        int findQuorumCorrelationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(findQuorumCorrelationId,
             findQuorumResponse(-1, 1, voters), -1));
 
         pollUntilSend(client);
 
-        int voteRequestId = assertSentVoteRequest(1, 0, 0L);
+        int voteCorrelationId = assertSentVoteRequest(1, 0, 0L);
         VoteResponseData voteResponse = voteResponse(true, Optional.empty(), 1);
-        channel.mockReceive(new RaftResponse.Inbound(voteRequestId, voteResponse, otherNodeId));
+        channel.mockReceive(new RaftResponse.Inbound(voteCorrelationId, voteResponse, otherNodeId));
         client.poll();
         assertEquals(ElectionState.withElectedLeader(1, localId), electionStore.read());
 
@@ -442,7 +442,7 @@ public class KafkaRaftClientTest {
 
         // Graceful shutdown completes when the epoch is bumped
         VoteRequestData newVoteRequest = voteRequest(2, otherNodeId, 0, 0L);
-        channel.mockReceive(new RaftRequest.Inbound(channel.newRequestId(), newVoteRequest, time.milliseconds()));
+        channel.mockReceive(new RaftRequest.Inbound(channel.newCorrelationId(), newVoteRequest, time.milliseconds()));
 
         client.poll();
         assertFalse(client.isRunning());
@@ -459,15 +459,15 @@ public class KafkaRaftClientTest {
 
         pollUntilSend(client);
 
-        int findQuorumRequestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(findQuorumRequestId,
+        int findQuorumCorrelationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(findQuorumCorrelationId,
             findQuorumResponse(-1, 1, voters), -1));
 
         pollUntilSend(client);
 
-        int voteRequestId = assertSentVoteRequest(1, 0, 0L);
+        int voteCorrelationId = assertSentVoteRequest(1, 0, 0L);
         VoteResponseData voteResponse = voteResponse(true, Optional.empty(), 1);
-        channel.mockReceive(new RaftResponse.Inbound(voteRequestId, voteResponse, otherNodeId));
+        channel.mockReceive(new RaftResponse.Inbound(voteCorrelationId, voteResponse, otherNodeId));
         client.poll();
         assertEquals(ElectionState.withElectedLeader(1, localId), electionStore.read());
 
@@ -531,17 +531,17 @@ public class KafkaRaftClientTest {
 
         pollUntilSend(client);
 
-        int findQuorumRequestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(findQuorumRequestId,
+        int findQuorumCorrelationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(findQuorumCorrelationId,
             findQuorumResponse(otherNodeId, epoch, voters), -1));
 
         pollUntilSend(client);
 
-        int fetchQuorumRequestId = assertSentFetchQuorumRecordsRequest(epoch, 0L, 0);
+        int fetchQuorumCorrelationId = assertSentFetchQuorumRecordsRequest(epoch, 0L, 0);
         Records records = MemoryRecords.withRecords(0L, CompressionType.NONE,
             3, new SimpleRecord("a".getBytes()), new SimpleRecord("b".getBytes()));
         FetchQuorumRecordsResponseData response = fetchRecordsResponse(epoch, otherNodeId, records, 0L, Errors.NONE);
-        channel.mockReceive(new RaftResponse.Inbound(fetchQuorumRequestId, response, otherNodeId));
+        channel.mockReceive(new RaftResponse.Inbound(fetchQuorumCorrelationId, response, otherNodeId));
 
         client.poll();
         assertEquals(2L, log.endOffset());
@@ -573,7 +573,7 @@ public class KafkaRaftClientTest {
         // Now try reading it
         int otherNodeId = 1;
         FetchQuorumRecordsRequestData fetchRequest = fetchRecordsRequest(1, otherNodeId, 0L);
-        channel.mockReceive(new RaftRequest.Inbound(channel.newRequestId(), fetchRequest, time.milliseconds()));
+        channel.mockReceive(new RaftRequest.Inbound(channel.newCorrelationId(), fetchRequest, time.milliseconds()));
 
         client.poll();
 
@@ -618,17 +618,17 @@ public class KafkaRaftClientTest {
 
         pollUntilSend(client);
 
-        int findQuorumRequestId = assertSentFindQuorumRequest();
-        channel.mockReceive(new RaftResponse.Inbound(findQuorumRequestId,
+        int findQuorumCorrelationId = assertSentFindQuorumRequest();
+        channel.mockReceive(new RaftResponse.Inbound(findQuorumCorrelationId,
             findQuorumResponse(otherNodeId, epoch, voters), -1));
 
         pollUntilSend(client);
 
-        int requestId = assertSentFetchQuorumRecordsRequest(epoch, 2L, lastEpoch);
+        int correlationId = assertSentFetchQuorumRecordsRequest(epoch, 2L, lastEpoch);
 
         FetchQuorumRecordsResponseData response = outOfRangeFetchRecordsResponse(epoch, otherNodeId, 1L,
             lastEpoch, 1L);
-        channel.mockReceive(new RaftResponse.Inbound(requestId, response, otherNodeId));
+        channel.mockReceive(new RaftResponse.Inbound(correlationId, response, otherNodeId));
 
         // Poll again to complete truncation
         client.poll();
@@ -660,7 +660,7 @@ public class KafkaRaftClientTest {
         assertEquals(Errors.NONE, Errors.forCode(response.errorCode()));
         assertEquals(epoch, response.leaderEpoch());
         assertEquals(leaderId.orElse(-1).intValue(), response.leaderId());
-        return raftMessage.requestId();
+        return raftMessage.correlationId();
     }
 
     private MemoryRecords assertFetchQuorumRecordsResponse(int epoch, int leaderId) {
@@ -684,7 +684,7 @@ public class KafkaRaftClientTest {
         assertEquals(epoch, request.leaderEpoch());
         assertEquals(leaderId, request.leaderId());
         assertEquals(localId, request.replicaId());
-        return raftMessage.requestId();
+        return raftMessage.correlationId();
     }
 
     private int assertSentFindQuorumRequest() {
@@ -694,7 +694,7 @@ public class KafkaRaftClientTest {
         assertTrue(raftMessage.data() instanceof FindQuorumRequestData);
         FindQuorumRequestData request = (FindQuorumRequestData) raftMessage.data();
         assertEquals(localId, request.replicaId());
-        return raftMessage.requestId();
+        return raftMessage.correlationId();
     }
 
     private int assertSentVoteRequest(int epoch, int lastEpoch, long lastEpochOffset) {
@@ -707,7 +707,7 @@ public class KafkaRaftClientTest {
         assertEquals(localId, request.candidateId());
         assertEquals(lastEpoch, request.lastEpoch());
         assertEquals(lastEpochOffset, request.lastEpochEndOffset());
-        return raftMessage.requestId();
+        return raftMessage.correlationId();
     }
 
     private int assertBeginQuorumEpochRequest(int epoch) {
@@ -718,7 +718,7 @@ public class KafkaRaftClientTest {
         BeginQuorumEpochRequestData request = (BeginQuorumEpochRequestData) raftMessage.data();
         assertEquals(epoch, request.leaderEpoch());
         assertEquals(localId, request.leaderId());
-        return raftMessage.requestId();
+        return raftMessage.correlationId();
     }
 
     private int assertSentFetchQuorumRecordsRequest(
@@ -737,7 +737,7 @@ public class KafkaRaftClientTest {
         assertEquals(fetchOffset, request.fetchOffset());
         assertEquals(lastFetchedEpoch, request.lastFetchedEpoch());
         assertEquals(localId, request.replicaId());
-        return raftMessage.requestId();
+        return raftMessage.correlationId();
     }
 
     private FetchQuorumRecordsResponseData fetchRecordsResponse(

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -17,10 +17,8 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.common.record.CompressionType;
-import org.apache.kafka.common.record.ControlRecordType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
-import org.apache.kafka.common.record.ControlRecordUtils;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.Records;
@@ -33,20 +31,20 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class MockLog implements ReplicatedLog {
     private final List<EpochStartOffset> epochStartOffsets = new ArrayList<>();
-    private final List<LogEntry> log = new ArrayList<>();
+    private final List<LogBatch> log = new ArrayList<>();
     private long highWatermark = 0L;
 
     @Override
-    public boolean truncateTo(long offset) {
-        log.removeIf(entry -> entry.offset >= offset);
+    public void truncateTo(long offset) {
+        log.removeIf(entry -> entry.lastOffset() >= offset);
         epochStartOffsets.removeIf(epochStartOffset -> epochStartOffset.startOffset >= offset);
-        return offset < endOffset();
     }
 
     @Override
@@ -90,13 +88,13 @@ public class MockLog implements ReplicatedLog {
     private Optional<LogEntry> lastEntry() {
         if (log.isEmpty())
             return Optional.empty();
-        return Optional.of(log.get(log.size() - 1));
+        return Optional.of(log.get(log.size() - 1).last());
     }
 
     private Optional<LogEntry> firstEntry() {
         if (log.isEmpty())
             return Optional.empty();
-        return Optional.of(log.get(0));
+        return Optional.of(log.get(0).first());
     }
 
     @Override
@@ -109,128 +107,70 @@ public class MockLog implements ReplicatedLog {
         return firstEntry().map(entry -> entry.offset).orElse(0L);
     }
 
-    private List<LogEntry> convert(Records records, OptionalInt nodeEpoch) {
-        long offset = endOffset();
+    private List<LogEntry> buildEntries(RecordBatch batch,
+                                        Function<Record, Long> offsetSupplier) {
         List<LogEntry> entries = new ArrayList<>();
-        for (RecordBatch batch : records.batches()) {
-            final boolean isControlBatch = batch.isControlBatch();
-            for (Record record : batch) {
-                int epoch = nodeEpoch.orElse(batch.partitionLeaderEpoch());
-                Optional<ControlRecordType> controlRecordType =
-                    isControlBatch ? Optional.of(ControlRecordType.parse(record.key().duplicate()))
-                        : Optional.empty();
-                entries.add(new LogEntry(offset,
-                    epoch, new SimpleRecord(record), controlRecordType));
-                offset += 1;
-            }
+        for (Record record : batch) {
+            long offset = offsetSupplier.apply(record);
+            entries.add(new LogEntry(offset, new SimpleRecord(record)));
         }
         return entries;
     }
 
     @Override
     public Long appendAsLeader(Records records, int epoch) {
-        return appendAsLeader(convert(records, OptionalInt.of(epoch)), epoch, endOffset());
+        long baseOffset = endOffset();
+        AtomicLong offsetSupplier = new AtomicLong(baseOffset);
+        for (RecordBatch batch : records.batches()) {
+            List<LogEntry> entries = buildEntries(batch, record -> offsetSupplier.getAndIncrement());
+            appendBatch(new LogBatch(epoch, batch.isControlBatch(), entries));
+        }
+        return baseOffset;
     }
 
     Long appendAsLeader(Collection<SimpleRecord> records, int epoch) {
-        long firstOffset = endOffset();
-        long offset = firstOffset;
+        long baseOffset = endOffset();
+        long offset = baseOffset;
 
         List<LogEntry> entries = new ArrayList<>();
         for (SimpleRecord record : records) {
-            entries.add(LogEntry.with(offset, epoch, record));
+            entries.add(new LogEntry(offset, record));
             offset += 1;
         }
-        return appendAsLeader(entries, epoch, firstOffset);
+        appendBatch(new LogBatch(epoch, false, entries));
+        return baseOffset;
     }
 
-    private Long appendAsLeader(Collection<LogEntry> entries, int epoch, long firstOffset) {
-        if (epoch > lastFetchedEpoch()) {
-            epochStartOffsets.add(new EpochStartOffset(epoch, firstOffset));
+    private Long appendBatch(LogBatch batch) {
+        if (batch.epoch > lastFetchedEpoch()) {
+            epochStartOffsets.add(new EpochStartOffset(batch.epoch, batch.firstOffset()));
         }
-
-        log.addAll(entries);
-        return firstOffset;
-    }
-
-    private void appendAsFollower(Collection<LogEntry> entries) {
-        for (LogEntry entry : entries) {
-            if (entry.epoch > lastFetchedEpoch()) {
-                epochStartOffsets.add(new EpochStartOffset(entry.epoch, entry.offset));
-            }
-        }
-        log.addAll(entries);
+        log.add(batch);
+        return batch.firstOffset();
     }
 
     @Override
     public void appendAsFollower(Records records) {
-        appendAsFollower(convert(records, OptionalInt.empty()));
-    }
-
-    public List<LogEntry> readEntries(long startOffset, long endOffset) {
-        return log.stream().filter(entry -> entry.offset >= startOffset && entry.offset < endOffset)
-                .collect(Collectors.toList());
-    }
-
-    private void writeToBuffer(ByteBuffer buffer, List<LogEntry> entries, int epoch) {
-        LogEntry first = entries.get(0);
-        MemoryRecordsBuilder builder;
-
-        if (first.controlRecordType.isPresent() &&
-                first.controlRecordType.get() == ControlRecordType.LEADER_CHANGE) {
-            final boolean controlBatch = true;
-            builder = MemoryRecords.builder(
-                buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
-                TimestampType.CREATE_TIME, first.offset, first.record.timestamp(),
-                RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH,
-                RecordBatch.NO_SEQUENCE, false, controlBatch, epoch);
-
-            builder.appendLeaderChangeMessage(first.record.timestamp(),
-                ControlRecordUtils.deserialize(first.record.value().duplicate()));
-            builder.close();
-            entries = entries.subList(1, entries.size());
-        }
-
-        if (entries.size() > 0) {
-            LogEntry firstRegularEntry = entries.get(0);
-            builder = MemoryRecords.builder(buffer,
-                RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
-                TimestampType.CREATE_TIME,
-                firstRegularEntry.offset,
-                firstRegularEntry.record.timestamp(),
-                epoch);
-
-            // Skip the first record if it is already being appended as control record.
-            for (LogEntry entry : entries) {
-                builder.appendWithOffset(entry.offset, entry.record);
-            }
-
-            builder.close();
+        for (RecordBatch batch : records.batches()) {
+            List<LogEntry> entries = buildEntries(batch, Record::offset);
+            appendBatch(new LogBatch(batch.partitionLeaderEpoch(), batch.isControlBatch(), entries));
         }
     }
 
     @Override
     public Records read(long startOffset, OptionalLong endOffset) {
-        List<LogEntry> entries = readEntries(startOffset, endOffset.orElseGet(this::endOffset));
-        if (entries.isEmpty()) {
+        long maxOffset = endOffset.orElse(Long.MAX_VALUE);
+        List<LogBatch> batches = log.stream()
+            .filter(batch -> batch.firstOffset() >= startOffset && batch.lastOffset() < maxOffset)
+            .collect(Collectors.toList());
+
+        if (batches.isEmpty()) {
             return MemoryRecords.EMPTY;
         } else {
             ByteBuffer buffer = ByteBuffer.allocate(1024);
-            int currentEpoch = entries.get(0).epoch;
-            List<LogEntry> epochEntries = new ArrayList<>();
-            for (LogEntry entry: entries) {
-                if (entry.epoch != currentEpoch) {
-                    writeToBuffer(buffer, epochEntries, currentEpoch);
-                    epochEntries.clear();
-                    currentEpoch = entry.epoch;
-                }
-                epochEntries.add(entry);
+            for (LogBatch batch : batches) {
+                buffer = batch.writeTo(buffer);
             }
-
-            if (!epochEntries.isEmpty())
-                writeToBuffer(buffer, epochEntries, currentEpoch);
-
             buffer.flip();
             return MemoryRecords.readableRecords(buffer);
         }
@@ -246,44 +186,77 @@ public class MockLog implements ReplicatedLog {
 
     static class LogEntry {
         final long offset;
-        final int epoch;
         final SimpleRecord record;
-        final Optional<ControlRecordType> controlRecordType;
 
-        private LogEntry(long offset,
-                         int epoch,
-                         SimpleRecord record,
-                         Optional<ControlRecordType> controlRecordType) {
+        LogEntry(long offset, SimpleRecord record) {
             this.offset = offset;
-            this.epoch = epoch;
             this.record = record;
-            this.controlRecordType = controlRecordType;
-        }
-
-        static LogEntry with(long offset, int epoch, SimpleRecord record) {
-            return new LogEntry(offset, epoch, record, Optional.empty());
         }
 
         @Override
-        public boolean equals(Object other) {
-            if (this == other) {
-                return true;
-            }
-
-            if (!(other instanceof LogEntry)) {
-                return false;
-            }
-            LogEntry otherEntry = (LogEntry) other;
-
-            return this.offset == otherEntry.offset
-                && this.epoch == otherEntry.epoch
-                && this.record == otherEntry.record
-                && this.controlRecordType == otherEntry.controlRecordType;
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LogEntry logEntry = (LogEntry) o;
+            return offset == logEntry.offset &&
+                Objects.equals(record, logEntry.record);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(offset, epoch, record, controlRecordType);
+            return Objects.hash(offset, record);
+        }
+    }
+
+    static class LogBatch {
+        final List<LogEntry> entries;
+        final int epoch;
+        final boolean isControlBatch;
+
+        LogBatch(int epoch, boolean isControlBatch, List<LogEntry> entries) {
+            if (entries.isEmpty())
+                throw new IllegalArgumentException("Empty batches are not supported");
+            this.entries = entries;
+            this.epoch = epoch;
+            this.isControlBatch = isControlBatch;
+        }
+
+        long firstOffset() {
+            return first().offset;
+        }
+
+        LogEntry first() {
+            return entries.get(0);
+        }
+
+        long lastOffset() {
+            return last().offset;
+        }
+
+        LogEntry last() {
+            return entries.get(entries.size() - 1);
+        }
+
+        ByteBuffer writeTo(ByteBuffer buffer) {
+            LogEntry first = first();
+
+            MemoryRecordsBuilder builder = MemoryRecords.builder(
+                buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
+                TimestampType.CREATE_TIME, first.offset, first.record.timestamp(),
+                RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH,
+                RecordBatch.NO_SEQUENCE, false,
+                isControlBatch, epoch);
+
+            for (LogEntry entry : entries) {
+                if (isControlBatch) {
+                    builder.appendControlRecordWithOffset(entry.offset, entry.record);
+                } else {
+                    builder.appendWithOffset(entry.offset, entry.record);
+                }
+            }
+
+            builder.close();
+            return builder.buffer();
         }
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/MockNetworkChannel.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockNetworkChannel.java
@@ -38,7 +38,7 @@ public class MockNetworkChannel implements NetworkChannel {
     }
 
     @Override
-    public int newRequestId() {
+    public int newCorrelationId() {
         return requestIdCounter.getAndIncrement();
     }
 


### PR DESCRIPTION
This PR addresses some of @guozhangwang's comments from this commit: https://github.com/confluentinc/kafka/commit/854133695b39518c5223c8e5b838b86e8cd01405. 

Specifically this patch makes the following changes:

1. Replace the usage of `requestId` with `correlationId`, which is already widely used in Kafka.
2. Make `MockLog` aware of record batching to make its behavior more consistent with the `Log` implementation and to 
3. Add test coverage to `ConnectionCache`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
