### PR TITLE
Address comments from review of core raft implementation

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
@@ -117,6 +117,18 @@ public class CandidateState implements EpochState {
             .collect(Collectors.toSet());
     }
 
+    /**
+     * Get the set of voters that have rejected our candidacy.
+     *
+     * @return The set of rejecting voters
+     */
+    public Set<Integer> rejectingVoters() {
+        return voteStates.entrySet().stream()
+            .filter(entry -> entry.getValue() == VoteState.REJECTED)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    }
+
     @Override
     public ElectionState election() {
         return ElectionState.withVotedCandidate(epoch, localId);

--- a/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
@@ -16,33 +16,45 @@
  */
 package org.apache.kafka.raft;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class CandidateState implements EpochState {
     private final int localId;
     private final int epoch;
-    private final Set<Integer> voters;
-    private final Set<Integer> rejectedVotes = new HashSet<>();
-    private final Set<Integer> grantedVotes = new HashSet<>();
+    private final Map<Integer, VoteState> voteStates = new HashMap<>();
 
     protected CandidateState(int localId, int epoch, Set<Integer> voters) {
         this.localId = localId;
         this.epoch = epoch;
-        this.voters = voters;
-        this.grantedVotes.add(localId);
-    }
 
-    private boolean isNonVoter(int nodeId) {
-        return !voters.contains(nodeId);
+        for (Integer voterId : voters) {
+            voteStates.put(voterId, VoteState.UNRECORDED);
+        }
+        voteStates.put(localId, VoteState.GRANTED);
     }
 
     public int majoritySize() {
-        return voters.size() / 2 + 1;
+        return voteStates.size() / 2 + 1;
     }
 
+    private long numGranted() {
+        return voteStates.values().stream().filter(state -> state == VoteState.GRANTED).count();
+    }
+
+    private long numUnrecorded() {
+        return voteStates.values().stream().filter(state -> state == VoteState.UNRECORDED).count();
+    }
+
+    /**
+     * Check whether we have received enough votes to conclude the election and become leader.
+     *
+     * @return true if at least a majority of nodes have granted the vote
+     */
     public boolean isVoteGranted() {
-        return grantedVotes.size() >= majoritySize();
+        return numGranted() >= majoritySize();
     }
 
     /**
@@ -52,35 +64,57 @@ public class CandidateState implements EpochState {
      * @return true if the vote is rejected, false if the vote is already or can still be granted
      */
     public boolean isVoteRejected() {
-        return grantedVotes.size() + remainingVoters().size() < majoritySize();
+        return numGranted() + numUnrecorded() < majoritySize();
     }
 
-    public boolean voteGrantedBy(int remoteNodeId) {
-        if (isNonVoter(remoteNodeId)) {
+    /**
+     * Record a granted vote from one of the voters.
+     *
+     * @param remoteNodeId The id of the voter
+     * @return true if the voter had not been previously recorded
+     * @throws IllegalArgumentException if the remote node is not a voter or if the vote had already been
+     *         rejected by this node
+     */
+    public boolean recordGrantedVote(int remoteNodeId) {
+        VoteState voteState = voteStates.get(remoteNodeId);
+        if (voteState == null) {
             throw new IllegalArgumentException("Attempt to grant vote to non-voter " + remoteNodeId);
-        } else if (rejectedVotes.contains(remoteNodeId)) {
+        } else if (voteState == VoteState.REJECTED) {
             throw new IllegalArgumentException("Attempt to grant vote from node " + remoteNodeId +
-                    " which previously rejected our request");
+                " which previously rejected our request");
         }
-
-        return grantedVotes.add(remoteNodeId);
+        return voteStates.put(remoteNodeId, VoteState.GRANTED) == VoteState.UNRECORDED;
     }
 
-    public boolean voteRejectedBy(int remoteNodeId) {
-        if (isNonVoter(remoteNodeId)) {
+    /**
+     * Record a rejected vote from one of the voters.
+     *
+     * @param remoteNodeId The id of the voter
+     * @return true if the rejected vote had not been previously recorded
+     * @throws IllegalArgumentException if the remote node is not a voter or if the vote had already been
+     *         granted by this node
+     */
+    public boolean recordRejectedVote(int remoteNodeId) {
+        VoteState voteState = voteStates.get(remoteNodeId);
+        if (voteState == null) {
             throw new IllegalArgumentException("Attempt to reject vote to non-voter " + remoteNodeId);
-        } else if (grantedVotes.contains(remoteNodeId)) {
+        } else if (voteState == VoteState.GRANTED) {
             throw new IllegalArgumentException("Attempt to reject vote from node " + remoteNodeId +
-                    " which previously granted our request");
+                " which previously granted our request");
         }
-        return rejectedVotes.add(remoteNodeId);
+        return voteStates.put(remoteNodeId, VoteState.REJECTED) == VoteState.UNRECORDED;
     }
 
-    public Set<Integer> remainingVoters() {
-        Set<Integer> remaining = new HashSet<>(voters);
-        remaining.removeAll(grantedVotes);
-        remaining.removeAll(rejectedVotes);
-        return remaining;
+    /**
+     * Get the set of voters which have not been counted as granted or rejected yet.
+     *
+     * @return The set of unrecorded voters
+     */
+    public Set<Integer> unrecordedVoters() {
+        return voteStates.entrySet().stream()
+            .filter(entry -> entry.getValue() == VoteState.UNRECORDED)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
     }
 
     @Override
@@ -93,4 +127,9 @@ public class CandidateState implements EpochState {
         return epoch;
     }
 
+    private enum VoteState {
+        UNRECORDED,
+        GRANTED,
+        REJECTED
+    }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -104,19 +104,6 @@ public class FollowerState implements EpochState {
         return leaderIdOpt.getAsInt();
     }
 
-    public int votedId() {
-        if (hasLeader()) {
-            throw new IllegalArgumentException("Cannot access votedId of epoch " + epoch +
-                    " since we already have a leader");
-        }
-        if (!votedIdOpt.isPresent()) {
-            throw new IllegalArgumentException("Cannot access votedId of epoch " + epoch +
-                    " because we have not voted");
-
-        }
-        return votedIdOpt.getAsInt();
-    }
-
     public boolean hasVoted() {
         return votedIdOpt.isPresent();
     }

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -983,6 +983,7 @@ public class KafkaRaftClient implements RaftClient {
     /**
      * Read from the local log. This will only return records which have been committed to the quorum.
      * @param offsetAndEpoch The first offset to read from and the previous consumed epoch
+     * @param highWatermark The current high watermark
      * @return A set of records beginning at the request offset
      */
     private Records readCommitted(OffsetAndEpoch offsetAndEpoch, long highWatermark) {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -353,8 +353,8 @@ public class KafkaRaftClient implements RaftClient {
                 state.recordRejectedVote(remoteNodeId);
                 if (state.isVoteRejected()) {
                     logger.info("Insufficient remaining votes to become leader (rejected by {}). " +
-                            "We will backoff before retrying", state.rejectingVoters());
-                    electionTimer.reset(randomElectionJitterMs());
+                            "We will await expiration of election timeout before retrying",
+                        state.rejectingVoters());
                 }
             }
         }

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -30,7 +30,7 @@ public class LeaderState implements EpochState {
     private final int epoch;
     private final long epochStartOffset;
     private OptionalLong highWatermark = OptionalLong.empty();
-    private Map<Integer, FollowerState> followers = new HashMap<>();
+    private Map<Integer, ReplicaState> voterReplicaStates = new HashMap<>();
 
     protected LeaderState(int localId, int epoch, long epochStartOffset, Set<Integer> voters) {
         this.localId = localId;
@@ -39,7 +39,7 @@ public class LeaderState implements EpochState {
 
         for (int voterId : voters) {
             boolean hasEndorsedLeader = voterId == localId;
-            followers.put(voterId, new FollowerState(voterId, hasEndorsedLeader, OptionalLong.empty()));
+            this.voterReplicaStates.put(voterId, new ReplicaState(voterId, hasEndorsedLeader, OptionalLong.empty()));
         }
     }
 
@@ -59,12 +59,12 @@ public class LeaderState implements EpochState {
     }
 
     public Set<Integer> followers() {
-        return followers.keySet().stream().filter(id -> id != localId).collect(Collectors.toSet());
+        return voterReplicaStates.keySet().stream().filter(id -> id != localId).collect(Collectors.toSet());
     }
 
     public Set<Integer> nonEndorsingFollowers() {
         Set<Integer> nonEndorsing = new HashSet<>();
-        for (FollowerState state : followers.values()) {
+        for (ReplicaState state : voterReplicaStates.values()) {
             if (!state.hasEndorsedLeader)
                 nonEndorsing.add(state.nodeId);
         }
@@ -73,10 +73,11 @@ public class LeaderState implements EpochState {
 
     private boolean updateHighWatermark() {
         // Find the largest offset which is replicated to a majority of replicas (the leader counts)
-        ArrayList<FollowerState> followersByFetchOffset = new ArrayList<>(this.followers.values());
+        ArrayList<ReplicaState> followersByFetchOffset = new ArrayList<>(this.voterReplicaStates.values());
         Collections.sort(followersByFetchOffset);
-        int indexOfHw = followers.size() / 2 - (followers.size() % 2 == 0 ? 1 : 0);
+        int indexOfHw = voterReplicaStates.size() / 2;
         OptionalLong highWatermarkUpdateOpt = followersByFetchOffset.get(indexOfHw).endOffset;
+
         if (highWatermarkUpdateOpt.isPresent()) {
             // When a leader is first elected, it cannot know the high watermark of the previous
             // leader. In order to avoid exposing a non-monotonically increasing value, we have
@@ -91,7 +92,7 @@ public class LeaderState implements EpochState {
     }
 
     public boolean updateEndOffset(int remoteNodeId, long endOffset) {
-        FollowerState state = ensureValidFollower(remoteNodeId);
+        ReplicaState state = ensureValidVoter(remoteNodeId);
         state.endOffset.ifPresent(currentEndOffset -> {
             if (currentEndOffset > endOffset)
                 throw new IllegalArgumentException("Non-monotonic update to end offset for nodeId " + remoteNodeId);
@@ -102,12 +103,12 @@ public class LeaderState implements EpochState {
     }
 
     public void addEndorsementFrom(int remoteNodeId) {
-        FollowerState followerState = ensureValidFollower(remoteNodeId);
-        followerState.hasEndorsedLeader = true;
+        ReplicaState replicaState = ensureValidVoter(remoteNodeId);
+        replicaState.hasEndorsedLeader = true;
     }
 
-    private FollowerState ensureValidFollower(int remoteNodeId) {
-        FollowerState state = followers.get(remoteNodeId);
+    private ReplicaState ensureValidVoter(int remoteNodeId) {
+        ReplicaState state = voterReplicaStates.get(remoteNodeId);
         if (state == null)
             throw new IllegalArgumentException("Unexpected endorsement from non-voter " + remoteNodeId);
         return state;
@@ -117,29 +118,29 @@ public class LeaderState implements EpochState {
         return updateEndOffset(localId, endOffset);
     }
 
-    private static class FollowerState implements Comparable<FollowerState> {
+    private static class ReplicaState implements Comparable<ReplicaState> {
         final int nodeId;
         boolean hasEndorsedLeader;
         OptionalLong endOffset;
 
-        public FollowerState(int nodeId,
-                             boolean hasEndorsedLeader,
-                             OptionalLong endOffset) {
+        public ReplicaState(int nodeId,
+                            boolean hasEndorsedLeader,
+                            OptionalLong endOffset) {
             this.nodeId = nodeId;
             this.hasEndorsedLeader = hasEndorsedLeader;
             this.endOffset = endOffset;
         }
 
         @Override
-        public int compareTo(FollowerState that) {
-            if (this.endOffset == that.endOffset)
+        public int compareTo(ReplicaState that) {
+            if (this.endOffset.equals(that.endOffset))
                 return Integer.compare(this.nodeId, that.nodeId);
             else if (!this.endOffset.isPresent())
-                return -1;
-            else if (!that.endOffset.isPresent())
                 return 1;
+            else if (!that.endOffset.isPresent())
+                return -1;
             else
-                return Long.compare(this.endOffset.getAsLong(), that.endOffset.getAsLong());
+                return Long.compare(that.endOffset.getAsLong(), this.endOffset.getAsLong());
         }
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -73,10 +73,10 @@ public class LeaderState implements EpochState {
 
     private boolean updateHighWatermark() {
         // Find the largest offset which is replicated to a majority of replicas (the leader counts)
-        ArrayList<ReplicaState> followersByFetchOffset = new ArrayList<>(this.voterReplicaStates.values());
-        Collections.sort(followersByFetchOffset);
+        ArrayList<ReplicaState> followersByDescendingFetchOffset = new ArrayList<>(this.voterReplicaStates.values());
+        Collections.sort(followersByDescendingFetchOffset);
         int indexOfHw = voterReplicaStates.size() / 2;
-        OptionalLong highWatermarkUpdateOpt = followersByFetchOffset.get(indexOfHw).endOffset;
+        OptionalLong highWatermarkUpdateOpt = followersByDescendingFetchOffset.get(indexOfHw).endOffset;
 
         if (highWatermarkUpdateOpt.isPresent()) {
             // When a leader is first elected, it cannot know the high watermark of the previous

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -366,7 +366,7 @@ public class KafkaRaftClientTest {
     }
 
     @Test
-    public void testFetchResponseReceivedAfterBecomingCandidate() throws Exception {
+    public void testFetchResponseIgnoredAfterBecomingCandidate() throws Exception {
         int otherNodeId = 1;
         int epoch = 5;
 
@@ -402,7 +402,7 @@ public class KafkaRaftClientTest {
     }
 
     @Test
-    public void testFetchResponseReceivedAfterBecomingFollowerOfDifferentLeader() throws Exception {
+    public void testFetchResponseIgnoredAfterBecomingFollowerOfDifferentLeader() throws Exception {
         int voter1 = localId;
         int voter2 = localId + 1;
         int voter3 = localId + 2;

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -207,7 +207,8 @@ public class KafkaRaftClientTest {
         VoteResponseData voteResponse = voteResponse(false, Optional.empty(), 1);
         channel.mockReceive(new RaftResponse.Inbound(correlationId, voteResponse, otherNodeId));
 
-        // Add 50ms jitter on the next random call
+        // Add some jitter on the next random call. This is how long we should wait before
+        // we start a new election
         int jitterMs = 85;
         Mockito.doReturn(jitterMs).when(random).nextInt(Mockito.anyInt());
         client.poll();

--- a/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
@@ -115,6 +115,8 @@ public class LeaderStateTest {
         assertEquals(OptionalLong.of(15L), state.highWatermark());
         state.updateEndOffset(node2, 20L);
         assertEquals(OptionalLong.of(20L), state.highWatermark());
+        state.updateEndOffset(node1, 20L);
+        assertEquals(OptionalLong.of(20L), state.highWatermark());
     }
 
 }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assume.assumeTrue;
 
 public class RaftEventSimulationTest {
     private static final int ELECTION_TIMEOUT_MS = 1000;
-    private static final int ELECTION_JITTER_MS = 0;
+    private static final int ELECTION_JITTER_MS = 10;
     private static final int RETRY_BACKOFF_MS = 50;
     private static final int REQUEST_TIMEOUT_MS = 500;
 
@@ -632,7 +632,8 @@ public class RaftEventSimulationTest {
 
             KafkaRaftClient client = new KafkaRaftClient(channel, persistentState.log, quorum, time,
                 new InetSocketAddress("localhost", 9990 + nodeId), bootstrapServers,
-                ELECTION_TIMEOUT_MS, ELECTION_JITTER_MS, RETRY_BACKOFF_MS, REQUEST_TIMEOUT_MS, logContext);
+                ELECTION_TIMEOUT_MS, ELECTION_JITTER_MS, RETRY_BACKOFF_MS, REQUEST_TIMEOUT_MS,
+                logContext, random);
             RaftNode node = new RaftNode(nodeId, client, persistentState.log, channel,
                     persistentState.store, quorum, logContext);
             node.initialize();

--- a/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -54,7 +55,8 @@ public class SimpleKeyValueStoreTest {
 
         return new KafkaRaftClient(channel, log, quorum, time,
             new InetSocketAddress("localhost", 9990 + localId), bootstrapServers,
-            electionTimeoutMs, electionJitterMs, retryBackoffMs, requestTimeoutMs, logContext);
+            electionTimeoutMs, electionJitterMs, retryBackoffMs, requestTimeoutMs, logContext,
+            new Random());
     }
 
     @Test


### PR DESCRIPTION
Address review comments from https://github.com/confluentinc/kafka/commit/9f52a740aba457dcf27c5babd12d6dbbe31d5e4f. Most of the changes are cosmetic (changing naming or state representation), but we also fix a couple issues:

1. We ensure that jitter is respected after the election timeout expires when we are a candidate.
2. We reject appends if we are not the leader.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
