### PR TITLE
KCORE-440: add voter information towards the quorum-state file

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
@@ -131,7 +131,7 @@ public class CandidateState implements EpochState {
 
     @Override
     public ElectionState election() {
-        return ElectionState.withVotedCandidate(epoch, localId);
+        return ElectionState.withVotedCandidate(epoch, localId, voteStates.keySet());
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -18,18 +18,21 @@ package org.apache.kafka.raft;
 
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 
 public class FollowerState implements EpochState {
     private final int epoch;
     private OptionalInt leaderIdOpt;
     private OptionalInt votedIdOpt;
     private OptionalLong highWatermark;
+    private final Set<Integer> voters;
 
-    public FollowerState(int epoch) {
+    public FollowerState(int epoch, Set<Integer> voters) {
         this.epoch = epoch;
         this.leaderIdOpt = OptionalInt.empty();
         this.votedIdOpt = OptionalInt.empty();
         this.highWatermark = OptionalLong.empty();
+        this.voters = voters;
     }
 
     @Override
@@ -40,10 +43,10 @@ public class FollowerState implements EpochState {
     @Override
     public ElectionState election() {
         if (votedIdOpt.isPresent())
-            return ElectionState.withVotedCandidate(epoch, votedIdOpt.getAsInt());
+            return ElectionState.withVotedCandidate(epoch, votedIdOpt.getAsInt(), voters);
         if (leaderIdOpt.isPresent())
-            return ElectionState.withElectedLeader(epoch, leaderIdOpt.getAsInt());
-        return ElectionState.withUnknownLeader(epoch);
+            return ElectionState.withElectedLeader(epoch, leaderIdOpt.getAsInt(), voters);
+        return ElectionState.withUnknownLeader(epoch, voters);
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -51,7 +51,7 @@ public class LeaderState implements EpochState {
 
     @Override
     public ElectionState election() {
-        return ElectionState.withElectedLeader(epoch, localId);
+        return ElectionState.withElectedLeader(epoch, localId, voterReplicaStates.keySet());
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -66,7 +66,12 @@ public class QuorumState {
             state = new FollowerState(election.epoch, voters);
         }
 
-        if (election.epoch < logEndOffsetAndEpoch.epoch) {
+        if (voters != election.voters()) {
+            throw new IllegalStateException("Configured voter set: " + voters
+                + " is different from the voter set read from the state file: " + voters +
+                ". Check if the quorum configuration is up to date, " +
+                "or wipe out the local state file if necessary");
+        } else if (election.epoch < logEndOffsetAndEpoch.epoch) {
             log.warn("Epoch from quorum-state file is {}, which is " +
                 "smaller than last written epoch {} in the log",
                 election.epoch, logEndOffsetAndEpoch.epoch);

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -48,7 +48,7 @@ public class QuorumState {
         this.log = logContext.logger(QuorumState.class);
     }
 
-    public void initialize(OffsetAndEpoch logEndOffsetAndEpoch) throws IOException {
+    public void initialize(OffsetAndEpoch logEndOffsetAndEpoch) throws IOException, IllegalStateException {
         // We initialize in whatever state we were in on shutdown. If we were a leader
         // or candidate, probably an election was held, but we will find out about it
         // when we send Vote or BeginEpoch requests.
@@ -66,9 +66,9 @@ public class QuorumState {
             state = new FollowerState(election.epoch, voters);
         }
 
-        if (voters != election.voters()) {
+        if (!voters.equals(election.voters())) {
             throw new IllegalStateException("Configured voter set: " + voters
-                + " is different from the voter set read from the state file: " + voters +
+                + " is different from the voter set read from the state file: " + election.voters() +
                 ". Check if the quorum configuration is up to date, " +
                 "or wipe out the local state file if necessary");
         } else if (election.epoch < logEndOffsetAndEpoch.epoch) {

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -62,8 +62,8 @@ public class QuorumState {
             log.warn("Clear local quorum state store {}", store.toString(), e);
             store.clear();
 
-            election = ElectionState.withUnknownLeader(0);
-            state = new FollowerState(election.epoch);
+            election = ElectionState.withUnknownLeader(0, voters);
+            state = new FollowerState(election.epoch, voters);
         }
 
         if (election.epoch < logEndOffsetAndEpoch.epoch) {
@@ -76,7 +76,7 @@ public class QuorumState {
         } else if (election.isCandidate(localId)) {
             state = new CandidateState(localId, election.epoch, voters);
         } else {
-            state = new FollowerState(election.epoch);
+            state = new FollowerState(election.epoch, voters);
             if (election.hasLeader()) {
                 becomeFetchingFollower(election.epoch, election.leaderId());
             } else if (election.hasVoted()) {
@@ -193,7 +193,7 @@ public class QuorumState {
             throw new IllegalArgumentException("Cannot become follower in epoch " + newEpoch +
                     " since it is smaller epoch than our current epoch " + currentEpoch);
         } else if (newEpoch > currentEpoch || isCandidate()) {
-            state = new FollowerState(newEpoch);
+            state = new FollowerState(newEpoch, voters);
             stateChanged = true;
         } else if (isLeader()) {
             throw new IllegalArgumentException("Cannot become follower of epoch " + newEpoch +

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -66,7 +66,7 @@ public class QuorumState {
             state = new FollowerState(election.epoch, voters);
         }
 
-        if (!voters.equals(election.voters())) {
+        if (!election.voters().isEmpty() && !voters.equals(election.voters())) {
             throw new IllegalStateException("Configured voter set: " + voters
                 + " is different from the voter set read from the state file: " + election.voters() +
                 ". Check if the quorum configuration is up to date, " +

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1305,6 +1305,9 @@ public class KafkaRaftClientTest {
         int otherNodeId = 1;
         int epoch = 5;
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+
+        quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId, voters));
+
         KafkaRaftClient client = buildClient(voters, stateMachine);
         assertEquals(ElectionState.withElectedLeader(epoch, otherNodeId, voters), quorumStateStore.readElectionState());
         assertTrue(stateMachine.isFollower());
@@ -1332,7 +1335,9 @@ public class KafkaRaftClientTest {
     public void testAppendToNonLeaderFails() throws IOException {
         int otherNodeId = 1;
         int epoch = 5;
+
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+        quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, otherNodeId, voters));
 
         MockStateMachine stateMachine = new MockStateMachine();
         buildClient(voters, stateMachine);

--- a/raft/src/test/java/org/apache/kafka/raft/MockQuorumStateStore.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockQuorumStateStore.java
@@ -17,9 +17,10 @@
 package org.apache.kafka.raft;
 
 import java.io.IOException;
+import java.util.Collections;
 
 public class MockQuorumStateStore implements QuorumStateStore {
-    private ElectionState current = ElectionState.withUnknownLeader(0);
+    private ElectionState current = ElectionState.withUnknownLeader(0, Collections.emptySet());
 
     @Override
     public ElectionState readElectionState() throws IOException {
@@ -33,6 +34,6 @@ public class MockQuorumStateStore implements QuorumStateStore {
 
     @Override
     public void clear() {
-        current = ElectionState.withUnknownLeader(0);
+        current = ElectionState.withUnknownLeader(0, Collections.emptySet());
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -39,9 +39,6 @@ public class QuorumStateTest {
     public void testInitializePrimordialEpoch() throws IOException {
         Set<Integer> voters = Utils.mkSet(localId);
         assertEquals(0, store.readElectionState().epoch);
-//
-//        QuorumState state = new QuorumState(localId, voters, store, new LogContext());
-//        state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
 
         QuorumState state = initializeState(voters, store);
         assertTrue(state.isFollower());

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -55,7 +55,7 @@ public class QuorumStateTest {
         int node2 = 2;
         int epoch = 5;
         Set<Integer> voters = Utils.mkSet(localId, node1, node2);
-        store.writeElectionState(ElectionState.withElectedLeader(epoch, node1));
+        store.writeElectionState(ElectionState.withElectedLeader(epoch, node1, voters));
 
         QuorumState state = new QuorumState(localId, voters, store, new LogContext());
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
@@ -74,7 +74,7 @@ public class QuorumStateTest {
         int node2 = 2;
         int epoch = 5;
         Set<Integer> voters = Utils.mkSet(localId, node1, node2);
-        store.writeElectionState(ElectionState.withVotedCandidate(epoch, node1));
+        store.writeElectionState(ElectionState.withVotedCandidate(epoch, node1, voters));
 
         QuorumState state = new QuorumState(localId, voters, store, new LogContext());
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
@@ -93,7 +93,7 @@ public class QuorumStateTest {
         int node2 = 2;
         int epoch = 5;
         Set<Integer> voters = Utils.mkSet(localId, node1, node2);
-        store.writeElectionState(ElectionState.withVotedCandidate(epoch, localId));
+        store.writeElectionState(ElectionState.withVotedCandidate(epoch, localId, voters));
 
         QuorumState state = new QuorumState(localId, voters, store, new LogContext());
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
@@ -111,7 +111,7 @@ public class QuorumStateTest {
         int node2 = 2;
         int epoch = 5;
         Set<Integer> voters = Utils.mkSet(localId, node1, node2);
-        store.writeElectionState(ElectionState.withElectedLeader(epoch, localId));
+        store.writeElectionState(ElectionState.withElectedLeader(epoch, localId, voters));
 
         QuorumState state = new QuorumState(localId, voters, store, new LogContext());
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
@@ -166,7 +166,7 @@ public class QuorumStateTest {
         int leaderId = 1;
         int epoch = 5;
         Set<Integer> voters = Utils.mkSet(localId, leaderId);
-        store.writeElectionState(ElectionState.withVotedCandidate(epoch, leaderId));
+        store.writeElectionState(ElectionState.withVotedCandidate(epoch, leaderId, voters));
         QuorumState state = new QuorumState(localId, voters, store, new LogContext());
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         assertTrue(state.isFollower());
@@ -212,7 +212,7 @@ public class QuorumStateTest {
         assertTrue(state.becomeFetchingFollower(5, otherNodeId));
         assertEquals(5, state.epoch());
         assertEquals(OptionalInt.of(otherNodeId), state.leaderId());
-        assertEquals(ElectionState.withElectedLeader(5, otherNodeId), store.readElectionState());
+        assertEquals(ElectionState.withElectedLeader(5, otherNodeId, voters), store.readElectionState());
     }
 
     @Test
@@ -227,7 +227,7 @@ public class QuorumStateTest {
         assertTrue(state.becomeUnattachedFollower(5));
         assertEquals(5, state.epoch());
         assertEquals(OptionalInt.empty(), state.leaderId());
-        assertEquals(ElectionState.withUnknownLeader(5), store.readElectionState());
+        assertEquals(ElectionState.withUnknownLeader(5, voters), store.readElectionState());
     }
 
     @Test
@@ -245,7 +245,7 @@ public class QuorumStateTest {
         FollowerState followerState = state.followerStateOrThrow();
         assertTrue(followerState.hasVoted());
         assertTrue(followerState.hasVotedFor(otherNodeId));
-        assertEquals(ElectionState.withVotedCandidate(5, otherNodeId), store.readElectionState());
+        assertEquals(ElectionState.withVotedCandidate(5, otherNodeId, voters), store.readElectionState());
     }
 
     @Test
@@ -257,7 +257,7 @@ public class QuorumStateTest {
         assertTrue(state.becomeFetchingFollower(5, otherNodeId));
         assertEquals(5, state.epoch());
         assertEquals(OptionalInt.of(otherNodeId), state.leaderId());
-        assertEquals(ElectionState.withElectedLeader(5, otherNodeId), store.readElectionState());
+        assertEquals(ElectionState.withElectedLeader(5, otherNodeId, voters), store.readElectionState());
     }
 
     @Test
@@ -269,7 +269,7 @@ public class QuorumStateTest {
         assertTrue(state.becomeUnattachedFollower(5));
         assertEquals(5, state.epoch());
         assertEquals(OptionalInt.empty(), state.leaderId());
-        assertEquals(ElectionState.withUnknownLeader(5), store.readElectionState());
+        assertEquals(ElectionState.withUnknownLeader(5, voters), store.readElectionState());
     }
 
     @Test
@@ -284,7 +284,7 @@ public class QuorumStateTest {
         FollowerState followerState = state.followerStateOrThrow();
         assertTrue(followerState.hasVoted());
         assertTrue(followerState.hasVotedFor(otherNodeId));
-        assertEquals(ElectionState.withVotedCandidate(5, otherNodeId), store.readElectionState());
+        assertEquals(ElectionState.withVotedCandidate(5, otherNodeId, voters), store.readElectionState());
     }
 
     @Test
@@ -299,7 +299,7 @@ public class QuorumStateTest {
         assertEquals(5, followerState.epoch());
         assertTrue(followerState.hasVoted());
         assertTrue(followerState.hasVotedFor(otherNodeId));
-        assertEquals(ElectionState.withVotedCandidate(5, otherNodeId), store.readElectionState());
+        assertEquals(ElectionState.withVotedCandidate(5, otherNodeId, voters), store.readElectionState());
     }
 
     @Test
@@ -314,7 +314,7 @@ public class QuorumStateTest {
         assertEquals(8, followerState.epoch());
         assertTrue(followerState.hasVoted());
         assertTrue(followerState.hasVotedFor(otherNodeId));
-        assertEquals(ElectionState.withVotedCandidate(8, otherNodeId), store.readElectionState());
+        assertEquals(ElectionState.withVotedCandidate(8, otherNodeId, voters), store.readElectionState());
     }
 
     @Test
@@ -331,7 +331,7 @@ public class QuorumStateTest {
         assertTrue(followerState.hasLeader());
         assertFalse(followerState.hasVoted());
         assertEquals(node2, followerState.leaderId());
-        assertEquals(ElectionState.withElectedLeader(5, node2), store.readElectionState());
+        assertEquals(ElectionState.withElectedLeader(5, node2, voters), store.readElectionState());
     }
 
     @Test
@@ -348,7 +348,7 @@ public class QuorumStateTest {
         assertTrue(followerState.hasLeader());
         assertFalse(followerState.hasVoted());
         assertEquals(node2, followerState.leaderId());
-        assertEquals(ElectionState.withElectedLeader(8, node2), store.readElectionState());
+        assertEquals(ElectionState.withElectedLeader(8, node2, voters), store.readElectionState());
     }
 
     @Test
@@ -364,7 +364,7 @@ public class QuorumStateTest {
         assertFalse(followerState.hasLeader());
         assertTrue(followerState.hasVoted());
         assertTrue(followerState.hasVotedFor(node1));
-        assertEquals(ElectionState.withVotedCandidate(5, node1), store.readElectionState());
+        assertEquals(ElectionState.withVotedCandidate(5, node1, voters), store.readElectionState());
     }
 
     @Test
@@ -381,7 +381,7 @@ public class QuorumStateTest {
         assertTrue(followerState.hasLeader());
         assertFalse(followerState.hasVoted());
         assertEquals(node2, followerState.leaderId());
-        assertEquals(ElectionState.withElectedLeader(8, node2), store.readElectionState());
+        assertEquals(ElectionState.withElectedLeader(8, node2, voters), store.readElectionState());
     }
 
     @Test
@@ -398,7 +398,7 @@ public class QuorumStateTest {
         assertTrue(followerState.hasLeader());
         assertFalse(followerState.hasVoted());
         assertEquals(node2, followerState.leaderId());
-        assertEquals(ElectionState.withElectedLeader(8, node2), store.readElectionState());
+        assertEquals(ElectionState.withElectedLeader(8, node2, voters), store.readElectionState());
     }
 
     @Test
@@ -412,7 +412,7 @@ public class QuorumStateTest {
         assertThrows(IllegalArgumentException.class, () -> state.becomeVotedFollower(4, otherNodeId));
         assertThrows(IllegalArgumentException.class, () -> state.becomeFetchingFollower(4, otherNodeId));
         assertEquals(5, state.epoch());
-        assertEquals(ElectionState.withUnknownLeader(5), store.readElectionState());
+        assertEquals(ElectionState.withUnknownLeader(5, voters), store.readElectionState());
     }
 
     @Test
@@ -427,7 +427,7 @@ public class QuorumStateTest {
         assertThrows(IllegalArgumentException.class, () -> state.becomeVotedFollower(4, otherNodeId));
         assertThrows(IllegalArgumentException.class, () -> state.becomeFetchingFollower(4, otherNodeId));
         assertEquals(6, state.epoch());
-        assertEquals(ElectionState.withVotedCandidate(6, localId), store.readElectionState());
+        assertEquals(ElectionState.withVotedCandidate(6, localId, voters), store.readElectionState());
     }
 
     @Test
@@ -444,7 +444,7 @@ public class QuorumStateTest {
         assertThrows(IllegalArgumentException.class, () -> state.becomeVotedFollower(4, otherNodeId));
         assertThrows(IllegalArgumentException.class, () -> state.becomeFetchingFollower(4, otherNodeId));
         assertEquals(6, state.epoch());
-        assertEquals(ElectionState.withElectedLeader(6, localId), store.readElectionState());
+        assertEquals(ElectionState.withElectedLeader(6, localId, voters), store.readElectionState());
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -129,13 +129,16 @@ public class RaftEventSimulationTest {
     }
 
     private void testReplicationNoLeaderChange(QuorumConfig config) throws IOException {
+        Set<Integer> voters = getVoters(config.numVoters);
+
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
             MessageRouter router = new MessageRouter(cluster);
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
+
             // Start with node 0 as the leader
-            cluster.initializeElection(ElectionState.withElectedLeader(2, 0));
+            cluster.initializeElection(ElectionState.withElectedLeader(2, 0, voters));
             cluster.startAll();
             assertTrue(cluster.hasConsistentLeader());
 
@@ -179,6 +182,7 @@ public class RaftEventSimulationTest {
     private void testElectionAfterLeaderFailure(QuorumConfig config) throws IOException {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
+        Set<Integer> voters = getVoters(config.numVoters);
 
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
@@ -186,7 +190,7 @@ public class RaftEventSimulationTest {
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
             // Start with node 1 as the leader
-            cluster.initializeElection(ElectionState.withElectedLeader(2, 0));
+            cluster.initializeElection(ElectionState.withElectedLeader(2, 0, voters));
             cluster.startAll();
             assertTrue(cluster.hasConsistentLeader());
 
@@ -236,6 +240,7 @@ public class RaftEventSimulationTest {
     private void testElectionAfterLeaderNetworkPartition(QuorumConfig config) throws IOException {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
+        Set<Integer> voters = getVoters(config.numVoters);
 
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
@@ -243,7 +248,7 @@ public class RaftEventSimulationTest {
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
             // Start with node 1 as the leader
-            cluster.initializeElection(ElectionState.withElectedLeader(2, 1));
+            cluster.initializeElection(ElectionState.withElectedLeader(2, 1, voters));
             cluster.startAll();
             assertTrue(cluster.hasConsistentLeader());
 
@@ -277,6 +282,7 @@ public class RaftEventSimulationTest {
     private void testElectionAfterMultiNodeNetworkPartition(QuorumConfig config) throws IOException {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
+        Set<Integer> voters = getVoters(config.numVoters);
 
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
@@ -284,7 +290,7 @@ public class RaftEventSimulationTest {
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
             // Start with node 1 as the leader
-            cluster.initializeElection(ElectionState.withElectedLeader(2, 1));
+            cluster.initializeElection(ElectionState.withElectedLeader(2, 1, voters));
             cluster.startAll();
             assertTrue(cluster.hasConsistentLeader());
 
@@ -318,6 +324,14 @@ public class RaftEventSimulationTest {
 
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(30));
         }
+    }
+
+    private Set<Integer> getVoters(int numVoters) {
+        Set<Integer> voters = new HashSet<>(numVoters);
+        for (int nodeId = 0; nodeId < numVoters; nodeId++) {
+            voters.add(nodeId);
+        }
+        return voters;
     }
 
     private EventScheduler schedulerWithDefaultInvariants(Cluster cluster) {

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -129,14 +129,12 @@ public class RaftEventSimulationTest {
     }
 
     private void testReplicationNoLeaderChange(QuorumConfig config) throws IOException {
-        Set<Integer> voters = getVoters(config.numVoters);
-
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
             MessageRouter router = new MessageRouter(cluster);
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
-
+            Set<Integer> voters = cluster.nodes();
             // Start with node 0 as the leader
             cluster.initializeElection(ElectionState.withElectedLeader(2, 0, voters));
             cluster.startAll();
@@ -182,7 +180,6 @@ public class RaftEventSimulationTest {
     private void testElectionAfterLeaderFailure(QuorumConfig config) throws IOException {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
-        Set<Integer> voters = getVoters(config.numVoters);
 
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
@@ -190,6 +187,7 @@ public class RaftEventSimulationTest {
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
             // Start with node 1 as the leader
+            Set<Integer> voters = cluster.nodes();
             cluster.initializeElection(ElectionState.withElectedLeader(2, 0, voters));
             cluster.startAll();
             assertTrue(cluster.hasConsistentLeader());
@@ -240,7 +238,6 @@ public class RaftEventSimulationTest {
     private void testElectionAfterLeaderNetworkPartition(QuorumConfig config) throws IOException {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
-        Set<Integer> voters = getVoters(config.numVoters);
 
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
@@ -248,6 +245,7 @@ public class RaftEventSimulationTest {
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
             // Start with node 1 as the leader
+            Set<Integer> voters = cluster.nodes();
             cluster.initializeElection(ElectionState.withElectedLeader(2, 1, voters));
             cluster.startAll();
             assertTrue(cluster.hasConsistentLeader());
@@ -282,7 +280,6 @@ public class RaftEventSimulationTest {
     private void testElectionAfterMultiNodeNetworkPartition(QuorumConfig config) throws IOException {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
-        Set<Integer> voters = getVoters(config.numVoters);
 
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
@@ -290,6 +287,7 @@ public class RaftEventSimulationTest {
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
             // Start with node 1 as the leader
+            Set<Integer> voters = cluster.nodes();
             cluster.initializeElection(ElectionState.withElectedLeader(2, 1, voters));
             cluster.startAll();
             assertTrue(cluster.hasConsistentLeader());
@@ -324,14 +322,6 @@ public class RaftEventSimulationTest {
 
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(30));
         }
-    }
-
-    private Set<Integer> getVoters(int numVoters) {
-        Set<Integer> voters = new HashSet<>(numVoters);
-        for (int nodeId = 0; nodeId < numVoters; nodeId++) {
-            voters.add(nodeId);
-        }
-        return voters;
     }
 
     private EventScheduler schedulerWithDefaultInvariants(Cluster cluster) {

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -134,7 +134,7 @@ public class RaftEventSimulationTest {
             MessageRouter router = new MessageRouter(cluster);
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
-            Set<Integer> voters = cluster.nodes();
+            Set<Integer> voters = cluster.voters();
             // Start with node 0 as the leader
             cluster.initializeElection(ElectionState.withElectedLeader(2, 0, voters));
             cluster.startAll();
@@ -187,7 +187,7 @@ public class RaftEventSimulationTest {
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
             // Start with node 1 as the leader
-            Set<Integer> voters = cluster.nodes();
+            Set<Integer> voters = cluster.voters();
             cluster.initializeElection(ElectionState.withElectedLeader(2, 0, voters));
             cluster.startAll();
             assertTrue(cluster.hasConsistentLeader());
@@ -245,7 +245,7 @@ public class RaftEventSimulationTest {
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
             // Start with node 1 as the leader
-            Set<Integer> voters = cluster.nodes();
+            Set<Integer> voters = cluster.voters();
             cluster.initializeElection(ElectionState.withElectedLeader(2, 1, voters));
             cluster.startAll();
             assertTrue(cluster.hasConsistentLeader());
@@ -287,7 +287,7 @@ public class RaftEventSimulationTest {
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
             // Start with node 1 as the leader
-            Set<Integer> voters = cluster.nodes();
+            Set<Integer> voters = cluster.voters();
             cluster.initializeElection(ElectionState.withElectedLeader(2, 1, voters));
             cluster.startAll();
             assertTrue(cluster.hasConsistentLeader());
@@ -629,6 +629,7 @@ public class RaftEventSimulationTest {
             LogContext logContext = new LogContext("[Node " + nodeId + "] ");
             PersistentState persistentState = nodes.get(nodeId);
             MockNetworkChannel channel = new MockNetworkChannel(correlationIdCounter);
+
             QuorumState quorum = new QuorumState(nodeId, voters(), persistentState.store, logContext);
             MockFuturePurgatory<Void> purgatory = new MockFuturePurgatory<>(time);
 

--- a/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/SimpleKeyValueStoreTest.java
@@ -51,7 +51,7 @@ public class SimpleKeyValueStoreTest {
         MockTime time = new MockTime();
         MockFuturePurgatory<Void> purgatory = new MockFuturePurgatory<>(time);
 
-        store.writeElectionState(ElectionState.withElectedLeader(epoch, localId));
+        store.writeElectionState(ElectionState.withElectedLeader(epoch, localId, Collections.singleton(localId)));
 
         ReplicatedLog log = new MockLog();
         NetworkChannel channel = new MockNetworkChannel();


### PR DESCRIPTION
Amend a gap for quorum state information to add the known voters into the state file.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
