### PR TITLE
CPKAFKA-5791: Bump Jersey and Jackson versions for 6.0.x: Align jersey and jackson versions with `confluentinc/common` for 2.6/6.0.x

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -66,13 +66,13 @@ versions += [
   grgit: "4.0.1",
   httpclient: "4.5.11",
   easymock: "4.2",
-  jackson: "2.10.2",
+  jackson: "2.10.5",
   jacoco: "0.8.5",
   // 9.4.25 renamed closeOutput to completeOutput (https://github.com/eclipse/jetty.project/commit/c5acf965067478784b54e2d241ec58fdb0b2c9fe)
   // which is a method used by recent Jersey versions when this comment was written (2.30.1 was the latest). Please
   // verify that this is fixed in some way before bumping the Jetty version.
   jetty: "9.4.24.v20191120",
-  jersey: "2.28",
+  jersey: "2.30",
   jmh: "1.23",
   hamcrest: "2.2",
   log4j: "1.2.17-cp2",


### PR DESCRIPTION
Update Jackson to 2.10.5 and Jersey to 2.30. Note that the versions in
master are already aligned.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
