### PR TITLE
Move CCS Kafka to Confluent Versions in 2.6

### DIFF
--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>2.6.0-SNAPSHOT</kafka.version>
+        <kafka.version>6.0.0-ccs-SNAPSHOT</kafka.version>
         <slf4j.version>1.7.7</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
     </properties>

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>6.0.0-ccs-SNAPSHOT</version>
 
     <name>Kafka Streams :: Quickstart</name>
 


### PR DESCRIPTION
Manual version bump for CCS Kafka. `gradle.properties` is already at `version=6.0.0-ccs-SNAPSHOT`