### PR TITLE
Minor: enable downstreamValidation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,12 @@ def job = {
             echo "Building cp-downstream-builds"
             stage('Downstream validation') {
                 if (config.isPrJob && config.downStreamValidate) {
-                    downStreamValidation(true)
+                    try{
+                        downStreamValidation(true)
+                    } catch (Exception e) {
+                        currentBuild.result = 'UNSTABLE'
+                        return "some downstream builds failed"
+                    }
                 } else {
                     return "skip downStreamValidation"
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,12 +99,7 @@ def job = {
             echo "Building cp-downstream-builds"
             stage('Downstream validation') {
                 if (config.isPrJob && config.downStreamValidate) {
-                    try{
-                        downStreamValidation(true)
-                    } catch (Exception e) {
-                        currentBuild.result = 'UNSTABLE'
-                        return "some downstream builds failed"
-                    }
+                    downStreamValidation(true, true)
                 } else {
                     return "skip downStreamValidation"
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ def config = jobConfig {
     slackChannel = '#kafka-warn'
     timeoutHours = 4
     runMergeCheck = false
+    downStreamValidate = true
 }
 
 def retryFlagsString(jobConfig) {
@@ -96,36 +97,15 @@ def job = {
         },
         downstreamBuildsStepName: {
             echo "Building cp-downstream-builds"
-            if (config.isPrJob) {
-                try {
-                    def muckrakeBranch = kafkaMuckrakeVersionMap[env.CHANGE_TARGET]
-                    def forkRepo = "${env.CHANGE_FORK ?: "confluentinc"}/kafka.git"
-                    def forkBranch = env.CHANGE_BRANCH
-                    echo "Schedule test-cp-downstream-builds with :"
-                    echo "Muckrake branch : ${muckrakeBranch}"
-                    echo "PR fork repo : ${forkRepo}"
-                    echo "PR fork branch : ${forkBranch}"
-                    buildResult = build job: 'test-cp-downstream-builds', parameters: [
-                            [$class: 'StringParameterValue', name: 'BRANCH', value: muckrakeBranch],
-                            [$class: 'StringParameterValue', name: 'TEST_PATH', value: "muckrake/tests/dummy_test.py"],
-                            [$class: 'StringParameterValue', name: 'KAFKA_REPO', value: forkRepo],
-                            [$class: 'StringParameterValue', name: 'KAFKA_BRANCH', value: forkBranch]],
-                            propagate: true, wait: true
-                    downstreamBuildFailureOutput = "cp-downstream-builds result: " + buildResult.getResult();
-                    return downstreamBuildFailureOutput
-                } catch (Exception e) {
-                    currentBuild.result = 'UNSTABLE'
-                    downstreamBuildFailureOutput = "cp-downstream-builds result: " + e.getMessage()
-                    writeFile file: "downstream/cp-downstream-build-failure.txt", text: downstreamBuildFailureOutput
-                    archiveArtifacts artifacts: 'downstream/*.txt'
-
-                    return downstreamBuildFailureOutput
+            stage('Downstream validation') {
+                if (config.isPrJob && config.downStreamValidate) {
+                    downStreamValidation(true)
+                } else {
+                    return "skip downStreamValidation"
                 }
-            } else {
-                return ""
             }
-         }
-        ]
+        }
+    ]
 
         result = parallel testTargets
         // combine results of the two targets into one result string


### PR DESCRIPTION
# what
This pr is to enable downstream validation on kafka master branch and some minor changes. 

1. It will compile all downstream repos that depend on kafka. If some repos fail to compile, the result will be marked `UNSTABLE`.
2. Add gradlew install as part of the build cmd since we need artifacts to be install at local m2 repository.
3. I think the stage Run Tests and build cp-downstream-builds did not output anything, I don't think we need that stage at all. Remove it can make the stage view more clear.
4. Following ce-kafka's decision, the build frequency will be changed to `@weekly` instead `@midnight` to prevent build storm(all pr build at the same time).

