### PR TITLE
ST-3458: Implement Nano versioning.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,12 +18,14 @@
  */
 
 def config = jobConfig {
-    cron = '@midnight'
+    cron = ''
     nodeLabel = 'docker-oraclejdk8'
     testResultSpecs = ['junit': '**/build/test-results/**/TEST-*.xml']
-    slackChannel = '#kafka-warn'
+    slackChannel = ''
     timeoutHours = 4
     runMergeCheck = false
+    testbreakReporting = false
+    downStreamRepos = ["common",]
 }
 
 def retryFlagsString(jobConfig) {
@@ -34,9 +36,10 @@ def retryFlagsString(jobConfig) {
 def downstreamBuildFailureOutput = ""
 def publishStep(String configSettings) {
   configFileProvider([configFile(fileId: configSettings, variable: 'GRADLE_NEXUS_SETTINGS')]) {
-          sh "./gradlewAll --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchives"
+      sh "./gradlewAll --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchives"
   }
 }
+
 def job = {
     // https://github.com/confluentinc/common-tools/blob/master/confluent/config/dev/versions.json
     def kafkaMuckrakeVersionMap = [
@@ -46,6 +49,10 @@ def job = {
             "trunk": "master",
             "master": "master"
     ]
+
+    if (!config.isReleaseJob && !config.isPrJob) {
+        ciTool("ci-update-version --repo-path=${env.WORKSPACE} --repo-name=kafka")
+    }
 
     stage("Check compilation compatibility with Scala 2.12") {
         sh "./gradlew clean assemble spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain " +
@@ -58,14 +65,30 @@ def job = {
                 "--no-daemon --stacktrace -PxmlSpotBugsReport=true"
     }
 
-    if (config.publish) {
-      stage("Publish to artifactory") {
-        if (config.isDevJob) {
-          publishStep('Gradle-Artifactory-Settings')
-        } else if (config.isPreviewJob) {
-          publishStep('Gradle-Artifactory-Preview-Release-Settings')
+    if (config.publish && (config.isDevJob || config.isPreviewJob)) {
+        stage("Publish to artifactory") {
+            if (!config.isReleaseJob && !config.isPrJob) {
+                ciTool("ci-push-tag --repo-path=${env.WORKSPACE} --repo-name=kafka")
+            }
+
+            if (config.isDevJob) {
+                publishStep('Gradle-Artifactory-Settings')
+            } else if (config.isPreviewJob) {
+                publishStep('Gradle-Artifactory-Preview-Release-Settings')
+            }
         }
-      }
+    }
+
+    if (config.publish && config.isDevJob && !config.isReleaseJob && !config.isPrJob) {
+        stage("Start Downstream Builds") {
+            config.downStreamRepos.each { repo ->
+              // TODO: change to confluent org after done testing.
+                build(job: "nano_versioning/${repo}/${env.BRANCH_NAME}",
+                    wait: false,
+                    propagate: false
+                )
+            }
+        }
     }
 
     stage("Run Tests and build cp-downstream-builds") {
@@ -93,7 +116,9 @@ def job = {
                    summary = summary + (", Skipped: " + skipped)
                    return summary;
                }
-        },
+        }
+        //TODO re-enable when done testing.
+        /*,
         downstreamBuildsStepName: {
             echo "Building cp-downstream-builds"
             if (config.isPrJob) {
@@ -124,7 +149,7 @@ def job = {
             } else {
                 return ""
             }
-         }
+         }*/
         ]
 
         result = parallel testTargets

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ ext {
   userMaxTestRetryFailures = project.hasProperty('maxTestRetryFailures') ? maxTestRetryFailures.toInteger() : 0
 
   skipSigning = project.hasProperty('skipSigning') && skipSigning.toBoolean()
-  shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && !version.contains("-alpha") && project.gradle.startParameter.taskNames.any { it.contains("upload") }
+  shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && !version.contains("-alpha") && !version.matches("[0-9]*\\.[0-9]*\\.[0-9]*-[0-9]*") && project.gradle.startParameter.taskNames.any { it.contains("upload") }
 
   mavenUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : ''
   mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : ''

--- a/ci.py
+++ b/ci.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+
+import os
+import logging
+import re
+import subprocess
+import sys
+
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+log = logging.getLogger(__name__)
+
+
+class CI:
+
+    def __init__(self, new_version, repo_path):
+        """Initialize class variables"""
+        # List of all the files that were modified by this script so the parent
+        # script that runs this update can commit them.
+        self.updated_files = []
+        # The new version
+        self.new_version = new_version
+        # The path the root of the repo so we can use full absolute paths
+        self.repo_path = repo_path
+
+    def run_update(self):
+        """Update all the files with the new version"""
+        log.info("Running additional version updates for kafka")
+        self.update_kafkatest()
+        self.update_quickstart()
+        log.info("Finished all kafka additional version updates.")
+
+    def update_kafkatest(self):
+        """Update kafka test python scripts"""
+        log.info("Updating kafkatest init script.")
+        init_file = os.path.join(self.repo_path, "tests/kafkatest/__init__.py")
+        dev_version = "{}.dev0".format(self.new_version.split("-ccs")[0])
+        self.replace(init_file, "__version__", "__version__ = '{}'".format(dev_version))
+        self.updated_files.append(init_file)
+        log.info("Updating ducktape version.py")
+        ducktape_version_file = os.path.join(self.repo_path, "tests/kafkatest/version.py")
+        ducktape_version = self.new_version.split("-ccs")[0]
+        self.regexReplace(ducktape_version_file,
+                          "^DEV_VERSION = KafkaVersion.*",
+                          "DEV_VERSION = KafkaVersion(\"{}\")".format(ducktape_version))
+        self.updated_files.append(ducktape_version_file)
+
+    def update_quickstart(self):
+        """Uodate the streams quick start pom files."""
+        log.info("Updating streams quickstart pom files.")
+        quickstart_pom = os.path.join(self.repo_path, "streams/quickstart/pom.xml")
+        self.update_project_versions(quickstart_pom, self.new_version)
+        self.updated_files.append(quickstart_pom)
+        # Do not need to explicitly update this file because the above command updates all pom files in the project.
+        # Just need to add it to the list of modified files.
+        quickstart_java_pom = os.path.join(self.repo_path, "streams/quickstart/java/pom.xml")
+        self.updated_files.append(quickstart_java_pom)
+        # The maven plugin has fails to process this pom file because it is an archetype style, so have to use regex.
+        log.info("Updating streams quickstart archetype pom")
+        archetype_resources_pom = os.path.join(self.repo_path,
+                                               "streams/quickstart/java/src/main/resources/archetype-resources/pom.xml")
+        self.regexReplace(archetype_resources_pom,
+                          "<kafka\.version>.*</kafka\.version>",
+                          "<kafka.version>{}</kafka.version>".format(self.new_version))
+        self.updated_files.append(archetype_resources_pom)
+
+    def replace(self, path, pattern, replacement):
+        updated = []
+        with open(path, 'r') as f:
+            for line in f:
+                updated.append((replacement + '\n') if line.startswith(pattern) else line)
+
+        with open(path, 'w') as f:
+            for line in updated:
+                f.write(line)
+
+    def regexReplace(self, path, pattern, replacement):
+        updated = []
+        with open(path, 'r') as f:
+            for line in f:
+                updated.append(re.sub(pattern, replacement, line))
+
+        with open(path, 'w') as f:
+            for line in updated:
+                f.write(line)
+
+    def run_cmd(self, cmd):
+        """Execute a shell command. Return true if successful, false otherwise."""
+        proc = subprocess.Popen(cmd,
+                                cwd=self.repo_path,
+                                shell=True,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                universal_newlines=True)
+        stdout = proc.communicate()
+
+        if stdout:
+            log.info(stdout)
+
+        if proc.returncode != 0:
+            return False
+        else:
+            return True
+
+    def update_project_versions(self, pom_file, new_version):
+        """Set the project version in the pom files to the new project version."""
+        cmd = "mvn --batch-mode versions:set -DnewVersion={} ".format(new_version)
+        cmd += "-DallowSnapshots=false "
+        cmd += "-DgenerateBackupPoms=false "
+        cmd += "-DprocessAllModules=true "
+        cmd += "-DprocessDependencies=false "
+        cmd += "-DprocessPlugins=false "
+        cmd += "-f {}".format(pom_file)
+        log.info("Updating pom files with new project version.")
+
+        if self.run_cmd(cmd):
+            log.info("Finished updating the pom files with new project version.")
+        else:
+            log.error("Failed to set the new version in the pom files.")
+            sys.exit(1)

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
-version=6.0.0-ccs-SNAPSHOT
+version=6.0.0-0-ccs
 scalaVersion=2.13.2
 task=build
 org.gradle.jvmargs=-Xmx1024m -Xss2m

--- a/streams/quickstart/java/pom.xml
+++ b/streams/quickstart/java/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.kafka</groupId>
         <artifactId>streams-quickstart</artifactId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>6.0.0-0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>2.6.0-SNAPSHOT</kafka.version>
+        <kafka.version>6.0.0-0</kafka.version>
         <slf4j.version>1.7.7</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
     </properties>

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>6.0.0-0</version>
 
     <name>Kafka Streams :: Quickstart</name>
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,7 +38,7 @@ TC_PATHS="tests/kafkatest/tests/client/pluggable_test.py::PluggableConsumerTest.
 ```
 * Run a specific test method with specific parameters
 ```
-TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py::StreamsUpgradeTest.test_metadata_upgrade" _DUCKTAPE_OPTIONS='--parameters '\''{"from_version":"0.10.1.1","to_version":"2.6.0-SNAPSHOT"}'\' bash tests/docker/run_tests.sh
+TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py::StreamsUpgradeTest.test_metadata_upgrade" _DUCKTAPE_OPTIONS='--parameters '\''{"from_version":"0.10.1.1","to_version":"2.6.0"}'\' bash tests/docker/run_tests.sh
 ```
 * Run tests with a different JVM
 ```

--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -21,5 +21,5 @@
 #
 # Instead, in development branches, the version should have a suffix of the form ".devN"
 #
-# For example, when Kafka is at version 1.0.0-SNAPSHOT, this should be something like "1.0.0.dev0"
-__version__ = '6.0.0.dev0'
+# For example, when Kafka is at version 1.0.0-0, this should be something like "1.0.0-0.dev0"
+__version__ = '6.0.0-0.dev0'

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -69,7 +69,7 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("6.0.0-SNAPSHOT")
+DEV_VERSION = KafkaVersion("6.0.0-0")
 
 # 0.8.2.x versions
 V_0_8_2_1 = KafkaVersion("0.8.2.1")


### PR DESCRIPTION
Implementing nano versioning for kafka repo. 
- Set all the version properties to include a build number and no longer use snapshot qualifier
- Updated the skip signing condition to skip signing for these new versions.
- Added a ci.py script to perform additional updates to version properties during CI builds.

This was tested on the nano versioning branch in the nano versioning jenkins org. The PR build will probably fail right now because there are changes to ci-tools and jenkins-common that need to be merged in order for this to work properly. The nano versioning jenkins organization contained these changes which is why the tests work there.

Note: There are several changes here that will be reverted in the final commit as they are for testing on the nano version branch only. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
