### PR TITLE
Graceful shutdown improvements

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
@@ -52,6 +52,7 @@ public class Timer {
     private long startMs;
     private long currentTimeMs;
     private long deadlineMs;
+    private long timeoutMs;
 
     Timer(Time time, long timeoutMs) {
         this.time = time;
@@ -101,6 +102,7 @@ public class Timer {
         if (timeoutMs < 0)
             throw new IllegalArgumentException("Invalid negative timeout " + timeoutMs);
 
+        this.timeoutMs = timeoutMs;
         this.startMs = this.currentTimeMs;
 
         if (currentTimeMs > Long.MAX_VALUE - timeoutMs)
@@ -118,6 +120,7 @@ public class Timer {
         if (deadlineMs < 0)
             throw new IllegalArgumentException("Invalid negative deadline " + deadlineMs);
 
+        this.timeoutMs = Math.max(0, deadlineMs - this.currentTimeMs);
         this.startMs = this.currentTimeMs;
         this.deadlineMs = deadlineMs;
     }
@@ -177,6 +180,16 @@ public class Timer {
      */
     public long elapsedMs() {
         return currentTimeMs - startMs;
+    }
+
+    /**
+     * Get the current timeout value specified through {@link #reset(long)} or {@link #resetDeadline(long)}.
+     * This value is constant until altered by one of these API calls.
+     *
+     * @return The timeout in milliseconds
+     */
+    public long timeoutMs() {
+        return timeoutMs;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/utils/TimerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/TimerTest.java
@@ -30,18 +30,21 @@ public class TimerTest {
     @Test
     public void testTimerUpdate() {
         Timer timer = time.timer(500);
+        assertEquals(500, timer.timeoutMs());
         assertEquals(500, timer.remainingMs());
         assertEquals(0, timer.elapsedMs());
 
         time.sleep(100);
         timer.update();
 
+        assertEquals(500, timer.timeoutMs());
         assertEquals(400, timer.remainingMs());
         assertEquals(100, timer.elapsedMs());
 
         time.sleep(400);
         timer.update(time.milliseconds());
 
+        assertEquals(500, timer.timeoutMs());
         assertEquals(0, timer.remainingMs());
         assertEquals(500, timer.elapsedMs());
         assertTrue(timer.isExpired());
@@ -51,6 +54,7 @@ public class TimerTest {
         time.sleep(200);
         timer.update(time.milliseconds());
         assertTrue(timer.isExpired());
+        assertEquals(500, timer.timeoutMs());
         assertEquals(0, timer.remainingMs());
         assertEquals(700, timer.elapsedMs());
     }
@@ -59,10 +63,12 @@ public class TimerTest {
     public void testTimerUpdateAndReset() {
         Timer timer = time.timer(500);
         timer.sleep(200);
+        assertEquals(500, timer.timeoutMs());
         assertEquals(300, timer.remainingMs());
         assertEquals(200, timer.elapsedMs());
 
         timer.updateAndReset(400);
+        assertEquals(400, timer.timeoutMs());
         assertEquals(400, timer.remainingMs());
         assertEquals(0, timer.elapsedMs());
 
@@ -70,6 +76,7 @@ public class TimerTest {
         assertTrue(timer.isExpired());
 
         timer.updateAndReset(200);
+        assertEquals(200, timer.timeoutMs());
         assertEquals(200, timer.remainingMs());
         assertEquals(0, timer.elapsedMs());
         assertFalse(timer.isExpired());
@@ -99,10 +106,12 @@ public class TimerTest {
 
         timer.sleep(100);
         timer.resetDeadline(time.milliseconds() + 200);
+        assertEquals(200, timer.timeoutMs());
         assertEquals(200, timer.remainingMs());
 
-        timer.update();
-        assertEquals(200, timer.remainingMs());
+        timer.sleep(100);
+        assertEquals(200, timer.timeoutMs());
+        assertEquals(100, timer.remainingMs());
     }
 
     @Test

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -22,13 +22,12 @@ import kafka.log.{AppendOrigin, Log}
 import kafka.server.{FetchHighWatermark, FetchLogEnd}
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.record.{MemoryRecords, Records}
-import org.apache.kafka.common.utils.Time
 import org.apache.kafka.raft
 import org.apache.kafka.raft.{LogAppendInfo, LogFetchInfo, LogOffsetMetadata, ReplicatedLog}
 
 import scala.compat.java8.OptionConverters._
 
-class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1024) extends ReplicatedLog {
+class KafkaMetadataLog(log: Log, maxFetchSizeInBytes: Int = 1024 * 1024) extends ReplicatedLog {
 
   override def read(startOffset: Long, endOffsetExclusive: OptionalLong): LogFetchInfo = {
     val isolation = if (endOffsetExclusive.isPresent)
@@ -120,4 +119,9 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
       case _ => log.updateHighWatermark(offsetMetadata.offset)
     }
   }
+
+  override def close(): Unit = {
+    log.close()
+  }
+
 }

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -216,4 +216,8 @@ class KafkaNetworkChannel(time: Time,
     wakeup()
   }
 
+  override def close(): Unit = {
+    client.close()
+  }
+
 }

--- a/core/src/main/scala/kafka/server/RaftServer.scala
+++ b/core/src/main/scala/kafka/server/RaftServer.scala
@@ -273,8 +273,8 @@ class RaftServer(val config: KafkaConfig) extends Logging {
     override def doWork(): Unit = {
       if (counter.isLeader) {
         counter.increment()
-        pause(500, TimeUnit.MILLISECONDS)
       }
+      pause(500, TimeUnit.MILLISECONDS)
     }
   }
 

--- a/core/src/main/scala/kafka/server/RaftServer.scala
+++ b/core/src/main/scala/kafka/server/RaftServer.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.net.{InetAddress, InetSocketAddress}
 import java.nio.file.Files
 import java.util.Properties
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import joptsimple.OptionParser
 import kafka.log.{Log, LogConfig, LogManager}
@@ -29,7 +29,7 @@ import kafka.network.SocketServer
 import kafka.raft.{KafkaFuturePurgatory, KafkaMetadataLog, KafkaNetworkChannel}
 import kafka.security.CredentialProvider
 import kafka.utils.timer.SystemTimer
-import kafka.utils.{CommandLineUtils, Exit, KafkaScheduler, Logging}
+import kafka.utils.{CommandLineUtils, CoreUtils, Exit, KafkaScheduler, Logging, ShutdownableThread}
 import org.apache.kafka.clients.{ApiVersions, ClientDnsLookup, ManualMetadataUpdater, NetworkClient}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.ConfigException
@@ -47,6 +47,7 @@ class RaftServer(val config: KafkaConfig) extends Logging {
 
   private val partition = new TopicPartition("__cluster_metadata", 0)
   private val time = Time.SYSTEM
+  private val shutdownLatch = new CountDownLatch(1)
 
   var socketServer: SocketServer = _
   var credentialProvider: CredentialProvider = _
@@ -54,6 +55,10 @@ class RaftServer(val config: KafkaConfig) extends Logging {
   var dataPlaneRequestHandlerPool: KafkaRequestHandlerPool = _
   var scheduler: KafkaScheduler = _
   var metrics: Metrics = _
+  var raftIoThread: RaftIoThread = _
+  var incrementCounterThread: IncrementCounterThread = _
+  var networkChannel: KafkaNetworkChannel = _
+  var metadataLog: KafkaMetadataLog = _
 
   def startup(): Unit = {
     metrics = new Metrics()
@@ -101,30 +106,39 @@ class RaftServer(val config: KafkaConfig) extends Logging {
 
     socketServer.startProcessingRequests(Map.empty)
 
-    val shutdown = new AtomicBoolean(false)
-    try {
-      val counter = new ReplicatedCounter(config.brokerId, logContext, true)
-      val incrementThread = new Thread() {
-        override def run(): Unit = {
-          while (!shutdown.get()) {
-            if (counter.isLeader) {
-              counter.increment()
-              Thread.sleep(500)
-            }
-          }
-        }
-      }
+    val counter = new ReplicatedCounter(config.brokerId, logContext, true)
+    raftClient.initialize(counter)
 
-      raftClient.initialize(counter)
-      incrementThread.start()
+    raftIoThread = new RaftIoThread(raftClient)
+    raftIoThread.start()
 
-      while (true) {
-        raftClient.poll()
-      }
-    } finally {
-      shutdown.set(true)
-      raftClient.shutdown(5000)
-    }
+    incrementCounterThread = new IncrementCounterThread(counter)
+    incrementCounterThread.start()
+  }
+
+  def shutdown(): Unit = {
+    if (incrementCounterThread != null)
+      CoreUtils.swallow(incrementCounterThread.shutdown(), this)
+    if (raftIoThread != null)
+      CoreUtils.swallow(raftIoThread.shutdown(), this)
+    if (dataPlaneRequestHandlerPool != null)
+      CoreUtils.swallow(dataPlaneRequestHandlerPool.shutdown(), this)
+    if (socketServer != null)
+      CoreUtils.swallow(socketServer.shutdown(), this)
+    if (networkChannel != null)
+      CoreUtils.swallow(networkChannel.close(), this)
+    if (scheduler != null)
+      CoreUtils.swallow(scheduler.shutdown(), this)
+    if (metrics != null)
+      CoreUtils.swallow(metrics.close(), this)
+    if (metadataLog != null)
+      CoreUtils.swallow(metadataLog.close(), this)
+
+    shutdownLatch.countDown()
+  }
+
+  def awaitShutdown(): Unit = {
+    shutdownLatch.await()
   }
 
   private def buildNetworkChannel(raftConfig: RaftConfig,
@@ -156,7 +170,7 @@ class RaftServer(val config: KafkaConfig) extends Logging {
       producerIdExpirationCheckIntervalMs = LogManager.ProducerIdExpirationCheckIntervalMs,
       logDirFailureChannel = new LogDirFailureChannel(5)
     )
-    new KafkaMetadataLog(time, log)
+    new KafkaMetadataLog(log)
   }
 
   private def createLogDirectory(logDir: File, logDirName: String): File = {
@@ -255,6 +269,40 @@ class RaftServer(val config: KafkaConfig) extends Logging {
     new InetSocketAddress(host, port)
   }
 
+  class IncrementCounterThread(counter: ReplicatedCounter) extends ShutdownableThread("counter-incrementer") {
+    override def doWork(): Unit = {
+      if (counter.isLeader) {
+        counter.increment()
+        pause(500, TimeUnit.MILLISECONDS)
+      }
+    }
+  }
+
+  class RaftIoThread(client: KafkaRaftClient) extends ShutdownableThread("raft-io-thread") {
+    override def doWork(): Unit = {
+      client.poll()
+    }
+
+    override def initiateShutdown(): Boolean = {
+      if (super.initiateShutdown()) {
+        client.shutdown(5000).whenComplete { (_, exception) =>
+          if (exception != null) {
+            logger.error("Shutdown of RaftClient failed", exception)
+          } else {
+            logger.info("Completed shutdown of RaftClient")
+          }
+        }
+        true
+      } else {
+        false
+      }
+    }
+
+    override def isRunning: Boolean = {
+      client.isRunning
+    }
+  }
+
 }
 
 object RaftServer extends Logging {
@@ -298,7 +346,11 @@ object RaftServer extends Logging {
       val serverProps = getPropsFromArgs(args)
       val config = KafkaConfig.fromProps(serverProps, false)
       val server = new RaftServer(config)
+
+      Exit.addShutdownHook("raft-shutdown-hook", server.shutdown)
+
       server.startup()
+      server.awaitShutdown()
     }
     catch {
       case e: Throwable =>

--- a/core/src/test/scala/unit/kafka/raft/KafkaFuturePurgatoryTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaFuturePurgatoryTest.scala
@@ -77,12 +77,12 @@ class KafkaFuturePurgatoryTest {
 
     purgatory.completeAll(null)
     assertTrue(future1.isDone)
-    assertEquals((), future1.get())
+    assertEquals(null, future1.get())
 
     assertTrue(future2.isDone)
-    assertEquals((), future2.get())
+    assertEquals(null, future2.get())
 
     assertTrue(future3.isDone)
-    assertEquals((), future3.get())
+    assertEquals(null, future3.get())
   }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -64,7 +64,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -1457,7 +1456,6 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     private class GracefulShutdown {
-        final long shutdownTimeoutMs;
         final int epoch;
         final Timer finishTimer;
         final CompletableFuture<Void> completeFuture;
@@ -1465,7 +1463,6 @@ public class KafkaRaftClient implements RaftClient {
         public GracefulShutdown(long shutdownTimeoutMs,
                                 int epoch,
                                 CompletableFuture<Void> completeFuture) {
-            this.shutdownTimeoutMs = shutdownTimeoutMs;
             this.finishTimer = time.timer(shutdownTimeoutMs);
             this.epoch = epoch;
             this.completeFuture = completeFuture;
@@ -1482,7 +1479,7 @@ public class KafkaRaftClient implements RaftClient {
         public void update() {
             finishTimer.update();
             if (finishTimer.isExpired()) {
-                logger.warn("Graceful shutdown timed out after {}ms", shutdownTimeoutMs);
+                logger.warn("Graceful shutdown timed out after {}ms", timer.timeoutMs());
                 completeFuture.completeExceptionally(
                     new TimeoutException("Timeout expired before shutdown completed"));
             }

--- a/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
+++ b/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.raft;
 
+import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.util.List;
 
@@ -23,7 +24,7 @@ import java.util.List;
  * A simple network interface with few assumptions. We do not assume ordering
  * of requests or even that every request will receive a response.
  */
-public interface NetworkChannel {
+public interface NetworkChannel extends Closeable {
 
     /**
      * Generate a new and unique correlationId for a new request to be sent.
@@ -56,5 +57,7 @@ public interface NetworkChannel {
      * Update connection information for the given id.
      */
     void updateEndpoint(int id, InetSocketAddress address);
+
+    default void close() {}
 
 }

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -126,6 +126,10 @@ public class QuorumState {
         return leaderId().isPresent();
     }
 
+    public boolean hasRemoteLeader() {
+        return hasLeader() && leaderIdOrNil() != localId;
+    }
+
     public boolean isLeader() {
         return state instanceof LeaderState;
     }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
@@ -19,6 +19,7 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.record.Records;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 public interface RaftClient {
 
@@ -36,6 +37,7 @@ public interface RaftClient {
      * Shutdown the client.
      *
      * @param timeoutMs How long to wait for graceful completion of pending operations.
+     * @return A future which is completed when shutdown completes successfully or the timeout expires.
      */
-    void shutdown(int timeoutMs);
+    CompletableFuture<Void> shutdown(int timeoutMs);
 }

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
@@ -18,10 +18,11 @@ package org.apache.kafka.raft;
 
 import org.apache.kafka.common.record.Records;
 
+import java.io.Closeable;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-public interface ReplicatedLog {
+public interface ReplicatedLog extends Closeable {
 
     /**
      * Write a set of records to the local leader log. These messages will either
@@ -120,4 +121,7 @@ public interface ReplicatedLog {
         truncateTo(truncationOffset);
         return OptionalLong.of(truncationOffset);
     }
+
+    default void close() {}
+
 }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1626,7 +1626,10 @@ public class KafkaRaftClientTest {
         assertEquals((double) 4L, getMetric(metrics, "log-end-offset").metricValue());
         assertEquals((double) epoch, getMetric(metrics, "log-end-epoch").metricValue());
 
-        client.shutdown(100);
+        CompletableFuture<Void> shutdownFuture = client.shutdown(100);
+        client.poll();
+        assertTrue(shutdownFuture.isDone());
+        assertNull(shutdownFuture.get());
 
         // should only have total-metrics-count left
         assertEquals(1, metrics.metrics().size());

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -65,11 +65,13 @@ import java.util.OptionalLong;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -567,7 +569,7 @@ public class KafkaRaftClientTest {
         int epoch = 5;
 
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = initializeAsLeader(voters, epoch, stateMachine);
+        KafkaRaftClient client = initializeAsLeader(voters, epoch);
 
         // First poll has no high watermark advance
         client.poll();
@@ -777,7 +779,7 @@ public class KafkaRaftClientTest {
         int epoch = 1;
         Set<Integer> voters = Utils.mkSet(localId, 1, 2, 3, 4);
         quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, localId, voters));
-        KafkaRaftClient client = initializeAsLeader(voters, epoch, stateMachine);
+        KafkaRaftClient client = initializeAsLeader(voters, epoch);
         assertNoSentMessages();
 
         time.sleep(1L);
@@ -834,7 +836,7 @@ public class KafkaRaftClientTest {
         int otherNodeId = 1;
         int epoch = 5;
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = initializeAsLeader(voters, epoch, stateMachine);
+        KafkaRaftClient client = initializeAsLeader(voters, epoch);
 
         deliverRequest(fetchQuorumRecordsRequest(
             epoch, otherNodeId, -5L, 0, 0));
@@ -867,7 +869,7 @@ public class KafkaRaftClientTest {
         int otherNodeId = 1;
         int epoch = 5;
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = initializeAsLeader(voters, epoch, stateMachine);
+        KafkaRaftClient client = initializeAsLeader(voters, epoch);
 
         int nonVoterId = 2;
         deliverRequest(voteRequest(epoch, nonVoterId, 0, 0));
@@ -919,7 +921,7 @@ public class KafkaRaftClientTest {
         int epoch = 5;
 
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = initializeAsLeader(voters, epoch, stateMachine);
+        KafkaRaftClient client = initializeAsLeader(voters, epoch);
 
         // Follower sends a fetch which cannot be satisfied immediately
         int maxWaitTimeMs = 500;
@@ -940,7 +942,7 @@ public class KafkaRaftClientTest {
         int epoch = 5;
 
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = initializeAsLeader(voters, epoch, stateMachine);
+        KafkaRaftClient client = initializeAsLeader(voters, epoch);
 
         // Follower sends a fetch which cannot be satisfied immediately
         deliverRequest(fetchQuorumRecordsRequest(epoch, otherNodeId, 1L, epoch, 500));
@@ -974,7 +976,7 @@ public class KafkaRaftClientTest {
         int epoch = 5;
 
         Set<Integer> voters = Utils.mkSet(voter1, voter2, voter3);
-        KafkaRaftClient client = initializeAsLeader(voters, epoch, stateMachine);
+        KafkaRaftClient client = initializeAsLeader(voters, epoch);
 
         // Follower sends a fetch which cannot be satisfied immediately
         deliverRequest(fetchQuorumRecordsRequest(epoch, voter2, 1L, epoch, 500));
@@ -1008,7 +1010,7 @@ public class KafkaRaftClientTest {
             findQuorumResponse(leaderId, epoch, voters));
     }
 
-    private KafkaRaftClient initializeAsLeader(Set<Integer> voters, int epoch, MockStateMachine stateMachine) throws Exception {
+    private KafkaRaftClient initializeAsLeader(Set<Integer> voters, int epoch) throws Exception {
         ElectionState leaderElectionState = ElectionState.withElectedLeader(epoch, localId, voters);
         quorumStateStore.writeElectionState(leaderElectionState);
         KafkaRaftClient client = buildClient(voters, stateMachine);
@@ -1196,44 +1198,40 @@ public class KafkaRaftClientTest {
     public void testLeaderGracefulShutdown() throws Exception {
         int otherNodeId = 1;
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = buildClient(voters);
-
-        // Elect ourselves as the leader
-        assertEquals(ElectionState.withVotedCandidate(1, localId, voters), quorumStateStore.readElectionState());
-
-        pollUntilSend(client);
-
-        initializeVoterConnections(client, voters, 1, OptionalInt.empty());
-
-        pollUntilSend(client);
-
-        int voteCorrelationId = assertSentVoteRequest(1, 0, 0L);
-        VoteResponseData voteResponse = voteResponse(true, Optional.empty(), 1);
-        deliverResponse(voteCorrelationId, otherNodeId, voteResponse);
-        client.poll();
-        assertEquals(ElectionState.withElectedLeader(1, localId, voters), quorumStateStore.readElectionState());
+        int epoch = 1;
+        KafkaRaftClient client = initializeAsLeader(voters, epoch);
 
         // Now shutdown
         int shutdownTimeoutMs = 5000;
-        client.shutdown(shutdownTimeoutMs);
+        CompletableFuture<Void> shutdownFuture = client.shutdown(shutdownTimeoutMs);
 
         // We should still be running until we have had a chance to send EndQuorumEpoch
         assertTrue(client.isShuttingDown());
         assertTrue(client.isRunning());
+        assertFalse(shutdownFuture.isDone());
 
-        // Send EndQuorumEpoch request to the other vote
+        // Send EndQuorumEpoch request to the other voter
         client.poll();
         assertTrue(client.isShuttingDown());
         assertTrue(client.isRunning());
-
         assertSentEndQuorumEpochRequest(1, OptionalInt.of(localId), otherNodeId);
 
-        // Graceful shutdown completes when the epoch is bumped
-        deliverRequest(voteRequest(2, otherNodeId, 0, 0L));
-
+        // We should still be able to handle vote requests during graceful shutdown
+        // in order to help the new leader get elected
+        deliverRequest(voteRequest(epoch + 1, otherNodeId, epoch, 1L));
         client.poll();
+        assertSentVoteResponse(Errors.NONE, epoch + 1, OptionalInt.empty(), true);
+
+        // Graceful shutdown completes when a new leader is elected
+        deliverRequest(beginEpochRequest(2, otherNodeId));
+
+        TestUtils.waitForCondition(() -> {
+            client.poll();
+            return !client.isRunning();
+        }, 5000, "Client failed to shutdown before expiration of timeout");
         assertFalse(client.isShuttingDown());
-        assertFalse(client.isRunning());
+        assertTrue(shutdownFuture.isDone());
+        assertNull(shutdownFuture.get());
     }
 
     @Test
@@ -1242,34 +1240,7 @@ public class KafkaRaftClientTest {
         int laggingFollower = 1;
         int epoch = 1;
         Set<Integer> voters = Utils.mkSet(localId, closeFollower, laggingFollower);
-
-        // Bootstrap as the leader
-        quorumStateStore.writeElectionState(ElectionState.withElectedLeader(epoch, localId, voters));
-
-        KafkaRaftClient client = buildClient(voters);
-
-        pollUntilSend(client);
-
-        int findQuorumCorrelationId = assertSentFindQuorumRequest().correlationId;
-
-        deliverResponse(findQuorumCorrelationId, -1, findQuorumResponse(OptionalInt.of(localId), 1, voters));
-
-        // Accept connection information for followers
-        client.poll();
-
-        assertTrue(channel.drainSendQueue().isEmpty());
-
-        // Send out begin quorum to followers
-        client.poll();
-
-        List<RaftRequest.Outbound> beginEpochRequests = collectBeginEpochRequests(epoch);
-
-        assertEquals(2, beginEpochRequests.size());
-
-        for (RaftMessage message : beginEpochRequests) {
-            deliverResponse(message.correlationId(), ((RaftRequest.Outbound) message).destinationId(),
-                beginQuorumEpochResponse(epoch, localId));
-        }
+        KafkaRaftClient client = initializeAsLeader(voters, epoch);
 
         // The lagging follower fetches first
         deliverRequest(fetchQuorumRecordsRequest(1, laggingFollower, 0L, 0, 0));
@@ -1308,42 +1279,34 @@ public class KafkaRaftClientTest {
     public void testLeaderGracefulShutdownTimeout() throws Exception {
         int otherNodeId = 1;
         Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
-        KafkaRaftClient client = buildClient(voters);
-
-        // Elect ourselves as the leader
-        assertEquals(ElectionState.withVotedCandidate(1, localId, voters), quorumStateStore.readElectionState());
-        initializeVoterConnections(client, voters, 1, OptionalInt.empty());
-
-        pollUntilSend(client);
-
-        int voteCorrelationId = assertSentVoteRequest(1, 0, 0L);
-        VoteResponseData voteResponse = voteResponse(true, Optional.empty(), 1);
-        deliverResponse(voteCorrelationId, otherNodeId, voteResponse);
-        client.poll();
-        assertEquals(ElectionState.withElectedLeader(1, localId, voters), quorumStateStore.readElectionState());
+        int epoch = 1;
+        KafkaRaftClient client = initializeAsLeader(voters, epoch);
 
         // Now shutdown
         int shutdownTimeoutMs = 5000;
-        client.shutdown(shutdownTimeoutMs);
+        CompletableFuture<Void> shutdownFuture = client.shutdown(shutdownTimeoutMs);
 
         // We should still be running until we have had a chance to send EndQuorumEpoch
         assertTrue(client.isRunning());
+        assertFalse(shutdownFuture.isDone());
 
         // Send EndQuorumEpoch request to the other vote
         client.poll();
         assertTrue(client.isRunning());
 
-        assertSentEndQuorumEpochRequest(1, OptionalInt.of(localId), otherNodeId);
+        assertSentEndQuorumEpochRequest(epoch, OptionalInt.of(localId), otherNodeId);
 
         // The shutdown timeout is hit before we receive any requests or responses indicating an epoch bump
         time.sleep(shutdownTimeoutMs);
 
         client.poll();
         assertFalse(client.isRunning());
+        assertTrue(shutdownFuture.isCompletedExceptionally());
+        TestUtils.assertFutureThrows(shutdownFuture, TimeoutException.class);
     }
 
     @Test
-    public void testFollowerGracefulShutdown() throws IOException {
+    public void testFollowerGracefulShutdown() throws Exception {
         int otherNodeId = 1;
         int epoch = 5;
 
@@ -1358,10 +1321,14 @@ public class KafkaRaftClientTest {
         client.poll();
 
         int shutdownTimeoutMs = 5000;
-        client.shutdown(shutdownTimeoutMs);
+        CompletableFuture<Void> shutdownFuture = client.shutdown(shutdownTimeoutMs);
         assertTrue(client.isRunning());
+        assertFalse(shutdownFuture.isDone());
+
         client.poll();
         assertFalse(client.isRunning());
+        assertTrue(shutdownFuture.isDone());
+        assertNull(shutdownFuture.get());
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1218,10 +1218,12 @@ public class KafkaRaftClientTest {
         client.shutdown(shutdownTimeoutMs);
 
         // We should still be running until we have had a chance to send EndQuorumEpoch
+        assertTrue(client.isShuttingDown());
         assertTrue(client.isRunning());
 
         // Send EndQuorumEpoch request to the other vote
         client.poll();
+        assertTrue(client.isShuttingDown());
         assertTrue(client.isRunning());
 
         assertSentEndQuorumEpochRequest(1, OptionalInt.of(localId), otherNodeId);
@@ -1230,6 +1232,7 @@ public class KafkaRaftClientTest {
         deliverRequest(voteRequest(2, otherNodeId, 0, 0L));
 
         client.poll();
+        assertFalse(client.isShuttingDown());
         assertFalse(client.isRunning());
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -45,6 +45,7 @@ import java.util.PriorityQueue;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -180,6 +181,45 @@ public class RaftEventSimulationTest {
     }
 
     private void testElectionAfterLeaderFailure(QuorumConfig config) throws IOException {
+        testElectionAfterLeaderShutdown(config, Cluster::kill);
+    }
+
+    @Test
+    public void testElectionAfterLeaderGracefulShutdownQuorumSizeThree() throws IOException {
+        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(3, 0));
+    }
+
+    @Test
+    public void testElectionAfterLeaderGracefulShutdownQuorumSizeThreeAndTwoObservers() throws IOException {
+        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(3, 2));
+    }
+
+    @Test
+    public void testElectionAfterLeaderGracefulShutdownQuorumSizeFour() throws IOException {
+        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(4, 0));
+    }
+
+    @Test
+    public void testElectionAfterLeaderGracefulShutdownQuorumSizeFourAndTwoObservers() throws IOException {
+        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(4, 2));
+    }
+
+    @Test
+    public void testElectionAfterLeaderGracefulShutdownQuorumSizeFive() throws IOException {
+        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(5, 0));
+    }
+
+    @Test
+    public void testElectionAfterLeaderGracefulShutdownQuorumSizeFiveAndThreeObservers() throws IOException {
+        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(5, 3));
+    }
+
+    private void testElectionAfterLeaderGracefulShutdown(QuorumConfig config) throws IOException {
+        testElectionAfterLeaderShutdown(config, Cluster::shutdown);
+    }
+
+    private void testElectionAfterLeaderShutdown(QuorumConfig config,
+                                                 BiConsumer<Cluster, Integer> doShutdown) throws IOException {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
 
@@ -201,9 +241,9 @@ public class RaftEventSimulationTest {
             scheduler.schedule(new SequentialAppendAction(cluster), 0, 2, 3);
             scheduler.runUntil(() -> cluster.anyReachedHighWatermark(10));
 
-            // Kill the leader and write some more data. We can verify the new leader has been elected
+            // Shutdown the leader and write some more data. We can verify the new leader has been elected
             // by verifying that the high watermark can still advance.
-            cluster.kill(leaderId);
+            doShutdown.accept(cluster, leaderId);
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(20));
         }
     }
@@ -410,7 +450,10 @@ public class RaftEventSimulationTest {
 
         @Override
         public void execute() {
-            cluster.withCurrentLeader(node -> node.counter.increment());
+            cluster.withCurrentLeader(node -> {
+                if (!node.client.isShuttingDown())
+                    node.counter.increment();
+            });
         }
     }
 
@@ -581,6 +624,14 @@ public class RaftEventSimulationTest {
 
         void kill(int nodeId) {
             running.remove(nodeId);
+        }
+
+        void shutdown(int nodeId) {
+            RaftNode node = running.get(nodeId);
+            if (node == null) {
+                throw new IllegalStateException("Attempt to shutdown a node which is not currently running");
+            }
+            node.client.shutdown(500).whenComplete((res, exception) -> kill(nodeId));
         }
 
         void pollIfRunning(int nodeId) {


### PR DESCRIPTION
This patch does the following:

- Fixes shutdown logic so that the resigning leader stays alive long enough to help its successor get elected.
- Add graceful shutdown to simulation test cases
- Add graceful shutdown logic to `RaftServer`
- Improve graceful shutdown test coverage
- Add more logging on shutdown

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
