### PR TITLE
Add test logging support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1144,6 +1144,8 @@ project(':raft') {
     testCompile project(':clients').sourceSets.test.output
     testCompile libs.junit
     testCompile libs.mockitoCore
+
+    testRuntime libs.slf4jlog4j
   }
 
   task createVersionFile(dependsOn: determineCommitId) {

--- a/raft/src/test/resources/log4j.properties
+++ b/raft/src/test/resources/log4j.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+log4j.rootLogger=OFF, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.logger.org.apache.kafka.raft=ERROR


### PR DESCRIPTION
Adds default log4j.properties to test resources and the log4j library as a test dependence.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
