### PR TITLE
KCORE-414; Make request/response error handling more conventional

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/InconsistentVoterSetException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InconsistentVoterSetException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class InconsistentVoterSetException extends ApiException {
+
+    private static final long serialVersionUID = 1;
+
+    public InconsistentVoterSetException(String s) {
+        super(s);
+    }
+
+    public InconsistentVoterSetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -321,7 +321,7 @@ public enum Errors {
         GroupSubscribedToTopicException::new),
     INVALID_RECORD(87, "This record has failed the validation on broker and hence will be rejected.", InvalidRecordException::new),
     UNSTABLE_OFFSET_COMMIT(88, "There are unstable offsets that need to be cleared.", UnstableOffsetCommitException::new),
-    INCONSISTENT_VOTER_SET(90, "Indicates that the either the sender or recipient of a " +
+    INCONSISTENT_VOTER_SET(89, "Indicates that the either the sender or recipient of a " +
         "voter-only request is not one of the expected voters", InconsistentVoterSetException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -21,27 +21,30 @@ import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.BrokerNotAvailableException;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.ConcurrentTransactionsException;
-import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.errors.ControllerMovedException;
 import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
 import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.CorruptRecordException;
-import org.apache.kafka.common.errors.DuplicateSequenceException;
 import org.apache.kafka.common.errors.DelegationTokenAuthorizationException;
 import org.apache.kafka.common.errors.DelegationTokenDisabledException;
 import org.apache.kafka.common.errors.DelegationTokenExpiredException;
 import org.apache.kafka.common.errors.DelegationTokenNotFoundException;
 import org.apache.kafka.common.errors.DelegationTokenOwnerMismatchException;
+import org.apache.kafka.common.errors.DuplicateSequenceException;
+import org.apache.kafka.common.errors.ElectionNotNeededException;
+import org.apache.kafka.common.errors.EligibleLeadersNotAvailableException;
+import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.FencedLeaderEpochException;
-import org.apache.kafka.common.errors.ListenerNotFoundException;
 import org.apache.kafka.common.errors.FetchSessionIdNotFoundException;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupMaxSizeReachedException;
 import org.apache.kafka.common.errors.GroupNotEmptyException;
+import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.IllegalSaslStateException;
 import org.apache.kafka.common.errors.InconsistentGroupProtocolException;
+import org.apache.kafka.common.errors.InconsistentVoterSetException;
 import org.apache.kafka.common.errors.InvalidCommitOffsetSizeException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.InvalidFetchSessionEpochException;
@@ -61,11 +64,9 @@ import org.apache.kafka.common.errors.InvalidTxnStateException;
 import org.apache.kafka.common.errors.InvalidTxnTimeoutException;
 import org.apache.kafka.common.errors.KafkaStorageException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
+import org.apache.kafka.common.errors.ListenerNotFoundException;
 import org.apache.kafka.common.errors.LogDirNotFoundException;
-import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.MemberIdRequiredException;
-import org.apache.kafka.common.errors.ElectionNotNeededException;
-import org.apache.kafka.common.errors.EligibleLeadersNotAvailableException;
 import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.common.errors.NoReassignmentInProgressException;
 import org.apache.kafka.common.errors.NotControllerException;
@@ -78,7 +79,6 @@ import org.apache.kafka.common.errors.OffsetNotAvailableException;
 import org.apache.kafka.common.errors.OffsetOutOfRangeException;
 import org.apache.kafka.common.errors.OperationNotAttemptedException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
-import org.apache.kafka.common.errors.UnstableOffsetCommitException;
 import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.errors.PreferredLeaderNotAvailableException;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -90,23 +90,24 @@ import org.apache.kafka.common.errors.ReplicaNotAvailableException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.StaleBrokerEpochException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.TopicExistsException;
-import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
 import org.apache.kafka.common.errors.TransactionCoordinatorFencedException;
+import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
 import org.apache.kafka.common.errors.UnknownLeaderEpochException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.errors.UnknownProducerIdException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.errors.UnstableOffsetCommitException;
 import org.apache.kafka.common.errors.UnsupportedByAuthenticationException;
 import org.apache.kafka.common.errors.UnsupportedCompressionTypeException;
 import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
 import org.apache.kafka.common.errors.UnsupportedSaslMechanismException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.apache.kafka.common.errors.StaleBrokerEpochException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -319,7 +320,9 @@ public enum Errors {
     GROUP_SUBSCRIBED_TO_TOPIC(86, "Deleting offsets of a topic is forbidden while the consumer group is actively subscribed to it.",
         GroupSubscribedToTopicException::new),
     INVALID_RECORD(87, "This record has failed the validation on broker and hence will be rejected.", InvalidRecordException::new),
-    UNSTABLE_OFFSET_COMMIT(88, "There are unstable offsets that need to be cleared.", UnstableOffsetCommitException::new);
+    UNSTABLE_OFFSET_COMMIT(88, "There are unstable offsets that need to be cleared.", UnstableOffsetCommitException::new),
+    INCONSISTENT_VOTER_SET(90, "Indicates that the either the sender or recipient of a " +
+        "voter-only request is not one of the expected voters", InconsistentVoterSetException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/raft/src/main/java/org/apache/kafka/raft/ConnectionCache.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ConnectionCache.java
@@ -222,6 +222,18 @@ public class ConnectionCache {
             state = State.READY;
             inFlightCorrelationId = Optional.empty();
         }
+
+        @Override
+        public String toString() {
+            return "ConnectionState(" +
+                "id=" + id +
+                ", hostInfo=" + hostInfo +
+                ", state=" + state +
+                ", lastSendTimeMs=" + lastSendTimeMs +
+                ", lastFailTimeMs=" + lastFailTimeMs +
+                ", inFlightCorrelationId=" + inFlightCorrelationId +
+                ')';
+        }
     }
 
 }

--- a/raft/src/main/java/org/apache/kafka/raft/ConnectionCache.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ConnectionCache.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.raft;
 
-import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
@@ -206,14 +205,6 @@ public class ConnectionCache {
                     inFlightCorrelationId = Optional.empty();
                 }
             });
-        }
-
-        void onResponse(long correlationId, Errors error, long timeMs) {
-            if (error != Errors.NONE) {
-                onResponseError(correlationId, timeMs);
-            } else {
-                onResponseReceived(correlationId);
-            }
         }
 
         void onRequestSent(long correlationId, long timeMs) {

--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -80,6 +80,12 @@ public class FollowerState implements EpochState {
         return leaderIdOpt.isPresent();
     }
 
+    public boolean hasLeader(int replicaId) {
+        if (replicaId < 0)
+            throw new IllegalArgumentException("Illegal negative replicaId " + replicaId);
+        return leaderIdOpt.orElse(-1) == replicaId;
+    }
+
     public boolean acknowledgeLeader(int leaderId) {
         if (leaderId < 0) {
             throw new IllegalArgumentException("Invalid negative leaderId: " + leaderId);
@@ -108,7 +114,7 @@ public class FollowerState implements EpochState {
         return votedIdOpt.isPresent();
     }
 
-    public boolean isVotedCandidate(int candidateId) {
+    public boolean hasVotedFor(int candidateId) {
         if (candidateId < 0)
             throw new IllegalArgumentException("Illegal negative candidateId " + candidateId);
         return votedIdOpt.orElse(-1) == candidateId;
@@ -147,4 +153,7 @@ public class FollowerState implements EpochState {
         return true;
     }
 
+    public boolean isUnattached() {
+        return !hasVoted() && !hasLeader();
+    }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -828,7 +828,6 @@ public class KafkaRaftClient implements RaftClient {
         }
     }
 
-
     private boolean handleUnexpectedError(Errors error, RaftResponse.Inbound response) {
         logger.error("Unexpected error {} in {} response: {}",
             error, response.data.apiKey(), response);

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -152,6 +152,9 @@ public class QuorumState {
      * is invoked.
      */
     public boolean becomeVotedFollower(int epoch, int candidateId) throws IOException {
+        if (candidateId == localId)
+            throw new IllegalArgumentException("Cannot become a follower of " + candidateId +
+                " since that matches the local `broker.id`");
         if (!isVoter(candidateId))
             throw new IllegalArgumentException("Cannot become follower of non-voter " + candidateId);
 
@@ -165,6 +168,9 @@ public class QuorumState {
      * Become a follower of an elected leader so that we can begin fetching.
      */
     public boolean becomeFetchingFollower(int epoch, int leaderId) throws IOException {
+        if (leaderId == localId)
+            throw new IllegalArgumentException("Cannot become a follower of " + leaderId +
+                " since that matches the local `broker.id`");
         if (!isVoter(leaderId))
             throw new IllegalArgumentException("Cannot become follower of non-voter " + leaderId);
         boolean transitioned = becomeFollower(epoch, state -> state.acknowledgeLeader(leaderId));

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -111,6 +111,10 @@ public class QuorumState {
             return OptionalInt.empty();
     }
 
+    public boolean hasLeader() {
+        return leaderId().isPresent();
+    }
+
     public boolean isLeader() {
         return state instanceof LeaderState;
     }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftResponse.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftResponse.java
@@ -51,7 +51,7 @@ public abstract class RaftResponse implements RaftMessage {
 
         @Override
         public String toString() {
-            return "Inbound(" +
+            return "InboundResponse(" +
                     "correlationId=" + correlationId +
                     ", data=" + data +
                     ", sourceId=" + sourceId +

--- a/raft/src/test/java/org/apache/kafka/raft/FollowerStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/FollowerStateTest.java
@@ -37,7 +37,7 @@ public class FollowerStateTest {
         int votedId = 1;
         assertTrue(state.grantVoteTo(votedId));
         assertTrue(state.hasVoted());
-        assertTrue(state.isVotedCandidate(votedId));
+        assertTrue(state.hasVotedFor(votedId));
     }
 
     @Test
@@ -56,7 +56,7 @@ public class FollowerStateTest {
         assertTrue(state.grantVoteTo(votedId));
         assertFalse(state.grantVoteTo(votedId));
         assertTrue(state.hasVoted());
-        assertTrue(state.isVotedCandidate(votedId));
+        assertTrue(state.hasVotedFor(votedId));
     }
 
     @Test
@@ -87,7 +87,7 @@ public class FollowerStateTest {
         int leaderId = 2;
         assertTrue(state.grantVoteTo(candidateId));
         assertTrue(state.acknowledgeLeader(leaderId));
-        assertFalse(state.isVotedCandidate(candidateId));
+        assertFalse(state.hasVotedFor(candidateId));
         assertFalse(state.hasVoted());
         assertTrue(state.hasLeader());
         assertEquals(leaderId, state.leaderId());

--- a/raft/src/test/java/org/apache/kafka/raft/MockNetworkChannel.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockNetworkChannel.java
@@ -19,6 +19,7 @@ package org.apache.kafka.raft;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -73,6 +74,19 @@ public class MockNetworkChannel implements NetworkChannel {
         List<RaftMessage> messages = sendQueue;
         sendQueue = new ArrayList<>();
         return messages;
+    }
+
+    public List<RaftResponse.Outbound> drainSentResponses() {
+        List<RaftResponse.Outbound> responses = new ArrayList<>();
+        Iterator<RaftMessage> iterator = sendQueue.iterator();
+        while (iterator.hasNext()) {
+            RaftMessage message = iterator.next();
+            if (message instanceof RaftResponse.Outbound) {
+                responses.add((RaftResponse.Outbound) message);
+                iterator.remove();
+            }
+        }
+        return responses;
     }
 
     public boolean hasSentMessages() {

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -152,6 +152,17 @@ public class QuorumStateTest {
     }
 
     @Test
+    public void testCannotBecomeFollowerOfSelf() throws IOException {
+        int otherNodeId = localId + 1;
+        Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+        assertEquals(0, store.readElectionState().epoch);
+        QuorumState state = new QuorumState(localId, voters, store, new LogContext());
+        state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
+        assertThrows(IllegalArgumentException.class, () -> state.becomeFetchingFollower(0, localId));
+        assertThrows(IllegalArgumentException.class, () -> state.becomeVotedFollower(0, localId));
+    }
+
+    @Test
     public void testCannotBecomeLeaderIfCurrentlyFollowing() throws IOException {
         int leaderId = 1;
         int epoch = 5;

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -153,8 +153,7 @@ public class QuorumStateTest {
 
     @Test
     public void testCannotBecomeFollowerOfSelf() throws IOException {
-        int otherNodeId = localId + 1;
-        Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+        Set<Integer> voters = Utils.mkSet(localId);
         assertEquals(0, store.readElectionState().epoch);
         QuorumState state = new QuorumState(localId, voters, store, new LogContext());
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -84,7 +84,7 @@ public class QuorumStateTest {
         FollowerState followerState = state.followerStateOrThrow();
         assertTrue(followerState.hasVoted());
         assertEquals(epoch, followerState.epoch());
-        assertTrue(followerState.isVotedCandidate(node1));
+        assertTrue(followerState.hasVotedFor(node1));
     }
 
     @Test
@@ -244,7 +244,7 @@ public class QuorumStateTest {
         assertEquals(OptionalInt.empty(), state.leaderId());
         FollowerState followerState = state.followerStateOrThrow();
         assertTrue(followerState.hasVoted());
-        assertTrue(followerState.isVotedCandidate(otherNodeId));
+        assertTrue(followerState.hasVotedFor(otherNodeId));
         assertEquals(ElectionState.withVotedCandidate(5, otherNodeId), store.readElectionState());
     }
 
@@ -283,7 +283,7 @@ public class QuorumStateTest {
         assertEquals(OptionalInt.empty(), state.leaderId());
         FollowerState followerState = state.followerStateOrThrow();
         assertTrue(followerState.hasVoted());
-        assertTrue(followerState.isVotedCandidate(otherNodeId));
+        assertTrue(followerState.hasVotedFor(otherNodeId));
         assertEquals(ElectionState.withVotedCandidate(5, otherNodeId), store.readElectionState());
     }
 
@@ -298,7 +298,7 @@ public class QuorumStateTest {
         FollowerState followerState = state.followerStateOrThrow();
         assertEquals(5, followerState.epoch());
         assertTrue(followerState.hasVoted());
-        assertTrue(followerState.isVotedCandidate(otherNodeId));
+        assertTrue(followerState.hasVotedFor(otherNodeId));
         assertEquals(ElectionState.withVotedCandidate(5, otherNodeId), store.readElectionState());
     }
 
@@ -313,7 +313,7 @@ public class QuorumStateTest {
         FollowerState followerState = state.followerStateOrThrow();
         assertEquals(8, followerState.epoch());
         assertTrue(followerState.hasVoted());
-        assertTrue(followerState.isVotedCandidate(otherNodeId));
+        assertTrue(followerState.hasVotedFor(otherNodeId));
         assertEquals(ElectionState.withVotedCandidate(8, otherNodeId), store.readElectionState());
     }
 
@@ -363,7 +363,7 @@ public class QuorumStateTest {
         FollowerState followerState = state.followerStateOrThrow();
         assertFalse(followerState.hasLeader());
         assertTrue(followerState.hasVoted());
-        assertTrue(followerState.isVotedCandidate(node1));
+        assertTrue(followerState.hasVotedFor(node1));
         assertEquals(ElectionState.withVotedCandidate(5, node1), store.readElectionState());
     }
 


### PR DESCRIPTION
The purpose of this patch is to get rid of the clumsy error handling in `maybeHandleError` and establish more consistent conventions for request/response handling.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
