### PR TITLE
SEC-1334: update confluent-log4j version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ allprojects {
       all {
         resolutionStrategy {
           dependencySubstitution {
-            substitute module("log4j:log4j:1.2.17") because "we use a custom version with security patches" with module("io.confluent:confluent-log4j:1.2.17-cp1")
+            substitute module("log4j:log4j:1.2.17") because "we use a custom version with security patches" with module("io.confluent:confluent-log4j:1.2.17-cp2")
           }
         }
       }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -72,7 +72,7 @@ versions += [
   jersey: "2.31",
   jmh: "1.23",
   hamcrest: "2.2",
-  log4j: "1.2.17-cp1",
+  log4j: "1.2.17-cp2",
   scalaLogging: "3.9.2",
   jaxb: "2.3.0",
   jaxrs: "2.1.1",


### PR DESCRIPTION
This pull request updates `confluent-log4j` from `1.2.17-cp1` to `1.2.17-cp2`. The former had a few accidental commits that made the repackaged version slightly different than the upstream `log4j`. `1.2.17-cp2` fixes the issue and applies a CVE fix (and no additional code changes) to the upstream `log4j:1.2.17`.

This commit ought to be cherry picked to 2.6 branch as well.

Testing performed: Confluent jenkins system testing with a draft branch with the requested change with two small smoke tests that services start appropriately, and that logging is as expected. Also checked class paths for any odd issues. More details: https://confluentinc.atlassian.net/browse/SEC-1334?focusedCommentId=340490