### PR TITLE
KC-700: Replace Begin/EndQuorum RPC with Multi-raft

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochRequest.java
@@ -67,9 +67,7 @@ public class BeginQuorumEpochRequest extends AbstractRequest {
 
     @Override
     public BeginQuorumEpochResponse getErrorResponse(int throttleTimeMs, Throwable e) {
-        BeginQuorumEpochResponseData data = new BeginQuorumEpochResponseData();
-        data.setErrorCode(Errors.forException(e).code());
-        return new BeginQuorumEpochResponse(data);
+        return new BeginQuorumEpochResponse(getTopLevelErrorResponse(Errors.forException(e)));
     }
 
     public static BeginQuorumEpochRequestData singletonRequest(TopicPartition topicPartition,

--- a/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochRequest.java
@@ -83,10 +83,10 @@ public class BeginQuorumEpochRequest extends AbstractRequest {
         return new BeginQuorumEpochRequestData()
                    .setClusterId(clusterId)
                    .setTopics(Collections.singletonList(
-                       new BeginQuorumEpochRequestData.BeginQuorumTopicRequest()
+                       new BeginQuorumEpochRequestData.TopicData()
                            .setTopicName(topicPartition.topic())
                            .setPartitions(Collections.singletonList(
-                               new BeginQuorumEpochRequestData.BeginQuorumPartitionRequest()
+                               new BeginQuorumEpochRequestData.PartitionData()
                                    .setPartitionIndex(topicPartition.partition())
                                    .setLeaderEpoch(leaderEpoch)
                                    .setLeaderId(leaderId))))
@@ -96,13 +96,13 @@ public class BeginQuorumEpochRequest extends AbstractRequest {
 
     public static BeginQuorumEpochResponseData getPartitionLevelErrorResponse(BeginQuorumEpochRequestData data, Errors error) {
         short errorCode = error.code();
-        List<BeginQuorumEpochResponseData.BeginQuorumTopicResponse> topicResponses = new ArrayList<>();
-        for (BeginQuorumEpochRequestData.BeginQuorumTopicRequest topic : data.topics()) {
+        List<BeginQuorumEpochResponseData.TopicData> topicResponses = new ArrayList<>();
+        for (BeginQuorumEpochRequestData.TopicData topic : data.topics()) {
             topicResponses.add(
-                new BeginQuorumEpochResponseData.BeginQuorumTopicResponse()
+                new BeginQuorumEpochResponseData.TopicData()
                     .setTopicName(topic.topicName())
                     .setPartitions(topic.partitions().stream().map(
-                        requestPartition -> new BeginQuorumEpochResponseData.BeginQuorumPartitionResponse()
+                        requestPartition -> new BeginQuorumEpochResponseData.PartitionData()
                                                 .setPartitionIndex(requestPartition.partitionIndex())
                                                 .setErrorCode(errorCode)
                     ).collect(Collectors.toList())));

--- a/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochResponse.java
@@ -67,10 +67,10 @@ public class BeginQuorumEpochResponse extends AbstractResponse {
         return new BeginQuorumEpochResponseData()
                    .setErrorCode(topLevelError.code())
                    .setTopics(Collections.singletonList(
-                       new BeginQuorumEpochResponseData.BeginQuorumTopicResponse()
+                       new BeginQuorumEpochResponseData.TopicData()
                            .setTopicName(topicPartition.topic())
                            .setPartitions(Collections.singletonList(
-                               new BeginQuorumEpochResponseData.BeginQuorumPartitionResponse()
+                               new BeginQuorumEpochResponseData.PartitionData()
                                    .setErrorCode(partitionLevelError.code())
                                    .setLeaderId(leaderId)
                                    .setLeaderEpoch(leaderEpoch)
@@ -92,8 +92,8 @@ public class BeginQuorumEpochResponse extends AbstractResponse {
             errors.put(topLevelError, 1);
         }
 
-        for (BeginQuorumEpochResponseData.BeginQuorumTopicResponse topicResponse : data.topics()) {
-            for (BeginQuorumEpochResponseData.BeginQuorumPartitionResponse partitionResponse : topicResponse.partitions()) {
+        for (BeginQuorumEpochResponseData.TopicData topicResponse : data.topics()) {
+            for (BeginQuorumEpochResponseData.PartitionData partitionResponse : topicResponse.partitions()) {
                 errors.compute(Errors.forCode(partitionResponse.errorCode()),
                     (error, count) -> count == null ? 1 : count + 1);
             }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumRequest.java
@@ -18,11 +18,7 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.DescribeQuorumRequestData;
-import org.apache.kafka.common.message.DescribeQuorumRequestData.DescribeQuorumPartitionRequest;
-import org.apache.kafka.common.message.DescribeQuorumRequestData.DescribeQuorumTopicRequest;
 import org.apache.kafka.common.message.DescribeQuorumResponseData;
-import org.apache.kafka.common.message.DescribeQuorumResponseData.DescribeQuorumPartitionResponse;
-import org.apache.kafka.common.message.DescribeQuorumResponseData.DescribeQuorumTopicResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -71,10 +67,10 @@ public class DescribeQuorumRequest extends AbstractRequest {
     public static DescribeQuorumRequestData singletonRequest(TopicPartition topicPartition) {
         return new DescribeQuorumRequestData()
             .setTopics(Collections.singletonList(
-                new DescribeQuorumTopicRequest()
+                new DescribeQuorumRequestData.TopicData()
                     .setTopicName(topicPartition.topic())
                     .setPartitions(Collections.singletonList(
-                        new DescribeQuorumPartitionRequest()
+                        new DescribeQuorumRequestData.PartitionData()
                             .setPartitionIndex(topicPartition.partition()))
             )));
     }
@@ -92,13 +88,13 @@ public class DescribeQuorumRequest extends AbstractRequest {
     public static DescribeQuorumResponseData getPartitionLevelErrorResponse(DescribeQuorumRequestData data, Errors error) {
         short errorCode = error.code();
 
-        List<DescribeQuorumTopicResponse> topicResponses = new ArrayList<>();
-        for (DescribeQuorumTopicRequest topic : data.topics()) {
+        List<DescribeQuorumResponseData.TopicData> topicResponses = new ArrayList<>();
+        for (DescribeQuorumRequestData.TopicData topic : data.topics()) {
             topicResponses.add(
-                new DescribeQuorumTopicResponse()
+                new DescribeQuorumResponseData.TopicData()
                     .setTopicName(topic.topicName())
                     .setPartitions(topic.partitions().stream().map(
-                        requestPartition -> new DescribeQuorumPartitionResponse()
+                        requestPartition -> new DescribeQuorumResponseData.PartitionData()
                                                 .setPartitionIndex(requestPartition.partitionIndex())
                                                 .setErrorCode(errorCode)
                     ).collect(Collectors.toList())));

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumResponse.java
@@ -18,8 +18,6 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.DescribeQuorumResponseData;
-import org.apache.kafka.common.message.DescribeQuorumResponseData.DescribeQuorumPartitionResponse;
-import org.apache.kafka.common.message.DescribeQuorumResponseData.DescribeQuorumTopicResponse;
 import org.apache.kafka.common.message.DescribeQuorumResponseData.ReplicaState;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
@@ -67,8 +65,8 @@ public class DescribeQuorumResponse extends AbstractResponse {
             errors.put(topLevelError, 1);
         }
 
-        for (DescribeQuorumTopicResponse topicResponse : data.topics()) {
-            for (DescribeQuorumPartitionResponse partitionResponse : topicResponse.partitions()) {
+        for (DescribeQuorumResponseData.TopicData topicResponse : data.topics()) {
+            for (DescribeQuorumResponseData.PartitionData partitionResponse : topicResponse.partitions()) {
                 errors.compute(Errors.forCode(partitionResponse.errorCode()),
                     (error, count) -> count == null ? 1 : count + 1);
             }
@@ -83,9 +81,9 @@ public class DescribeQuorumResponse extends AbstractResponse {
                                                                List<ReplicaState> voterStates,
                                                                List<ReplicaState> observerStates) {
         return new DescribeQuorumResponseData()
-            .setTopics(Collections.singletonList(new DescribeQuorumTopicResponse()
+            .setTopics(Collections.singletonList(new DescribeQuorumResponseData.TopicData()
                 .setTopicName(topicPartition.topic())
-                .setPartitions(Collections.singletonList(new DescribeQuorumPartitionResponse()
+                .setPartitions(Collections.singletonList(new DescribeQuorumResponseData.PartitionData()
                     .setErrorCode(Errors.NONE.code())
                     .setLeaderId(leaderId)
                     .setLeaderEpoch(leaderEpoch)

--- a/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochRequest.java
@@ -17,8 +17,6 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
-import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.message.EndQuorumEpochRequestData;
 import org.apache.kafka.common.message.EndQuorumEpochResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -69,9 +67,7 @@ public class EndQuorumEpochRequest extends AbstractRequest {
 
     @Override
     public EndQuorumEpochResponse getErrorResponse(int throttleTimeMs, Throwable e) {
-        EndQuorumEpochResponseData data = new EndQuorumEpochResponseData();
-        data.setErrorCode(Errors.forException(e).code());
-        return new EndQuorumEpochResponse(data);
+        return new EndQuorumEpochResponse(getTopLevelErrorResponse(Errors.forException(e)));
     }
 
     public static EndQuorumEpochRequestData singletonRequest(TopicPartition topicPartition,

--- a/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochRequest.java
@@ -87,10 +87,10 @@ public class EndQuorumEpochRequest extends AbstractRequest {
         return new EndQuorumEpochRequestData()
                    .setClusterId(clusterId)
                    .setTopics(Collections.singletonList(
-                       new EndQuorumEpochRequestData.EndQuorumTopicRequest()
+                       new EndQuorumEpochRequestData.TopicData()
                            .setTopicName(topicPartition.topic())
                            .setPartitions(Collections.singletonList(
-                               new EndQuorumEpochRequestData.EndQuorumPartitionRequest()
+                               new EndQuorumEpochRequestData.PartitionData()
                                    .setPartitionIndex(topicPartition.partition())
                                    .setReplicaId(replicaId)
                                    .setLeaderEpoch(leaderEpoch)
@@ -102,13 +102,13 @@ public class EndQuorumEpochRequest extends AbstractRequest {
 
     public static EndQuorumEpochResponseData getPartitionLevelErrorResponse(EndQuorumEpochRequestData data, Errors error) {
         short errorCode = error.code();
-        List<EndQuorumEpochResponseData.EndQuorumTopicResponse> topicResponses = new ArrayList<>();
-        for (EndQuorumEpochRequestData.EndQuorumTopicRequest topic : data.topics()) {
+        List<EndQuorumEpochResponseData.TopicData> topicResponses = new ArrayList<>();
+        for (EndQuorumEpochRequestData.TopicData topic : data.topics()) {
             topicResponses.add(
-                new EndQuorumEpochResponseData.EndQuorumTopicResponse()
+                new EndQuorumEpochResponseData.TopicData()
                     .setTopicName(topic.topicName())
                     .setPartitions(topic.partitions().stream().map(
-                        requestPartition -> new EndQuorumEpochResponseData.EndQuorumPartitionResponse()
+                        requestPartition -> new EndQuorumEpochResponseData.PartitionData()
                                                 .setPartitionIndex(requestPartition.partitionIndex())
                                                 .setErrorCode(errorCode)
                     ).collect(Collectors.toList())));

--- a/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochResponse.java
@@ -71,8 +71,8 @@ public class EndQuorumEpochResponse extends AbstractResponse {
             errors.put(topLevelError, 1);
         }
 
-        for (EndQuorumEpochResponseData.EndQuorumTopicResponse topicResponse : data.topics()) {
-            for (EndQuorumEpochResponseData.EndQuorumPartitionResponse partitionResponse : topicResponse.partitions()) {
+        for (EndQuorumEpochResponseData.TopicData topicResponse : data.topics()) {
+            for (EndQuorumEpochResponseData.PartitionData partitionResponse : topicResponse.partitions()) {
                 errors.compute(Errors.forCode(partitionResponse.errorCode()),
                     (error, count) -> count == null ? 1 : count + 1);
             }
@@ -90,10 +90,10 @@ public class EndQuorumEpochResponse extends AbstractResponse {
         return new EndQuorumEpochResponseData()
                    .setErrorCode(topLevelError.code())
                    .setTopics(Collections.singletonList(
-                       new EndQuorumEpochResponseData.EndQuorumTopicResponse()
+                       new EndQuorumEpochResponseData.TopicData()
                            .setTopicName(topicPartition.topic())
                            .setPartitions(Collections.singletonList(
-                               new EndQuorumEpochResponseData.EndQuorumPartitionResponse()
+                               new EndQuorumEpochResponseData.PartitionData()
                                    .setErrorCode(partitionLevelError.code())
                                    .setLeaderId(leaderId)
                                    .setLeaderEpoch(leaderEpoch)

--- a/clients/src/main/java/org/apache/kafka/common/requests/VoteRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/VoteRequest.java
@@ -92,10 +92,10 @@ public class VoteRequest extends AbstractRequest {
         return new VoteRequestData()
                    .setClusterId(clusterId)
                    .setTopics(Collections.singletonList(
-                       new VoteRequestData.VoteTopicRequest()
+                       new VoteRequestData.TopicData()
                            .setTopicName(topicPartition.topic())
                            .setPartitions(Collections.singletonList(
-                               new VoteRequestData.VotePartitionRequest()
+                               new VoteRequestData.PartitionData()
                                    .setPartitionIndex(topicPartition.partition())
                                    .setCandidateEpoch(candidateEpoch)
                                    .setCandidateId(candidateId)
@@ -106,13 +106,13 @@ public class VoteRequest extends AbstractRequest {
 
     public static VoteResponseData getPartitionLevelErrorResponse(VoteRequestData data, Errors error) {
         short errorCode = error.code();
-        List<VoteResponseData.VoteTopicResponse> topicResponses = new ArrayList<>();
-        for (VoteRequestData.VoteTopicRequest topic : data.topics()) {
+        List<VoteResponseData.TopicData> topicResponses = new ArrayList<>();
+        for (VoteRequestData.TopicData topic : data.topics()) {
             topicResponses.add(
-                new VoteResponseData.VoteTopicResponse()
+                new VoteResponseData.TopicData()
                     .setTopicName(topic.topicName())
                     .setPartitions(topic.partitions().stream().map(
-                        requestPartition -> new VoteResponseData.VotePartitionResponse()
+                        requestPartition -> new VoteResponseData.PartitionData()
                                                 .setPartitionIndex(requestPartition.partitionIndex())
                                                 .setErrorCode(errorCode)
                     ).collect(Collectors.toList())));

--- a/clients/src/main/java/org/apache/kafka/common/requests/VoteResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/VoteResponse.java
@@ -71,10 +71,10 @@ public class VoteResponse extends AbstractResponse {
         return new VoteResponseData()
             .setErrorCode(topLevelError.code())
             .setTopics(Collections.singletonList(
-                new VoteResponseData.VoteTopicResponse()
+                new VoteResponseData.TopicData()
                     .setTopicName(topicPartition.topic())
                     .setPartitions(Collections.singletonList(
-                        new VoteResponseData.VotePartitionResponse()
+                        new VoteResponseData.PartitionData()
                             .setErrorCode(partitionLevelError.code())
                             .setLeaderId(leaderId)
                             .setLeaderEpoch(leaderEpoch)
@@ -90,8 +90,8 @@ public class VoteResponse extends AbstractResponse {
             errors.put(topLevelError, 1);
         }
 
-        for (VoteResponseData.VoteTopicResponse topicResponse : data.topics()) {
-            for (VoteResponseData.VotePartitionResponse partitionResponse : topicResponse.partitions()) {
+        for (VoteResponseData.TopicData topicResponse : data.topics()) {
+            for (VoteResponseData.PartitionData partitionResponse : topicResponse.partitions()) {
                 errors.compute(Errors.forCode(partitionResponse.errorCode()),
                     (error, count) -> count == null ? 1 : count + 1);
             }

--- a/clients/src/main/resources/common/message/BeginQuorumEpochRequest.json
+++ b/clients/src/main/resources/common/message/BeginQuorumEpochRequest.json
@@ -20,11 +20,11 @@
   "validVersions": "0",
   "fields": [
     { "name": "ClusterId", "type": "string", "versions": "0+"},
-    { "name": "Topics", "type": "[]BeginQuorumTopicRequest",
+    { "name": "Topics", "type": "[]TopicData",
       "versions": "0+", "fields": [
       { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]BeginQuorumPartitionRequest",
+      { "name": "Partitions", "type": "[]PartitionData",
         "versions": "0+", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },

--- a/clients/src/main/resources/common/message/BeginQuorumEpochRequest.json
+++ b/clients/src/main/resources/common/message/BeginQuorumEpochRequest.json
@@ -18,12 +18,21 @@
   "type": "request",
   "name": "BeginQuorumEpochRequest",
   "validVersions": "0",
-  "flexibleVersions": "0+",
   "fields": [
-    {"name": "ClusterId", "type": "string", "versions": "0+"},
-    {"name": "LeaderId", "type": "int32", "versions": "0+",
-      "about": "The ID of the newly elected leader"},
-    {"name": "LeaderEpoch", "type": "int32", "versions": "0+",
-      "about": "The epoch of the newly elected leader"}
+    { "name": "ClusterId", "type": "string", "versions": "0+"},
+    { "name": "Topics", "type": "[]BeginQuorumTopicRequest",
+      "versions": "0+", "fields": [
+      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]BeginQuorumPartitionRequest",
+        "versions": "0+", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "LeaderId", "type": "int32", "versions": "0+",
+          "about": "The ID of the newly elected leader"},
+        { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
+          "about": "The epoch of the newly elected leader"}
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/BeginQuorumEpochResponse.json
+++ b/clients/src/main/resources/common/message/BeginQuorumEpochResponse.json
@@ -21,11 +21,11 @@
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The top level error code."},
-    { "name": "Topics", "type": "[]BeginQuorumTopicResponse",
+    { "name": "Topics", "type": "[]TopicData",
       "versions": "0+", "fields": [
       { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]BeginQuorumPartitionResponse",
+      { "name": "Partitions", "type": "[]PartitionData",
         "versions": "0+", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },

--- a/clients/src/main/resources/common/message/BeginQuorumEpochResponse.json
+++ b/clients/src/main/resources/common/message/BeginQuorumEpochResponse.json
@@ -18,12 +18,23 @@
   "type": "response",
   "name": "BeginQuorumEpochResponse",
   "validVersions": "0",
-  "flexibleVersions": "0+",
   "fields": [
-    {"name": "ErrorCode", "type": "int16", "versions": "0+"},
-    {"name": "LeaderId", "type": "int32", "versions": "0+",
-      "about": "The ID of the current leader or -1 if the leader is unknown."},
-    {"name": "LeaderEpoch", "type": "int32", "versions": "0+",
-      "about": "The latest known leader epoch"}
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top level error code."},
+    { "name": "Topics", "type": "[]BeginQuorumTopicResponse",
+      "versions": "0+", "fields": [
+      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]BeginQuorumPartitionResponse",
+        "versions": "0+", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+"},
+        { "name": "LeaderId", "type": "int32", "versions": "0+",
+          "about": "The ID of the current leader or -1 if the leader is unknown."},
+        { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
+          "about": "The latest known leader epoch"}
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/DescribeQuorumRequest.json
+++ b/clients/src/main/resources/common/message/DescribeQuorumRequest.json
@@ -20,11 +20,11 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "Topics", "type": "[]DescribeQuorumTopicRequest",
+    { "name": "Topics", "type": "[]TopicData",
       "versions": "0+", "fields": [
       { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]DescribeQuorumPartitionRequest",
+      { "name": "Partitions", "type": "[]PartitionData",
         "versions": "0+", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." }

--- a/clients/src/main/resources/common/message/DescribeQuorumResponse.json
+++ b/clients/src/main/resources/common/message/DescribeQuorumResponse.json
@@ -22,11 +22,11 @@
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The top level error code."},
-    { "name": "Topics", "type": "[]DescribeQuorumTopicResponse",
+    { "name": "Topics", "type": "[]TopicData",
       "versions": "0+", "fields": [
       { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]DescribeQuorumPartitionResponse",
+      { "name": "Partitions", "type": "[]PartitionData",
         "versions": "0+", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },

--- a/clients/src/main/resources/common/message/EndQuorumEpochRequest.json
+++ b/clients/src/main/resources/common/message/EndQuorumEpochRequest.json
@@ -18,16 +18,25 @@
   "type": "request",
   "name": "EndQuorumEpochRequest",
   "validVersions": "0",
-  "flexibleVersions": "0+",
   "fields": [
-    {"name": "ClusterId", "type": "string", "versions": "0+"},
-    {"name": "ReplicaId", "type": "int32", "versions": "0+",
-      "about": "The ID of the replica sending this request"},
-    {"name": "LeaderId", "type": "int32", "versions": "0+",
-      "about": "The current leader ID or -1 if there is a vote in progress"},
-    {"name": "LeaderEpoch", "type": "int32", "versions": "0+",
-      "about": "The current epoch"},
-    {"name": "PreferredSuccessors", "type": "[]int32", "versions": "0+",
-      "about": "A sorted list of preferred successors to start the election"}
+    { "name": "ClusterId", "type": "string", "versions": "0+"},
+    { "name": "Topics", "type": "[]EndQuorumTopicRequest",
+      "versions": "0+", "fields": [
+      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]EndQuorumPartitionRequest",
+        "versions": "0+", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "ReplicaId", "type": "int32", "versions": "0+",
+          "about": "The ID of the replica sending this request"},
+        { "name": "LeaderId", "type": "int32", "versions": "0+",
+          "about": "The current leader ID or -1 if there is a vote in progress"},
+        { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
+          "about": "The current epoch"},
+        { "name": "PreferredSuccessors", "type": "[]int32", "versions": "0+",
+          "about": "A sorted list of preferred successors to start the election"}
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/EndQuorumEpochRequest.json
+++ b/clients/src/main/resources/common/message/EndQuorumEpochRequest.json
@@ -20,11 +20,11 @@
   "validVersions": "0",
   "fields": [
     { "name": "ClusterId", "type": "string", "versions": "0+"},
-    { "name": "Topics", "type": "[]EndQuorumTopicRequest",
+    { "name": "Topics", "type": "[]TopicData",
       "versions": "0+", "fields": [
       { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]EndQuorumPartitionRequest",
+      { "name": "Partitions", "type": "[]PartitionData",
         "versions": "0+", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },

--- a/clients/src/main/resources/common/message/EndQuorumEpochResponse.json
+++ b/clients/src/main/resources/common/message/EndQuorumEpochResponse.json
@@ -18,12 +18,23 @@
   "type": "response",
   "name": "EndQuorumEpochResponse",
   "validVersions": "0",
-  "flexibleVersions": "0+",
   "fields": [
-    {"name": "ErrorCode", "type": "int16", "versions": "0+"},
-    {"name": "LeaderId", "type": "int32", "versions": "0+",
-      "about": "The ID of the current leader or -1 if the leader is unknown."},
-    {"name": "LeaderEpoch", "type": "int32", "versions": "0+",
-      "about": "The latest known leader epoch"}
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top level error code."},
+    { "name": "Topics", "type": "[]EndQuorumTopicResponse",
+      "versions": "0+", "fields": [
+      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]EndQuorumPartitionResponse",
+        "versions": "0+", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+"},
+        { "name": "LeaderId", "type": "int32", "versions": "0+",
+          "about": "The ID of the current leader or -1 if the leader is unknown."},
+        { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
+          "about": "The latest known leader epoch"}
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/EndQuorumEpochResponse.json
+++ b/clients/src/main/resources/common/message/EndQuorumEpochResponse.json
@@ -21,11 +21,11 @@
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The top level error code."},
-    { "name": "Topics", "type": "[]EndQuorumTopicResponse",
+    { "name": "Topics", "type": "[]TopicData",
       "versions": "0+", "fields": [
       { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]EndQuorumPartitionResponse",
+      { "name": "Partitions", "type": "[]PartitionData",
         "versions": "0+", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },

--- a/clients/src/main/resources/common/message/VoteRequest.json
+++ b/clients/src/main/resources/common/message/VoteRequest.json
@@ -21,11 +21,11 @@
   "flexibleVersions": "0+",
   "fields": [
     { "name": "ClusterId", "type": "string", "versions": "0+"},
-    { "name": "Topics", "type": "[]VoteTopicRequest",
+    { "name": "Topics", "type": "[]TopicData",
       "versions": "0+", "fields": [
       { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]VotePartitionRequest",
+      { "name": "Partitions", "type": "[]PartitionData",
         "versions": "0+", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },

--- a/clients/src/main/resources/common/message/VoteResponse.json
+++ b/clients/src/main/resources/common/message/VoteResponse.json
@@ -22,11 +22,11 @@
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The top level error code."},
-    { "name": "Topics", "type": "[]VoteTopicResponse",
+    { "name": "Topics", "type": "[]TopicData",
       "versions": "0+", "fields": [
       { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]VotePartitionResponse",
+      { "name": "Partitions", "type": "[]PartitionData",
         "versions": "0+", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -562,17 +562,11 @@ class RequestQuotaTest extends BaseRequestTest {
           new VoteRequest.Builder(VoteRequest.singletonRequest(tp, 1, 2, 0, 10))
 
         case ApiKeys.BEGIN_QUORUM_EPOCH =>
-          new BeginQuorumEpochRequest.Builder(new BeginQuorumEpochRequestData()
-            .setLeaderId(5)
-            .setLeaderEpoch(2)
-            .setClusterId("cluster"))
+          new BeginQuorumEpochRequest.Builder(BeginQuorumEpochRequest.singletonRequest(tp, 2, 5))
 
         case ApiKeys.END_QUORUM_EPOCH =>
-          new EndQuorumEpochRequest.Builder(new EndQuorumEpochRequestData()
-            .setLeaderId(5)
-            .setLeaderEpoch(2)
-            .setClusterId("cluster")
-            .setReplicaId(10))
+          new EndQuorumEpochRequest.Builder(EndQuorumEpochRequest.singletonRequest(
+            tp, 10, 2, 5, Collections.singletonList(3)))
 
         case ApiKeys.FETCH_QUORUM_RECORDS =>
           new FetchQuorumRecordsRequest.Builder(new FetchQuorumRecordsRequestData()

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -584,8 +584,9 @@ public class KafkaRaftClient implements RaftClient {
             return false;
         }
 
-        if (Errors.forCode(response.errorCode()) != Errors.NONE) {
-            return false;
+        Errors topLevelError = Errors.forCode(response.errorCode());
+        if (topLevelError != Errors.NONE) {
+            return handleUnexpectedError(topLevelError, responseMetadata);
         }
 
         VotePartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
@@ -702,9 +703,11 @@ public class KafkaRaftClient implements RaftClient {
             return false;
         }
 
-        if (Errors.forCode(response.errorCode()) != Errors.NONE) {
-            return false;
+        Errors topLevelError = Errors.forCode(response.errorCode());
+        if (topLevelError != Errors.NONE) {
+            return handleUnexpectedError(topLevelError, responseMetadata);
         }
+
         BeginQuorumPartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
 
         Errors partitionError = Errors.forCode(partitionResponse.errorCode());
@@ -801,9 +804,9 @@ public class KafkaRaftClient implements RaftClient {
             return false;
         }
 
-        Errors error = Errors.forCode(response.errorCode());
-        if (error != Errors.NONE) {
-            return handleUnexpectedError(error, responseMetadata);
+        Errors topLevelError = Errors.forCode(response.errorCode());
+        if (topLevelError != Errors.NONE) {
+            return handleUnexpectedError(topLevelError, responseMetadata);
         }
 
         EndQuorumPartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
@@ -812,7 +815,7 @@ public class KafkaRaftClient implements RaftClient {
         OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
         int responseEpoch = partitionResponse.leaderEpoch();
 
-        Optional<Boolean> handled = maybeHandleCommonResponse(error, responseLeaderId, responseEpoch);
+        Optional<Boolean> handled = maybeHandleCommonResponse(partitionError, responseLeaderId, responseEpoch);
         if (handled.isPresent()) {
             return handled.get();
         } else if (partitionError == Errors.NONE) {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -651,12 +651,8 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     private BeginQuorumEpochResponseData buildBeginQuorumEpochResponse(Errors partitionLevelError) {
-        return buildBeginQuorumEpochResponse(Errors.NONE, partitionLevelError);
-    }
-
-    private BeginQuorumEpochResponseData buildBeginQuorumEpochResponse(Errors topLevelError, Errors partitionLevelError) {
         return BeginQuorumEpochResponse.singletonResponse(
-            topLevelError,
+            Errors.NONE,
             log.topicPartition(),
             partitionLevelError,
             quorum.epoch(),
@@ -728,12 +724,8 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     private EndQuorumEpochResponseData buildEndQuorumEpochResponse(Errors partitionLevelError) {
-        return buildEndQuorumEpochResponse(Errors.NONE, partitionLevelError);
-    }
-
-    private EndQuorumEpochResponseData buildEndQuorumEpochResponse(Errors topLevelError, Errors partitionLevelError) {
         return EndQuorumEpochResponse.singletonResponse(
-            topLevelError,
+            Errors.NONE,
             log.topicPartition(),
             partitionLevelError,
             quorum.epoch(),

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -21,11 +21,13 @@ import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.NotLeaderForPartitionException;
 import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
+import org.apache.kafka.common.message.BeginQuorumEpochResponseData.BeginQuorumPartitionResponse;
 import org.apache.kafka.common.message.DescribeQuorumRequestData;
 import org.apache.kafka.common.message.DescribeQuorumResponseData;
 import org.apache.kafka.common.message.DescribeQuorumResponseData.ReplicaState;
 import org.apache.kafka.common.message.EndQuorumEpochRequestData;
 import org.apache.kafka.common.message.EndQuorumEpochResponseData;
+import org.apache.kafka.common.message.EndQuorumEpochResponseData.EndQuorumPartitionResponse;
 import org.apache.kafka.common.message.FetchQuorumRecordsRequestData;
 import org.apache.kafka.common.message.FetchQuorumRecordsResponseData;
 import org.apache.kafka.common.message.FindQuorumRequestData;
@@ -41,8 +43,12 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Records;
+import org.apache.kafka.common.requests.BeginQuorumEpochRequest;
+import org.apache.kafka.common.requests.BeginQuorumEpochResponse;
 import org.apache.kafka.common.requests.DescribeQuorumRequest;
 import org.apache.kafka.common.requests.DescribeQuorumResponse;
+import org.apache.kafka.common.requests.EndQuorumEpochRequest;
+import org.apache.kafka.common.requests.EndQuorumEpochResponse;
 import org.apache.kafka.common.requests.VoteRequest;
 import org.apache.kafka.common.requests.VoteResponse;
 import org.apache.kafka.common.utils.LogContext;
@@ -644,12 +650,17 @@ public class KafkaRaftClient implements RaftClient {
         return Math.min(electionBackoffMaxMs, retryBackOffBaseMs << (positionInSuccessors - 1));
     }
 
+    private BeginQuorumEpochResponseData buildBeginQuorumEpochResponse(Errors partitionLevelError) {
+        return buildBeginQuorumEpochResponse(Errors.NONE, partitionLevelError);
+    }
 
-    private BeginQuorumEpochResponseData buildBeginQuorumEpochResponse(Errors error) {
-        return new BeginQuorumEpochResponseData()
-                .setErrorCode(error.code())
-                .setLeaderEpoch(quorum.epoch())
-                .setLeaderId(quorum.leaderIdOrNil());
+    private BeginQuorumEpochResponseData buildBeginQuorumEpochResponse(Errors topLevelError, Errors partitionLevelError) {
+        return BeginQuorumEpochResponse.singletonResponse(
+            topLevelError,
+            log.topicPartition(),
+            partitionLevelError,
+            quorum.epoch(),
+            quorum.leaderIdOrNil());
     }
 
     /**
@@ -664,12 +675,22 @@ public class KafkaRaftClient implements RaftClient {
         RaftRequest.Inbound requestMetadata
     ) throws IOException {
         BeginQuorumEpochRequestData request = (BeginQuorumEpochRequestData) requestMetadata.data;
-        Optional<Errors> errorOpt = validateVoterOnlyRequest(request.leaderId(), request.leaderEpoch());
+
+        if (!hasValidTopicPartition(request, log.topicPartition())) {
+            return BeginQuorumEpochRequest.getPartitionLevelErrorResponse(
+                request, Errors.UNKNOWN_TOPIC_OR_PARTITION);
+        }
+
+        BeginQuorumEpochRequestData.BeginQuorumPartitionRequest partitionRequest =
+            request.topics().get(0).partitions().get(0);
+
+        Optional<Errors> errorOpt = validateVoterOnlyRequest(
+            partitionRequest.leaderId(), partitionRequest.leaderEpoch());
         if (errorOpt.isPresent()) {
             return buildBeginQuorumEpochResponse(errorOpt.get());
         } else {
-            int requestLeaderId = request.leaderId();
-            int requestEpoch = request.leaderEpoch();
+            int requestLeaderId = partitionRequest.leaderId();
+            int requestEpoch = partitionRequest.leaderEpoch();
             becomeFetchingFollower(requestLeaderId, requestEpoch);
             return buildBeginQuorumEpochResponse(Errors.NONE);
         }
@@ -680,27 +701,43 @@ public class KafkaRaftClient implements RaftClient {
     ) throws IOException {
         int remoteNodeId = responseMetadata.sourceId();
         BeginQuorumEpochResponseData response = (BeginQuorumEpochResponseData) responseMetadata.data;
-        Errors error = Errors.forCode(response.errorCode());
-        OptionalInt responseLeaderId = optionalLeaderId(response.leaderId());
-        int responseEpoch = response.leaderEpoch();
 
-        Optional<Boolean> handled = maybeHandleCommonResponse(error, responseLeaderId, responseEpoch);
+        if (!hasValidTopicPartition(response, log.topicPartition())) {
+            return false;
+        }
+
+        if (Errors.forCode(response.errorCode()) != Errors.NONE) {
+            return false;
+        }
+        BeginQuorumPartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
+
+        Errors partitionError = Errors.forCode(partitionResponse.errorCode());
+        OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
+        int responseEpoch = partitionResponse.leaderEpoch();
+
+        Optional<Boolean> handled = maybeHandleCommonResponse(partitionError, responseLeaderId, responseEpoch);
         if (handled.isPresent()) {
             return handled.get();
-        } else if (error == Errors.NONE) {
+        } else if (partitionError == Errors.NONE) {
             LeaderState state = quorum.leaderStateOrThrow();
             state.addEndorsementFrom(remoteNodeId);
             return true;
         } else {
-            return handleUnexpectedError(error, responseMetadata);
+            return handleUnexpectedError(partitionError, responseMetadata);
         }
     }
 
-    private EndQuorumEpochResponseData buildEndQuorumEpochResponse(Errors error) {
-        return new EndQuorumEpochResponseData()
-                .setErrorCode(error.code())
-                .setLeaderEpoch(quorum.epoch())
-                .setLeaderId(quorum.leaderIdOrNil());
+    private EndQuorumEpochResponseData buildEndQuorumEpochResponse(Errors partitionLevelError) {
+        return buildEndQuorumEpochResponse(Errors.NONE, partitionLevelError);
+    }
+
+    private EndQuorumEpochResponseData buildEndQuorumEpochResponse(Errors topLevelError, Errors partitionLevelError) {
+        return EndQuorumEpochResponse.singletonResponse(
+            topLevelError,
+            log.topicPartition(),
+            partitionLevelError,
+            quorum.epoch(),
+            quorum.leaderIdOrNil());
     }
 
     /**
@@ -715,8 +752,17 @@ public class KafkaRaftClient implements RaftClient {
         RaftRequest.Inbound requestMetadata
     ) throws IOException {
         EndQuorumEpochRequestData request = (EndQuorumEpochRequestData) requestMetadata.data;
-        int requestEpoch = request.leaderEpoch();
-        int requestReplicaId = request.replicaId();
+
+        if (!hasValidTopicPartition(request, log.topicPartition())) {
+            return EndQuorumEpochRequest.getPartitionLevelErrorResponse(
+                request, Errors.UNKNOWN_TOPIC_OR_PARTITION);
+        }
+
+        EndQuorumEpochRequestData.EndQuorumPartitionRequest partitionRequest =
+            request.topics().get(0).partitions().get(0);
+
+        int requestEpoch = partitionRequest.leaderEpoch();
+        int requestReplicaId = partitionRequest.replicaId();
 
         Optional<Errors> errorOpt = validateVoterOnlyRequest(requestReplicaId, requestEpoch);
         if (errorOpt.isPresent()) {
@@ -724,7 +770,7 @@ public class KafkaRaftClient implements RaftClient {
         }
 
         // We still update our state if the request indicates a larger epoch
-        OptionalInt requestLeaderId = optionalLeaderId(request.leaderId());
+        OptionalInt requestLeaderId = optionalLeaderId(partitionRequest.leaderId());
         maybeBecomeFollower(requestLeaderId, requestEpoch);
 
         if (quorum.isFollower()) {
@@ -732,7 +778,7 @@ public class KafkaRaftClient implements RaftClient {
             if (state.isUnattached()
                 || state.hasLeader(requestReplicaId)
                 || state.hasVotedFor(requestReplicaId)) {
-                List<Integer> preferredSuccessors = request.preferredSuccessors();
+                List<Integer> preferredSuccessors = partitionRequest.preferredSuccessors();
                 // We didn't find the corresponding voters inside the request.
                 if (!preferredSuccessors.contains(quorum.localId)) {
                     return buildEndQuorumEpochResponse(Errors.INCONSISTENT_VOTER_SET);
@@ -758,17 +804,29 @@ public class KafkaRaftClient implements RaftClient {
         RaftResponse.Inbound responseMetadata
     ) throws IOException {
         EndQuorumEpochResponseData response = (EndQuorumEpochResponseData) responseMetadata.data;
+
+        if (!hasValidTopicPartition(response, log.topicPartition())) {
+            return false;
+        }
+
         Errors error = Errors.forCode(response.errorCode());
-        OptionalInt responseLeaderId = optionalLeaderId(response.leaderId());
-        int responseEpoch = response.leaderEpoch();
+        if (error != Errors.NONE) {
+            return handleUnexpectedError(error, responseMetadata);
+        }
+
+        EndQuorumPartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
+        Errors partitionError = Errors.forCode(partitionResponse.errorCode());
+
+        OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
+        int responseEpoch = partitionResponse.leaderEpoch();
 
         Optional<Boolean> handled = maybeHandleCommonResponse(error, responseLeaderId, responseEpoch);
         if (handled.isPresent()) {
             return handled.get();
-        } else if (error == Errors.NONE) {
+        } else if (partitionError == Errors.NONE) {
             return true;
         } else {
-            return handleUnexpectedError(error, responseMetadata);
+            return handleUnexpectedError(partitionError, responseMetadata);
         }
     }
 
@@ -1325,12 +1383,13 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     private EndQuorumEpochRequestData buildEndQuorumEpochRequest() {
-        return new EndQuorumEpochRequestData()
-                .setReplicaId(quorum.localId)
-                .setLeaderId(quorum.leaderIdOrNil())
-                .setLeaderEpoch(quorum.epoch())
-                .setPreferredSuccessors(
-                    quorum.leaderStateOrThrow().nonLeaderVotersByDescendingFetchOffset());
+        return EndQuorumEpochRequest.singletonRequest(
+            log.topicPartition(),
+            quorum.localId,
+            quorum.epoch(),
+            quorum.leaderIdOrNil(),
+            quorum.leaderStateOrThrow().nonLeaderVotersByDescendingFetchOffset()
+        );
     }
 
     private void maybeSendEndQuorumEpoch(long currentTimeMs) throws IOException {
@@ -1340,9 +1399,11 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     private BeginQuorumEpochRequestData buildBeginQuorumEpochRequest() {
-        return new BeginQuorumEpochRequestData()
-                .setLeaderId(quorum.localId)
-                .setLeaderEpoch(quorum.epoch());
+        return BeginQuorumEpochRequest.singletonRequest(
+            log.topicPartition(),
+            quorum.epoch(),
+            quorum.localId
+        );
     }
 
     private void maybeSendBeginQuorumEpochToFollowers(long currentTimeMs, LeaderState state) throws IOException {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -21,13 +21,11 @@ import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.NotLeaderForPartitionException;
 import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
-import org.apache.kafka.common.message.BeginQuorumEpochResponseData.BeginQuorumPartitionResponse;
 import org.apache.kafka.common.message.DescribeQuorumRequestData;
 import org.apache.kafka.common.message.DescribeQuorumResponseData;
 import org.apache.kafka.common.message.DescribeQuorumResponseData.ReplicaState;
 import org.apache.kafka.common.message.EndQuorumEpochRequestData;
 import org.apache.kafka.common.message.EndQuorumEpochResponseData;
-import org.apache.kafka.common.message.EndQuorumEpochResponseData.EndQuorumPartitionResponse;
 import org.apache.kafka.common.message.FetchQuorumRecordsRequestData;
 import org.apache.kafka.common.message.FetchQuorumRecordsResponseData;
 import org.apache.kafka.common.message.FindQuorumRequestData;
@@ -36,7 +34,6 @@ import org.apache.kafka.common.message.LeaderChangeMessage;
 import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
 import org.apache.kafka.common.message.VoteRequestData;
 import org.apache.kafka.common.message.VoteResponseData;
-import org.apache.kafka.common.message.VoteResponseData.VotePartitionResponse;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
@@ -515,7 +512,7 @@ public class KafkaRaftClient implements RaftClient {
             return VoteRequest.getPartitionLevelErrorResponse(request, Errors.UNKNOWN_TOPIC_OR_PARTITION);
         }
 
-        VoteRequestData.VotePartitionRequest partitionRequest =
+        VoteRequestData.PartitionData partitionRequest =
             request.topics().get(0).partitions().get(0);
 
         int candidateId = partitionRequest.candidateId();
@@ -589,7 +586,7 @@ public class KafkaRaftClient implements RaftClient {
             return handleUnexpectedError(topLevelError, responseMetadata);
         }
 
-        VotePartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
+        VoteResponseData.PartitionData partitionResponse = response.topics().get(0).partitions().get(0);
 
         Errors error = Errors.forCode(partitionResponse.errorCode());
         OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
@@ -678,7 +675,7 @@ public class KafkaRaftClient implements RaftClient {
                 request, Errors.UNKNOWN_TOPIC_OR_PARTITION);
         }
 
-        BeginQuorumEpochRequestData.BeginQuorumPartitionRequest partitionRequest =
+        BeginQuorumEpochRequestData.PartitionData partitionRequest =
             request.topics().get(0).partitions().get(0);
 
         Optional<Errors> errorOpt = validateVoterOnlyRequest(
@@ -708,7 +705,8 @@ public class KafkaRaftClient implements RaftClient {
             return handleUnexpectedError(topLevelError, responseMetadata);
         }
 
-        BeginQuorumPartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
+        BeginQuorumEpochResponseData.PartitionData partitionResponse =
+            response.topics().get(0).partitions().get(0);
 
         Errors partitionError = Errors.forCode(partitionResponse.errorCode());
         OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
@@ -753,7 +751,7 @@ public class KafkaRaftClient implements RaftClient {
                 request, Errors.UNKNOWN_TOPIC_OR_PARTITION);
         }
 
-        EndQuorumEpochRequestData.EndQuorumPartitionRequest partitionRequest =
+        EndQuorumEpochRequestData.PartitionData partitionRequest =
             request.topics().get(0).partitions().get(0);
 
         int requestEpoch = partitionRequest.leaderEpoch();
@@ -809,7 +807,8 @@ public class KafkaRaftClient implements RaftClient {
             return handleUnexpectedError(topLevelError, responseMetadata);
         }
 
-        EndQuorumPartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
+        EndQuorumEpochResponseData.PartitionData partitionResponse =
+            response.topics().get(0).partitions().get(0);
         Errors partitionError = Errors.forCode(partitionResponse.errorCode());
 
         OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -17,8 +17,10 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.message.DescribeQuorumRequestData;
+import org.apache.kafka.common.message.EndQuorumEpochRequestData;
 import org.apache.kafka.common.message.EndQuorumEpochResponseData;
 import org.apache.kafka.common.message.FetchQuorumRecordsResponseData;
 import org.apache.kafka.common.message.FindQuorumResponseData;
@@ -30,6 +32,8 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Records;
+import org.apache.kafka.common.requests.BeginQuorumEpochRequest;
+import org.apache.kafka.common.requests.EndQuorumEpochRequest;
 import org.apache.kafka.common.requests.VoteRequest;
 
 import java.io.IOException;
@@ -68,15 +72,9 @@ public class RaftUtil {
             case VOTE:
                 return VoteRequest.getTopLevelErrorResponse(error);
             case BEGIN_QUORUM_EPOCH:
-                return new BeginQuorumEpochResponseData()
-                    .setErrorCode(error.code())
-                    .setLeaderEpoch(epoch)
-                    .setLeaderId(leaderId);
+                return BeginQuorumEpochRequest.getTopLevelErrorResponse(error);
             case END_QUORUM_EPOCH:
-                return new EndQuorumEpochResponseData()
-                    .setErrorCode(error.code())
-                    .setLeaderEpoch(epoch)
-                    .setLeaderId(leaderId);
+                return EndQuorumEpochRequest.getTopLevelErrorResponse(error);
             case FETCH_QUORUM_RECORDS:
                 return new FetchQuorumRecordsResponseData()
                     .setErrorCode(error.code())
@@ -102,6 +100,34 @@ public class RaftUtil {
     }
 
     static boolean hasValidTopicPartition(VoteRequestData data, TopicPartition topicPartition) {
+        return data.topics().size() == 1 &&
+                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
+                   data.topics().get(0).partitions().size() == 1 &&
+                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    }
+
+    static boolean hasValidTopicPartition(BeginQuorumEpochRequestData data, TopicPartition topicPartition) {
+        return data.topics().size() == 1 &&
+                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
+                   data.topics().get(0).partitions().size() == 1 &&
+                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    }
+
+    static boolean hasValidTopicPartition(BeginQuorumEpochResponseData data, TopicPartition topicPartition) {
+        return data.topics().size() == 1 &&
+                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
+                   data.topics().get(0).partitions().size() == 1 &&
+                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    }
+
+    static boolean hasValidTopicPartition(EndQuorumEpochRequestData data, TopicPartition topicPartition) {
+        return data.topics().size() == 1 &&
+                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
+                   data.topics().get(0).partitions().size() == 1 &&
+                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    }
+
+    static boolean hasValidTopicPartition(EndQuorumEpochResponseData data, TopicPartition topicPartition) {
         return data.topics().size() == 1 &&
                    data.topics().get(0).topicName().equals(topicPartition.topic()) &&
                    data.topics().get(0).partitions().size() == 1 &&

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -18,15 +18,11 @@ package org.apache.kafka.raft;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
-import org.apache.kafka.common.message.BeginQuorumEpochRequestData.BeginQuorumPartitionRequest;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
-import org.apache.kafka.common.message.BeginQuorumEpochResponseData.BeginQuorumPartitionResponse;
 import org.apache.kafka.common.message.DescribeQuorumResponseData;
 import org.apache.kafka.common.message.DescribeQuorumResponseData.ReplicaState;
 import org.apache.kafka.common.message.EndQuorumEpochRequestData;
-import org.apache.kafka.common.message.EndQuorumEpochRequestData.EndQuorumPartitionRequest;
 import org.apache.kafka.common.message.EndQuorumEpochResponseData;
-import org.apache.kafka.common.message.EndQuorumEpochResponseData.EndQuorumPartitionResponse;
 import org.apache.kafka.common.message.FetchQuorumRecordsRequestData;
 import org.apache.kafka.common.message.FetchQuorumRecordsResponseData;
 import org.apache.kafka.common.message.FindQuorumRequestData;
@@ -34,9 +30,7 @@ import org.apache.kafka.common.message.FindQuorumResponseData;
 import org.apache.kafka.common.message.LeaderChangeMessage;
 import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
 import org.apache.kafka.common.message.VoteRequestData;
-import org.apache.kafka.common.message.VoteRequestData.VotePartitionRequest;
 import org.apache.kafka.common.message.VoteResponseData;
-import org.apache.kafka.common.message.VoteResponseData.VotePartitionResponse;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -1749,7 +1743,7 @@ public class KafkaRaftClientTest {
         VoteResponseData response = (VoteResponseData) raftMessage.data();
         assertTrue(hasValidTopicPartition(response, METADATA_PARTITION));
 
-        VotePartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
+        VoteResponseData.PartitionData partitionResponse = response.topics().get(0).partitions().get(0);
 
         assertEquals(voteGranted, partitionResponse.voteGranted());
         assertEquals(error, Errors.forCode(partitionResponse.errorCode()));
@@ -1769,7 +1763,8 @@ public class KafkaRaftClientTest {
         EndQuorumEpochResponseData response = (EndQuorumEpochResponseData) raftMessage.data();
         assertEquals(Errors.NONE, Errors.forCode(response.errorCode()));
 
-        EndQuorumPartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
+        EndQuorumEpochResponseData.PartitionData partitionResponse =
+            response.topics().get(0).partitions().get(0);
 
         assertEquals(epoch, partitionResponse.leaderEpoch());
         assertEquals(leaderId.orElse(-1), partitionResponse.leaderId());
@@ -1805,7 +1800,8 @@ public class KafkaRaftClientTest {
         BeginQuorumEpochResponseData response = (BeginQuorumEpochResponseData) raftMessage.data();
         assertEquals(Errors.NONE, Errors.forCode(response.errorCode()));
 
-        BeginQuorumPartitionResponse partitionResponse = response.topics().get(0).partitions().get(0);
+        BeginQuorumEpochResponseData.PartitionData partitionResponse =
+            response.topics().get(0).partitions().get(0);
 
         assertEquals(epoch, partitionResponse.leaderEpoch());
         assertEquals(leaderId.orElse(-1), partitionResponse.leaderId());
@@ -1826,7 +1822,8 @@ public class KafkaRaftClientTest {
             if (raftMessage.data() instanceof EndQuorumEpochRequestData) {
                 EndQuorumEpochRequestData request = (EndQuorumEpochRequestData) raftMessage.data();
 
-                EndQuorumPartitionRequest partitionRequest = request.topics().get(0).partitions().get(0);
+                EndQuorumEpochRequestData.PartitionData partitionRequest =
+                    request.topics().get(0).partitions().get(0);
 
                 assertEquals(epoch, partitionRequest.leaderEpoch());
                 assertEquals(leaderId.orElse(-1), partitionRequest.leaderId());
@@ -1865,7 +1862,7 @@ public class KafkaRaftClientTest {
                 VoteRequestData request = (VoteRequestData) raftMessage.data();
                 assertTrue(hasValidTopicPartition(request, METADATA_PARTITION));
 
-                VotePartitionRequest partitionRequest = request.topics().get(0).partitions().get(0);
+                VoteRequestData.PartitionData partitionRequest = request.topics().get(0).partitions().get(0);
 
                 assertEquals(epoch, partitionRequest.candidateEpoch());
                 assertEquals(localId, partitionRequest.candidateId());
@@ -1889,7 +1886,8 @@ public class KafkaRaftClientTest {
             assertTrue(raftRequest.data() instanceof BeginQuorumEpochRequestData);
             BeginQuorumEpochRequestData request = (BeginQuorumEpochRequestData) raftRequest.data();
 
-            BeginQuorumPartitionRequest partitionRequest = request.topics().get(0).partitions().get(0);
+            BeginQuorumEpochRequestData.PartitionData partitionRequest =
+                request.topics().get(0).partitions().get(0);
 
             assertEquals(epoch, partitionRequest.leaderEpoch());
             assertEquals(localId, partitionRequest.leaderId());


### PR DESCRIPTION
On top of https://github.com/confluentinc/kafka/pull/357. Will be rebased after the dependent PR gets merged.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
