### PR TITLE
MINOR: Remove target voters from quorum state data

### DIFF
--- a/raft/src/main/resources/common/message/QuorumState.json
+++ b/raft/src/main/resources/common/message/QuorumState.json
@@ -24,8 +24,7 @@
     {"name": "LeaderEpoch", "type": "int32", "versions": "0+", "default": "-1"},
     {"name": "VotedId", "type": "int32", "versions": "0+", "default": "-1"},
     {"name": "AppliedOffset", "type": "int64", "versions": "0+"},
-    {"name": "CurrentVoters", "type": "[]Voter", "versions": "0+", "nullableVersions": "0+"},
-    {"name": "TargetVoters", "type": "[]Voter", "versions": "0+", "nullableVersions": "0+"}
+    {"name": "CurrentVoters", "type": "[]Voter", "versions": "0+", "nullableVersions": "0+"}
   ],
   "commonStructs": [
     { "name": "Voter", "versions": "0+", "fields": [


### PR DESCRIPTION
To align with KIP-595, we need to remove the target voter set for now.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
