### PR TITLE
KCORE-579: Cache high watermark on the leader

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -360,6 +360,20 @@ class Log(@volatile private var _dir: File,
     newHighWatermark
   }
 
+  def updateHighWatermarkOffsetMetadata(hw: LogOffsetMetadata): Long = {
+    val newHighWatermark = if (hw.messageOffset < logStartOffset) {
+      updateHighWatermarkMetadata(LogOffsetMetadata(logStartOffset))
+      logStartOffset
+    } else if (hw.messageOffset > logEndOffset) {
+      updateHighWatermarkMetadata(LogOffsetMetadata(logEndOffset))
+      logEndOffset
+    } else {
+      updateHighWatermarkMetadata(hw)
+      hw.messageOffset
+    }
+    newHighWatermark
+  }
+
   /**
    * Update the high watermark to a new value if and only if it is larger than the old value. It is
    * an error to update to a value which is larger than the log end offset.

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -365,7 +365,7 @@ class Log(@volatile private var _dir: File,
       updateHighWatermarkMetadata(LogOffsetMetadata(logStartOffset))
       logStartOffset
     } else if (hw.messageOffset > logEndOffset) {
-      updateHighWatermarkMetadata(LogOffsetMetadata(logEndOffset))
+      updateHighWatermarkMetadata(logEndOffsetMetadata)
       logEndOffset
     } else {
       updateHighWatermarkMetadata(hw)

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -24,13 +24,13 @@ import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.record.{MemoryRecords, Records}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.raft
-import org.apache.kafka.raft.{LogAppendInfo, ReplicatedLog}
+import org.apache.kafka.raft.{LogAppendInfo, LogFetchInfo, LogOffsetMetadata, ReplicatedLog}
 
 import scala.compat.java8.OptionConverters._
 
 class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1024) extends ReplicatedLog {
 
-  override def read(startOffset: Long, endOffsetExclusive: OptionalLong): Records = {
+  override def read(startOffset: Long, endOffsetExclusive: OptionalLong): LogFetchInfo = {
     val isolation = if (endOffsetExclusive.isPresent)
       FetchHighWatermark
     else
@@ -40,7 +40,14 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
       maxLength = maxFetchSizeInBytes,
       isolation = isolation,
       minOneMessage = true)
-    fetchInfo.records
+
+    new LogFetchInfo(
+      fetchInfo.records,
+      new LogOffsetMetadata(
+        fetchInfo.fetchOffsetMetadata.messageOffset,
+        fetchInfo.fetchOffsetMetadata.segmentBaseOffset,
+        fetchInfo.fetchOffsetMetadata.relativePositionInSegment)
+    )
   }
 
   override def appendAsLeader(records: Records, epoch: Int): LogAppendInfo = {
@@ -54,6 +61,7 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
 
   override def appendAsFollower(records: Records): LogAppendInfo = {
     val appendInfo = log.appendAsFollower(records.asInstanceOf[MemoryRecords])
+    log.logEndOffsetMetadata
     new LogAppendInfo(appendInfo.firstOffset.getOrElse {
       throw new KafkaException("Append failed unexpectedly")
     }, appendInfo.lastOffset)
@@ -71,8 +79,12 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
     endOffsetOpt.asJava
   }
 
-  override def endOffset: Long = {
-    log.logEndOffset
+  override def endOffset: LogOffsetMetadata = {
+    val endOffsetMetadata = log.logEndOffsetMetadata
+    new LogOffsetMetadata(
+      endOffsetMetadata.messageOffset,
+      endOffsetMetadata.segmentBaseOffset,
+      endOffsetMetadata.relativePositionInSegment)
   }
 
   override def startOffset: Long = {
@@ -87,8 +99,11 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
     log.maybeAssignEpochStartOffset(epoch, startOffset)
   }
 
-  override def updateHighWatermark(offset: Long): Unit = {
-    log.updateHighWatermark(offset)
+  override def updateHighWatermark(offsetMetadata: LogOffsetMetadata): Unit = {
+    log.updateHighWatermarkOffsetMetadata(new kafka.server.LogOffsetMetadata(
+      offsetMetadata.offset,
+      offsetMetadata.segmentBaseOffset,
+      offsetMetadata.relativePositionInSegment)
+    )
   }
-
 }

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -16,7 +16,7 @@
  */
 package kafka.raft
 
-import java.util.{Objects, Optional, OptionalLong}
+import java.util.{Optional, OptionalLong}
 
 import kafka.log.{AppendOrigin, Log}
 import kafka.server.{FetchHighWatermark, FetchLogEnd}
