### PR TITLE
MockLog should only read full batches

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -222,6 +222,8 @@ public class KafkaRaftClient implements RaftClient {
             while (stateMachine.position().offset < highWatermark && shutdown.get() == null) {
                 OffsetAndEpoch position = stateMachine.position();
                 Records records = readCommitted(position, highWatermark);
+                if (records.sizeInBytes() == 0)
+                    break;
 
                 stateMachine.apply(records);
                 logger.trace("Applied committed records at {} to the state machine; position " +

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -598,18 +598,11 @@ public class KafkaRaftClientTest {
         assertEquals(OptionalLong.of(1L), client.highWatermark());
         assertEquals(new OffsetAndEpoch(1, epoch), stateMachine.position());
 
-        // Let the follower to send another fetch from offset 2
-        deliverRequest(fetchQuorumRecordsRequest(epoch, otherNodeId, 2L, epoch, 500));
-        pollUntilSend(client);
-        assertEquals(OptionalLong.of(2L), client.highWatermark());
-        assertEquals(new OffsetAndEpoch(2, epoch), stateMachine.position());
-
-        // Let the follower to send another fetch from offset 4, only then the append future can be satisified
+        // Let the follower to send another fetch from offset 4
         deliverRequest(fetchQuorumRecordsRequest(epoch, otherNodeId, 4L, epoch, 500));
         client.poll();
         assertEquals(OptionalLong.of(4L), client.highWatermark());
         assertEquals(new OffsetAndEpoch(4, epoch), stateMachine.position());
-
     }
 
     @Test


### PR DESCRIPTION
It is important that we preserve batch boundaries in the MockLog implementation since they may (eventually) have semantic significance. For example, we may use batches to atomically apply a set of operations.

Note that the replication protocol guarantees that followers can only send fetch offsets on batch boundaries, which also implies that the high watermark is aligned. If there was a misaligned fetch, then it would result in a validation error and an offset reset.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
