### PR TITLE
MINOR: Bump version to 5.4.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
-version=5.4.2-ccs-SNAPSHOT
+version=5.4.3-ccs-SNAPSHOT
 scalaVersion=2.12.10
 task=build
 org.gradle.jvmargs=-Xmx1024m -Xss2m

--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -22,4 +22,4 @@
 # Instead, in
 #
 # For example, when Kafka is at version 1.0.0-SNAPSHOT, this should be something like "1.0.0
-__version__ = '5.4.2.dev0'
+__version__ = '5.4.3.dev0'

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -63,7 +63,7 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("5.4.2-SNAPSHOT")
+DEV_VERSION = KafkaVersion("5.4.3-SNAPSHOT")
 
 # 0.8.2.x versions
 V_0_8_2_1 = KafkaVersion("0.8.2.1")


### PR DESCRIPTION
This is a version bump for CCS Kafka now that 5.4.2 is released. I will merge this over to ce-kafka after approval here.