@@ -24,20 +24,11 @@ import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.record.{MemoryRecords, Records}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.raft
-import org.apache.kafka.raft.{LogAppendInfo, LogFetchInfo, LogOffsetMetadata, OffsetMetadata, ReplicatedLog}
+import org.apache.kafka.raft.{LogAppendInfo, LogFetchInfo, LogOffsetMetadata, ReplicatedLog}
 
 import scala.compat.java8.OptionConverters._
 
 class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1024) extends ReplicatedLog {
-
-  case class KafkaLogOffsetMetadata(segmentBaseOffset: Long, relativePositionInSegment: Int) extends OffsetMetadata {
-    override def hashCode: Int = Objects.hash(segmentBaseOffset, relativePositionInSegment)
-    override def equals(obj: Any): Boolean = obj match {
-      case other: KafkaLogOffsetMetadata => segmentBaseOffset == other.segmentBaseOffset && relativePositionInSegment == other.relativePositionInSegment
-      case _ => false
-    }
-    override def toString: String = s"(segmentBaseOffset=$segmentBaseOffset,relativePositionInSegment=$relativePositionInSegment)"
-  }
 
   override def read(startOffset: Long, endOffsetExclusive: OptionalLong): LogFetchInfo = {
     val isolation = if (endOffsetExclusive.isPresent)
@@ -55,7 +46,7 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
 
       new LogOffsetMetadata(
         fetchInfo.fetchOffsetMetadata.messageOffset,
-        Optional.of(KafkaLogOffsetMetadata(
+        Optional.of(SegmentPosition(
           fetchInfo.fetchOffsetMetadata.segmentBaseOffset,
           fetchInfo.fetchOffsetMetadata.relativePositionInSegment))
         )
@@ -100,7 +91,7 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
     val endOffsetMetadata = log.logEndOffsetMetadata
     new LogOffsetMetadata(
       endOffsetMetadata.messageOffset,
-      Optional.of(KafkaLogOffsetMetadata(
+      Optional.of(SegmentPosition(
         endOffsetMetadata.segmentBaseOffset,
         endOffsetMetadata.relativePositionInSegment))
       )
@@ -119,15 +110,14 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
   }
 
   override def updateHighWatermark(offsetMetadata: LogOffsetMetadata): Unit = {
-    if (offsetMetadata.metadata.isPresent && offsetMetadata.metadata.get.isInstanceOf[KafkaLogOffsetMetadata]) {
-      val logOffsetMetadata = offsetMetadata.metadata.get.asInstanceOf[KafkaLogOffsetMetadata]
-      log.updateHighWatermarkOffsetMetadata(new kafka.server.LogOffsetMetadata(
-        offsetMetadata.offset,
-        logOffsetMetadata.segmentBaseOffset,
-        logOffsetMetadata.relativePositionInSegment)
+    offsetMetadata.metadata.asScala match {
+      case Some(segmentPosition: SegmentPosition) => log.updateHighWatermarkOffsetMetadata(
+        new kafka.server.LogOffsetMetadata(
+          offsetMetadata.offset,
+          segmentPosition.segmentBaseOffset,
+          segmentPosition.relativePositionInSegment)
       )
-    } else {
-      log.updateHighWatermark(offsetMetadata.offset)
+      case _ => log.updateHighWatermark(offsetMetadata.offset)
     }
   }
 }

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -114,8 +114,8 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
       case Some(segmentPosition: SegmentPosition) => log.updateHighWatermarkOffsetMetadata(
         new kafka.server.LogOffsetMetadata(
           offsetMetadata.offset,
-          segmentPosition.segmentBaseOffset,
-          segmentPosition.relativePositionInSegment)
+          segmentPosition.baseOffset,
+          segmentPosition.relativePosition)
       )
       case _ => log.updateHighWatermark(offsetMetadata.offset)
     }

--- a/core/src/main/scala/kafka/raft/SegmentPosition.scala
+++ b/core/src/main/scala/kafka/raft/SegmentPosition.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.raft
+
+import org.apache.kafka.raft.OffsetMetadata
+
+case class SegmentPosition(segmentBaseOffset: Long, relativePositionInSegment: Int) extends OffsetMetadata {
+  override def toString: String = s"(segmentBaseOffset=$segmentBaseOffset,relativePositionInSegment=$relativePositionInSegment)"
+}

--- a/core/src/main/scala/kafka/raft/SegmentPosition.scala
+++ b/core/src/main/scala/kafka/raft/SegmentPosition.scala
@@ -18,6 +18,6 @@ package kafka.raft
 
 import org.apache.kafka.raft.OffsetMetadata
 
-case class SegmentPosition(segmentBaseOffset: Long, relativePositionInSegment: Int) extends OffsetMetadata {
-  override def toString: String = s"(segmentBaseOffset=$segmentBaseOffset,relativePositionInSegment=$relativePositionInSegment)"
+case class SegmentPosition(baseOffset: Long, relativePosition: Int) extends OffsetMetadata {
+  override def toString: String = s"(segmentBaseOffset=$baseOffset,relativePositionInSegment=$relativePosition)"
 }

--- a/raft/src/main/java/org/apache/kafka/raft/EpochState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/EpochState.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.raft;
 
-import java.util.OptionalLong;
+import java.util.Optional;
 
 public interface EpochState {
 
-    default OptionalLong highWatermark() {
-        return OptionalLong.empty();
+    default Optional<LogOffsetMetadata> highWatermark() {
+        return Optional.empty();
     }
 
     ElectionState election();

--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.raft;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -36,8 +37,8 @@ public class FollowerState implements EpochState {
     }
 
     @Override
-    public OptionalLong highWatermark() {
-        return highWatermark;
+    public Optional<LogOffsetMetadata> highWatermark() {
+        return highWatermark.isPresent() ? Optional.of(new LogOffsetMetadata(highWatermark.getAsLong())) : Optional.empty();
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -219,9 +219,9 @@ public class KafkaRaftClient implements RaftClient {
             logger.debug("Applying committed entries up to high watermark {}. " +
                 "Current position is {}", highWatermark, stateMachine.position());
 
-            while (stateMachine.position().offset < highWatermark && shutdown.get() == null) {
+            while (stateMachine.position().offset < highWatermark.offset && shutdown.get() == null) {
                 OffsetAndEpoch position = stateMachine.position();
-                Records records = readCommitted(position, highWatermark);
+                Records records = readCommitted(position, highWatermark.offset);
 
                 stateMachine.apply(records);
                 logger.trace("Applied committed records at {} to the state machine; position " +
@@ -230,12 +230,12 @@ public class KafkaRaftClient implements RaftClient {
         });
     }
 
-    private void maybeCommitPendingAppends(long highWatermark, long currentTimeMs) {
+    private void maybeCommitPendingAppends(LogOffsetMetadata highWatermark, long currentTimeMs) {
         Iterator<Map.Entry<OffsetAndEpoch, AppendBatchAndTime>> iter = uncommittedAppends.entrySet().iterator();
         while (iter.hasNext()) {
             Map.Entry<OffsetAndEpoch, AppendBatchAndTime> entry = iter.next();
             OffsetAndEpoch offsetAndEpoch = entry.getKey();
-            if (offsetAndEpoch.offset < highWatermark) {
+            if (offsetAndEpoch.offset < highWatermark.offset) {
                 AppendBatchAndTime appendBatchAndTime = entry.getValue();
                 long elapsedTime = Math.max(0, currentTimeMs - appendBatchAndTime.appendTimeMs);
                 double elapsedTimePerRecord = elapsedTime / (double) appendBatchAndTime.numRecords;
@@ -270,10 +270,10 @@ public class KafkaRaftClient implements RaftClient {
         purgatory.completeAll(null);
     }
 
-    private void updateReplicaEndOffset(LeaderState state, int replicaId, long endOffset) {
-        if (state.updateEndOffset(replicaId, endOffset)) {
+    private void updateReplicaEndOffset(LeaderState state, int replicaId, LogOffsetMetadata endOffsetMetadata) {
+        if (state.updateEndOffset(replicaId, endOffsetMetadata)) {
             logger.debug("Leader high watermark updated to {} after replica {} end offset updated to {}",
-                    state.highWatermark(), replicaId, endOffset);
+                    state.highWatermark(), replicaId, endOffsetMetadata);
             applyCommittedRecordsToStateMachine();
         }
 
@@ -293,7 +293,7 @@ public class KafkaRaftClient implements RaftClient {
     @Override
     public void initialize(ReplicatedStateMachine stateMachine) throws IOException {
         this.stateMachine = stateMachine;
-        quorum.initialize(new OffsetAndEpoch(log.endOffset(), log.lastFetchedEpoch()));
+        quorum.initialize(new OffsetAndEpoch(log.endOffset().offset, log.lastFetchedEpoch()));
         stateMachine.initialize(this::append);
 
         if (quorum.isLeader()) {
@@ -314,7 +314,7 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     private OffsetAndEpoch endOffset() {
-        return new OffsetAndEpoch(log.endOffset(), log.lastFetchedEpoch());
+        return new OffsetAndEpoch(log.endOffset().offset, log.lastFetchedEpoch());
     }
 
     private void resetConnections() {
@@ -337,7 +337,7 @@ public class KafkaRaftClient implements RaftClient {
                         follower -> new Voter().setVoterId(follower)).collect(Collectors.toList())))
         );
 
-        log.assignEpochStartOffset(quorum.epoch(), log.endOffset());
+        log.assignEpochStartOffset(quorum.epoch(), log.endOffset().offset);
         resetConnections();
 
         timer.reset(fetchTimeoutMs);
@@ -354,7 +354,7 @@ public class KafkaRaftClient implements RaftClient {
 
     private void maybeBecomeLeader(CandidateState state) throws IOException {
         if (state.isVoteGranted()) {
-            long endOffset = log.endOffset();
+            long endOffset = log.endOffset().offset;
             LeaderState leaderState = quorum.becomeLeader(endOffset);
             onBecomeLeader(leaderState);
         }
@@ -688,7 +688,7 @@ public class KafkaRaftClient implements RaftClient {
     private FetchQuorumRecordsResponseData buildFetchQuorumRecordsResponse(
         Errors error,
         Records records,
-        OptionalLong highWatermark
+        Optional<LogOffsetMetadata> highWatermark
     ) throws IOException {
         return buildEmptyFetchQuorumRecordsResponse(error, highWatermark)
             .setRecords(RaftUtil.serializeRecords(records));
@@ -696,14 +696,14 @@ public class KafkaRaftClient implements RaftClient {
 
     private FetchQuorumRecordsResponseData buildEmptyFetchQuorumRecordsResponse(
         Errors error,
-        OptionalLong highWatermark
+        Optional<LogOffsetMetadata> highWatermark
     ) {
         return new FetchQuorumRecordsResponseData()
             .setErrorCode(error.code())
             .setLeaderEpoch(quorum.epoch())
             .setLeaderId(quorum.leaderIdOrNil())
             .setRecords(ByteBuffer.wrap(new byte[0]))
-            .setHighWatermark(highWatermark.orElse(-1L));
+            .setHighWatermark(highWatermark.map(logOffsetMetadata -> logOffsetMetadata.offset).orElse(-1L));
     }
 
     /**
@@ -728,7 +728,7 @@ public class KafkaRaftClient implements RaftClient {
             || request.lastFetchedEpoch() < 0
             || request.lastFetchedEpoch() > request.leaderEpoch()) {
             return completedFuture(buildEmptyFetchQuorumRecordsResponse(
-                Errors.INVALID_REQUEST, OptionalLong.empty()));
+                Errors.INVALID_REQUEST, Optional.empty()));
         }
 
         FetchQuorumRecordsResponseData response = tryCompleteFetchQuorumRecordsRequest(request);
@@ -751,7 +751,7 @@ public class KafkaRaftClient implements RaftClient {
                 // any other error, we need to return it.
                 Errors error = Errors.forException(cause);
                 if (error != Errors.REQUEST_TIMED_OUT) {
-                    return buildEmptyFetchQuorumRecordsResponse(error, OptionalLong.empty());
+                    return buildEmptyFetchQuorumRecordsResponse(error, Optional.empty());
                 }
             }
 
@@ -759,7 +759,7 @@ public class KafkaRaftClient implements RaftClient {
                 return tryCompleteFetchQuorumRecordsRequest(request);
             } catch (Exception e) {
                 logger.error("Caught unexpected error in fetch completion of request {}", request, e);
-                return buildEmptyFetchQuorumRecordsResponse(Errors.UNKNOWN_SERVER_ERROR, OptionalLong.empty());
+                return buildEmptyFetchQuorumRecordsResponse(Errors.UNKNOWN_SERVER_ERROR, Optional.empty());
             }
         });
     }
@@ -772,14 +772,14 @@ public class KafkaRaftClient implements RaftClient {
             return buildFetchQuorumRecordsResponse(
                 errorOpt.get(),
                 MemoryRecords.EMPTY,
-                OptionalLong.empty());
+                Optional.empty());
         }
 
         int replicaId = request.replicaId();
         long fetchOffset = request.fetchOffset();
         int lastFetchedEpoch = request.lastFetchedEpoch();
         LeaderState state = quorum.leaderStateOrThrow();
-        OptionalLong highWatermark = state.highWatermark();
+        Optional<LogOffsetMetadata> highWatermark = state.highWatermark();
         Optional<OffsetAndEpoch> nextOffsetOpt = validateFetchOffsetAndEpoch(fetchOffset, lastFetchedEpoch);
 
         if (nextOffsetOpt.isPresent()) {
@@ -787,15 +787,18 @@ public class KafkaRaftClient implements RaftClient {
             return buildEmptyFetchQuorumRecordsResponse(Errors.NONE, highWatermark)
                 .setNextFetchOffset(nextOffsetAndEpoch.offset)
                 .setNextFetchOffsetEpoch(nextOffsetAndEpoch.epoch);
-        } else if (quorum.isVoter(replicaId)) {
-            updateReplicaEndOffset(state, replicaId, fetchOffset);
-        }
+        } else {
+            LogFetchInfo info = log.read(fetchOffset, OptionalLong.empty());
 
-        Records records = log.read(fetchOffset, OptionalLong.empty());
-        return buildFetchQuorumRecordsResponse(
-            Errors.NONE,
-            records,
-            highWatermark);
+            if (quorum.isVoter(replicaId)) {
+                updateReplicaEndOffset(state, replicaId, info.startOffsetMetadata);
+            }
+
+            return buildFetchQuorumRecordsResponse(
+                    Errors.NONE,
+                    info.records,
+                    highWatermark);
+        }
     }
 
     /**
@@ -1250,7 +1253,7 @@ public class KafkaRaftClient implements RaftClient {
         return new FetchQuorumRecordsRequestData()
             .setLeaderEpoch(quorum.epoch())
             .setReplicaId(quorum.localId)
-            .setFetchOffset(log.endOffset())
+            .setFetchOffset(log.endOffset().offset)
             .setLastFetchedEpoch(log.lastFetchedEpoch())
             .setMaxWaitTimeMs(fetchMaxWaitMs);
     }
@@ -1424,7 +1427,7 @@ public class KafkaRaftClient implements RaftClient {
             throw new LogTruncationException("The requested offset and epoch " + offsetAndEpoch +
                     " are not in range. The closest offset we found is " + endOffset + ".");
         }
-        return log.read(offsetAndEpoch.offset, OptionalLong.of(highWatermark));
+        return log.read(offsetAndEpoch.offset, OptionalLong.of(highWatermark)).records;
     }
 
     @Override
@@ -1436,7 +1439,7 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     public OptionalLong highWatermark() {
-        return quorum.highWatermark();
+        return quorum.highWatermark().isPresent() ? OptionalLong.of(quorum.highWatermark().get().offset) : OptionalLong.empty();
     }
 
     private class GracefulShutdown {

--- a/raft/src/main/java/org/apache/kafka/raft/LogFetchInfo.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LogFetchInfo.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.record.Records;
+
+/**
+ * Metadata for the records fetched from log, including the records itself
+ */
+public class LogFetchInfo {
+
+    public final Records records;
+    public final LogOffsetMetadata startOffsetMetadata;
+
+    public LogFetchInfo(Records records, LogOffsetMetadata startOffsetMetadata) {
+        this.records = records;
+        this.startOffsetMetadata = startOffsetMetadata;
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/LogOffsetMetadata.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LogOffsetMetadata.java
@@ -16,30 +16,29 @@
  */
 package org.apache.kafka.raft;
 
+import java.util.Optional;
+
 /**
  * Metadata for specific local log offset
  */
 public class LogOffsetMetadata {
 
     public final long offset;
-    public final long segmentBaseOffset;
-    public final int relativePositionInSegment;
+    public final Optional<OffsetMetadata> metadata;
 
     public LogOffsetMetadata(long offset) {
-        this(offset, -1L, -1);
+        this(offset, Optional.empty());
     }
 
-    public LogOffsetMetadata(long offset, long segmentBaseOffset, int relativePositionInSegment) {
+    public LogOffsetMetadata(long offset, Optional<OffsetMetadata> metadata) {
         this.offset = offset;
-        this.segmentBaseOffset = segmentBaseOffset;
-        this.relativePositionInSegment = relativePositionInSegment;
+        this.metadata = metadata;
     }
 
     @Override
     public String toString() {
         return "LogOffsetMetadata(offset=" + offset +
-                ", segmentBaseOffset=" + segmentBaseOffset +
-                ", relativePositionInSegment=" + relativePositionInSegment + ")";
+                ", metadata=" + metadata + ")";
     }
 
     @Override
@@ -47,8 +46,7 @@ public class LogOffsetMetadata {
         if (obj instanceof LogOffsetMetadata) {
             LogOffsetMetadata other = (LogOffsetMetadata) obj;
             return this.offset == other.offset &&
-                   this.segmentBaseOffset == other.segmentBaseOffset &&
-                   this.relativePositionInSegment == other.relativePositionInSegment;
+                   this.metadata.equals(other.metadata);
         } else {
             return false;
         }

--- a/raft/src/main/java/org/apache/kafka/raft/LogOffsetMetadata.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LogOffsetMetadata.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.raft;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -50,5 +51,10 @@ public class LogOffsetMetadata {
         } else {
             return false;
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(offset, metadata);
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/LogOffsetMetadata.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LogOffsetMetadata.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+/**
+ * Metadata for specific local log offset
+ */
+public class LogOffsetMetadata {
+
+    public final long offset;
+    public final long segmentBaseOffset;
+    public final int relativePositionInSegment;
+
+    public LogOffsetMetadata(long offset) {
+        this(offset, -1L, -1);
+    }
+
+    public LogOffsetMetadata(long offset, long segmentBaseOffset, int relativePositionInSegment) {
+        this.offset = offset;
+        this.segmentBaseOffset = segmentBaseOffset;
+        this.relativePositionInSegment = relativePositionInSegment;
+    }
+
+    @Override
+    public String toString() {
+        return "LogOffsetMetadata(offset=" + offset +
+                ", segmentBaseOffset=" + segmentBaseOffset +
+                ", relativePositionInSegment=" + relativePositionInSegment + ")";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof LogOffsetMetadata) {
+            LogOffsetMetadata other = (LogOffsetMetadata) obj;
+            return this.offset == other.offset &&
+                   this.segmentBaseOffset == other.segmentBaseOffset &&
+                   this.relativePositionInSegment == other.relativePositionInSegment;
+        } else {
+            return false;
+        }
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/OffsetMetadata.java
+++ b/raft/src/main/java/org/apache/kafka/raft/OffsetMetadata.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+// Opaque metadata type which should be instantiate by the log implementation
+public interface OffsetMetadata {
+}

--- a/raft/src/main/java/org/apache/kafka/raft/OffsetMetadata.java
+++ b/raft/src/main/java/org/apache/kafka/raft/OffsetMetadata.java
@@ -16,6 +16,6 @@
  */
 package org.apache.kafka.raft;
 
-// Opaque metadata type which should be instantiate by the log implementation
+// Opaque metadata type which should be instantiated by the log implementation
 public interface OffsetMetadata {
 }

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -110,7 +111,7 @@ public class QuorumState {
         return leaderId().orElse(-1);
     }
 
-    public OptionalLong highWatermark() {
+    public Optional<LogOffsetMetadata> highWatermark() {
         return state.highWatermark();
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
@@ -44,7 +44,7 @@ public interface ReplicatedLog {
     /**
      * Read a set of records within a range of offsets.
      */
-    Records read(long startOffsetInclusive, OptionalLong endOffsetExclusive);
+    LogFetchInfo read(long startOffsetInclusive, OptionalLong endOffsetExclusive);
 
     /**
      * Return the latest epoch. For an empty log, the latest epoch is defined
@@ -62,10 +62,10 @@ public interface ReplicatedLog {
     Optional<OffsetAndEpoch> endOffsetForEpoch(int leaderEpoch);
 
     /**
-     * Get the current log end offset. This is always one plus the offset of the last
+     * Get the current log end offset metadata. This is always one plus the offset of the last
      * written record. When the log is empty, the end offset is equal to the start offset.
      */
-    long endOffset();
+    LogOffsetMetadata endOffset();
 
     /**
      * Get the current log start offset. This is the offset of the first written
@@ -86,7 +86,7 @@ public interface ReplicatedLog {
      */
     void truncateTo(long offset);
 
-    void updateHighWatermark(long offset);
+    void updateHighWatermark(LogOffsetMetadata offsetMetadata);
 
     /**
      * Truncate to an offset and epoch.
@@ -106,7 +106,7 @@ public interface ReplicatedLog {
                 if (localEndOffset.epoch == leaderEpoch) {
                     truncationOffset = Math.min(localEndOffset.offset, endOffset.offset);
                 } else {
-                    truncationOffset = Math.min(localEndOffset.offset, endOffset());
+                    truncationOffset = Math.min(localEndOffset.offset, endOffset().offset);
                 }
             } else {
                 // The leader has no epoch which is less than or equal to our own epoch. We simply truncate

--- a/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
@@ -103,7 +103,7 @@ public class KafkaRaftMetrics implements AutoCloseable {
         metrics.addMetric(this.currentEpochMetricName, (mConfig, currentTimeMs) -> state.epoch());
 
         this.highWatermarkMetricName = metrics.metricName("high-watermark", metricGroupName, "The high watermark maintained on this member; -1 if it is unknown");
-        metrics.addMetric(this.highWatermarkMetricName, (mConfig, currentTimeMs) -> state.highWatermark().orElse(-1L));
+        metrics.addMetric(this.highWatermarkMetricName, (mConfig, currentTimeMs) -> state.highWatermark().map(hw -> hw.offset).orElse(-1L));
 
         this.logEndOffsetMetricName = metrics.metricName("log-end-offset", metricGroupName, "The current raft log end offset.");
         metrics.addMetric(this.logEndOffsetMetricName, (mConfig, currentTimeMs) -> logEndOffset.offset);

--- a/raft/src/test/java/org/apache/kafka/raft/FollowerStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/FollowerStateTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.Test;
 
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -128,7 +129,7 @@ public class FollowerStateTest {
         int leaderId = 2;
         assertTrue(state.acknowledgeLeader(leaderId));
         state.updateHighWatermark(highWatermark);
-        assertEquals(highWatermark, state.highWatermark());
+        assertEquals(Optional.of(new LogOffsetMetadata(15L)), state.highWatermark());
     }
 
     @Test
@@ -141,6 +142,6 @@ public class FollowerStateTest {
         assertThrows(IllegalArgumentException.class, () -> state.updateHighWatermark(OptionalLong.empty()));
         assertThrows(IllegalArgumentException.class, () -> state.updateHighWatermark(OptionalLong.of(14L)));
         state.updateHighWatermark(highWatermark);
-        assertEquals(highWatermark, state.highWatermark());
+        assertEquals(Optional.of(new LogOffsetMetadata(15L)), state.highWatermark());
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1603,7 +1603,7 @@ public class KafkaRaftClientTest {
 
         // Poll again to complete truncation
         client.poll();
-        assertEquals(new LogOffsetMetadata(2L), log.endOffset());
+        assertEquals(2L, log.endOffset().offset);
 
         // Now we should be fetching
         client.poll();

--- a/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
@@ -56,9 +56,9 @@ public class MockLogTest {
         log.appendAsLeader(Collections.singleton(recordOne), epoch);
         assertEquals(epoch, log.lastFetchedEpoch());
         assertEquals(0L, log.startOffset());
-        assertEquals(1L, log.endOffset());
+        assertEquals(1L, log.endOffset().offset);
 
-        Records records = log.read(0, OptionalLong.of(1));
+        Records records = log.read(0, OptionalLong.of(1)).records;
         List<? extends RecordBatch> batches = Utils.toList(records.batches().iterator());
 
         RecordBatch batch = batches.get(0);
@@ -74,9 +74,9 @@ public class MockLogTest {
         SimpleRecord recordThree = new SimpleRecord("three".getBytes());
         log.appendAsLeader(Arrays.asList(recordTwo, recordThree), epoch);
         assertEquals(0L, log.startOffset());
-        assertEquals(3L, log.endOffset());
+        assertEquals(3L, log.endOffset().offset);
 
-        records = log.read(0, OptionalLong.empty());
+        records = log.read(0, OptionalLong.empty()).records;
         batches = Utils.toList(records.batches().iterator());
         assertEquals(2, batches.size());
 
@@ -103,28 +103,29 @@ public class MockLogTest {
         log.appendAsLeader(Collections.singleton(recordThree), epoch);
 
         assertEquals(0L, log.startOffset());
-        assertEquals(3L, log.endOffset());
+        assertEquals(3L, log.endOffset().offset);
 
         log.truncateTo(2);
         assertEquals(0L, log.startOffset());
-        assertEquals(2L, log.endOffset());
+        assertEquals(2L, log.endOffset().offset);
 
         log.truncateTo(1);
         assertEquals(0L, log.startOffset());
-        assertEquals(0L, log.endOffset());
+        assertEquals(0L, log.endOffset().offset);
     }
 
     @Test
     public void testUpdateHighWatermark() {
-        long newOffset = 5L;
+        LogOffsetMetadata newOffset = new LogOffsetMetadata(5L);
         log.updateHighWatermark(newOffset);
         assertEquals(newOffset, log.highWatermark());
     }
 
     @Test
     public void testDecrementHighWatermark() {
-        log.updateHighWatermark(4);
-        assertThrows(IllegalArgumentException.class, () -> log.updateHighWatermark(3));
+        LogOffsetMetadata newOffset = new LogOffsetMetadata(4L);
+        log.updateHighWatermark(newOffset);
+        assertThrows(IllegalArgumentException.class, () -> log.updateHighWatermark(new LogOffsetMetadata(3L)));
     }
 
     @Test
@@ -147,10 +148,10 @@ public class MockLogTest {
         log.appendAsLeader(MemoryRecords.withRecords(initialOffset, CompressionType.NONE, recordFoo), currentEpoch);
 
         assertEquals(0, log.startOffset());
-        assertEquals(1, log.endOffset());
+        assertEquals(1, log.endOffset().offset);
         assertEquals(currentEpoch, log.lastFetchedEpoch());
 
-        Records records = log.read(0, OptionalLong.empty());
+        Records records = log.read(0, OptionalLong.empty()).records;
         List<ByteBuffer> extractRecords = new ArrayList<>();
         for (Record record : records.records()) {
             extractRecords.add(record.value());
@@ -170,10 +171,10 @@ public class MockLogTest {
             initialOffset, 2, messageData), currentEpoch);
 
         assertEquals(0, log.startOffset());
-        assertEquals(1, log.endOffset());
+        assertEquals(1, log.endOffset().offset);
         assertEquals(currentEpoch, log.lastFetchedEpoch());
 
-        Records records = log.read(0, OptionalLong.empty());
+        Records records = log.read(0, OptionalLong.empty()).records;
         for (RecordBatch batch : records.batches()) {
             assertTrue(batch.isControlBatch());
         }
@@ -196,10 +197,10 @@ public class MockLogTest {
         log.appendAsFollower(MemoryRecords.withRecords(initialOffset, CompressionType.NONE, epoch, recordFoo));
 
         assertEquals(5L, log.startOffset());
-        assertEquals(6L, log.endOffset());
+        assertEquals(6L, log.endOffset().offset);
         assertEquals(3, log.lastFetchedEpoch());
 
-        Records records = log.read(0, OptionalLong.empty());
+        Records records = log.read(0, OptionalLong.empty()).records;
         List<ByteBuffer> extractRecords = new ArrayList<>();
         for (Record record : records.records()) {
             extractRecords.add(record.value());
@@ -208,7 +209,7 @@ public class MockLogTest {
         assertEquals(1, extractRecords.size());
         assertEquals(recordFoo.value(), extractRecords.get(0));
         assertEquals(Optional.of(new OffsetAndEpoch(5, 0)), log.endOffsetForEpoch(0));
-        assertEquals(Optional.of(new OffsetAndEpoch(log.endOffset(), epoch)), log.endOffsetForEpoch(epoch));
+        assertEquals(Optional.of(new OffsetAndEpoch(log.endOffset().offset, epoch)), log.endOffsetForEpoch(epoch));
     }
 
     @Test
@@ -225,7 +226,7 @@ public class MockLogTest {
 
         log.appendAsLeader(Arrays.asList(recordOne, recordTwo), epoch);
 
-        Records records = log.read(0, OptionalLong.empty());
+        Records records = log.read(0, OptionalLong.empty()).records;
 
         List<ByteBuffer> extractRecords = new ArrayList<>();
         for (Record record : records.records()) {

--- a/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
@@ -262,7 +262,7 @@ public class MockLogTest {
     }
 
     private Optional<OffsetRange> readOffsets(long startOffset, OptionalLong maxOffset) {
-        Records records = log.read(startOffset, maxOffset);
+        Records records = log.read(startOffset, maxOffset).records;
         long firstReadOffset = -1L;
         long lastReadOffset = -1L;
         for (Record record : records.records()) {

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -21,8 +21,8 @@ import org.apache.kafka.common.utils.Utils;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.OptionalLong;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -137,7 +137,7 @@ public class QuorumStateTest {
         LeaderState leaderState = state.becomeLeader(0L);
         assertTrue(state.isLeader());
         assertEquals(1, leaderState.epoch());
-        assertEquals(OptionalLong.empty(), leaderState.highWatermark());
+        assertEquals(Optional.empty(), leaderState.highWatermark());
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -818,7 +818,7 @@ public class RaftEventSimulationTest {
             cluster.leaderHighWatermark().ifPresent(highWatermark -> {
                 long numReachedHighWatermark = cluster.nodes.entrySet().stream()
                     .filter(entry -> cluster.voters.contains(entry.getKey()))
-                    .filter(entry -> entry.getValue().log.endOffset() >= highWatermark)
+                    .filter(entry -> entry.getValue().log.endOffset().offset >= highWatermark)
                     .count();
                 assertTrue("Insufficient nodes have reached current high watermark",
                     numReachedHighWatermark >= cluster.majoritySize());

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -524,26 +524,26 @@ public class RaftEventSimulationTest {
 
         boolean anyReachedHighWatermark(long offset) {
             return running.values().stream()
-                    .anyMatch(node -> node.quorum.highWatermark().orElse(0) > offset);
+                    .anyMatch(node -> node.quorum.highWatermark().map(hw -> hw.offset).orElse(0L) > offset);
         }
 
         long maxHighWatermarkReached(Set<Integer> nodeIds) {
             return running.values().stream()
                 .filter(node -> nodeIds.contains(node.nodeId))
-                .map(node -> node.quorum.highWatermark().orElse(0))
+                .map(node -> node.quorum.highWatermark().map(hw -> hw.offset).orElse(0L))
                 .max(Long::compareTo)
                 .orElse(0L);
         }
 
         boolean allReachedHighWatermark(long offset, Set<Integer> nodeIds) {
             return nodeIds.stream()
-                .allMatch(nodeId -> running.get(nodeId).quorum.highWatermark()
-                    .orElse(0) > offset);
+                .allMatch(nodeId -> running.get(nodeId).quorum.highWatermark().map(hw -> hw.offset)
+                    .orElse(0L) > offset);
         }
 
         boolean allReachedHighWatermark(long offset) {
             return running.values().stream()
-                .allMatch(node -> node.quorum.highWatermark().orElse(0) > offset);
+                .allMatch(node -> node.quorum.highWatermark().map(hw -> hw.offset).orElse(0L) > offset);
         }
 
         boolean hasConsistentLeader() throws IOException {
@@ -590,7 +590,7 @@ public class RaftEventSimulationTest {
                 if (election.hasLeader()) {
                     Optional<OffsetAndEpoch> endOffset = state.log.endOffsetForEpoch(election.epoch);
                     if (!endOffset.isPresent())
-                        state.log.assignEpochStartOffset(election.epoch, state.log.endOffset());
+                        state.log.assignEpochStartOffset(election.epoch, state.log.endOffset().offset);
                 }
             });
         }

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.raft.LogFetchInfo;
+import org.apache.kafka.raft.LogOffsetMetadata;
 import org.apache.kafka.raft.MockQuorumStateStore;
 import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.raft.QuorumState;
@@ -94,8 +96,8 @@ public class KafkaRaftMetricsTest {
         assertEquals((double) 1, getMetric(metrics, "current-epoch").metricValue());
         assertEquals((double) -1L, getMetric(metrics, "high-watermark").metricValue());
 
-        state.leaderStateOrThrow().updateLocalEndOffset(5L);
-        state.leaderStateOrThrow().updateEndOffset(1, 5L);
+        state.leaderStateOrThrow().updateLocalEndOffset(new LogOffsetMetadata(5L));
+        state.leaderStateOrThrow().updateEndOffset(1, new LogOffsetMetadata(5L));
         assertEquals((double) 5L, getMetric(metrics, "high-watermark").metricValue());
 
         state.becomeFetchingFollower(2, 1);

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.raft.LogFetchInfo;
 import org.apache.kafka.raft.LogOffsetMetadata;
 import org.apache.kafka.raft.MockQuorumStateStore;
 import org.apache.kafka.raft.OffsetAndEpoch;


### PR DESCRIPTION
Cache the high watermark by remembering all replica's end offset as the LogOffsetMetadata.

Note that comparing with https://github.com/confluentinc/kafka/pull/344 we are only caching hw on the leader side, not on follower since the updated HW does not match the append log info, while the state machine application executes on both leader and followers --- i.e. on follower-side we still need to read the hw every time.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
