### PR TITLE
Add MetaLogManager

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -67,6 +67,13 @@ if [ -z "$UPGRADE_KAFKA_STREAMS_TEST_VERSION" ]; then
   done
 fi
 
+for file in "$base_dir"/metadata/build/libs/kafka-*.jar;
+do
+  if should_include_file "$file"; then
+    CLASSPATH="$CLASSPATH":"$file"
+  fi
+done
+
 for file in "$base_dir"/examples/build/libs/kafka-examples*.jar;
 do
   if should_include_file "$file"; then

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -179,6 +179,20 @@
     </subpackage>
   </subpackage>
 
+  <subpackage name="controller">
+    <allow pkg="org.apache.kafka.clients" />
+    <allow pkg="org.apache.kafka.common.feature" />
+    <allow pkg="org.apache.kafka.common.message" />
+    <allow pkg="org.apache.kafka.common.metadata" />
+    <allow pkg="org.apache.kafka.common.metrics" />
+    <allow pkg="org.apache.kafka.common.network" />
+    <allow pkg="org.apache.kafka.common.protocol" />
+    <allow pkg="org.apache.kafka.common.requests" />
+    <allow pkg="org.apache.kafka.controller" />
+    <allow pkg="org.apache.kafka.metadata" />
+    <allow pkg="org.apache.kafka.test" />
+  </subpackage>
+
   <subpackage name="metadata">
     <allow pkg="org.apache.kafka.clients" />
     <allow pkg="org.apache.kafka.common.message" />

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -138,6 +138,10 @@
     <suppress checks="MethodLength"
               files="(RequestResponse|WorkerSinkTask)Test.java"/>
 
