### PR TITLE
MINOR: Use new version of ducktape

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -34,7 +34,7 @@ LABEL ducker.creator=$ducker_creator
 # Update Linux and install necessary utilities.
 RUN apt update && apt install -y sudo netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python-pip python-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute && apt-get -y clean
 RUN python -m pip install -U pip==9.0.3;
-RUN pip install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip install --upgrade ducktape==0.7.8
+RUN pip install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip install --upgrade ducktape==0.7.9
 
 # Set up ssh
 COPY ./ssh-config /root/.ssh/config

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.7.8", "requests==2.22.0"],
+      install_requires=["ducktape==0.7.9", "requests==2.22.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       )


### PR DESCRIPTION
ducktape diff: https://github.com/confluentinc/ducktape/compare/v0.7.8...v0.7.9

- bcrypt (a dependency of ducktape) dropped Python2.7 support.
ducktape-0.7.9 now pins bcrypt to a Python2.7-supported version.

Author: Andrew Egelhofer <aegelhofer@confluent.io>

Reviewers: Dhruvil Shah <dhruvil@confluent.io>, Manikumar Reddy <manikumar.reddy@gmail.com>

Closes #9192 from andrewegel/trunk

(cherry picked from commit f6c26eaa04d8eb44c8decf91bb80b621e4086e84)
Signed-off-by: Manikumar Reddy <manikumar.reddy@gmail.com>

Cherry-picking this fix into 2.6

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
