### PR TITLE
KCORE-403: Refactor Raft StateMachine API

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/RecordAppender.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RecordAppender.java
@@ -18,24 +18,19 @@ package org.apache.kafka.raft;
 
 import org.apache.kafka.common.record.Records;
 
-import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
-public interface RaftClient {
-
-    /**
-     * Initialize the state machine that will be used by this client. This should
-     * only be called once after creation and calls to {@link RecordAppender#append(Records)} should
-     * be made until this method returns.
-     *
-     * @param stateMachine The state machine implementation
-     * @throws IOException For any IO errors during initialization
-     */
-    void initialize(ReplicatedStateMachine stateMachine) throws IOException;
+public interface RecordAppender {
 
     /**
-     * Shutdown the client.
+     * Append a new entry to the log. The client must be in the leader state to
+     * accept an append: it is up to the {@link ReplicatedStateMachine} implementation
+     * to ensure this using {@link ReplicatedStateMachine#becomeLeader(int, RecordAppender)}.
      *
-     * @param timeoutMs How long to wait for graceful completion of pending operations.
+     * This method must be thread-safe.
+     *
+     * @param records The records to append to the log
+     * @return A future containing the base offset and epoch of the appended records (if successful)
      */
-    void shutdown(int timeoutMs);
+    CompletableFuture<OffsetAndEpoch> append(Records records);
 }

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedStateMachine.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedStateMachine.java
@@ -24,7 +24,15 @@ import org.apache.kafka.common.record.Records;
  * record appends will be routed to the leader, which will have an opportunity to either
  * accept or reject the append attempt.
  */
-public interface DistributedStateMachine {
+public interface ReplicatedStateMachine extends AutoCloseable {
+
+
+    /**
+     * Initialize the state machine.
+     *
+     * @param recordAppender handler for appending records.
+     */
+    void initialize(RecordAppender recordAppender);
 
     /**
      * Become a leader. This is invoked after a new election in the quorum if this
@@ -70,4 +78,11 @@ public interface DistributedStateMachine {
      * @return true if the records should be appended to the log
      */
     boolean accept(Records records);
+
+    /**
+     * Close the state machine.
+     */
+    @Override
+    default void close() {
+    }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -81,7 +81,7 @@ public class KafkaRaftClientTest {
     private final MockLog log = new MockLog();
     private final MockNetworkChannel channel = new MockNetworkChannel();
     private final Random random = Mockito.spy(new Random());
-    private final NoOpStateMachine stateMachine = new NoOpStateMachine();
+    private final MockStateMachine stateMachine = new MockStateMachine();
     private final QuorumStateStore quorumStateStore = new MockQuorumStateStore();
 
     @After
@@ -94,7 +94,7 @@ public class KafkaRaftClientTest {
     }
 
     private KafkaRaftClient buildClient(Set<Integer> voters) throws IOException {
-        return buildClient(voters, new NoOpStateMachine());
+        return buildClient(voters, new MockStateMachine());
     }
 
     private KafkaRaftClient buildClient(Set<Integer> voters, ReplicatedStateMachine stateMachine) throws IOException {
@@ -1325,7 +1325,7 @@ public class KafkaRaftClientTest {
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId));
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
 
-        NoOpStateMachine stateMachine = new NoOpStateMachine();
+        MockStateMachine stateMachine = new MockStateMachine();
         buildClient(voters, stateMachine);
         assertEquals(ElectionState.withElectedLeader(epoch, otherNodeId), quorumStateStore.readElectionState());
         assertTrue(stateMachine.isFollower());
@@ -1380,7 +1380,7 @@ public class KafkaRaftClientTest {
     public void testLeaderAppendSingleMemberQuorum() throws IOException {
         long now = time.milliseconds();
 
-        NoOpStateMachine stateMachine = new NoOpStateMachine();
+        MockStateMachine stateMachine = new MockStateMachine();
         KafkaRaftClient client = buildClient(Collections.singleton(localId), stateMachine);
         assertEquals(ElectionState.withElectedLeader(1, localId), quorumStateStore.readElectionState());
 

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.raft;
 
-import org.apache.kafka.common.errors.NotLeaderForPartitionException;
 import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.message.EndQuorumEpochRequestData;
@@ -67,6 +66,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class KafkaRaftClientTest {
@@ -94,6 +94,10 @@ public class KafkaRaftClientTest {
     }
 
     private KafkaRaftClient buildClient(Set<Integer> voters) throws IOException {
+        return buildClient(voters, new NoOpStateMachine());
+    }
+
+    private KafkaRaftClient buildClient(Set<Integer> voters, ReplicatedStateMachine stateMachine) throws IOException {
         LogContext logContext = new LogContext();
         QuorumState quorum = new QuorumState(localId, voters, quorumStateStore, logContext);
 
@@ -122,8 +126,7 @@ public class KafkaRaftClientTest {
         Set<Integer> voters = Utils.mkSet(localId, 1);
         int epoch = 2;
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, localId));
-        KafkaRaftClient client = buildClient(voters);
-        assertTrue(stateMachine.isLeader());
+        KafkaRaftClient client = buildClient(voters, stateMachine);
         assertEquals(epoch, stateMachine.epoch());
 
         assertEquals(1L, log.endOffset());
@@ -711,7 +714,7 @@ public class KafkaRaftClientTest {
         int epoch = 1;
         Set<Integer> voters = Utils.mkSet(localId, 1, 2, 3, 4);
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, localId));
-        KafkaRaftClient client = buildClient(voters);
+        KafkaRaftClient client = buildClient(voters, stateMachine);
 
         // Initialize ourselves as the leader
         assertEquals(ElectionState.withElectedLeader(epoch, localId), quorumStateStore.readElectionState());
@@ -891,7 +894,7 @@ public class KafkaRaftClientTest {
         int epoch = 5;
 
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = initializeAsLeader(voters, epoch);
+        KafkaRaftClient client = initializeAsLeader(voters, epoch, stateMachine);
 
         // Follower sends a fetch which cannot be satisfied immediately
         int maxWaitTimeMs = 500;
@@ -912,7 +915,7 @@ public class KafkaRaftClientTest {
         int epoch = 5;
 
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = initializeAsLeader(voters, epoch);
+        KafkaRaftClient client = initializeAsLeader(voters, epoch, stateMachine);
 
         // Follower sends a fetch which cannot be satisfied immediately
         deliverRequest(fetchQuorumRecordsRequest(epoch, otherNodeId, 1L, epoch, 500));
@@ -926,7 +929,7 @@ public class KafkaRaftClientTest {
             new SimpleRecord("c".getBytes())
         };
         Records records = MemoryRecords.withRecords(0L, CompressionType.NONE, 1, appendRecords);
-        CompletableFuture<OffsetAndEpoch> future = client.append(records);
+        CompletableFuture<OffsetAndEpoch> future = stateMachine.append(records);
         client.poll();
         assertTrue(future.isDone());
 
@@ -946,7 +949,7 @@ public class KafkaRaftClientTest {
         int epoch = 5;
 
         Set<Integer> voters = Utils.mkSet(voter1, voter2, voter3);
-        KafkaRaftClient client = initializeAsLeader(voters, epoch);
+        KafkaRaftClient client = initializeAsLeader(voters, epoch, stateMachine);
 
         // Follower sends a fetch which cannot be satisfied immediately
         deliverRequest(fetchQuorumRecordsRequest(epoch, voter2, 1L, epoch, 500));
@@ -968,9 +971,13 @@ public class KafkaRaftClientTest {
         assertEquals(0, fetchedRecords.sizeInBytes());
     }
 
-    private KafkaRaftClient initializeAsLeader(Set<Integer> voters, int epoch) throws Exception {
+    private KafkaRaftClient initializeAsLeader(
+        Set<Integer> voters,
+        int epoch,
+        ReplicatedStateMachine stateMachine
+    ) throws Exception {
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, localId));
-        KafkaRaftClient client = buildClient(voters);
+        KafkaRaftClient client = buildClient(voters, stateMachine);
         assertEquals(ElectionState.withElectedLeader(epoch, localId), quorumStateStore.readElectionState());
 
         // Handle FindQuorum
@@ -1255,7 +1262,7 @@ public class KafkaRaftClientTest {
         int otherNodeId = 1;
         int epoch = 5;
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId));
-        KafkaRaftClient client = buildClient(Utils.mkSet(localId, otherNodeId));
+        KafkaRaftClient client = buildClient(Utils.mkSet(localId, otherNodeId), stateMachine);
         assertEquals(ElectionState.withElectedLeader(epoch, otherNodeId), quorumStateStore.readElectionState());
         assertTrue(stateMachine.isFollower());
         assertEquals(epoch, stateMachine.epoch());
@@ -1288,7 +1295,7 @@ public class KafkaRaftClientTest {
         int epoch = 5;
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId));
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = buildClient(voters);
+        KafkaRaftClient client = buildClient(voters, stateMachine);
         assertEquals(ElectionState.withElectedLeader(epoch, otherNodeId), quorumStateStore.readElectionState());
         assertTrue(stateMachine.isFollower());
         assertEquals(epoch, stateMachine.epoch());
@@ -1317,7 +1324,9 @@ public class KafkaRaftClientTest {
         int epoch = 5;
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId));
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = buildClient(voters);
+
+        NoOpStateMachine stateMachine = new NoOpStateMachine();
+        buildClient(voters, stateMachine);
         assertEquals(ElectionState.withElectedLeader(epoch, otherNodeId), quorumStateStore.readElectionState());
         assertTrue(stateMachine.isFollower());
         assertEquals(epoch, stateMachine.epoch());
@@ -1329,11 +1338,7 @@ public class KafkaRaftClientTest {
         };
         Records records = MemoryRecords.withRecords(0L, CompressionType.NONE, 1, appendRecords);
 
-        CompletableFuture<OffsetAndEpoch> future = client.append(records);
-        client.poll();
-
-        assertTrue(future.isCompletedExceptionally());
-        TestUtils.assertFutureThrows(future, NotLeaderForPartitionException.class);
+        assertThrows(IllegalStateException.class, () -> stateMachine.append(records));
     }
 
     @Test
@@ -1375,7 +1380,8 @@ public class KafkaRaftClientTest {
     public void testLeaderAppendSingleMemberQuorum() throws IOException {
         long now = time.milliseconds();
 
-        KafkaRaftClient client = buildClient(Collections.singleton(localId));
+        NoOpStateMachine stateMachine = new NoOpStateMachine();
+        KafkaRaftClient client = buildClient(Collections.singleton(localId), stateMachine);
         assertEquals(ElectionState.withElectedLeader(1, localId), quorumStateStore.readElectionState());
 
         SimpleRecord[] appendRecords = new SimpleRecord[] {
@@ -1389,7 +1395,7 @@ public class KafkaRaftClientTest {
         client.poll();
         assertEquals(OptionalLong.of(0L), client.highWatermark());
 
-        client.append(records);
+        stateMachine.append(records);
 
         // Then poll the appended data with leader change record
         client.poll();

--- a/raft/src/test/java/org/apache/kafka/raft/MockStateMachine.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockStateMachine.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.record.Records;
 
 import java.util.concurrent.CompletableFuture;
 
-public class NoOpStateMachine implements ReplicatedStateMachine {
+public class MockStateMachine implements ReplicatedStateMachine {
     private OffsetAndEpoch position = new OffsetAndEpoch(0, 0);
 
     private RecordAppender recordAppender = null;

--- a/raft/src/test/java/org/apache/kafka/raft/NoOpStateMachine.java
+++ b/raft/src/test/java/org/apache/kafka/raft/NoOpStateMachine.java
@@ -19,37 +19,39 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.Records;
 
-public class NoOpStateMachine implements DistributedStateMachine {
+import java.util.concurrent.CompletableFuture;
+
+public class NoOpStateMachine implements ReplicatedStateMachine {
     private OffsetAndEpoch position = new OffsetAndEpoch(0, 0);
 
-    enum STATE {
-        INITIALIZING,
-        LEADER,
-        FOLLOWER
-    }
-
-    private STATE state = STATE.INITIALIZING;
+    private RecordAppender recordAppender = null;
 
     private int epoch = -1;
+    private boolean isLeader = false;
+
+    boolean isLeader() {
+        return isLeader;
+    }
+
+    boolean isFollower() {
+        return !isLeader;
+    }
+
+    @Override
+    public void initialize(RecordAppender recordAppender) {
+        this.recordAppender = recordAppender;
+    }
 
     @Override
     public void becomeLeader(int epoch) {
         this.epoch = epoch;
-        state = STATE.LEADER;
+        this.isLeader = true;
     }
 
     @Override
     public void becomeFollower(int epoch) {
         this.epoch = epoch;
-        state = STATE.FOLLOWER;
-    }
-
-    boolean isLeader() {
-        return state == STATE.LEADER;
-    }
-
-    boolean isFollower() {
-        return state == STATE.FOLLOWER;
+        this.isLeader = false;
     }
 
     @Override
@@ -69,8 +71,23 @@ public class NoOpStateMachine implements DistributedStateMachine {
         return true;
     }
 
+    CompletableFuture<OffsetAndEpoch> append(Records records) {
+        if (recordAppender == null) {
+            throw new IllegalStateException("Record appender is not set");
+        }
+        if (!isLeader) {
+            throw new IllegalStateException("The raft client is not leader yet");
+        }
+        return recordAppender.append(records);
+    }
+
+    @Override
+    public void close() {
+        clear();
+    }
+
     void clear() {
-        state = STATE.INITIALIZING;
+        isLeader = false;
         epoch = -1;
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -652,7 +652,7 @@ public class RaftEventSimulationTest {
         final MockQuorumStateStore store;
         final QuorumState quorum;
         final LogContext logContext;
-        DistributedCounter counter;
+        ReplicatedCounter counter;
 
         private RaftNode(int nodeId,
                          KafkaRaftClient client,
@@ -671,9 +671,9 @@ public class RaftEventSimulationTest {
         }
 
         void initialize() {
-            this.counter = new DistributedCounter(client, logContext);
+            this.counter = new ReplicatedCounter(nodeId, logContext);
             try {
-                counter.initialize();
+                client.initialize(counter);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
This PR addresses some of the suggested improvements from KCORE-403, including:

1. Rename `DistributedStateMachine` to `ReplicatedStateMachine`
2. Make StateMachine interface extends `AutoClosable`
3. Get a separate `RecordAppender` interface to decouple the circular dependency between state machine and raft client

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