+    <!-- Controller -->
+    <suppress checks="CyclomaticComplexity|NPathComplexity"
+              files="(LocalLogManager).java"/>
+
     <!-- Streams -->
     <suppress checks="ClassFanOutComplexity"
               files="(KafkaStreams|KStreamImpl|KTableImpl).java"/>

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiMessageAndVersion.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiMessageAndVersion.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.protocol;
+
+/**
+ * An ApiMessage and an associated version.
+ */
+public class ApiMessageAndVersion {
+    private final ApiMessage message;
+    private final short version;
+
+    public ApiMessageAndVersion(ApiMessage message, short version) {
+        this.message = message;
+        this.version = version;
+    }
+
+    public ApiMessage message() {
+        return message;
+    }
+
+    public short version() {
+        return version;
+    }
+
+    @Override
+    public int hashCode() {
+        return message.hashCode() ^ version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ApiMessageAndVersion)) return false;
+        ApiMessageAndVersion other = (ApiMessageAndVersion) o; 
+        return version == other.version && message.equals(other.message);
+    }
+
+    @Override
+    public String toString() {
+        return "ApiMessageAndVersion(" + message + " at version " + version + ")";
+    }
+}

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -269,6 +269,18 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <!-- Suppress a warning about ignoring the return value of await.
+             This is done intentionally because we use other clues to determine
+             if the wait was cut short.
+
+             Also suppress a warning about calling wait() unconditionally.  This was done
+             intentionally as well. -->
+        <Package name="org.apache.kafka.controller"/>
+        <Source name="LocalLogManager.java"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED,RV_RETURN_VALUE_IGNORED_BAD_PRACTICE,UW_UNCOND_WAIT"/>
+    </Match>
+
+    <Match>
         <!-- Suppress some warnings about intentional switch statement fallthrough. -->
         <Class name="org.apache.kafka.connect.runtime.WorkerConnector"/>
         <Or>

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public interface Controller extends AutoCloseable {
+    /**
+     * Change partition ISRs.
+     *
+     * @param brokerId      The ID of the broker making the change.
+     * @param brokerEpoch   The epoch of the broker making the change.
+     * @param changes       The changes to make.
+     *
+     * @return              A map from partitions to error results.
+     */
+    CompletableFuture<Map<TopicPartition, Errors>>
+        alterIsr(int brokerId, long brokerEpoch, Map<TopicPartition, LeaderAndIsr> changes);
+
+    /**
+     * Elect new partition leaders.
+     *
+     * @param timeoutMs     The timeout to use.
+     * @param parts         The partitions to elect new leaders for.
+     * @param unclean       If this is true, we will elect the first live replic if
+     *                      there are no in-sync replicas.
+     *
+     * @return              A map from partitions to error results.
+     */
+    CompletableFuture<Map<TopicPartition, PartitionLeaderElectionResult>>
+        electLeaders(int timeoutMs, Set<TopicPartition> parts, boolean unclean);
+
+    /**
+     * Begin shutting down, but don't block.  You must still call close to clean up all
+     * resources.
+     */
+    void beginShutdown();
+
+    /**
+     * Blocks until we have shut down and freed all resources.
+     */
+    void close();
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/LeaderAndIsr.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/LeaderAndIsr.java
@@ -17,7 +17,35 @@
 
 package org.apache.kafka.controller;
 
-public final class QuorumControllerManager {
-    QuorumControllerManager() {
+import java.util.List;
+
+public class LeaderAndIsr {
+    private final int leaderId;
+    private final int leaderEpoch;
+    private final List<Integer> isr;
+    private final int currentZkVersion;
+
+    public LeaderAndIsr(int leaderId, int leaderEpoch, List<Integer> isr,
+                        int currentZkVersion) {
+        this.leaderId = leaderId;
+        this.leaderEpoch = leaderEpoch;
+        this.isr = isr;
+        this.currentZkVersion = currentZkVersion;
+    }
+
+    public int leaderId() {
+        return leaderId;
+    }
+
+    public int leaderEpoch() {
+        return leaderEpoch;
+    }
+
+    public List<Integer> isr() {
+        return isr;
+    }
+
+    public int currentZkVersion() {
+        return currentZkVersion;
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/LocalLogManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/LocalLogManager.java
@@ -253,7 +253,13 @@ public final class LocalLogManager implements MetaLogManager {
                                     }
                                 }
                             } catch (InterruptedException e) {
-                                log.trace("LeadershipClaimerThread received InterruptedException.");
+                                // Other threads send an InterruptedException to this thread
+                                // in order to break us out of FileChannel#lock (if we
+                                // haven't take the lock) or Object#wait (if we have).
+                                // Once we catch the exception, we're done with it and
+                                // can discard it.
+                                log.trace("LeadershipClaimerThread received " +
+                                    "InterruptedException.");
                             } finally {
                                 try {
                                     scribeThread.blockingRenounce();
@@ -345,7 +351,7 @@ public final class LocalLogManager implements MetaLogManager {
                             if (state != ScribeState.LEADER) {
                                 // If claim is non-null here, that means we are ready
                                 // to become a leader.  Otherwise, we have to enter
-                                // the BECOME_LEADER state.
+                                // the BECOMING_LEADER state.
                                 if (claim != null) {
                                     state = ScribeState.LEADER;
                                     incomingWrites = null;

--- a/metadata/src/main/java/org/apache/kafka/controller/LocalLogManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/LocalLogManager.java
@@ -1,0 +1,798 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.ApiMessageAndVersion;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.utils.KafkaThread;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.metadata.MetadataParser;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.FileLockInterruptionException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.WatchService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static java.nio.file.StandardOpenOption.READ;
+
+/**
+ * The LocalLogManager has a test log that relies on a single local directory.  Each
+ * process tries to lock the "leader" file in that directory.  Whatever process succeeds
+ * in locking it is the leader, with the ability to write to the "log" file in that
+ * directory.
+ *
+ * The LocalLogManager has three threads: LeadershipClaimerThread, ScribeThread, and
+ * LogDirWatcherThread.
+ *
+ * The LeadershipClaimerThread tries to take the lock on the "leader" file.
+ * If it succeeds, it will tell the ScribeThread to claim the leadership.
+ * It also tells the ScribeThread when to renounce the leadership.
+ *
+ * The ScribeThread handles reading and writing the log.  When in follower mode, it will
+ * read the latest messages in the log.  When in writer mode, it will write to the end of
+ * the log.  In both cases, it will inform the listener of what event just happened.
+ *
+ * The WatcherThread watches the log directory and wakes up the ScribeThread when bytes
+ * are added to the log file.  The ScribeThread will pause this thread when the scribe
+ * is active, since its services are not needed at that point.
+ *
+ *                            |                |
+ *                            | beginShutdown  | renounce
+ *                            V                V
+ *                 +-------------------------------------------+
+ *                 |         LeadershipClaimerThread           |
+ *                 +-------------------------------------------+
+ *                      | blocking | blocking |
+ *                      | claim    | renounce | beginShutdown
+ *                      V          V          V
+ *                +-------------------------------------------+      +----------+
+ * maybeWrite --} |               ScribeThread                | ---} | Listener |
+ *                +-------------------------------------------+      +----------+
+ *                      |        |          ^       |
+ *                      | pause  | unpause  | wake  | beginShutdown
+ *                      V        V          |       V
+ *                +-------------------------------------------+
+ *                |               WatcherThread               |
+ *                +-------------------------------------------+
+ */
+public final class LocalLogManager implements MetaLogManager {
+    /**
+     * The global registry of locks on a particular path.
+     */
+    private static final LockRegistry LOCK_REGISTRY = new LockRegistry();
+
+    /**
+     * An empty byte buffer object.
+     */
+    private static final ByteBuffer EMPTY = ByteBuffer.allocate(0);
+
+    /**
+     * A lock plus the number of threads waiting on it.  Waiters must be updated while
+     * holding the lock of the LockRegistry itself.
+     */
+    static class LockData {
+        final ReentrantLock lock;
+        int waiters;
+
+        LockData() {
+            this.lock = new ReentrantLock();
+            this.waiters = 0;
+        }
+    }
+
+    /**
+     * A registry for locks on paths.
+     *
+     * We want a lock that works in a cross-process fashion, so that multiple processes
+     * on the same machine can attempt to become the leader of our file-backed mock log.
+     *
+     * FileChannel#lock is almost good enough to do the job on its own, but it has a
+     * quirk: if two threads from the same process try to lock the same file, one of them
+     * will get an OverlappingFileLockException.  This would be bad for the case where
+     * we run multiple controllers in the same process in JUnit.  So we add another layer
+     * of in-memory locking to ensure that we don't hit this case.
+     */
+    static class LockRegistry {
+        private final Map<String, LockData> locks = new HashMap<>();
+
+        void lock(String path, FileChannel channel, Runnable onTakeLock)
+                throws IOException {
+            try {
+                LockData lockData = null;
+                FileLock fileLock = null;
+                synchronized (this) {
+                    lockData = locks.computeIfAbsent(path, __ -> new LockData());
+                    lockData.waiters++;
+                }
+                lockData.lock.lockInterruptibly();
+                try {
+                    fileLock = channel.lock();
+                    onTakeLock.run();
+                } catch (FileLockInterruptionException e) {
+                    throw new InterruptedException();
+                } finally {
+                    Utils.closeQuietly(fileLock, "fileLock");
+                    lockData.lock.unlock();
+                    synchronized (this) {
+                        lockData.waiters--;
+                        if (lockData.waiters == 0) {
+                            locks.remove(path, lockData);
+                        }
+                    }
+                }
+            } catch (InterruptedException e) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * The information that is stored inside the leader file.
+     */
+    public static class LeaderInfo {
+        private final int nodeId;
+        private final long epoch;
+
+        public LeaderInfo(int nodeId, long epoch) {
+            this.nodeId = nodeId;
+            this.epoch = epoch;
+        }
+
+        public int nodeId() {
+            return nodeId;
+        }
+
+        public long epoch() {
+            return epoch;
+        }
+
+        static LeaderInfo read(ByteBuffer buf) {
+            int nodeId = buf.getInt();
+            long epoch = buf.getLong();
+            return new LeaderInfo(nodeId, epoch);
+        }
+
+        int size() {
+            return Integer.BYTES + Long.BYTES;
+        }
+
+        void write(ByteBuffer buf) {
+            buf.putInt(nodeId);
+            buf.putLong(epoch);
+        }
+
+        @Override
+        public String toString() {
+            return "LeaderInfo(nodeId=" + nodeId + ", epoch=" + epoch + ")";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(nodeId, epoch);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof LeaderInfo)) return false;
+            LeaderInfo other = (LeaderInfo) o;
+            return other.nodeId == nodeId && other.epoch == epoch;
+        }
+    }
+
+    /**
+     * The LeadershipClaimer continuously tries to claim the leadership of the log.
+     * It always needs to be ready to receive InterruptedExceptions, which somewhat
+     * limits what it can do.  For example, we don't want to write in this thread
+     * since if we get interrupted in the middle, we might have a partial write.
+     */
+    class LeadershipClaimerThread extends KafkaThread {
+        private final String leaderPath;
+        private final FileChannel leaderChannel;
+        private volatile boolean shuttingDown = false;
+        private volatile long claimedEpoch = -1;
+
+        LeadershipClaimerThread(Path leaderPath,
+                                FileChannel leaderChannel,
+                                String threadNamePrefix) {
+            super(threadNamePrefix + "LeadershipClaimerThread", true);
+            this.leaderPath = leaderPath.toString();
+            this.leaderChannel = leaderChannel;
+        }
+
+        @Override
+        public void run() {
+            try {
+                log.debug("starting LeadershipClaimerThread");
+                while (!shuttingDown) {
+                    LOCK_REGISTRY.lock(leaderPath, leaderChannel,
+                        () -> {
+                            try {
+                                claimedEpoch = scribeThread.blockingClaim();
+                                while (!shuttingDown) {
+                                    synchronized (this) {
+                                        this.wait();
+                                    }
+                                }
+                            } catch (InterruptedException e) {
+                                log.trace("LeadershipClaimerThread received InterruptedException.");
+                            } finally {
+                                try {
+                                    scribeThread.blockingRenounce();
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                                claimedEpoch = -1;
+                            }
+                        });
+                }
+                log.debug("shutting down LeadershipClaimerThread.");
+            } catch (Throwable e) {
+                log.error("exiting LeadershipClaimer with error", e);
+            } finally {
+                Utils.closeQuietly(leaderChannel, leaderPath);
+                scribeThread.beginShutdown();
+            }
+        }
+
+        void renounce(long epoch) {
+            if (claimedEpoch == epoch) {
+                this.interrupt();
+            }
+        }
+
+        void beginShutdown() {
+            shuttingDown = true;
+            this.interrupt();
+        }
+    }
+
+    enum ScribeState {
+        FOLLOWER,
+        BECOMING_LEADER,
+        LEADER;
+    }
+
+    private final static int FRAME_LENGTH = 4;
+
+    class ScribeThread extends KafkaThread {
+        private final ReentrantLock lock = new ReentrantLock();
+        private final Condition wakeCond = lock.newCondition();
+        private final Condition claimedCond = lock.newCondition();
+        private final Condition renouncedCond = lock.newCondition();
+        private final FileChannel logChannel;
+        private final Listener listener;
+        private final long logCheckIntervalMs;
+        private final MetadataParser parser = new MetadataParser();
+        private boolean shuttingDown = false;
+        private boolean shouldLead = false;
+        private long nextLogCheckMs = 0;
+        private List<ApiMessageAndVersion> incomingWrites = null;
+        private ScribeState state = ScribeState.FOLLOWER;
+        private LeaderInfo leaderInfo = new LeaderInfo(-1, -1);
+        private long index = 0;
+        private long nextWriteIndex = 0;
+        private long fileOffset = 0;
+        private final ByteBuffer frameBuffer = ByteBuffer.allocate(FRAME_LENGTH);
+        private ByteBuffer dataBuffer = EMPTY;
+
+        ScribeThread(FileChannel logChannel,
+                     Listener listener,
+                     long logCheckIntervalMs,
+                     String threadNamePrefix) {
+            super(threadNamePrefix + "LeadershipClaimerThread", true);
+            this.logChannel = logChannel;
+            this.listener = listener;
+            this.logCheckIntervalMs = logCheckIntervalMs;
+        }
+
+        @Override
+        public void run() {
+            try {
+                log.debug("starting ScribeThread");
+                LeaderInfo claim = null;
+                while (true) {
+                    List<ApiMessageAndVersion> toWrite = null;
+                    long shouldRenounceEpoch = -1, shouldClaimEpoch = -1;
+                    ScribeState curState;
+                    lock.lock();
+                    try {
+                        if (shuttingDown) {
+                            break;
+                        }
+                        if (shouldLead) {
+                            // If shouldLead is true then we need to become a leader.
+                            // This requires reading all the previous log entries, and
+                            // writing out our claim to the log file.
+                            if (state != ScribeState.LEADER) {
+                                // If claim is non-null here, that means we are ready
+                                // to become a leader.  Otherwise, we have to enter
+                                // the BECOME_LEADER state.
+                                if (claim != null) {
+                                    state = ScribeState.LEADER;
+                                    incomingWrites = null;
+                                    leaderInfo = claim;
+                                    index = 0;
+                                    nextWriteIndex = 0;
+                                    shouldClaimEpoch = leaderInfo.epoch;
+                                    claimedCond.signalAll();
+                                } else {
+                                    state = ScribeState.BECOMING_LEADER;
+                                }
+                            }
+                        } else if (state != ScribeState.FOLLOWER) {
+                            // If shouldLead is false, and we're not already a follower,
+                            // become one immediately.
+                            shouldRenounceEpoch = leaderInfo.epoch;
+                            state = ScribeState.FOLLOWER;
+                            nextLogCheckMs = 0;
+                            renouncedCond.signalAll();
+                        }
+                        if (shouldClaimEpoch == -1 && shouldRenounceEpoch == -1) {
+                            switch (state) {
+                                case FOLLOWER:
+                                    // Followers wait until they get woken up, or until a
+                                    // few milliseconds have elapsed, before rechecking
+                                    // the log.
+                                    long now = SystemTime.SYSTEM.milliseconds();
+                                    if (nextLogCheckMs > now) {
+                                        wakeCond.await(nextLogCheckMs - now,
+                                            TimeUnit.MILLISECONDS);
+                                        now = SystemTime.SYSTEM.milliseconds();
+                                    }
+                                    nextLogCheckMs = now + logCheckIntervalMs;
+                                    break;
+                                case BECOMING_LEADER:
+                                    // No need to wait here.
+                                    break;
+                                case LEADER:
+                                    // Wait to be signalled before waking up.  The signal
+                                    // may indicate that we should stop being the leader,
+                                    // or that there are new writes to be done.
+                                    if (incomingWrites == null && shouldLead) {
+                                        wakeCond.await();
+                                    }
+                                    toWrite = (incomingWrites == null) ?
+                                        Collections.emptyList() : incomingWrites;
+                                    incomingWrites = null;
+                                    break;
+                            }
+                        }
+                        claim = null;
+                    } finally {
+                        curState = state;
+                        lock.unlock();
+                    }
+                    if (log.isTraceEnabled()) {
+                        log.trace("ScribeThread state = {}, shouldRenounceEpoch = {}, " +
+                            "shouldClaimEpoch = {}", curState, shouldRenounceEpoch,
+                            shouldClaimEpoch);
+                    }
+                    if (shouldRenounceEpoch > -1L) {
+                        listener.handleRenounce(shouldRenounceEpoch);
+                    }
+                    if (shouldClaimEpoch > -1L) {
+                        listener.handleClaim(shouldClaimEpoch);
+                    }
+                    switch (curState) {
+                        case FOLLOWER:
+                        case BECOMING_LEADER:
+                            // Read until we get EOF or a partial read.
+                            int result;
+                            do {
+                                result = readNextMessage();
+                                if (log.isTraceEnabled()) {
+                                    if (result < 0) {
+                                        log.trace("ScribeThread read partial message.");
+                                    } else if (result == 0) {
+                                        log.trace("ScribeThread hit EOF while reading.");
+                                    } else {
+                                        log.trace("ScribeThread read message of length " +
+                                            result);
+                                    }
+                                }
+                            } while (result > 0);
+                            if (curState == ScribeState.BECOMING_LEADER && result == 0) {
+                                // If the result is 0, that means did not read a partial
+                                // record at the end.  So we should be ready to write our
+                                // claim to the file.
+                                claim = new LeaderInfo(nodeId, leaderInfo.epoch + 1);
+                                writeClaim(claim);
+                                log.debug("ScribeThread wrote claim {}", claim);
+                            }
+                            break;
+                        case LEADER:
+                            // Write out the messages that we were given earlier.
+                            if (toWrite != null) {
+                                for (ApiMessageAndVersion message : toWrite) {
+                                    writeMessage(message);
+                                    listener.handleCommit(leaderInfo.epoch, index,
+                                        message.message());
+                                    index++;
+                                }
+                            }
+                            break;
+                    }
+                }
+                log.debug("shutting down ScribeThread.");
+                listener.beginShutdown();
+            } catch (Throwable t) {
+                log.error("exiting ScribeThread with unexpected error", t);
+            } finally {
+                Utils.closeQuietly(logChannel, "logChannel");
+                lock.lock();
+                try {
+                    renouncedCond.signal();
+                } finally {
+                    lock.unlock();
+                }
+                watcherThread.beginShutdown();
+                listener.beginShutdown();
+            }
+        }
+
+        private void writeMessage(ApiMessageAndVersion messageAndVersion)
+                throws IOException {
+            ObjectSerializationCache cache = new ObjectSerializationCache();
+            int size = MetadataParser.size(messageAndVersion.message(),
+                messageAndVersion.version(), cache);
+            writeFrame(size);
+            setupDataBuffer(size);
+            MetadataParser.write(messageAndVersion.message(),
+                messageAndVersion.version(), cache, dataBuffer);
+            dataBuffer.flip();
+            writeBuffer(dataBuffer);
+        }
+
+        private void writeClaim(LeaderInfo claim) throws IOException {
+            writeFrame(-claim.size());
+            setupDataBuffer(claim.size());
+            claim.write(dataBuffer);
+            dataBuffer.flip();
+            writeBuffer(dataBuffer);
+        }
+
+        /**
+         * Read a message from the log.  If it is a regular message, send it to the
+         * log listener.  If it is a leader epoch message, update the leader epoch.
+         *
+         * @return  A negative number if we got a partial message.
+         *          0 if we hit EOF.
+         *          A positive size of what we read, if we read a message.
+         */
+        private int readNextMessage() throws IOException {
+            frameBuffer.clear();
+            int frameLength = readData(frameBuffer, fileOffset);
+            if (frameLength <= 0) {
+                return frameLength;
+            }
+            int frameInt = frameBuffer.getInt();
+            int length = frameInt < 0 ? -frameInt : frameInt;
+            setupDataBuffer(length);
+            int dataLength = readData(dataBuffer, fileOffset + FRAME_LENGTH);
+            if (dataLength < 0) {
+                return -FRAME_LENGTH + dataLength;
+            }
+            if (frameInt < 0) {
+                leaderInfo = LeaderInfo.read(dataBuffer);
+            } else {
+                ApiMessage message = MetadataParser.read(dataBuffer);
+                listener.handleCommit(leaderInfo.epoch, index, message);
+                index++;
+            }
+            fileOffset += FRAME_LENGTH + dataLength;
+            return FRAME_LENGTH + dataLength;
+        }
+
+        /**
+         * Read data from the log into a provided buffer.
+         *
+         * @param buf           The buffer to read the data into.
+         * @param curOffset     The offset in the file to read from.
+         *
+         * @return              A negative number if we got a partial message.
+         *                      0 if we hit EOF.
+         *                      The positive size of what we read, if we read everything.
+         */
+        private int readData(ByteBuffer buf, long curOffset) throws IOException {
+            int numRead = 0;
+            while (buf.hasRemaining()) {
+                int result = logChannel.read(buf, curOffset + buf.position());
+                if (result < 0) {
+                    return -numRead;
+                }
+                numRead += result;
+            }
+            buf.flip();
+            return numRead;
+        }
+
+        /**
+         * Set up the dataBuffer so that it is long enough to include the given number of
+         * bytes.  Also clear it and set the limit.
+         *
+         * @param size          The requested size.
+         */
+        private void setupDataBuffer(int size) {
+            if (size > MetadataParser.MAX_SERIALIZED_EVENT_SIZE) {
+                throw new RuntimeException("Event size " + size + " is too large.");
+            } else if (size < 0) {
+                throw new RuntimeException("Event size " + size + " is negative.");
+            }
+            if (dataBuffer.capacity() < size) {
+                int toAllocate = 64;
+                while (toAllocate < size) {
+                    toAllocate *= 2;
+                }
+                toAllocate =
+                    Math.min(toAllocate, MetadataParser.MAX_SERIALIZED_EVENT_SIZE);
+                dataBuffer = ByteBuffer.allocate(toAllocate);
+            }
+            dataBuffer.clear();
+            dataBuffer.limit(size);
+        }
+
+        /**
+         * Write a 4-byte frame to disk and advance the file offset.
+         *
+         * @param value         The frame value to write.
+         */
+        private void writeFrame(int value) throws IOException {
+            frameBuffer.clear();
+            frameBuffer.putInt(value);
+            frameBuffer.flip();
+            writeBuffer(frameBuffer);
+        }
+
+        /**
+         * Write a buffer to disk and advance the file offset.
+         *
+         * @param buf           The buffer to write.
+         */
+        private void writeBuffer(ByteBuffer buf) throws IOException {
+            int size = buf.remaining();
+            while (buf.hasRemaining()) {
+                logChannel.write(buf, fileOffset + buf.position());
+            }
+            fileOffset += size;
+        }
+
+        void beginShutdown() {
+            lock.lock();
+            try {
+                shuttingDown = true;
+                wakeCond.signal();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        long blockingClaim() throws InterruptedException {
+            lock.lock();
+            try {
+                if (log.isTraceEnabled()) {
+                    log.trace("ScribeThread setting shouldLead to true.");
+                }
+                shouldLead = true;
+                wakeCond.signal();
+                do {
+                    if (shuttingDown) throw new InterruptedException();
+                    claimedCond.await();
+                } while (state != ScribeState.LEADER);
+                return leaderInfo.epoch();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        void blockingRenounce() throws InterruptedException {
+            lock.lock();
+            try {
+                shouldLead = false;
+                wakeCond.signal();
+                while (state != ScribeState.FOLLOWER) {
+                    if (shuttingDown) throw new InterruptedException();
+                    renouncedCond.await();
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        long scheduleWrite(long epoch, ApiMessageAndVersion message) {
+            lock.lock();
+            try {
+                if (shuttingDown || leaderInfo.epoch != epoch) {
+                    return Long.MAX_VALUE;
+                }
+                if (incomingWrites == null) {
+                    incomingWrites = new ArrayList<>();
+                }
+                incomingWrites.add(message);
+                long curWriteIndex = nextWriteIndex;
+                nextWriteIndex++;
+                wakeCond.signal();
+                return curWriteIndex;
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        void wake() {
+            lock.lock();
+            try {
+                wakeCond.signal();
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    class WatcherThread extends KafkaThread {
+        private final Path basePath;
+        private final WatchService watchService;
+        private volatile boolean shuttingDown = false;
+
+        WatcherThread(Path basePath,
+                      WatchService watchService,
+                      String threadNamePrefix) {
+            super(threadNamePrefix + "WatcherThread", true);
+            this.basePath = basePath;
+            this.watchService = watchService;
+        }
+
+        @Override
+        public void run() {
+            try {
+                log.debug("starting WatcherThread for {}", basePath);
+                while (!shuttingDown) {
+                    try {
+                        watchService.take();
+                        scribeThread.wake();
+                    } catch (InterruptedException e) {
+                        log.trace("WatcherThread received InterruptedException.");
+                    }
+                }
+                log.debug("shutting down WatcherThread.");
+            } catch (Throwable e) {
+                log.error("exiting WatcherThread with unexpected error", e);
+            } finally {
+                Utils.closeQuietly(watchService, "watchService");
+            }
+        }
+
+        void beginShutdown() {
+            shuttingDown = true;
+            this.interrupt();
+        }
+    }
+
+    private final Logger log;
+    private final int nodeId;
+    private final LeadershipClaimerThread leadershipClaimerThread;
+    private final ScribeThread scribeThread;
+    private final WatcherThread watcherThread;
+
+    public LocalLogManager(LogContext logContext,
+                           int nodeId,
+                           String basePath,
+                           String threadNamePrefix,
+                           Listener listener,
+                           int logCheckIntervalMs) throws IOException {
+        FileChannel leaderChannel = null;
+        FileChannel logChannel = null;
+        WatchService watchService = null;
+        LeadershipClaimerThread leadershipClaimerThread = null;
+        ScribeThread scribeThread = null;
+        WatcherThread watcherThread = null;
+        this.log = logContext.logger(LocalLogManager.class);
+        try {
+            this.nodeId = nodeId;
+            Path base = Paths.get(basePath);
+            Files.createDirectories(base);
+            Path realBase = base.toRealPath();
+            Path leaderPath = realBase.resolve("leader");
+            leaderChannel = FileChannel.open(leaderPath, CREATE, WRITE, READ);
+            Path logPath = realBase.resolve("log");
+            logChannel = FileChannel.open(logPath, CREATE, WRITE, READ);
+            watchService = FileSystems.getDefault().newWatchService();
+            this.leadershipClaimerThread = leadershipClaimerThread =
+                new LeadershipClaimerThread(leaderPath, leaderChannel, threadNamePrefix);
+            this.scribeThread = scribeThread =
+                new ScribeThread(logChannel, listener, logCheckIntervalMs, threadNamePrefix);
+            this.watcherThread = watcherThread =
+                new WatcherThread(realBase, watchService, threadNamePrefix);
+            this.leadershipClaimerThread.start();
+            this.scribeThread.start();
+            this.watcherThread.start();
+        } catch (Throwable t) {
+            log.error("Error creating LocalFileMetaLog", t);
+            Utils.closeQuietly(leaderChannel, "leaderChannel");
+            Utils.closeQuietly(logChannel, "logPath");
+            Utils.closeQuietly(watchService, "watchService");
+            if (leadershipClaimerThread != null) {
+                leadershipClaimerThread.beginShutdown();
+                try {
+                    leadershipClaimerThread.join();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (scribeThread != null) {
+                scribeThread.beginShutdown();
+                try {
+                    scribeThread.join();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (watcherThread != null) {
+                watcherThread.beginShutdown();
+                try {
+                    watcherThread.join();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            throw t;
+        }
+    }
+
+    @Override
+    public long scheduleWrite(long epoch, ApiMessageAndVersion message) {
+        return scribeThread.scheduleWrite(epoch, message);
+    }
+
+    @Override
+    public void renounce(long epoch) {
+        leadershipClaimerThread.renounce(epoch);
+    }
+
+    @Override
+    public void beginShutdown() {
+        leadershipClaimerThread.beginShutdown();
+    }
+
+    @Override
+    public void close() throws InterruptedException {
+        beginShutdown();
+        leadershipClaimerThread.join();
+        scribeThread.join();
+        watcherThread.join();
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/MetaLogManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/MetaLogManager.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.ApiMessageAndVersion;
+
+/**
+ * The MetaLogManager handles storing metadata and electing leaders.
+ */
+public interface MetaLogManager extends AutoCloseable {
+    /**
+     * Listeners receive notifications from the MetaLogManager.
+     */
+    interface Listener {
+        /**
+         * Called when the MetaLogManager commits a message.
+         *
+         * @param epoch         The controller epoch of the message.
+         * @param index         The index of the message within the controller epoch.
+         * @param message       The message.
+         */
+        void handleCommit(long epoch, long index, ApiMessage message);
+
+        /**
+         * Called when the MetaLogManager has claimed the leadership.
+         *
+         * @param epoch         The controller epoch that is starting.
+         */
+        void handleClaim(long epoch);
+
+        /**
+         * Called when the MetaLogManager has renounced the leadership.
+         *
+         * @param epoch         The controller epoch that has ended.
+         */
+        void handleRenounce(long epoch);
+
+        /**
+         * Called when the MetaLogManager has finished shutting down, and wants to tell its
+         * listener that it is safe to shut down as well.
+         */
+        void beginShutdown();
+    }
+
+    /**
+     * Schedule a write to the log.
+     *
+     * The write will be scheduled to happen at some time in the future.  There is no
+     * error return or exception thrown if the write fails.  Instead, the listener may
+     * regard the write as successful if and only if the MetaLogManager reaches the given
+     * index before renouncing its leadership.  The listener should determine this by
+     * monitoring the committed indexes.
+     *
+     * @param epoch         The controller epoch.
+     * @param message       The message to write and the version to use.
+     *
+     * @return              The index of the message.
+     */
+    long scheduleWrite(long epoch, ApiMessageAndVersion message);
+
+    /**
+     * Renounce the leadership.
+     *
+     * @param epoch         The epoch.  If this does not match the current epoch, this
+     *                      call will be ignored.
+     */
+    void renounce(long epoch);
+
+    /**
+     * Begin shutting down, but don't block.  You must still call close to clean up all
+     * resources.
+     */
+    void beginShutdown();
+
+    /**
+     * Blocks until we have shut down and freed all resources.  It is not necessary to
+     * call beginShutdown before calling this function.
+     */
+    void close() throws InterruptedException;
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionLeaderElectionResult.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionLeaderElectionResult.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.requests.ApiError;
+
+public class PartitionLeaderElectionResult {
+    private final int leaderId;
+    private final ApiError error;
+
+    public PartitionLeaderElectionResult(int leaderId, ApiError error) {
+        this.leaderId = leaderId;
+        this.error = error;
+    }
+
+    public int leaderId() {
+        return leaderId;
+    }
+
+    public ApiError error() {
+        return error;
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public final class QuorumController implements Controller {
+    QuorumController() {
+    }
+
+    @Override
+    public CompletableFuture<Map<TopicPartition, Errors>>
+            alterIsr(int brokerId, long brokerEpoch,
+                     Map<TopicPartition, LeaderAndIsr> changes) {
+        CompletableFuture<Map<TopicPartition, Errors>> future = new CompletableFuture<>();
+        future.completeExceptionally(new UnsupportedVersionException("unimplemented"));
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Map<TopicPartition, PartitionLeaderElectionResult>>
+            electLeaders(int timeoutMs, Set<TopicPartition> parts, boolean unclean) {
+        CompletableFuture<Map<TopicPartition, PartitionLeaderElectionResult>> future =
+            new CompletableFuture<>();
+        future.completeExceptionally(new UnsupportedVersionException("unimplemented"));
+        return future;
+    }
+
+    @Override
+    public void beginShutdown() {
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/MetadataParser.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/MetadataParser.java
@@ -48,14 +48,14 @@ public class MetadataParser {
             type = unsignedIntToShort(ByteUtils.readUnsignedVarint(buffer), "type");
         } catch (Exception e) {
             throw new MetadataParseException("Failed to read variable-length type " +
-                "number: " + e.getMessage());
+                "number: " + e.getClass().getSimpleName() + ": " + e.getMessage());
         }
         short version;
         try {
             version = unsignedIntToShort(ByteUtils.readUnsignedVarint(buffer), "version");
         } catch (Exception e) {
             throw new MetadataParseException("Failed to read variable-length " +
-                "version number: " + e.getMessage());
+                "version number: " + e.getClass().getSimpleName() + ": " + e.getMessage());
         }
         MetadataRecordType recordType = MetadataRecordType.fromId(type);
         ApiMessage message = recordType.newMetadataRecord();
@@ -63,7 +63,7 @@ public class MetadataParser {
             message.read(new ByteBufferAccessor(buffer), version);
         } catch (Exception e) {
             throw new MetadataParseException(recordType + "#parse failed: " +
-                e.getMessage());
+                e.getClass().getSimpleName() + ": " + e.getMessage());
         }
         if (buffer.hasRemaining()) {
             throw new MetadataParseException("Found " + buffer.remaining() +

--- a/metadata/src/test/java/org/apache/kafka/controller/LocalLogManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/LocalLogManagerTest.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.metadata.BrokerRecord;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.ApiMessageAndVersion;
+import org.apache.kafka.controller.LocalLogManager.LeaderInfo;
+import org.apache.kafka.controller.LocalLogManager.LockRegistry;
+import org.apache.kafka.controller.MockMetaLogManagerListener.CommitHandler;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class LocalLogManagerTest {
+    private static final Logger log = LoggerFactory.getLogger(LocalLogManagerTest.class);
+
+    @Rule
+    final public Timeout globalTimeout = Timeout.seconds(40);
+
+    /**
+     * Test that when a bunch of threads race to take a lock registry lock, only one
+     * thread at a time can get it.
+     */
+    @Test
+    public void testLockRegistryWithRacingThreads() throws Exception {
+        List<Thread> threads = new ArrayList<>();
+        try (LocalLogManagerTestEnv env = new LocalLogManagerTestEnv(0)) {
+            final Path leaderPath = env.dir().toPath().resolve("leader").toAbsolutePath();
+            final LockRegistry registry = new LockRegistry();
+            final AtomicInteger threadsWithLock = new AtomicInteger(0);
+            try (FileChannel leaderChannel = FileChannel.open(leaderPath,
+                    StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+                for (int i = 0; i < 20; i++) {
+                    Thread thread = new Thread(() -> {
+                        try {
+                            registry.lock(leaderPath.toString(), leaderChannel, () -> {
+                                if (threadsWithLock.getAndIncrement() != 0) {
+                                    env.firstError().compareAndSet(null, "threadsWithLock " +
+                                        "was non-zero when we got the lock.");
+                                    return;
+                                }
+                                try {
+                                    Thread.sleep(0, 1000);
+                                } catch (InterruptedException e) {
+                                }
+                                threadsWithLock.decrementAndGet();
+                            });
+                        } catch (Throwable t) {
+                            env.firstError().compareAndSet(null, "unexpected " +
+                                t.getClass().getName() + " :" + t.getMessage());
+                        }
+                    });
+                    threads.add(thread);
+                    thread.start();
+                }
+                joinAll(threads);
+            }
+            assertEquals(null, env.firstError.get());
+        } finally {
+            joinAll(threads);
+        }
+    }
+
+    private static void joinAll(List<Thread> threads) throws Exception {
+        for (Thread thread : threads) {
+            thread.join();
+        }
+    }
+
+    @Test
+    public void testRoundTripLeaderInfo() {
+        LeaderInfo info = new LeaderInfo(123, 123456789L);
+        ByteBuffer buffer = ByteBuffer.allocate(info.size());
+        buffer.clear();
+        info.write(buffer);
+        buffer.flip();
+        LeaderInfo info2 = LeaderInfo.read(buffer);
+        assertEquals(info, info2);
+    }
+
+    /**
+     * Test creating a LocalLogManager and closing it.
+     */
+    @Test
+    public void testCreateAndClose() throws Exception {
+        try (LocalLogManagerTestEnv env = new LocalLogManagerTestEnv(1)) {
+            env.close();
+            assertEquals(null, env.firstError.get());
+        }
+    }
+
+    /**
+     * Test creating a LocalLogManager and closing it.
+     */
+    @Test
+    public void testClaimsLeadership() throws Exception {
+        try (LocalLogManagerTestEnv env = new LocalLogManagerTestEnv(1)) {
+            assertEquals(new LeaderInfo(0, 0), env.waitForLeader());
+            env.close();
+            assertEquals(null, env.firstError.get());
+        }
+    }
+
+    /**
+     * Test that we can pass leadership back and forth between log managers.
+     */
+    @Test
+    public void testPassLeadership() throws Exception {
+        try (LocalLogManagerTestEnv env = new LocalLogManagerTestEnv(3)) {
+            LeaderInfo first = env.waitForLeader();
+            LeaderInfo cur = first;
+            do {
+                env.logManagers().get(cur.nodeId()).renounce(cur.epoch());
+                LeaderInfo next = env.waitForLeader();
+                while (next.epoch() == cur.epoch()) {
+                    Thread.sleep(1);
+                    next = env.waitForLeader();
+                }
+                long expectedNextEpoch = cur.epoch() + 1;
+                assertEquals("Expected next epoch to be " + expectedNextEpoch +
+                    ", but found  " + next, expectedNextEpoch, next.epoch());
+                cur = next;
+            } while (cur.nodeId() == first.nodeId());
+            env.close();
+            assertEquals(null, env.firstError.get());
+        }
+    }
+
+    static class TestCommit {
+        final long epoch;
+        final long index;
+        final ApiMessage message;
+
+        public TestCommit(long epoch, long index, ApiMessage message) {
+            this.epoch = epoch;
+            this.index = index;
+            this.message = message;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(epoch, index, message);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof TestCommit)) {
+                return false;
+            }
+            TestCommit other = (TestCommit) o;
+            return epoch == other.epoch &&
+                index == other.index &&
+                message.equals(other.message);
+        }
+
+        @Override
+        public String toString() {
+            return "TestCommit(epoch=" + epoch + ", index=" + index +
+                ", message=" + message + ")";
+        }
+    }
+
+    static class CommitChecker implements CommitHandler {
+        private final List<TestCommit> commits;
+        private final Map<Integer, Integer> cursors = new HashMap<>();
+
+        CommitChecker(List<TestCommit> commits) {
+            this.commits = commits;
+        }
+
+        @Override
+        public synchronized void handle(int nodeId, long epoch, long index,
+                                        ApiMessage message) throws Exception {
+            int commitNumber = cursors.getOrDefault(nodeId, 0);
+            TestCommit newCommit = new TestCommit(epoch, index, message);
+            TestCommit expectedCommit = commits.get(commitNumber);
+            assertEquals("Unexpected commit on node " + nodeId, expectedCommit, newCommit);
+            cursors.put(nodeId, commitNumber + 1);
+        }
+
+        synchronized void verifyCursorsHaveReachedCommitNumber(int expectedNumCursors,
+                                                               int expectedCommitNumber) {
+            if (cursors.size() < expectedNumCursors) {
+                throw new RuntimeException("Expected " + expectedNumCursors +
+                    " cursors, but there were only " + cursors.size());
+            }
+            for (Map.Entry<Integer, Integer> entry : cursors.entrySet()) {
+                if (entry.getValue() < expectedCommitNumber) {
+                    throw new RuntimeException("Node " + entry.getKey() + " has " +
+                        "only reached commit number " + entry.getValue() + ", not " +
+                        expectedCommitNumber);
+                }
+            }
+        }
+    }
+
+    /**
+     * Test that all the log managers see all the commits.
+     */
+    @Test
+    public void testCommits() throws Exception {
+        CommitChecker checker = new CommitChecker(Arrays.asList(
+            new TestCommit(0, 0, new BrokerRecord().setBrokerId(0)),
+            new TestCommit(0, 1, new BrokerRecord().setBrokerId(1)),
+            new TestCommit(0, 2, new BrokerRecord().setBrokerId(2)),
+            new TestCommit(0, 3, new BrokerRecord().setBrokerId(0))
+        ));
+        try (LocalLogManagerTestEnv env = new LocalLogManagerTestEnv(checker, 3)) {
+            LeaderInfo leaderInfo = env.waitForLeader();
+            for (int i = 0; i < checker.commits.size(); i++) {
+                TestCommit testCommit = checker.commits.get(i);
+                long index = env.logManagers().get(leaderInfo.nodeId()).
+                    scheduleWrite(testCommit.epoch,
+                        new ApiMessageAndVersion(testCommit.message, (short) 0));
+                log.trace("scheduleWrite(epoch=" + testCommit.epoch +
+                    ", nodeId=" + leaderInfo.nodeId() + ") = " + index);
+            }
+            TestUtils.retryOnExceptionWithTimeout(3, 20000, () -> {
+                checker.verifyCursorsHaveReachedCommitNumber(3, checker.commits.size());
+            });
+            env.close();
+            assertEquals(null, env.firstError.get());
+        }
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/controller/LocalLogManagerTestEnv.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/LocalLogManagerTestEnv.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.controller.LocalLogManager.LeaderInfo;
+import org.apache.kafka.controller.MockMetaLogManagerListener.CommitHandler;
+import org.apache.kafka.test.TestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class LocalLogManagerTestEnv implements AutoCloseable {
+    private static final Logger log =
+        LoggerFactory.getLogger(LocalLogManagerTestEnv.class);
+
+    /**
+     * The first error we encountered during this test, or the empty string if we have
+     * not encountered any.
+     */
+    final AtomicReference<String> firstError = new AtomicReference<>(null);
+
+    /**
+     * The test directory, which we will delete once the test is over.
+     */
+    private final File dir;
+
+    /**
+     * A list of listeners-- one for each log manager.
+     */
+    private final List<MockMetaLogManagerListener> listeners;
+
+    /**
+     * A list of log managers.
+     */
+    private final List<LocalLogManager> logManagers;
+
+    public LocalLogManagerTestEnv(int numManagers) throws Exception {
+        this((__, ___, ____, _____) -> { }, numManagers);
+    }
+
+    public LocalLogManagerTestEnv(CommitHandler commitHandler,
+                                  int numManagers) throws Exception {
+        dir = TestUtils.tempDirectory();
+        this.listeners = new ArrayList<>(numManagers);
+        for (int i = 0; i < numManagers; i++) {
+            this.listeners.add(new MockMetaLogManagerListener(firstError, commitHandler, i));
+        }
+        List<LocalLogManager> newLogManagers = new ArrayList<>(numManagers);
+        try {
+            for (int i = 0; i < numManagers; i++) {
+                String prefix = String.format("Manager%d", i);
+                newLogManagers.add(new LocalLogManager(
+                    new LogContext(prefix + ": "),
+                    i,
+                    dir.getAbsolutePath(),
+                    prefix,
+                    this.listeners.get(i),
+                    50));
+            }
+        } catch (Throwable t) {
+            for (LocalLogManager logManager : newLogManagers) {
+                logManager.close();
+            }
+            throw t;
+        }
+        this.logManagers = newLogManagers;
+    }
+
+    AtomicReference<String> firstError() {
+        return firstError;
+    }
+
+    File dir() {
+        return dir;
+    }
+
+    LeaderInfo waitForLeader() throws InterruptedException {
+        AtomicReference<LeaderInfo> value = new AtomicReference<>(null);
+        TestUtils.retryOnExceptionWithTimeout(3, 20000, () -> {
+            LeaderInfo leaderInfo = null;
+            for (MockMetaLogManagerListener listener : listeners) {
+                long curEpoch = listener.curEpoch();
+                if (curEpoch != -1) {
+                    if (leaderInfo != null) {
+                        throw new RuntimeException("node " + leaderInfo.nodeId() +
+                            " thinks it's the leader, but so does " + listener.nodeId());
+                    }
+                    leaderInfo = new LeaderInfo(listener.nodeId(), curEpoch);
+                }
+            }
+            if (leaderInfo == null) {
+                throw new RuntimeException("No leader found.");
+            }
+            value.set(leaderInfo);
+        });
+        LeaderInfo result = value.get();
+        return result;
+    }
+
+    List<LocalLogManager> logManagers() {
+        return logManagers;
+    }
+
+    @Override
+    public void close() throws InterruptedException {
+        try {
+            for (LocalLogManager logManager : logManagers) {
+                logManager.beginShutdown();
+            }
+            for (LocalLogManager logManager : logManagers) {
+                logManager.close();
+            }
+            Utils.delete(dir);
+        } catch (IOException e) {
+            log.error("Error deleting {}", dir.getAbsolutePath(), e);
+        }
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/controller/MockMetaLogManagerListener.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockMetaLogManagerListener.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class MockMetaLogManagerListener implements MetaLogManager.Listener {
+    private final AtomicReference<String> firstError;
+    private final CommitHandler commitHandler;
+    private final int nodeId;
+    private boolean shutdown = false;
+    private long curEpoch = -1;
+
+    interface CommitHandler {
+        void handle(int nodeId, long epoch, long index, ApiMessage message) throws Exception;
+    }
+
+    MockMetaLogManagerListener(AtomicReference<String> firstError,
+                               CommitHandler commitHandler,
+                               int nodeId) {
+        this.firstError = firstError;
+        this.commitHandler = commitHandler;
+        this.nodeId = nodeId;
+    }
+
+    @Override
+    public void handleCommit(long epoch, long index, ApiMessage message) {
+        try {
+            commitHandler.handle(nodeId, epoch, index, message);
+        } catch (Exception e) {
+            firstError.compareAndSet(null, "error handling commit(epoch=" + epoch +
+                ", index=" + index + ", message=" + message + "): " +
+                e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+    }
+
+    @Override
+    public synchronized void handleClaim(long epoch) {
+        if (epoch < 0) {
+            firstError.compareAndSet(null, nodeId + " invalid negative epoch in claim(" +
+                epoch + ")");
+            return;
+        }
+        if (shutdown) {
+            firstError.compareAndSet(null, nodeId + " invoked claim(" + epoch + ") after " +
+                "shutdown.");
+            return;
+        }
+        if (curEpoch != -1L) {
+            firstError.compareAndSet(null, nodeId + " invoked claim(" + epoch + ") before " +
+                "renouncing epoch " + curEpoch);
+            return;
+        }
+        curEpoch = epoch;
+    }
+
+    @Override
+    public synchronized void handleRenounce(long epoch) {
+        if (curEpoch != epoch) {
+            firstError.compareAndSet(null, nodeId + " invoked renounce(" + epoch + ") " +
+                "but the current epoch is " + curEpoch);
+            return;
+        }
+        curEpoch = -1;
+    }
+
+    @Override
+    public synchronized void beginShutdown() {
+        this.shutdown = true;
+    }
+
+    public int nodeId() {
+        return nodeId;
+    }
+
+    public synchronized boolean isShutdown() {
+        return shutdown;
+    }
+
+    public synchronized long curEpoch() {
+        return curEpoch;
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -23,9 +23,9 @@ import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class QuorumControllerManagerTest {
+public class QuorumControllerTest {
     private static final Logger log =
-        LoggerFactory.getLogger(QuorumControllerManagerTest.class);
+        LoggerFactory.getLogger(QuorumControllerTest.class);
 
     @Rule
     final public Timeout globalTimeout = Timeout.seconds(40);


### PR DESCRIPTION
Add MetaLogManager, which manages the log which the kip-500 controller
relies on.  It handles things like claiming leadership, renouncing
leadership, applying records that have been committed, and so forth.

Eventually, we will have a MetaLogManager that hooks up to Raft.  For
now, we have a simple implementation based on a local log file which is
shared.