### PR TITLE
Require non-empty record set in append APIs

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -44,6 +44,9 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
   }
 
   override def appendAsLeader(records: Records, epoch: Int): LogAppendInfo = {
+    if (records.sizeInBytes == 0)
+      throw new IllegalArgumentException("Attempt to append an empty record set")
+
     val appendInfo = log.appendAsLeader(records.asInstanceOf[MemoryRecords],
       leaderEpoch = epoch,
       origin = AppendOrigin.Coordinator)
@@ -53,6 +56,9 @@ class KafkaMetadataLog(time: Time, log: Log, maxFetchSizeInBytes: Int = 1024 * 1
   }
 
   override def appendAsFollower(records: Records): LogAppendInfo = {
+    if (records.sizeInBytes == 0)
+      throw new IllegalArgumentException("Attempt to append an empty record set")
+
     val appendInfo = log.appendAsFollower(records.asInstanceOf[MemoryRecords])
     new LogAppendInfo(appendInfo.firstOffset.getOrElse {
       throw new KafkaException("Append failed unexpectedly")

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
@@ -29,6 +29,7 @@ public interface ReplicatedLog {
      * exception.
      *
      * @return the metadata information of the appended batch
+     * @throws IllegalArgumentException if the record set is empty
      */
     LogAppendInfo appendAsLeader(Records records, int epoch);
 
@@ -38,6 +39,7 @@ public interface ReplicatedLog {
      * or do additional validation.
      *
      * @return the metadata information of the appended batch
+     * @throws IllegalArgumentException if the record set is empty
      */
     LogAppendInfo appendAsFollower(Records records);
 

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -121,6 +121,9 @@ public class MockLog implements ReplicatedLog {
 
     @Override
     public LogAppendInfo appendAsLeader(Records records, int epoch) {
+        if (records.sizeInBytes() == 0)
+            throw new IllegalArgumentException("Attempt to append an empty record set");
+
         long baseOffset = endOffset();
         AtomicLong offsetSupplier = new AtomicLong(baseOffset);
         for (RecordBatch batch : records.batches()) {
@@ -153,6 +156,9 @@ public class MockLog implements ReplicatedLog {
 
     @Override
     public LogAppendInfo appendAsFollower(Records records) {
+        if (records.sizeInBytes() == 0)
+            throw new IllegalArgumentException("Attempt to append an empty record set");
+
         long baseOffset = endOffset();
         long lastOffset = baseOffset;
         for (RecordBatch batch : records.batches()) {

--- a/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
@@ -260,6 +260,12 @@ public class MockLogTest {
         assertEquals(Optional.of(new OffsetRange(30L, 59L)), readOffsets(35L, OptionalLong.of(60L)));
     }
 
+    @Test
+    public void testEmptyAppendNotAllowed() {
+        assertThrows(IllegalArgumentException.class, () -> log.appendAsFollower(MemoryRecords.EMPTY));
+        assertThrows(IllegalArgumentException.class, () -> log.appendAsLeader(MemoryRecords.EMPTY, 1));
+    }
+
     private Optional<OffsetRange> readOffsets(long startOffset, OptionalLong maxOffset) {
         Records records = log.read(startOffset, maxOffset);
         long firstReadOffset = -1L;


### PR DESCRIPTION
If the fetch response has no data, then the log append currently fails with an `Append failed unexpectedly` error. The problem is that there is no start offset for an empty append. This patch fixes the problem by adding a check in the response handler and skipping the append if the record set is empty. We also formally make empty appends invalid in the API and add some testing for this.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
