### PR TITLE
KCORE-444: Revise EndQuorum logic to send to preferred followers first

### DIFF
--- a/clients/src/main/resources/common/message/EndQuorumEpochRequest.json
+++ b/clients/src/main/resources/common/message/EndQuorumEpochRequest.json
@@ -26,6 +26,8 @@
     {"name": "LeaderId", "type": "int32", "versions": "0+",
       "about": "The current leader ID or -1 if there is a vote in progress"},
     {"name": "LeaderEpoch", "type": "int32", "versions": "0+",
-      "about": "The current epoch"}
+      "about": "The current epoch"},
+    {"name": "PreferredSuccessors", "type": "[]int32", "versions": "0+",
+      "about": "A sorted list of preferred successors to start the election"}
   ]
 }

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -487,6 +487,11 @@ public class KafkaRaftClient implements RaftClient {
         }
     }
 
+    private int positiveRandomElectionJitterMs() {
+        final int randomJitterMs = randomElectionJitterMs();
+        return randomJitterMs == 0 ? 1 : randomJitterMs;
+    }
+
     private int randomElectionJitterMs() {
         if (electionJitterMs == 0)
             return 0;
@@ -580,9 +585,15 @@ public class KafkaRaftClient implements RaftClient {
             if (state.isUnattached()
                 || state.hasLeader(requestReplicaId)
                 || state.hasVotedFor(requestReplicaId)) {
-                // reset the timer to election jitter so that they would become candidate
-                // after a pretty short period of time
-                timer.reset(randomElectionJitterMs());
+                List<Integer> preferredSuccessors = request.preferredSuccessors();
+                // We didn't find the corresponding voters inside the request.
+                if (!preferredSuccessors.contains(quorum.localId)) {
+                    return buildEndQuorumEpochResponse(Errors.INCONSISTENT_VOTER_SET);
+                }
+                // Based on the priority inside the preferred successors, choose the corresponding delayed
+                // election time so that the most up-to-date voter has a higher chance to be elected.
+                // The reasoning for always making it positive is for deterministic unit testing.
+                timer.reset(electionJitterMs * preferredSuccessors.indexOf(quorum.localId) + positiveRandomElectionJitterMs());
             }
         } // else if we are already leader or a candidate, then we take no action
 
@@ -1115,7 +1126,9 @@ public class KafkaRaftClient implements RaftClient {
         return new EndQuorumEpochRequestData()
                 .setReplicaId(quorum.localId)
                 .setLeaderId(quorum.leaderIdOrNil())
-                .setLeaderEpoch(quorum.epoch());
+                .setLeaderEpoch(quorum.epoch())
+                .setPreferredSuccessors(
+                    quorum.leaderStateOrThrow().nonLeaderVotersByDescendingFetchOffset());
     }
 
     private void maybeSendEndQuorumEpoch(long currentTimeMs) throws IOException {
@@ -1218,16 +1231,16 @@ public class KafkaRaftClient implements RaftClient {
         // to finish our term. We consider the term finished if we are a follower or if one of
         // the remaining voters bumps the existing epoch.
 
-        shutdown.timer.update();
+        shutdown.update();
 
         if (quorum.isFollower() || quorum.remoteVoters().isEmpty()) {
             // Shutdown immediately if we are a follower or we are the only voter
             shutdown.finished.set(true);
         } else if (!shutdown.isFinished()) {
-            long currentTimeMs = shutdown.timer.currentTimeMs();
+            long currentTimeMs = shutdown.finishTimer.currentTimeMs();
             maybeSendEndQuorumEpoch(currentTimeMs);
 
-            List<RaftMessage> inboundMessages = channel.receive(shutdown.timer.remainingMs());
+            List<RaftMessage> inboundMessages = channel.receive(shutdown.finishTimer.remainingMs());
             for (RaftMessage message : inboundMessages)
                 handleInboundMessage(message, currentTimeMs);
         }
@@ -1335,11 +1348,13 @@ public class KafkaRaftClient implements RaftClient {
 
     private class GracefulShutdown {
         final int epoch;
-        final Timer timer;
+        final Timer finishTimer;
+
         final AtomicBoolean finished = new AtomicBoolean(false);
 
-        public GracefulShutdown(int shutdownTimeoutMs, int epoch) {
-            this.timer = time.timer(shutdownTimeoutMs);
+        public GracefulShutdown(long shutdownTimeoutMs,
+                                int epoch) {
+            this.finishTimer = time.timer(shutdownTimeoutMs);
             this.epoch = epoch;
         }
 
@@ -1351,6 +1366,10 @@ public class KafkaRaftClient implements RaftClient {
                 finished.set(true);
         }
 
+        public void update() {
+            finishTimer.update();
+        }
+
         public boolean isFinished() {
             return succeeded() || failed();
         }
@@ -1360,9 +1379,8 @@ public class KafkaRaftClient implements RaftClient {
         }
 
         public boolean failed() {
-            return timer.isExpired();
+            return finishTimer.isExpired();
         }
-
     }
 
     private static class PendingAppend {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -588,9 +588,14 @@ public class KafkaRaftClient implements RaftClient {
                 }
                 final int position = preferredSuccessors.indexOf(quorum.localId);
                 // Based on the priority inside the preferred successors, choose the corresponding delayed
-                // election time so that the most up-to-date voter has a higher chance to be elected.
-                timer.reset(position <= 0 ? 0 :
-                    Math.min(retryBackOffMaxMs, retryBackoffMs * (long) Math.pow(2, position - 1)));
+                // election time so that the most up-to-date voter has a higher chance to be elected. If
+                // the node's priority is highest, become candidate immediately instead of waiting for next poll.
+                if (position == 0) {
+                    becomeCandidate();
+                } else {
+                    timer.reset(Math.min(retryBackOffMaxMs, retryBackoffMs * (long) Math.pow(2, position - 1)));
+                }
+
             }
         } // else if we are already leader or a candidate, then we take no action
 

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -68,6 +69,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class KafkaRaftClientTest {
     private final int localId = 0;
@@ -249,7 +251,8 @@ public class KafkaRaftClientTest {
         quorumStateStore.writeElectionState(ElectionState.withVotedCandidate(epoch, localId, voters));
         KafkaRaftClient client = buildClient(voters);
 
-        deliverRequest(endEpochRequest(epoch, OptionalInt.empty(), otherNodeId));
+        deliverRequest(endEpochRequest(epoch, OptionalInt.empty(), otherNodeId, Collections.singletonList(localId)));
+
         client.poll();
         assertSentEndQuorumEpochResponse(Errors.NONE, epoch, OptionalInt.empty());
 
@@ -278,7 +281,8 @@ public class KafkaRaftClientTest {
 
         // One of the voters may have sent EndEpoch as a candidate because it
         // had not yet been notified that the local node was the leader.
-        deliverRequest(endEpochRequest(epoch, OptionalInt.empty(), voter2));
+        deliverRequest(endEpochRequest(epoch, OptionalInt.empty(), voter2, Arrays.asList(localId, voter3)));
+
         client.poll();
         assertSentEndQuorumEpochResponse(Errors.NONE, epoch, OptionalInt.of(localId));
 
@@ -300,7 +304,8 @@ public class KafkaRaftClientTest {
         quorumStateStore.writeElectionState(ElectionState.withVotedCandidate(epoch, otherNodeId, voters));
         KafkaRaftClient client = buildClient(voters);
 
-        deliverRequest(endEpochRequest(epoch, OptionalInt.empty(), otherNodeId));
+        deliverRequest(endEpochRequest(epoch, OptionalInt.empty(), otherNodeId, Collections.singletonList(localId)));
+
         client.poll();
         assertSentEndQuorumEpochResponse(Errors.NONE, epoch, OptionalInt.empty());
 
@@ -327,7 +332,8 @@ public class KafkaRaftClientTest {
         quorumStateStore.writeElectionState(ElectionState.withUnknownLeader(epoch, voters));
         KafkaRaftClient client = buildClient(voters);
 
-        deliverRequest(endEpochRequest(epoch, OptionalInt.of(voter2), voter2));
+        deliverRequest(endEpochRequest(epoch, OptionalInt.of(voter2), voter2, Arrays.asList(localId, voter3)));
+
         client.poll();
         assertSentEndQuorumEpochResponse(Errors.NONE, epoch, OptionalInt.of(voter2));
 
@@ -354,7 +360,7 @@ public class KafkaRaftClientTest {
 
         initializeVoterConnections(client, voters, leaderEpoch, OptionalInt.of(oldLeaderId));
 
-        deliverRequest(endEpochRequest(leaderEpoch, OptionalInt.of(oldLeaderId), oldLeaderId));
+        deliverRequest(endEpochRequest(leaderEpoch, OptionalInt.of(oldLeaderId), oldLeaderId, Collections.singletonList(localId)));
         client.poll();
         assertSentEndQuorumEpochResponse(Errors.NONE, leaderEpoch, OptionalInt.of(oldLeaderId));
 
@@ -363,6 +369,56 @@ public class KafkaRaftClientTest {
         pollUntilSend(client);
 
         assertSentVoteRequest(leaderEpoch + 1, 0, 0);
+
+        // Should have already done self-voting
+        assertEquals(ElectionState.withVotedCandidate(leaderEpoch + 1, localId, voters),
+            quorumStateStore.readElectionState());
+    }
+
+    @Test
+    public void testHandleEndQuorumRequestWithLowerPriorityToBecomeLeader() throws Exception {
+        int oldLeaderId = 1;
+        int leaderEpoch = 2;
+        int preferredNextLeader = 3;
+        Set<Integer> voters = Utils.mkSet(localId, oldLeaderId, preferredNextLeader);
+
+        quorumStateStore.writeElectionState(ElectionState.withElectedLeader(leaderEpoch, oldLeaderId, voters));
+
+        KafkaRaftClient client = buildClient(voters);
+
+        deliverRequest(endEpochRequest(leaderEpoch,
+            OptionalInt.of(oldLeaderId), oldLeaderId, Arrays.asList(preferredNextLeader, localId)));
+
+        pollUntilSend(client);
+
+        List<RaftMessage> sentMessages = channel.drainSendQueue();
+        assertEquals(2, sentMessages.size());
+
+        RaftMessage findQuorumMessage = getSentMessageByType(sentMessages, ApiKeys.FIND_QUORUM);
+        assertTrue(findQuorumMessage.data() instanceof FindQuorumRequestData);
+
+        FindQuorumRequestData findQuorumData = (FindQuorumRequestData) findQuorumMessage.data();
+        assertEquals(localId, findQuorumData.replicaId());
+        int findQuorumCorrelationId = findQuorumMessage.correlationId();
+
+        RaftMessage endQuorumMessage = getSentMessageByType(sentMessages, ApiKeys.END_QUORUM_EPOCH);
+        assertTrue(endQuorumMessage.data() instanceof EndQuorumEpochResponseData);
+
+        deliverResponse(findQuorumCorrelationId, -1, findQuorumResponse(OptionalInt.of(localId), leaderEpoch, voters));
+
+        // The election won't trigger by one round election jitter
+        time.sleep(electionJitterMs);
+
+        pollUntilSend(client);
+
+        assertSentFetchQuorumRecordsRequest(leaderEpoch, 0, 0);
+
+        time.sleep(electionJitterMs);
+
+        pollUntilSend(client);
+
+        List<RaftRequest.Outbound> voteRequests = collectVoteRequests(leaderEpoch + 1, 0, 0);
+        assertEquals(2, voteRequests.size());
 
         // Should have already done self-voting
         assertEquals(ElectionState.withVotedCandidate(leaderEpoch + 1, localId, voters),
@@ -550,6 +606,7 @@ public class KafkaRaftClientTest {
         Mockito.doReturn(jitterMs).when(random).nextInt(Mockito.anyInt());
 
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+
         KafkaRaftClient client = buildClient(voters);
         assertEquals(ElectionState.withVotedCandidate(epoch, localId, voters), quorumStateStore.readElectionState());
 
@@ -586,9 +643,12 @@ public class KafkaRaftClientTest {
     public void testInitializeAsFollowerEmptyLog() throws Exception {
         int otherNodeId = 1;
         int epoch = 5;
+
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId, voters));
+
         KafkaRaftClient client = buildClient(voters);
+
         assertEquals(ElectionState.withElectedLeader(epoch, otherNodeId, voters), quorumStateStore.readElectionState());
 
         initializeVoterConnections(client, voters, epoch, OptionalInt.of(otherNodeId));
@@ -605,6 +665,7 @@ public class KafkaRaftClientTest {
         int lastEpoch = 3;
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId, voters));
+
         log.appendAsLeader(Collections.singleton(new SimpleRecord("foo".getBytes())), lastEpoch);
 
         KafkaRaftClient client = buildClient(voters);
@@ -624,8 +685,10 @@ public class KafkaRaftClientTest {
         int otherNodeId = 1;
         int epoch = 5;
         int lastEpoch = 3;
+
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId, voters));
+
         log.appendAsLeader(Collections.singleton(new SimpleRecord("foo".getBytes())), lastEpoch);
 
         KafkaRaftClient client = buildClient(voters);
@@ -789,8 +852,10 @@ public class KafkaRaftClientTest {
         client.poll();
         assertSentBeginQuorumEpochResponse(Errors.INCONSISTENT_VOTER_SET, epoch, OptionalInt.of(localId));
 
-        deliverRequest(endEpochRequest(epoch, OptionalInt.of(localId), nonVoterId));
+        deliverRequest(endEpochRequest(epoch, OptionalInt.of(localId), nonVoterId, Collections.singletonList(otherNodeId)));
         client.poll();
+
+        // The sent request has no localId as a preferable voter.
         assertSentEndQuorumEpochResponse(Errors.INCONSISTENT_VOTER_SET, epoch, OptionalInt.of(localId));
     }
 
@@ -1132,13 +1197,82 @@ public class KafkaRaftClientTest {
         // Send EndQuorumEpoch request to the other vote
         client.poll();
         assertTrue(client.isRunning());
-        assertSentEndQuorumEpochRequest(1, OptionalInt.of(localId));
+
+        assertSentEndQuorumEpochRequest(1, OptionalInt.of(localId), otherNodeId);
 
         // Graceful shutdown completes when the epoch is bumped
         deliverRequest(voteRequest(2, otherNodeId, 0, 0L));
 
         client.poll();
         assertFalse(client.isRunning());
+    }
+
+    @Test
+    public void testEndQuorumEpochSentBasedOnFetchOffset() throws Exception {
+        int closeFollower = 2;
+        int laggingFollower = 1;
+        int epoch = 1;
+        Set<Integer> voters = Utils.mkSet(localId, closeFollower, laggingFollower);
+
+        // Bootstrap as the leader
+        quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, localId, voters));
+
+        KafkaRaftClient client = buildClient(voters);
+
+        pollUntilSend(client);
+
+        int findQuorumCorrelationId = assertSentFindQuorumRequest().correlationId;
+
+        deliverResponse(findQuorumCorrelationId, -1, findQuorumResponse(OptionalInt.of(localId), 1, voters));
+
+        // Accept connection information for followers
+        client.poll();
+
+        assertTrue(channel.drainSendQueue().isEmpty());
+
+        // Send out begin quorum to followers
+        client.poll();
+
+        List<RaftRequest.Outbound> beginEpochRequests = collectBeginEpochRequests(epoch);
+
+        assertEquals(2, beginEpochRequests.size());
+
+        for (RaftMessage message : beginEpochRequests) {
+            deliverResponse(message.correlationId(), ((RaftRequest.Outbound) message).destinationId(),
+                beginQuorumEpochResponse(epoch, localId));
+        }
+
+        // The lagging follower fetches first
+        deliverRequest(fetchQuorumRecordsRequest(1, laggingFollower, 0L, 0, 0));
+
+        client.poll();
+
+        assertSentFetchQuorumRecordsResponse(-1L, epoch);
+
+        // Append some records, so that the close follower will be able to advance further.
+        log.appendAsLeader(Utils.mkSet(new SimpleRecord("foo".getBytes()),
+            new SimpleRecord("bar".getBytes())), epoch);
+
+        deliverRequest(fetchQuorumRecordsRequest(epoch, closeFollower, 1L, epoch, 0));
+
+        client.poll();
+
+        assertSentFetchQuorumRecordsResponse(0L, epoch);
+
+        // Now shutdown
+        client.shutdown(electionTimeoutMs * 2);
+
+        // We should still be running until we have had a chance to send EndQuorumEpoch
+        assertTrue(client.isRunning());
+
+        // Send EndQuorumEpoch request to the close follower
+        client.poll();
+        assertTrue(client.isRunning());
+
+        List<RaftRequest.Outbound> endQuorumRequests =
+            collectEndQuorumRequests(1, OptionalInt.of(localId), Utils.mkSet(closeFollower, laggingFollower));
+
+        assertEquals(2, endQuorumRequests.size());
     }
 
     @Test
@@ -1169,7 +1303,8 @@ public class KafkaRaftClientTest {
         // Send EndQuorumEpoch request to the other vote
         client.poll();
         assertTrue(client.isRunning());
-        assertSentEndQuorumEpochRequest(1, OptionalInt.of(localId));
+
+        assertSentEndQuorumEpochRequest(1, OptionalInt.of(localId), otherNodeId);
 
         // The shutdown timeout is hit before we receive any requests or responses indicating an epoch bump
         time.sleep(shutdownTimeoutMs);
@@ -1182,9 +1317,11 @@ public class KafkaRaftClientTest {
     public void testFollowerGracefulShutdown() throws IOException {
         int otherNodeId = 1;
         int epoch = 5;
+
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId, voters));
         KafkaRaftClient client = buildClient(voters);
+
         assertEquals(ElectionState.withElectedLeader(epoch, otherNodeId, voters), quorumStateStore.readElectionState());
         assertTrue(stateMachine.isFollower());
         assertEquals(epoch, stateMachine.epoch());
@@ -1218,7 +1355,9 @@ public class KafkaRaftClientTest {
         int epoch = 5;
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId, voters));
+
         KafkaRaftClient client = buildClient(voters);
+
         assertEquals(ElectionState.withElectedLeader(epoch, otherNodeId, voters), quorumStateStore.readElectionState());
         assertTrue(stateMachine.isFollower());
         assertEquals(epoch, stateMachine.epoch());
@@ -1353,8 +1492,10 @@ public class KafkaRaftClientTest {
         int otherNodeId = 1;
         int epoch = 5;
         int lastEpoch = 3;
+
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId, voters));
+
         log.appendAsLeader(Arrays.asList(
                 new SimpleRecord("foo".getBytes()),
                 new SimpleRecord("bar".getBytes())), lastEpoch);
@@ -1477,19 +1618,30 @@ public class KafkaRaftClientTest {
         assertEquals(leaderId.orElse(-1), response.leaderId());
     }
 
-    private int assertSentEndQuorumEpochRequest(
-        int epoch,
-        OptionalInt leaderId
-    ) {
-        List<RaftRequest.Outbound> sentMessages = channel.drainSentRequests(ApiKeys.END_QUORUM_EPOCH);
-        assertEquals(1, sentMessages.size());
-        RaftRequest.Outbound raftMessage = sentMessages.get(0);
-        assertTrue(raftMessage.data() instanceof EndQuorumEpochRequestData);
-        EndQuorumEpochRequestData request = (EndQuorumEpochRequestData) raftMessage.data();
-        assertEquals(epoch, request.leaderEpoch());
-        assertEquals(leaderId.orElse(-1), request.leaderId());
-        assertEquals(localId, request.replicaId());
-        return raftMessage.correlationId();
+    private int assertSentEndQuorumEpochRequest(int epoch, OptionalInt leaderId, int destinationId) {
+        List<RaftRequest.Outbound> endQuorumRequests = collectEndQuorumRequests(
+            epoch, leaderId, Collections.singleton(destinationId));
+        assertEquals(1, endQuorumRequests.size());
+        return endQuorumRequests.get(0).correlationId();
+    }
+
+    private List<RaftRequest.Outbound> collectEndQuorumRequests(int epoch, OptionalInt leaderId, Set<Integer> destinationIdSet) {
+        List<RaftRequest.Outbound> endQuorumRequests = new ArrayList<>();
+        Set<Integer> collectedDestinationIdSet = new HashSet<>();
+        for (RaftMessage raftMessage : channel.drainSendQueue()) {
+            if (raftMessage.data() instanceof EndQuorumEpochRequestData) {
+                EndQuorumEpochRequestData request = (EndQuorumEpochRequestData) raftMessage.data();
+                assertEquals(epoch, request.leaderEpoch());
+                assertEquals(leaderId.orElse(-1), request.leaderId());
+                assertEquals(localId, request.replicaId());
+
+                RaftRequest.Outbound outboundRequest = (RaftRequest.Outbound) raftMessage;
+                collectedDestinationIdSet.add(outboundRequest.destinationId());
+                endQuorumRequests.add(outboundRequest);
+            }
+        }
+        assertEquals(destinationIdSet, collectedDestinationIdSet);
+        return endQuorumRequests;
     }
 
     private RaftRequest.Outbound assertSentFindQuorumRequest() {
@@ -1560,6 +1712,31 @@ public class KafkaRaftClientTest {
         return raftMessage.correlationId();
     }
 
+    private RaftMessage getSentMessageByType(List<RaftMessage> messages, ApiKeys key) {
+        for (RaftMessage message : messages) {
+            if (ApiKeys.forId(message.data().apiKey()) == key) {
+                return message;
+            }
+        }
+        fail("Didn't find expected message type " + key);
+        return null;
+    }
+
+    private void assertSentFetchQuorumRecordsResponse(
+        long highWatermark,
+        int lastFetchedEpoch) {
+        List<RaftMessage> sentMessages = channel.drainSendQueue();
+        assertEquals(1, sentMessages.size());
+        RaftMessage raftMessage = sentMessages.get(0);
+        assertTrue("Unexpected request type " + raftMessage.data(),
+            raftMessage.data() instanceof FetchQuorumRecordsResponseData);
+        FetchQuorumRecordsResponseData response = (FetchQuorumRecordsResponseData) raftMessage.data();
+
+        assertEquals(Errors.NONE, Errors.forCode(response.errorCode()));
+        assertEquals(lastFetchedEpoch, response.leaderEpoch());
+        assertEquals(highWatermark, response.highWatermark());
+    }
+
     private FetchQuorumRecordsResponseData fetchRecordsResponse(
         int epoch,
         int leaderId,
@@ -1614,11 +1791,16 @@ public class KafkaRaftClientTest {
             .setLeaderEpoch(epoch);
     }
 
-    private EndQuorumEpochRequestData endEpochRequest(int epoch, OptionalInt leaderId, int replicaId) {
+    private EndQuorumEpochRequestData endEpochRequest(
+        int epoch,
+        OptionalInt leaderId,
+        int replicaId,
+        List<Integer> preferredSuccessors) {
         return new EndQuorumEpochRequestData()
             .setLeaderId(leaderId.orElse(-1))
             .setLeaderEpoch(epoch)
-            .setReplicaId(replicaId);
+            .setReplicaId(replicaId)
+            .setPreferredSuccessors(preferredSuccessors);
     }
 
     private BeginQuorumEpochResponseData beginEpochResponse(int epoch, int leaderId) {
@@ -1662,6 +1844,12 @@ public class KafkaRaftClientTest {
             .setLastFetchedEpoch(lastFetchedEpoch)
             .setReplicaId(replicaId)
             .setMaxWaitTimeMs(maxWaitTimeMs);
+    }
+
+    private BeginQuorumEpochResponseData beginQuorumEpochResponse(int epoch, int leaderId) {
+        return new BeginQuorumEpochResponseData()
+                   .setLeaderEpoch(epoch)
+                   .setLeaderId(leaderId);
     }
 
     private void pollUntilSend(KafkaRaftClient client) throws InterruptedException {

--- a/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.OptionalLong;
 
@@ -119,4 +120,17 @@ public class LeaderStateTest {
         assertEquals(OptionalLong.of(20L), state.highWatermark());
     }
 
+    @Test
+    public void testGetNonLeaderFollowersByFetchOffsetDescending() {
+        int node1 = 1;
+        int node2 = 2;
+        LeaderState state = new LeaderState(localId, epoch, 10L, Utils.mkSet(localId, node1, node2));
+        state.updateLocalEndOffset(15L);
+        assertEquals(OptionalLong.empty(), state.highWatermark());
+        state.updateEndOffset(node1, 10L);
+        state.updateEndOffset(node2, 15L);
+
+        // Leader should not be included; the follower with larger offset should be prioritized.
+        assertEquals(Arrays.asList(node2, node1), state.nonLeaderVotersByDescendingFetchOffset());
+    }
 }


### PR DESCRIPTION
This PR attempts to make the EndEpoch logic smarter by always picking the most up-to-date follower to send the TimeOut signal to. It will wait for every election timeout and resend the request to the next up-to-date follower who hasn't been sent yet. So eventually when we run out of followers to send EndQuorum to, the finish timer times out and shutdown will be complete.

Quote Guozhang's idea here:

> Given that the motivation of EndQuorum is to shorten the timeout before election, maybe we can just do sth. like: say the fetch.timeout is X, and `election.timeout` is Y << X let the old leader send the EndQuorum to her “favorite” voter right away, while intentionally delaying the EndQuorum by Z where Y < Z < X to other voters, hoping that by then the favorite voter already successfully elected. In that case the EndQuorum to other voters would not trigger them to re-elect since the epoch is smaller than their known latest epoch; if the favorite voter has not successfully elected because itself is slow etc, then other voters may still have a chance to complete the election.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
