### PR TITLE
KCORE-353: Leader progress timeout

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
@@ -110,6 +110,19 @@ public class Timer {
     }
 
     /**
+     * Reset the timer's deadline directly.
+     *
+     * @param deadlineMs The new deadline in milliseconds
+     */
+    public void resetDeadline(long deadlineMs) {
+        if (deadlineMs < 0)
+            throw new IllegalArgumentException("Invalid negative deadline " + deadlineMs);
+
+        this.startMs = this.currentTimeMs;
+        this.deadlineMs = deadlineMs;
+    }
+
+    /**
      * Use the underlying {@link Time} implementation to update the current cached time. If
      * the underlying time returns a value which is smaller than the current cached time,
      * the update will be ignored.

--- a/clients/src/test/java/org/apache/kafka/common/utils/TimerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/TimerTest.java
@@ -91,6 +91,21 @@ public class TimerTest {
     }
 
     @Test
+    public void testTimerResetDeadlineUsesCurrentTime() {
+        Timer timer = time.timer(500);
+        timer.sleep(200);
+        assertEquals(300, timer.remainingMs());
+        assertEquals(200, timer.elapsedMs());
+
+        timer.sleep(100);
+        timer.resetDeadline(time.milliseconds() + 200);
+        assertEquals(200, timer.remainingMs());
+
+        timer.update();
+        assertEquals(200, timer.remainingMs());
+    }
+
+    @Test
     public void testTimeoutOverflow() {
         Timer timer = time.timer(Long.MAX_VALUE);
         assertEquals(Long.MAX_VALUE - timer.currentTimeMs(), timer.remainingMs());

--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -122,7 +122,7 @@ public class FollowerState implements EpochState {
 
     public int votedId() {
         if (!votedIdOpt.isPresent()) {
-            throw new IllegalArgumentException("Cannot access leaderId of epoch " + epoch +
+            throw new IllegalArgumentException("Cannot access voted id of epoch " + epoch +
                     " since we do not know it");
         }
         return votedIdOpt.getAsInt();

--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -120,6 +120,14 @@ public class FollowerState implements EpochState {
         return votedIdOpt.orElse(-1) == candidateId;
     }
 
+    public int votedId() {
+        if (!votedIdOpt.isPresent()) {
+            throw new IllegalArgumentException("Cannot access leaderId of epoch " + epoch +
+                    " since we do not know it");
+        }
+        return votedIdOpt.getAsInt();
+    }
+
     public void updateHighWatermark(OptionalLong highWatermark) {
         if (!hasLeader())
             throw new IllegalArgumentException("Cannot update high watermark without an acknowledged leader");

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -190,7 +190,7 @@ public class KafkaRaftClient implements RaftClient {
             applyCommittedRecordsToStateMachine();
         }
 
-        maybeUpdateFetchTimerWithRemoteFetchTimestamp(state, state.localId(), time.milliseconds());
+        maybeUpdateFetchTimerWithRemoteFetchTimestamp(state, state.localId());
     }
 
     private void updateReplicaEndOffset(LeaderState state, int replicaId, long endOffset) {
@@ -201,10 +201,11 @@ public class KafkaRaftClient implements RaftClient {
         }
 
         // maybe extend the fetch timer with the majority of voter-fetching timestamps
-        maybeUpdateFetchTimerWithRemoteFetchTimestamp(state, replicaId, time.milliseconds());
+        maybeUpdateFetchTimerWithRemoteFetchTimestamp(state, replicaId);
     }
 
-    private void maybeUpdateFetchTimerWithRemoteFetchTimestamp(LeaderState state, int replicaId, long timestamp) {
+    private void maybeUpdateFetchTimerWithRemoteFetchTimestamp(LeaderState state, int replicaId) {
+        final long timestamp = time.milliseconds();
         final OptionalLong lastFetchTimestamp = state.updateFetchTimestamp(replicaId, timestamp);
         if (lastFetchTimestamp.isPresent()) {
             timer.resetDeadline(lastFetchTimestamp.getAsLong() + fetchTimeoutMs);

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -290,12 +290,13 @@ public class KafkaRaftClient implements RaftClient {
             if (quorum.isVoter()) {
                 timer.reset(electionTimeoutMs + randomElectionJitterMs());
             }
+            // if we are observer, do not reset fetch timer so that we will still find-quorum in time
         }
     }
 
     private void becomeVotedFollower(int candidateId, int epoch) throws IOException {
         if (quorum.becomeVotedFollower(epoch, candidateId)) {
-            timer.reset(electionTimeoutMs);
+            timer.reset(electionTimeoutMs + randomElectionJitterMs());
             resetConnections();
         }
     }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -42,6 +42,11 @@ public class RaftConfig extends AbstractConfig {
     private static final String QUORUM_ELECTION_TIMEOUT_MS_DOC = "Maximum time in milliseconds to wait " +
         "without being able to fetch from the leader before triggering a new election";
 
+    public static final String QUORUM_FETCH_TIMEOUT_MS_CONFIG = "quorum.fetch.timeout.ms";
+    private static final String QUORUM_FETCH_TIMEOUT_MS_DOC = "Maximum time without a successful fetch from " +
+        "the current leader before becoming a candidate and triggering a election for voters; Maximum time without " +
+        "receiving fetch from a majority of the quorum before asking around to see if there's a new epoch for leader";
+
     public static final String QUORUM_ELECTION_JITTER_MAX_MS_CONFIG = "quorum.election.jitter.max.ms";
     private static final String QUORUM_ELECTION_JITTER_MAX_MS_DOC = "Maximum jitter to delay new elections. " +
         "This helps prevent gridlocked elections";
@@ -75,15 +80,21 @@ public class RaftConfig extends AbstractConfig {
             .define(QUORUM_ELECTION_TIMEOUT_MS_CONFIG,
                 ConfigDef.Type.INT,
                 30000,
-                atLeast(0L),
+                atLeast(0),
                 ConfigDef.Importance.HIGH,
                 QUORUM_ELECTION_TIMEOUT_MS_DOC)
             .define(QUORUM_ELECTION_JITTER_MAX_MS_CONFIG,
                 ConfigDef.Type.INT,
                 100,
-                atLeast(0L),
+                atLeast(0),
                 ConfigDef.Importance.HIGH,
-                QUORUM_ELECTION_JITTER_MAX_MS_DOC);
+                QUORUM_ELECTION_JITTER_MAX_MS_DOC)
+            .define(QUORUM_FETCH_TIMEOUT_MS_CONFIG,
+                ConfigDef.Type.INT,
+                15000,
+                atLeast(0),
+                ConfigDef.Importance.HIGH,
+                QUORUM_FETCH_TIMEOUT_MS_DOC);
     }
 
 

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -780,7 +780,7 @@ public class KafkaRaftClientTest {
     }
 
     @Test
-    public void testLeaderFindQuorumAfterMajorityFetchTimeout() throws IOException {
+    public void testLeaderFindQuorumAfterMajorityFetchTimeout() throws IOException, InterruptedException {
         int epoch = 1;
         Set<Integer> voters = Utils.mkSet(localId, 1, 2, 3, 4);
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, localId));
@@ -797,8 +797,7 @@ public class KafkaRaftClientTest {
                 findQuorumResponse(OptionalInt.of(localId), epoch, voters), -1));
 
         // first update the connection, and then sent the begin-quorum requests
-        client.poll();
-        client.poll();
+        pollUntilSend(client);
         assertEquals(4, channel.drainSendQueue().size());
 
         time.sleep(1L);

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -67,9 +67,10 @@ import static org.junit.Assert.assertTrue;
 public class KafkaRaftClientTest {
     private final int localId = 0;
     private final int electionTimeoutMs = 10000;
+    private final int electionJitterMs = 100;
+    private final int fetchTimeoutMs = 5000;
     private final int retryBackoffMs = 50;
     private final int requestTimeoutMs = 5000;
-    private final int electionJitterMs = 100;
     private final MockTime time = new MockTime();
     private final MockLog log = new MockLog();
     private final MockNetworkChannel channel = new MockNetworkChannel();
@@ -96,7 +97,7 @@ public class KafkaRaftClientTest {
 
         KafkaRaftClient client = new KafkaRaftClient(channel, log, quorum, time,
             mockAddress(localId), bootstrapServers, electionTimeoutMs, electionJitterMs,
-            retryBackoffMs, requestTimeoutMs, logContext, random);
+                fetchTimeoutMs, retryBackoffMs, requestTimeoutMs, logContext, random);
         client.initialize(new NoOpStateMachine());
         return client;
     }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -54,6 +54,7 @@ import static org.junit.Assume.assumeTrue;
 public class RaftEventSimulationTest {
     private static final int ELECTION_TIMEOUT_MS = 1000;
     private static final int ELECTION_JITTER_MS = 10;
+    private static final int FETCH_TIMEOUT_MS = 1000;
     private static final int RETRY_BACKOFF_MS = 50;
     private static final int REQUEST_TIMEOUT_MS = 500;
 
@@ -509,7 +510,7 @@ public class RaftEventSimulationTest {
             Optional<RaftNode> leaderWithMaxEpoch = running.values().stream().filter(node -> node.quorum.isLeader())
                     .max((node1, node2) -> Integer.compare(node2.quorum.epoch(), node1.quorum.epoch()));
             if (leaderWithMaxEpoch.isPresent()) {
-                return leaderWithMaxEpoch.get().manager.highWatermark();
+                return leaderWithMaxEpoch.get().client.highWatermark();
             } else {
                 return OptionalLong.empty();
             }
@@ -632,7 +633,7 @@ public class RaftEventSimulationTest {
 
             KafkaRaftClient client = new KafkaRaftClient(channel, persistentState.log, quorum, time,
                 new InetSocketAddress("localhost", 9990 + nodeId), bootstrapServers,
-                ELECTION_TIMEOUT_MS, ELECTION_JITTER_MS, RETRY_BACKOFF_MS, REQUEST_TIMEOUT_MS,
+                ELECTION_TIMEOUT_MS, ELECTION_JITTER_MS, FETCH_TIMEOUT_MS, RETRY_BACKOFF_MS, REQUEST_TIMEOUT_MS,
                 logContext, random);
             RaftNode node = new RaftNode(nodeId, client, persistentState.log, channel,
                     persistentState.store, quorum, logContext);
@@ -643,7 +644,7 @@ public class RaftEventSimulationTest {
 
     private static class RaftNode {
         final int nodeId;
-        final KafkaRaftClient manager;
+        final KafkaRaftClient client;
         final MockLog log;
         final MockNetworkChannel channel;
         final MockQuorumStateStore store;
@@ -652,14 +653,14 @@ public class RaftEventSimulationTest {
         DistributedCounter counter;
 
         private RaftNode(int nodeId,
-                         KafkaRaftClient manager,
+                         KafkaRaftClient client,
                          MockLog log,
                          MockNetworkChannel channel,
                          MockQuorumStateStore store,
                          QuorumState quorum,
                          LogContext logContext) {
             this.nodeId = nodeId;
-            this.manager = manager;
+            this.client = client;
             this.log = log;
             this.channel = channel;
             this.store = store;
@@ -668,7 +669,7 @@ public class RaftEventSimulationTest {
         }
 
         void initialize() {
-            this.counter = new DistributedCounter(manager, logContext);
+            this.counter = new DistributedCounter(client, logContext);
             try {
                 counter.initialize();
             } catch (IOException e) {
@@ -678,7 +679,7 @@ public class RaftEventSimulationTest {
 
         void poll() {
             try {
-                manager.poll();
+                client.poll();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -861,7 +862,7 @@ public class RaftEventSimulationTest {
 
         @Override
         public void verify() {
-            cluster.forAllRunning(node -> assertCommittedData(node.nodeId, node.manager, node.log));
+            cluster.forAllRunning(node -> assertCommittedData(node.nodeId, node.client, node.log));
         }
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -53,8 +53,8 @@ import static org.junit.Assume.assumeTrue;
 
 public class RaftEventSimulationTest {
     private static final int ELECTION_TIMEOUT_MS = 1000;
-    private static final int ELECTION_JITTER_MS = 10;
-    private static final int FETCH_TIMEOUT_MS = 1000;
+    private static final int ELECTION_JITTER_MS = 100;
+    private static final int FETCH_TIMEOUT_MS = 5000;
     private static final int RETRY_BACKOFF_MS = 50;
     private static final int REQUEST_TIMEOUT_MS = 500;
 
@@ -260,6 +260,8 @@ public class RaftEventSimulationTest {
             nonPartitionedNodes.remove(1);
 
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(20, nonPartitionedNodes));
+
+            System.out.println(" >>>>>>>>>>>>>>>> Completed " + seed);
         }
     }
 
@@ -316,6 +318,8 @@ public class RaftEventSimulationTest {
             router.filter(4, new PermitAllTraffic());
 
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(30));
+
+            System.out.println(" >>>>>>>>>>>>>>>> Completed " + seed);
         }
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -260,8 +260,6 @@ public class RaftEventSimulationTest {
             nonPartitionedNodes.remove(1);
 
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(20, nonPartitionedNodes));
-
-            System.out.println(" >>>>>>>>>>>>>>>> Completed " + seed);
         }
     }
 
@@ -318,8 +316,6 @@ public class RaftEventSimulationTest {
             router.filter(4, new PermitAllTraffic());
 
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(30));
-
-            System.out.println(" >>>>>>>>>>>>>>>> Completed " + seed);
         }
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
@@ -39,6 +39,7 @@ public class SimpleKeyValueStoreTest {
         int localId = 1;
         int electionTimeoutMs = 10000;
         int electionJitterMs = 50;
+        int fetchTimeoutMs = 5000;
         int retryBackoffMs = 100;
         int requestTimeoutMs = 5000;
         Set<Integer> voters = Collections.singleton(localId);
@@ -55,8 +56,8 @@ public class SimpleKeyValueStoreTest {
 
         return new KafkaRaftClient(channel, log, quorum, time,
             new InetSocketAddress("localhost", 9990 + localId), bootstrapServers,
-            electionTimeoutMs, electionJitterMs, retryBackoffMs, requestTimeoutMs, logContext,
-            new Random());
+            electionTimeoutMs, electionJitterMs, fetchTimeoutMs, retryBackoffMs, requestTimeoutMs,
+            logContext, new Random());
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
@@ -37,7 +37,7 @@ public class SimpleKeyValueStoreTest {
 
     private KafkaRaftClient setupSingleNodeRaftManager() {
         int localId = 1;
-        int electionTimeoutMs = 10000;
+        int electionTimeoutMs = 1000;
         int electionJitterMs = 50;
         int fetchTimeoutMs = 5000;
         int retryBackoffMs = 100;


### PR DESCRIPTION
1. Introduce the fetch timeout config.
2. Leader relying on the fetch timeout to send find-quorum if does not receive from a majority of quorum.
3. Voter relying on fetch timeout to become candidate (not relying on election timeout).

We also merge the two timers into a single timer, and also added unit tests. Simulation tests now passed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
