### PR TITLE
backport METRICS-1988: add confluent-telemetry directory to kafka classpath 

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -171,6 +171,9 @@ done
 # CONFLUENT: classpath addition for releases with LSB-style layout
 CLASSPATH="$CLASSPATH":"$base_dir/share/java/kafka/*"
 
+# classpath for telemetry
+CLASSPATH="$CLASSPATH":"$base_dir/share/java/confluent-telemetry/*"
+
 for file in "$base_dir"/core/build/libs/kafka_${SCALA_BINARY_VERSION}*.jar;
 do
   if should_include_file "$file"; then


### PR DESCRIPTION
### what
backports https://github.com/confluentinc/kafka/pull/381 to 2.6 branch