### PR TITLE
ST-3461: Trigger down stream builds after publishing artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,17 @@ def job = {
       }
     }
 
+    if (config.publish && config.isDevJob && !config.isReleaseJob && !config.isPrJob) {
+        stage("Start Downstream Builds") {
+            config.downStreamRepos.each { repo ->
+                build(job: "confluentinc/${repo}/${env.BRANCH_NAME}",
+                    wait: false,
+                    propagate: false
+                )
+            }
+        }
+    }
+
     def runTestsStepName = "Step run-tests"
     def downstreamBuildsStepName = "Step cp-downstream-builds"
     def testTargets = [


### PR DESCRIPTION
In the initial nano versioning commit I forgot to include the code in the jenkins file to trigger the down stream repos, in this case common. After we publish the artifacts we need to trigger the common build. We do the same thing in ce-kafka, but some how when merging I missed this. This was tested in the nano versioning branch.

This does not address the issue that we are publishing the artifacts before we run the unit and integration tests. I will address that in another PR but need to get this fixed right away other wise new artifacts from kafka will never get used by down stream repos.