### PR TITLE
KCORE-368; Add basic purgatory for quorum fetches

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -36,7 +36,7 @@
               files="KerberosLogin.java|RequestResponseTest.java|ConnectMetricsRegistry.java|KafkaConsumer.java"/>
 
     <suppress checks="ParameterNumber"
-              files="NetworkClient.java|FieldSpec.java"/>
+              files="(NetworkClient|FieldSpec|KafkaRaftClient).java"/>
     <suppress checks="ParameterNumber"
               files="KafkaConsumer.java"/>
     <suppress checks="ParameterNumber"

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1046,6 +1046,10 @@ public final class Utils {
         }
     }
 
+    public static <T> List<T> toList(Iterable<T> iterable) {
+        return toList(iterable.iterator());
+    }
+
     public static <T> List<T> toList(Iterator<T> iterator) {
         List<T> res = new ArrayList<>();
         while (iterator.hasNext())

--- a/clients/src/main/resources/common/message/FetchQuorumRecordsRequest.json
+++ b/clients/src/main/resources/common/message/FetchQuorumRecordsRequest.json
@@ -28,6 +28,8 @@
     {"name": "FetchOffset", "type": "int64", "versions": "0+",
       "about": "The next expected offset to be replicated"},
     {"name": "LastFetchedEpoch", "type": "int32", "versions": "0+",
-      "about": "The epoch of the last replicated record"}
+      "about": "The epoch of the last replicated record"},
+    {"name":  "MaxWaitTimeMs", "type":  "int32", "versions": "0+",
+      "about": "The maximum time to wait for new data to arrive" }
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/MockScheduler.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/MockScheduler.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
-public class MockScheduler implements Scheduler, MockTime.MockTimeListener {
+public class MockScheduler implements Scheduler, MockTime.Listener {
     private static final Logger log = LoggerFactory.getLogger(MockScheduler.class);
 
     /**
@@ -53,7 +53,7 @@ public class MockScheduler implements Scheduler, MockTime.MockTimeListener {
     }
 
     @Override
-    public synchronized void tick() {
+    public synchronized void onTimeUpdated() {
         long timeMs = time.milliseconds();
         while (true) {
             Map.Entry<Long, List<KafkaFutureImpl<Long>>> entry = waiters.firstEntry();

--- a/clients/src/test/java/org/apache/kafka/common/utils/MockTime.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/MockTime.java
@@ -28,14 +28,14 @@ import java.util.function.Supplier;
  */
 public class MockTime implements Time {
 
-    interface MockTimeListener {
-        void tick();
+    public interface Listener {
+        void onTimeUpdated();
     }
 
     /**
      * Listeners which are waiting for time changes.
      */
-    private final CopyOnWriteArrayList<MockTimeListener> listeners = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<Listener> listeners = new CopyOnWriteArrayList<>();
 
     private final long autoTickMs;
 
@@ -58,7 +58,7 @@ public class MockTime implements Time {
         this.autoTickMs = autoTickMs;
     }
 
-    public void addListener(MockTimeListener listener) {
+    public void addListener(Listener listener) {
         listeners.add(listener);
     }
 
@@ -88,7 +88,7 @@ public class MockTime implements Time {
 
     @Override
     public void waitObject(Object obj, Supplier<Boolean> condition, long deadlineMs) throws InterruptedException {
-        MockTimeListener listener = () -> {
+        Listener listener = () -> {
             synchronized (obj) {
                 obj.notify();
             }
@@ -119,8 +119,8 @@ public class MockTime implements Time {
     }
 
     private void tick() {
-        for (MockTimeListener listener : listeners) {
-            listener.tick();
+        for (Listener listener : listeners) {
+            listener.onTimeUpdated();
         }
     }
 }

--- a/core/src/main/scala/kafka/raft/KafkaFuturePurgatory.scala
+++ b/core/src/main/scala/kafka/raft/KafkaFuturePurgatory.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.raft
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
+
+import kafka.server.{DelayedOperation, DelayedOperationPurgatory}
+import kafka.utils.Logging
+import kafka.utils.timer.Timer
+import org.apache.kafka.common.errors.TimeoutException
+import org.apache.kafka.raft.FuturePurgatory
+
+/**
+ * Simple purgatory shim for integration with the Raft library. We assume that
+ * both [[await()]] and [[completeAll()]] are called in the same thread.
+ */
+class KafkaFuturePurgatory(brokerId: Int, timer: Timer, reaperEnabled: Boolean = true)
+  extends FuturePurgatory[Unit] with Logging {
+
+  private val key = new Object()
+  private val purgatory = new DelayedOperationPurgatory[DelayedRaftRequest](
+    "raft-request-purgatory", timer, brokerId, reaperEnabled = reaperEnabled)
+
+  override def await(future: CompletableFuture[Unit], maxWaitTimeMs: Long): Unit = {
+    val op = new DelayedRaftRequest(future, maxWaitTimeMs)
+    purgatory.tryCompleteElseWatch(op, Seq(key))
+    op.isCompletable.set(true)
+  }
+
+  override def completeAll(value: Unit): Unit = {
+    purgatory.checkAndComplete(key)
+  }
+
+  override def numWaiting(): Int = {
+    purgatory.numDelayed
+  }
+}
+
+class DelayedRaftRequest(future: CompletableFuture[Unit], delayMs: Long)
+  extends DelayedOperation(delayMs) {
+
+  val isCompletable = new AtomicBoolean(false)
+  val isExpired = new AtomicBoolean(false)
+
+  override def onExpiration(): Unit = {}
+
+  override def onComplete(): Unit = {
+    if (isExpired.get())
+      future.completeExceptionally(new TimeoutException("Request timed out in purgatory"))
+    else
+      future.complete(())
+  }
+
+  override def tryComplete(): Boolean = {
+    isCompletable.get() && forceComplete()
+  }
+
+  override def run(): Unit = {
+    isExpired.set(true)
+    super.run()
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/raft/KafkaFuturePurgatoryTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaFuturePurgatoryTest.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package unit.kafka.raft
+
+import java.util.concurrent.CompletableFuture
+
+import kafka.raft.KafkaFuturePurgatory
+import kafka.utils.timer.MockTimer
+import org.apache.kafka.common.errors.TimeoutException
+import org.apache.kafka.test.TestUtils
+import org.junit.Assert._
+import org.junit.Test
+
+class KafkaFuturePurgatoryTest {
+
+  @Test
+  def testExpiration(): Unit = {
+    val brokerId = 0
+    val timer = new MockTimer()
+    val purgatory = new KafkaFuturePurgatory(brokerId, timer, reaperEnabled = false)
+    assertEquals(0, purgatory.numWaiting())
+
+    val future1 = new CompletableFuture[Unit]()
+    purgatory.await(future1, 500)
+    assertEquals(1, purgatory.numWaiting())
+
+    val future2 = new CompletableFuture[Unit]()
+    purgatory.await(future2, 500)
+    assertEquals(2, purgatory.numWaiting())
+
+    val future3 = new CompletableFuture[Unit]()
+    purgatory.await(future3, 1000)
+    assertEquals(3, purgatory.numWaiting())
+
+    timer.advanceClock(501)
+    assertEquals(1, purgatory.numWaiting())
+    TestUtils.assertFutureThrows(future1, classOf[TimeoutException])
+    TestUtils.assertFutureThrows(future2, classOf[TimeoutException])
+
+    timer.advanceClock(500)
+    assertEquals(0, purgatory.numWaiting())
+    TestUtils.assertFutureThrows(future3, classOf[TimeoutException])
+  }
+
+  @Test
+  def testCompletion(): Unit = {
+    val brokerId = 0
+    val timer = new MockTimer()
+    val purgatory = new KafkaFuturePurgatory(brokerId, timer, reaperEnabled = false)
+    assertEquals(0, purgatory.numWaiting())
+
+    val future1 = new CompletableFuture[Unit]()
+    purgatory.await(future1, 500)
+    assertEquals(1, purgatory.numWaiting())
+
+    val future2 = new CompletableFuture[Unit]()
+    purgatory.await(future2, 500)
+    assertEquals(2, purgatory.numWaiting())
+
+    val future3 = new CompletableFuture[Unit]()
+    purgatory.await(future3, 1000)
+    assertEquals(3, purgatory.numWaiting())
+
+    purgatory.completeAll(())
+    assertTrue(future1.isDone)
+    assertEquals((), future1.get())
+
+    assertTrue(future2.isDone)
+    assertEquals((), future2.get())
+
+    assertTrue(future3.isDone)
+    assertEquals((), future3.get())
+  }
+
+}

--- a/raft/src/main/java/org/apache/kafka/raft/FuturePurgatory.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FuturePurgatory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Simple purgatory interface which allows tracking a set of expirable futures.
+ *
+ * @param <T> Type completion type
+ */
+public interface FuturePurgatory<T> {
+
+    /**
+     * Add a future to this purgatory for tracking.
+     *
+     * @param future the future tracking the expected completion. A subsequent call
+     *               to {@link #completeAll(Object)} will complete this future
+     *               if it does not expire first.
+     * @param maxWaitTimeMs the maximum time to wait for completion. If this
+     *               timeout is reached, then the future will be completed exceptionally
+     *               with a {@link org.apache.kafka.common.errors.TimeoutException}
+     */
+    void await(CompletableFuture<T> future, long maxWaitTimeMs);
+
+    /**
+     * Complete all awaiting futures. The completion callbacks will be triggered
+     * from the calling thread.
+     *
+     * @param value the value that will be passed to {@link CompletableFuture#complete(Object)}
+     *              when the futures are completed
+     */
+    void completeAll(T value);
+
+    /**
+     * The number of currently waiting futures.
+     *
+     * @return the n
+     */
+    int numWaiting();
+
+}

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -141,6 +141,13 @@ public class LeaderState implements EpochState {
         return state;
     }
 
+    /**
+     * Update the local end offset after a log append to the leader. Return true if this
+     * update results in a bump to the high watermark.
+     *
+     * @param endOffset The new log end offset
+     * @return true if the high watermark increased, false otherwise
+     */
     public boolean updateLocalEndOffset(long endOffset) {
         return updateEndOffset(localId, endOffset);
     }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -16,12 +16,21 @@
  */
 package org.apache.kafka.raft;
 
+import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
+import org.apache.kafka.common.message.EndQuorumEpochResponseData;
+import org.apache.kafka.common.message.FetchQuorumRecordsResponseData;
+import org.apache.kafka.common.message.FindQuorumResponseData;
+import org.apache.kafka.common.message.VoteResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Records;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.OptionalInt;
 
 public class RaftUtil {
 
@@ -36,6 +45,51 @@ public class RaftUtil {
             return buffer;
         } else {
             throw new UnsupportedOperationException("Serialization not yet supported for " + records.getClass());
+        }
+    }
+
+    public static ApiMessage errorResponse(ApiKeys apiKey, Errors error) {
+        return errorResponse(apiKey, error, 0, OptionalInt.empty());
+    }
+
+    public static ApiMessage errorResponse(
+        ApiKeys apiKey,
+        Errors error,
+        int epoch,
+        OptionalInt leaderIdOpt
+    ) {
+        int leaderId = leaderIdOpt.orElse(-1);
+        switch (apiKey) {
+            case VOTE:
+                return new VoteResponseData()
+                    .setErrorCode(error.code())
+                    .setVoteGranted(false)
+                    .setLeaderEpoch(epoch)
+                    .setLeaderId(leaderId);
+            case BEGIN_QUORUM_EPOCH:
+                return new BeginQuorumEpochResponseData()
+                    .setErrorCode(error.code())
+                    .setLeaderEpoch(epoch)
+                    .setLeaderId(leaderId);
+            case END_QUORUM_EPOCH:
+                return new EndQuorumEpochResponseData()
+                    .setErrorCode(error.code())
+                    .setLeaderEpoch(epoch)
+                    .setLeaderId(leaderId);
+            case FETCH_QUORUM_RECORDS:
+                return new FetchQuorumRecordsResponseData()
+                    .setErrorCode(error.code())
+                    .setLeaderEpoch(epoch)
+                    .setLeaderId(leaderId)
+                    .setHighWatermark(-1)
+                    .setRecords(ByteBuffer.wrap(new byte[0]));
+            case FIND_QUORUM:
+                return new FindQuorumResponseData()
+                    .setErrorCode(error.code())
+                    .setLeaderEpoch(leaderId)
+                    .setLeaderId(epoch);
+            default:
+                throw new IllegalArgumentException("Received response for unexpected request type: " + apiKey);
         }
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/MockFuturePurgatory.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockFuturePurgatory.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.utils.MockTime;
+
+import java.util.PriorityQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MockFuturePurgatory<T> implements FuturePurgatory<T>, MockTime.Listener {
+    private final AtomicLong idGenerator = new AtomicLong(1L);
+    private final MockTime time;
+    private final PriorityQueue<DelayedFuture> delayedFutures = new PriorityQueue<>();
+
+    public MockFuturePurgatory(MockTime time) {
+        this.time = time;
+        time.addListener(this);
+    }
+
+    @Override
+    public void await(
+        CompletableFuture<T> future,
+        long maxWaitTimeMs
+    ) {
+        long id = idGenerator.getAndIncrement();
+        long expirationTimeMs = time.milliseconds() + maxWaitTimeMs;
+        delayedFutures.add(new DelayedFuture(id, expirationTimeMs, future));
+    }
+
+    @Override
+    public void completeAll(T value) {
+        while (!delayedFutures.isEmpty()) {
+            DelayedFuture delayedFuture = delayedFutures.poll();
+            delayedFuture.future.complete(value);
+        }
+    }
+
+    @Override
+    public int numWaiting() {
+        return delayedFutures.size();
+    }
+
+    @Override
+    public void onTimeUpdated() {
+        while (true) {
+            DelayedFuture delayedFuture = delayedFutures.peek();
+            if (delayedFuture == null || time.milliseconds() < delayedFuture.expirationTime) {
+                return;
+            } else {
+                delayedFutures.poll();
+
+                if (!delayedFuture.future.isDone()) {
+                    delayedFuture.future.completeExceptionally(new TimeoutException());
+                }
+            }
+        }
+    }
+
+    private class DelayedFuture implements Comparable<DelayedFuture> {
+        private final long id;
+        private final long expirationTime;
+        private final CompletableFuture<T> future;
+
+        private DelayedFuture(
+            long id,
+            long expirationTime,
+            CompletableFuture<T> future
+        ) {
+            this.id = id;
+            this.expirationTime = expirationTime;
+            this.future = future;
+        }
+
+        @Override
+        public int compareTo(DelayedFuture o) {
+            int compare = Long.compare(expirationTime, o.expirationTime);
+            if (compare != 0)
+                return compare;
+            return Long.compare(id, o.id);
+        }
+    }
+}

--- a/raft/src/test/java/org/apache/kafka/raft/MockFuturePurgatoryTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockFuturePurgatoryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.utils.MockTime;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.kafka.test.TestUtils.assertFutureThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MockFuturePurgatoryTest {
+    private final MockTime time = new MockTime();
+    private final MockFuturePurgatory<Long> purgatory = new MockFuturePurgatory<>(time);
+
+    @Test
+    public void testCompletion() throws Exception {
+        CompletableFuture<Long> future1 = new CompletableFuture<>();
+        purgatory.await(future1, 500L);
+        assertEquals(1, purgatory.numWaiting());
+
+        CompletableFuture<Long> future2 = new CompletableFuture<>();
+        purgatory.await(future2, 1000L);
+        assertEquals(2, purgatory.numWaiting());
+
+        purgatory.completeAll(1L);
+        assertEquals(0, purgatory.numWaiting());
+        assertTrue(future1.isDone());
+        assertEquals(1L, future1.get().longValue());
+        assertTrue(future2.isDone());
+        assertEquals(1L, future2.get().longValue());
+    }
+
+    @Test
+    public void testExpiration() {
+        CompletableFuture<Long> future1 = new CompletableFuture<>();
+        purgatory.await(future1, 500L);
+
+        CompletableFuture<Long> future2 = new CompletableFuture<>();
+        purgatory.await(future2, 500L);
+
+        CompletableFuture<Long> future3 = new CompletableFuture<>();
+        purgatory.await(future3, 1000L);
+
+        assertEquals(3, purgatory.numWaiting());
+
+        time.sleep(500);
+        assertTrue(future1.isDone());
+        assertFutureThrows(future1, TimeoutException.class);
+
+        assertTrue(future2.isDone());
+        assertFutureThrows(future2, TimeoutException.class);
+
+        assertEquals(1, purgatory.numWaiting());
+
+        time.sleep(500);
+        assertTrue(future3.isDone());
+        assertFutureThrows(future3, TimeoutException.class);
+        assertEquals(0, purgatory.numWaiting());
+    }
+
+}

--- a/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
@@ -42,9 +41,11 @@ public class SimpleKeyValueStoreTest {
         int fetchTimeoutMs = 5000;
         int retryBackoffMs = 100;
         int requestTimeoutMs = 5000;
+        int fetchMaxWaitMs = 500;
         Set<Integer> voters = Collections.singleton(localId);
         QuorumStateStore store = new MockQuorumStateStore();
-        Time time = new MockTime();
+        MockTime time = new MockTime();
+        MockFuturePurgatory<Void> purgatory = new MockFuturePurgatory<>(time);
         ReplicatedLog log = new MockLog();
         NetworkChannel channel = new MockNetworkChannel();
         LogContext logContext = new LogContext();
@@ -54,10 +55,10 @@ public class SimpleKeyValueStoreTest {
             .map(id -> new InetSocketAddress("localhost", 9990 + id))
             .collect(Collectors.toList());
 
-        return new KafkaRaftClient(channel, log, quorum, time,
+        return new KafkaRaftClient(channel, log, quorum, time, purgatory,
             new InetSocketAddress("localhost", 9990 + localId), bootstrapServers,
             electionTimeoutMs, electionJitterMs, fetchTimeoutMs, retryBackoffMs, requestTimeoutMs,
-            logContext, new Random());
+            fetchMaxWaitMs, logContext, new Random());
     }
 
     @Test


### PR DESCRIPTION
This patch adds a simple purgatory interface and integration with Kafka's `DelayedOperationPurgatory`. For the moment, we only support max wait time, which has been added to the `FetchQuorumRecords` request schema.

Note that this patch is piggy-backed on #319. The most-recent commit is the one that should be reviewed here. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
