### PR TITLE
MINOR: Increase scalac heap size to 2g

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -530,7 +530,7 @@ subprojects {
       scalaCompileOptions.additionalParameters += ["-release", minJavaVersion]
 
     configure(scalaCompileOptions.forkOptions) {
-      memoryMaximumSize = '1g'
+      memoryMaximumSize = '2g'
       jvmArgs = ['-Xss4m']
     }
   }


### PR DESCRIPTION
We have updated gradle daemon heap memory to 2g. This PR is to increase the scalac heap size to 2g. This will make consistent memory settings 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
