### PR TITLE
METRICS-1988: add confluent-telemetry directory to kafka classpath

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -171,6 +171,9 @@ done
 # CONFLUENT: classpath addition for releases with LSB-style layout
 CLASSPATH="$CLASSPATH":"$base_dir/share/java/kafka/*"
 
+# classpath for telemetry
+CLASSPATH="$CLASSPATH":"$base_dir/share/java/confluent-telemetry/*"
+
 for file in "$base_dir"/core/build/libs/kafka_${SCALA_BINARY_VERSION}*.jar;
 do
   if should_include_file "$file"; then


### PR DESCRIPTION
### what
Add share/java/confluent-telemetry to kafka's classpath.

### why
This is where we'll install the confluent-metrics jar (as part of packaging) and we need this jar for telemetry to work.