### PR TITLE
ST-3988: Update jackson version to 2.10.4

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -66,7 +66,7 @@ versions += [
   grgit: "4.0.1",
   httpclient: "4.5.11",
   easymock: "4.2",
-  jackson: "2.10.2",
+  jackson: "2.10.4",
   jacoco: "0.8.5",
   jetty: "9.4.30.v20200611",
   jersey: "2.31",


### PR DESCRIPTION
For jackson version 2.10.2, jackson-dataformat-yaml brings in a version of
snakeyaml which is supposedly affected by CVE-2017-18640.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
