### PR TITLE
CONFLUENT: Add license to ci.py to pass license check

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -1,5 +1,22 @@
 #!/usr/bin/python
 
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 import logging
 import re


### PR DESCRIPTION
Merge from AK trunk is failing because `gradlew :rat" fails due to missing license in `ci.py`. For example, https://jenkins.confluent.io/job/apache-kafka-test/job/trunk/1745 failed with:
```
14:53:00  > Task :rat FAILED
14:53:00  Unknown license: /home/jenkins/workspace/apache-kafka-test_trunk/kafka/ci.py
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
