### PR TITLE
Refactor state/poll backoffs and timeouts

### DIFF
--- a/config/raft-log4j.properties
+++ b/config/raft-log4j.properties
@@ -19,3 +19,5 @@ log4j.appender.stderr=org.apache.log4j.ConsoleAppender
 log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
 log4j.appender.stderr.layout.ConversionPattern=[%d] %p %m (%c)%n
 log4j.appender.stderr.Target=System.err
+
+log4j.logger.org.apache.kafka.raft=INFO

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -18,7 +18,6 @@ package kafka.raft
 
 import java.net.InetSocketAddress
 import java.util
-import java.util.Optional
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -32,7 +31,6 @@ import org.apache.kafka.common.{KafkaException, Node}
 import org.apache.kafka.raft.{NetworkChannel, RaftMessage, RaftRequest, RaftResponse, RaftUtil}
 
 import scala.collection.mutable
-import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
 
 object KafkaNetworkChannel {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2850,10 +2850,6 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleEndEpoch(request: RequestChannel.Request): Unit = ???
 
-  def handleFetchRecords(request: RequestChannel.Request): Unit = ???
-
-  def handleFindQuorum(request: RequestChannel.Request): Unit = ???
-
   def handleDescribeQuorum(request: RequestChannel.Request): Unit = ???
 
   def allowTokenRequests(request: RequestChannel.Request): Boolean = {

--- a/core/src/main/scala/kafka/server/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/server/TestRaftServer.scala
@@ -19,7 +19,7 @@ package kafka.server
 
 import java.io.File
 import java.nio.file.Files
-import java.util.Properties
+import java.util.{Properties, Random}
 import java.util.concurrent.CountDownLatch
 
 import joptsimple.OptionParser
@@ -183,8 +183,12 @@ class TestRaftServer(val config: KafkaConfig) extends Logging {
     val quorumState = new QuorumState(
       config.brokerId,
       raftConfig.quorumVoterIds,
+      raftConfig.electionTimeoutMs,
+      raftConfig.fetchTimeoutMs,
       new FileBasedStateStore(new File(logDir, "quorum-state")),
-      logContext
+      time,
+      logContext,
+      new Random()
     )
 
     val fetchPurgatory = new KafkaFuturePurgatory[LogOffset](
@@ -238,7 +242,7 @@ class TestRaftServer(val config: KafkaConfig) extends Logging {
     val clientId = s"broker-${config.brokerId}-raft-client"
     val maxInflightRequestsPerConnection = 1
     val reconnectBackoffMs = 50
-    val reconnectBackoffMsMs = 50
+    val reconnectBackoffMsMs = 500
     val discoverBrokerVersions = false
 
     new NetworkClient(

--- a/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
@@ -28,7 +28,7 @@ public class CandidateState implements EpochState {
     private final int localId;
     private final int epoch;
     private final int retries;
-    private final Map<Integer, VoteState> voteStates = new HashMap<>();
+    private final Map<Integer, State> voteStates = new HashMap<>();
     private final int electionTimeoutMs;
     private final Timer electionTimer;
     private final Timer backoffTimer;
@@ -60,9 +60,9 @@ public class CandidateState implements EpochState {
         this.backoffTimer = time.timer(0);
 
         for (Integer voterId : voters) {
-            voteStates.put(voterId, VoteState.UNRECORDED);
+            voteStates.put(voterId, State.UNRECORDED);
         }
-        voteStates.put(localId, VoteState.GRANTED);
+        voteStates.put(localId, State.GRANTED);
     }
 
     public int localId() {
@@ -74,11 +74,11 @@ public class CandidateState implements EpochState {
     }
 
     private long numGranted() {
-        return voteStates.values().stream().filter(state -> state == VoteState.GRANTED).count();
+        return voteStates.values().stream().filter(state -> state == State.GRANTED).count();
     }
 
     private long numUnrecorded() {
-        return voteStates.values().stream().filter(state -> state == VoteState.UNRECORDED).count();
+        return voteStates.values().stream().filter(state -> state == State.UNRECORDED).count();
     }
 
     /**
@@ -120,14 +120,14 @@ public class CandidateState implements EpochState {
      *         rejected by this node
      */
     public boolean recordGrantedVote(int remoteNodeId) {
-        VoteState voteState = voteStates.get(remoteNodeId);
-        if (voteState == null) {
+        State state = voteStates.get(remoteNodeId);
+        if (state == null) {
             throw new IllegalArgumentException("Attempt to grant vote to non-voter " + remoteNodeId);
-        } else if (voteState == VoteState.REJECTED) {
+        } else if (state == State.REJECTED) {
             throw new IllegalArgumentException("Attempt to grant vote from node " + remoteNodeId +
                 " which previously rejected our request");
         }
-        return voteStates.put(remoteNodeId, VoteState.GRANTED) == VoteState.UNRECORDED;
+        return voteStates.put(remoteNodeId, State.GRANTED) == State.UNRECORDED;
     }
 
     /**
@@ -139,15 +139,15 @@ public class CandidateState implements EpochState {
      *         granted by this node
      */
     public boolean recordRejectedVote(int remoteNodeId) {
-        VoteState voteState = voteStates.get(remoteNodeId);
-        if (voteState == null) {
+        State state = voteStates.get(remoteNodeId);
+        if (state == null) {
             throw new IllegalArgumentException("Attempt to reject vote to non-voter " + remoteNodeId);
-        } else if (voteState == VoteState.GRANTED) {
+        } else if (state == State.GRANTED) {
             throw new IllegalArgumentException("Attempt to reject vote from node " + remoteNodeId +
                 " which previously granted our request");
         }
 
-        return voteStates.put(remoteNodeId, VoteState.REJECTED) == VoteState.UNRECORDED;
+        return voteStates.put(remoteNodeId, State.REJECTED) == State.UNRECORDED;
     }
 
     /**
@@ -166,9 +166,18 @@ public class CandidateState implements EpochState {
      */
     public Set<Integer> unrecordedVoters() {
         return voteStates.entrySet().stream()
-            .filter(entry -> entry.getValue() == VoteState.UNRECORDED)
+            .filter(entry -> entry.getValue() == State.UNRECORDED)
             .map(Map.Entry::getKey)
             .collect(Collectors.toSet());
+    }
+
+    /**
+     * Get the set of voters that have granted our vote requests.
+     *
+     * @return The set of granting voters, which should always contain the ID of the candidate
+     */
+    public Set<Integer> grantingVoters() {
+        return votersInState(State.GRANTED);
     }
 
     /**
@@ -177,8 +186,12 @@ public class CandidateState implements EpochState {
      * @return The set of rejecting voters
      */
     public Set<Integer> rejectingVoters() {
+        return votersInState(State.REJECTED);
+    }
+
+    private Set<Integer> votersInState(State state) {
         return voteStates.entrySet().stream()
-            .filter(entry -> entry.getValue() == VoteState.REJECTED)
+            .filter(entry -> entry.getValue() == state)
             .map(Map.Entry::getKey)
             .collect(Collectors.toSet());
     }
@@ -231,7 +244,7 @@ public class CandidateState implements EpochState {
         return "Candidate";
     }
 
-    private enum VoteState {
+    private enum State {
         UNRECORDED,
         GRANTED,
         REJECTED

--- a/raft/src/main/java/org/apache/kafka/raft/ElectionState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ElectionState.java
@@ -24,8 +24,8 @@ import java.util.Set;
  */
 public class ElectionState {
     public final int epoch;
-    private final OptionalInt leaderIdOpt;
-    private final OptionalInt votedIdOpt;
+    public final OptionalInt leaderIdOpt;
+    public final OptionalInt votedIdOpt;
     private final Set<Integer> voters;
 
     ElectionState(int epoch,

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -472,7 +472,7 @@ public class KafkaRaftClient implements RaftClient {
         OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
         int responseEpoch = partitionResponse.leaderEpoch();
 
-        Optional<Boolean> handled = maybeHandleCommonResponse(responseMetadata.sourceId(),
+        Optional<Boolean> handled = maybeHandleCommonResponse(
             error, responseLeaderId, responseEpoch, currentTimeMs);
         if (handled.isPresent()) {
             return handled.get();
@@ -595,7 +595,7 @@ public class KafkaRaftClient implements RaftClient {
         OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
         int responseEpoch = partitionResponse.leaderEpoch();
 
-        Optional<Boolean> handled = maybeHandleCommonResponse(responseMetadata.sourceId(),
+        Optional<Boolean> handled = maybeHandleCommonResponse(
             partitionError, responseLeaderId, responseEpoch, currentTimeMs);
         if (handled.isPresent()) {
             return handled.get();
@@ -709,7 +709,7 @@ public class KafkaRaftClient implements RaftClient {
         OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
         int responseEpoch = partitionResponse.leaderEpoch();
 
-        Optional<Boolean> handled = maybeHandleCommonResponse(responseMetadata.sourceId(),
+        Optional<Boolean> handled = maybeHandleCommonResponse(
             partitionError, responseLeaderId, responseEpoch, currentTimeMs);
         if (handled.isPresent()) {
             return handled.get();
@@ -950,7 +950,7 @@ public class KafkaRaftClient implements RaftClient {
         int responseEpoch = currentLeaderIdAndEpoch.leaderEpoch();
         Errors error = Errors.forCode(partitionResponse.errorCode());
 
-        Optional<Boolean> handled = maybeHandleCommonResponse(responseMetadata.sourceId(),
+        Optional<Boolean> handled = maybeHandleCommonResponse(
             error, responseLeaderId, responseEpoch, currentTimeMs);
         if (handled.isPresent()) {
             return handled.get();
@@ -1066,7 +1066,6 @@ public class KafkaRaftClient implements RaftClient {
     /**
      * Handle response errors that are common across request types.
      *
-     * @param sourceId The source of the response (i.e. the destination of the corresponding request)
      * @param error Error from the received response
      * @param leaderId Optional leaderId from the response
      * @param epoch Epoch received from the response
@@ -1082,7 +1081,6 @@ public class KafkaRaftClient implements RaftClient {
      *        will need to be retried
      */
     private Optional<Boolean> maybeHandleCommonResponse(
-        int sourceId,
         Errors error,
         OptionalInt leaderId,
         int epoch,
@@ -1505,7 +1503,6 @@ public class KafkaRaftClient implements RaftClient {
             );
             return Math.min(backoffMs, state.remainingFetchTimeMs(currentTimeMs));
         }
-
     }
 
     private long pollFollowerAsObserver(FollowerState state, long currentTimeMs) {
@@ -1517,7 +1514,6 @@ public class KafkaRaftClient implements RaftClient {
             // If the current leader is backing off due to some failure or if the
             // request has timed out, then we attempt to send the Fetch to another
             // voter in order to discover if there has been a leader change.
-
             ConnectionState connection = requestManager.getOrCreate(state.leaderId());
             if (connection.hasRequestTimedOut(currentTimeMs)) {
                 backoffMs = maybeSendAnyVoterFetch(currentTimeMs);
@@ -1568,7 +1564,6 @@ public class KafkaRaftClient implements RaftClient {
         long fetchBackoffMs = maybeSendAnyVoterFetch(currentTimeMs);
         return Math.min(fetchBackoffMs, state.remainingElectionTimeMs(currentTimeMs));
     }
-
 
     private long pollCurrentState(long currentTimeMs) throws IOException {
         if (quorum.isLeader()) {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -503,7 +503,7 @@ public class KafkaRaftClient implements RaftClient {
 
                 }
             } else {
-                logger.debug("Ignoring vote response {} since we are now a follower for epoch {}",
+                logger.debug("Ignoring vote response {} since we are no longer a candidate in epoch {}",
                     partitionResponse, quorum.epoch());
             }
             return true;
@@ -512,13 +512,11 @@ public class KafkaRaftClient implements RaftClient {
         }
     }
 
-    // TODO: Let's move this into QuorumState
     private int binaryExponentialElectionBackoffMs(int retries) {
         if (retries <= 0) {
             throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
         }
-
-        // upper limit exponential co-efficients at 20
+        // upper limit exponential co-efficients at 20 to avoid overflow
         return Math.min(RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(20, retries - 1)), electionBackoffMaxMs);
     }
 
@@ -980,8 +978,6 @@ public class KafkaRaftClient implements RaftClient {
 
                     // Since the end offset has been updated, we should complete any delayed
                     // reads at the end offset.
-
-                    // FIXME: Come up with a better solution for completing all
                     fetchPurgatory.maybeComplete(
                         new LogOffset(Long.MAX_VALUE, Isolation.UNCOMMITTED),
                         currentTimeMs);

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -49,19 +49,21 @@ import org.apache.kafka.common.requests.VoteResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
-import org.apache.kafka.raft.ConnectionCache.ConnectionState;
+import org.apache.kafka.raft.RequestManager.ConnectionState;
 import org.apache.kafka.raft.internals.KafkaRaftMetrics;
 import org.apache.kafka.raft.internals.LogOffset;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -113,40 +115,15 @@ public class KafkaRaftClient implements RaftClient {
 
     private final AtomicReference<GracefulShutdown> shutdown = new AtomicReference<>();
     private final Logger logger;
-
-    /**
-     * This timer is used to encapsulate several timeout mechanism of the client. It should be continuously updated with
-     * new deadline time:
-     *
-     * 1. If the client is in leader state, the timer is for the fetch timeout from the majority of quorum;
-     *    when it expires, the leader should try to use find-quorum to discover if there's a new leader.
-     *
-     * 2. If the client is in candidate state requesting votes from others, the timer is for the election timeout;
-     *    when it expires, the candidate should treat the current election as already failed.
-     *
-     * 3. If the client is in candidate state completing a failed election, the timer is for the exponential election backoff
-     *    based on the number of retries; when it expired, the candidate can bump the epoch and start the next election.
-     *
-     * 4. If the client is in the non-leader voter state, the timer is for the fetch timeout;
-     *    when it expires, the voter should transit to candidate with bumped epoch and start the election.
-     *
-     * 5. If a non-leader voter received an end-epoch request from the old leader, it's timer would be set as the exponential
-     *    election backoff based on the old leader's successor preference; when it expired, the voter would bump the epoch
-     *    and start the election as a candidate.
-     */
     private final Time time;
-    private final Timer timer;
-
-    private final int electionTimeoutMs;
     private final int electionBackoffMaxMs;
-    private final int fetchTimeoutMs;
     private final int fetchMaxWaitMs;
     private final KafkaRaftMetrics kafkaRaftMetrics;
     private final NetworkChannel channel;
     private final ReplicatedLog log;
     private final QuorumState quorum;
     private final Random random;
-    private final ConnectionCache connections;
+    private final RequestManager requestManager;
     private final FuturePurgatory<LogOffset> appendPurgatory;
     private final FuturePurgatory<LogOffset> fetchPurgatory;
     private final BlockingQueue<UnwrittenAppend> unwrittenAppends;
@@ -167,12 +144,10 @@ public class KafkaRaftClient implements RaftClient {
             fetchPurgatory,
             appendPurgatory,
             raftConfig.quorumVoterConnections(),
-            raftConfig.electionTimeoutMs(),
             raftConfig.electionBackoffMaxMs(),
-            raftConfig.fetchTimeoutMs(),
             raftConfig.retryBackoffMs(),
             raftConfig.requestTimeoutMs(),
-            500,
+            1000,
             logContext,
             new Random());
     }
@@ -185,9 +160,7 @@ public class KafkaRaftClient implements RaftClient {
                            FuturePurgatory<LogOffset> fetchPurgatory,
                            FuturePurgatory<LogOffset> appendPurgatory,
                            Map<Integer, InetSocketAddress> voterAddresses,
-                           int electionTimeoutMs,
                            int electionBackoffMaxMs,
-                           int fetchTimeoutMs,
                            int retryBackoffMs,
                            int requestTimeoutMs,
                            int fetchMaxWaitMs,
@@ -199,14 +172,11 @@ public class KafkaRaftClient implements RaftClient {
         this.fetchPurgatory = fetchPurgatory;
         this.appendPurgatory = appendPurgatory;
         this.time = time;
-        this.timer = time.timer(fetchTimeoutMs);    // initialize assuming it is an observer
-        this.electionTimeoutMs = electionTimeoutMs;
         this.electionBackoffMaxMs = electionBackoffMaxMs;
-        this.fetchTimeoutMs = fetchTimeoutMs;
         this.fetchMaxWaitMs = fetchMaxWaitMs;
         this.logger = logContext.logger(KafkaRaftClient.class);
         this.random = random;
-        this.connections = new ConnectionCache(voterAddresses.keySet(), retryBackoffMs, requestTimeoutMs, random);
+        this.requestManager = new RequestManager(voterAddresses.keySet(), retryBackoffMs, requestTimeoutMs, random);
         this.unwrittenAppends = new LinkedBlockingQueue<>();
         this.kafkaRaftMetrics = new KafkaRaftMetrics(metrics, "raft", quorum);
         kafkaRaftMetrics.updateNumUnknownVoterConnections(quorum.remoteVoters().size());
@@ -216,18 +186,24 @@ public class KafkaRaftClient implements RaftClient {
         }
     }
 
-    private void updateFollowerHighWatermark(FollowerState state, OptionalLong highWatermarkOpt) {
+    private void updateFollowerHighWatermark(
+        FollowerState state,
+        OptionalLong highWatermarkOpt,
+        long currentTimeMs
+    ) {
         highWatermarkOpt.ifPresent(highWatermark -> {
             long newHighWatermark = Math.min(endOffset().offset, highWatermark);
             state.updateHighWatermark(OptionalLong.of(newHighWatermark));
-            updateHighWatermark(state, time.milliseconds());
+            updateHighWatermark(state, currentTimeMs);
         });
     }
 
-    private void updateLeaderEndOffsetAndTimestamp(LeaderState state) {
-        final long currentTimeMs = time.milliseconds();
+    private void updateLeaderEndOffsetAndTimestamp(
+        LeaderState state,
+        long currentTimeMs
+    ) {
         final LogOffsetMetadata endOffsetMetadata = log.endOffset();
-        if (state.updateLocalState(currentTimeMs, this::resetFetchTimeout, endOffsetMetadata)) {
+        if (state.updateLocalState(currentTimeMs, endOffsetMetadata)) {
             updateHighWatermark(state, currentTimeMs);
         }
 
@@ -238,15 +214,18 @@ public class KafkaRaftClient implements RaftClient {
     private void updateReplicaEndOffsetAndTimestamp(
         LeaderState state,
         int replicaId,
-        LogOffsetMetadata endOffsetMetadata
+        LogOffsetMetadata endOffsetMetadata,
+        long currentTimeMs
     ) {
-        long currentTimeMs = time.milliseconds();
-        if (state.updateReplicaState(replicaId, currentTimeMs, this::resetFetchTimeout, endOffsetMetadata)) {
+        if (state.updateReplicaState(replicaId, currentTimeMs, endOffsetMetadata)) {
             updateHighWatermark(state, currentTimeMs);
         }
     }
 
-    private void updateHighWatermark(EpochState state, long currentTimeMs) {
+    private void updateHighWatermark(
+        EpochState state,
+        long currentTimeMs
+    ) {
         state.highWatermark().ifPresent(highWatermark -> {
             logger.debug("High watermark updated to {}", highWatermark);
             log.updateHighWatermark(highWatermark);
@@ -255,10 +234,6 @@ public class KafkaRaftClient implements RaftClient {
             appendPurgatory.maybeComplete(offset, currentTimeMs);
             fetchPurgatory.maybeComplete(offset, currentTimeMs);
         });
-    }
-
-    private void resetFetchTimeout(long updatedFetchTimestamp) {
-        timer.resetDeadline(updatedFetchTimestamp + fetchTimeoutMs);
     }
 
     @Override
@@ -270,19 +245,21 @@ public class KafkaRaftClient implements RaftClient {
     public void initialize() throws IOException {
         quorum.initialize(new OffsetAndEpoch(log.endOffset().offset, log.lastFetchedEpoch()));
 
+        long currentTimeMs = time.milliseconds();
         if (quorum.isLeader()) {
-            onBecomeLeader(quorum.leaderStateOrThrow());
+            onBecomeLeader(currentTimeMs);
         } else if (quorum.isCandidate()) {
-            // If the quorum consists of a single node, we can become leader immediately
-            onBecomeCandidate(quorum.candidateStateOrThrow());
+            onBecomeCandidate(currentTimeMs);
         } else if (quorum.isFollower()) {
-            FollowerState state = quorum.followerStateOrThrow();
-            if (quorum.isVoter() && quorum.epoch() == 0) {
-                // If we're initializing for the first time, become a candidate immediately
-                becomeCandidate();
-            } else if (state.hasLeader()) {
-                onBecomeFollowerOfElectedLeader();
-            }
+            onBecomeFollower(currentTimeMs);
+        }
+
+        // When there is only a single voter, become candidate immediately
+        if (quorum.isVoter()
+            && quorum.remoteVoters().isEmpty()
+            && !quorum.isLeader()
+            && !quorum.isCandidate()) {
+            transitionToCandidate(currentTimeMs);
         }
     }
 
@@ -291,19 +268,22 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     private void resetConnections() {
-        connections.resetAll();
+        requestManager.resetAll();
     }
 
-    private void onBecomeLeader(LeaderState state) {
-        // Add a control message for faster high watermark advance.
-        final long currentTimeMs = time.milliseconds();
-        appendLeaderChangeMessage(state, currentTimeMs);
-        updateLeaderEndOffsetAndTimestamp(state);
+    private void onBecomeLeader(long currentTimeMs) {
+        LeaderState state = quorum.leaderStateOrThrow();
 
         log.assignEpochStartOffset(quorum.epoch(), log.endOffset().offset);
+
+        // The high watermark can only be advanced once we have written a record
+        // from the new leader's epoch. Hence we write a control message immediately
+        // to ensure there is no delay committing pending data.
+        appendLeaderChangeMessage(state, currentTimeMs);
+        updateLeaderEndOffsetAndTimestamp(state, currentTimeMs);
+
         resetConnections();
 
-        timer.reset(fetchTimeoutMs);
         kafkaRaftMetrics.maybeUpdateElectionLatency(currentTimeMs);
     }
 
@@ -316,64 +296,49 @@ public class KafkaRaftClient implements RaftClient {
             .setLeaderId(state.election().leaderId())
             .setVoters(voters);
 
-        appendAsLeader(state, MemoryRecords.withLeaderChangeMessage(
-            currentTimeMs, quorum.epoch(), leaderChangeMessage));
+        MemoryRecords records = MemoryRecords.withLeaderChangeMessage(
+            currentTimeMs, quorum.epoch(), leaderChangeMessage);
+
+        appendAsLeader(state, records, currentTimeMs);
     }
 
-    private boolean maybeBecomeLeader(CandidateState state) throws IOException {
+    private boolean maybeTransitionToLeader(CandidateState state, long currentTimeMs) throws IOException {
         if (state.isVoteGranted()) {
             long endOffset = log.endOffset().offset;
-            LeaderState leaderState = quorum.becomeLeader(endOffset);
-            onBecomeLeader(leaderState);
+            quorum.transitionToLeader(endOffset);
+            onBecomeLeader(currentTimeMs);
             return true;
         } else {
             return false;
         }
     }
 
-    private void onBecomeCandidate(CandidateState state) throws IOException {
-        if (!maybeBecomeLeader(state)) {
+    private void onBecomeCandidate(long currentTimeMs) throws IOException {
+        CandidateState state = quorum.candidateStateOrThrow();
+        if (!maybeTransitionToLeader(state, currentTimeMs)) {
             resetConnections();
-
-            kafkaRaftMetrics.updateElectionStartMs(time.milliseconds());
-            timer.reset(randomElectionTimeoutMs());
+            kafkaRaftMetrics.updateElectionStartMs(currentTimeMs);
         }
     }
 
-    private void becomeCandidate() throws IOException {
-        // after we become candidate, we may not fetch from leader any more
-        CandidateState state = quorum.becomeCandidate();
-        onBecomeCandidate(state);
+    private void transitionToCandidate(long currentTimeMs) throws IOException {
+        quorum.transitionToCandidate();
+        onBecomeCandidate(currentTimeMs);
     }
 
-    private void becomeUnattachedFollower(int epoch) throws IOException {
-        if (quorum.becomeUnattachedFollower(epoch)) {
-            // if we are voter, becoming unattached also means that we would no longer fetch
-            // from whoever the old leader already, while there's no new leader learned yet.
-            // So this member should qualify to elect as leader as well, and hence we shorten
-            // the timer to election timeout;
-            //
-            // if we are observer, nothing needed to be done as we would still try to find-quorum eventually
-            if (quorum.isVoter()) {
-                timer.reset(Math.min(timer.remainingMs(), randomElectionTimeoutMs()));
-            }
-
-            onBecomeFollower();
-        }
+    private void transitionToUnattached(int epoch) throws IOException {
+        quorum.transitionToUnattached(epoch);
+        resetConnections();
     }
 
-    private void becomeVotedFollower(int candidateId, int epoch) throws IOException {
-        if (quorum.becomeVotedFollower(epoch, candidateId)) {
-            // even though we've voted for someone, it still means that the previous leader
-            // would be replaced by a new one and there's no clear winner yet, so
-            // setting the timer to election timeout would allow this member
-            // to participate in the election as well
-            timer.reset(randomElectionTimeoutMs());
-            onBecomeFollower();
-        }
+    private void transitionToVoted(int candidateId, int epoch) throws IOException {
+        quorum.transitionToVoted(epoch, candidateId);
+        resetConnections();
     }
 
-    private void onBecomeFollower() {
+    private void onBecomeFollower(long currentTimeMs) {
+        kafkaRaftMetrics.maybeUpdateElectionLatency(currentTimeMs);
+
         resetConnections();
 
         // After becoming a follower, we need to complete all pending fetches so that
@@ -381,39 +346,21 @@ public class KafkaRaftClient implements RaftClient {
         fetchPurgatory.completeAllExceptionally(new NotLeaderOrFollowerException(
             "Cannot process the fetch request because the node is no longer the leader."));
 
-        for (UnwrittenAppend unwrittenAppend: unwrittenAppends) {
-            if (!unwrittenAppend.future.isDone()) {
-                unwrittenAppend.fail(new NotLeaderOrFollowerException("Append refused since this node is no longer " +
-                        "the leader"));
-            }
-        }
-        unwrittenAppends.clear();
-
         // Clearing the append purgatory should complete all future exceptionally since this node is no longer the leader
         appendPurgatory.completeAllExceptionally(new NotLeaderOrFollowerException(
             "Failed to receive sufficient acknowledgments for this append before leader change."));
+
+        failPendingAppends(new NotLeaderOrFollowerException(
+            "Append refused since this node is no longer the leader"));
     }
 
-    private void onBecomeFollowerOfElectedLeader() {
-        timer.reset(fetchTimeoutMs);
-
-        kafkaRaftMetrics.maybeUpdateElectionLatency(time.milliseconds());
-
-        onBecomeFollower();
-    }
-
-    private void becomeFetchingFollower(int leaderId, int epoch) throws IOException {
-        if (quorum.becomeFetchingFollower(epoch, leaderId)) {
-            onBecomeFollowerOfElectedLeader();
-        }
-    }
-
-    private void becomeFollower(OptionalInt leaderId, int epoch) throws IOException {
-        if (leaderId.isPresent()) {
-            becomeFetchingFollower(leaderId.getAsInt(), epoch);
-        } else {
-            becomeUnattachedFollower(epoch);
-        }
+    private void transitionToFollower(
+        int epoch,
+        int leaderId,
+        long currentTimeMs
+    ) throws IOException {
+        quorum.transitionToFollower(epoch, leaderId);
+        onBecomeFollower(currentTimeMs);
     }
 
     private VoteResponseData buildVoteResponse(Errors partitionLevelError, boolean voteGranted) {
@@ -462,17 +409,12 @@ public class KafkaRaftClient implements RaftClient {
             return buildVoteResponse(errorOpt.get(), false);
         }
 
-        OffsetAndEpoch lastEpochEndOffsetAndEpoch = new OffsetAndEpoch(lastEpochEndOffset, lastEpoch);
-        boolean voteGranted = lastEpochEndOffsetAndEpoch.compareTo(endOffset()) >= 0;
-
-        // we already confirmed that candidateEpoch >= quorum.epoch()
         if (candidateEpoch > quorum.epoch()) {
-            if (!voteGranted) {
-                // even if we rejected the vote, we'd still need to bump our epoch
-                // by transiting to unattached follower and resetting timer
-                becomeUnattachedFollower(candidateEpoch);
-            }
-        } else if (quorum.isLeader()) {
+            transitionToUnattached(candidateEpoch);
+        }
+
+        final boolean voteGranted;
+        if (quorum.isLeader()) {
             logger.debug("Ignoring vote request {} with epoch {} since we are already leader on that epoch",
                     request, candidateEpoch);
             voteGranted = false;
@@ -480,24 +422,28 @@ public class KafkaRaftClient implements RaftClient {
             logger.debug("Ignoring vote request {} with epoch {} since we are already candidate on that epoch",
                     request, candidateEpoch);
             voteGranted = false;
-        } else {
+        } else if (quorum.isFollower()) {
             FollowerState state = quorum.followerStateOrThrow();
+            logger.debug("Rejecting vote request {} with epoch {} since we already have a leader {} on that epoch",
+                request, candidateEpoch, state.leaderId());
+            voteGranted = false;
+        } else if (quorum.isVoted()) {
+            VotedState state = quorum.votedStateOrThrow();
+            voteGranted = state.votedId() == candidateId;
 
-            if (state.hasLeader()) {
-                logger.debug("Rejecting vote request {} with epoch {} since we already have a leader {} on that epoch",
-                    request, candidateEpoch, state.leaderId());
-                voteGranted = false;
-            } else if (state.hasVoted()) {
-                voteGranted = state.hasVotedFor(candidateId);
-                if (!voteGranted) {
-                    logger.debug("Rejecting vote request {} with epoch {} since we already have voted for " +
-                        "another candidate {} on that epoch", request, candidateEpoch, state.votedId());
-                }
+            if (!voteGranted) {
+                logger.debug("Rejecting vote request {} with epoch {} since we already have voted for " +
+                    "another candidate {} on that epoch", request, candidateEpoch, state.votedId());
             }
-        }
+        } else if (quorum.isUnattached()) {
+            OffsetAndEpoch lastEpochEndOffsetAndEpoch = new OffsetAndEpoch(lastEpochEndOffset, lastEpoch);
+            voteGranted = lastEpochEndOffsetAndEpoch.compareTo(endOffset()) >= 0;
 
-        if (voteGranted) {
-            becomeVotedFollower(candidateId, candidateEpoch);
+            if (voteGranted) {
+                transitionToVoted(candidateId, candidateEpoch);
+            }
+        } else {
+            throw new IllegalStateException("Unexpected quorum state " + quorum);
         }
 
         logger.info("Vote request {} is {}", request, voteGranted ? "granted" : "rejected");
@@ -505,7 +451,8 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     private boolean handleVoteResponse(
-        RaftResponse.Inbound responseMetadata
+        RaftResponse.Inbound responseMetadata,
+        long currentTimeMs
     ) throws IOException {
         int remoteNodeId = responseMetadata.sourceId();
         VoteResponseData response = (VoteResponseData) responseMetadata.data;
@@ -518,36 +465,46 @@ public class KafkaRaftClient implements RaftClient {
             return false;
         }
 
-        VoteResponseData.PartitionData partitionResponse = response.topics().get(0).partitions().get(0);
+        VoteResponseData.PartitionData partitionResponse =
+            response.topics().get(0).partitions().get(0);
+
         Errors error = Errors.forCode(partitionResponse.errorCode());
         OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
         int responseEpoch = partitionResponse.leaderEpoch();
 
-        Optional<Boolean> handled = maybeHandleCommonResponse(error, responseLeaderId, responseEpoch);
+        Optional<Boolean> handled = maybeHandleCommonResponse(responseMetadata.sourceId(),
+            error, responseLeaderId, responseEpoch, currentTimeMs);
         if (handled.isPresent()) {
             return handled.get();
         } else if (error == Errors.NONE) {
             if (quorum.isLeader()) {
                 logger.debug("Ignoring vote response {} since we already became leader for epoch {}",
                     partitionResponse, quorum.epoch());
-            } else if (quorum.isFollower()) {
-                logger.debug("Ignoring vote response {} since we are now a follower for epoch {}",
-                    partitionResponse, quorum.epoch());
-            } else {
+            } else if (quorum.isCandidate()) {
                 CandidateState state = quorum.candidateStateOrThrow();
                 if (partitionResponse.voteGranted()) {
                     state.recordGrantedVote(remoteNodeId);
-                    maybeBecomeLeader(state);
+                    maybeTransitionToLeader(state, currentTimeMs);
                 } else {
                     state.recordRejectedVote(remoteNodeId);
+
+                    // If our vote is rejected, we go immediately to the random backoff. This
+                    // ensures that we are not stuck waiting for the election timeout when the
+                    // vote has become gridlocked.
                     if (state.isVoteRejected() && !state.isBackingOff()) {
                         logger.info("Insufficient remaining votes to become leader (rejected by {}). " +
                             "We will backoff before retrying election again", state.rejectingVoters());
 
-                        state.startBackingOff();
-                        timer.reset(binaryExponentialElectionBackoffMs(state.retries()));
+                        state.startBackingOff(
+                            currentTimeMs,
+                            binaryExponentialElectionBackoffMs(state.retries())
+                        );
                     }
+
                 }
+            } else {
+                logger.debug("Ignoring vote response {} since we are now a follower for epoch {}",
+                    partitionResponse, quorum.epoch());
             }
             return true;
         } else {
@@ -555,12 +512,7 @@ public class KafkaRaftClient implements RaftClient {
         }
     }
 
-    private int randomElectionTimeoutMs() {
-        if (electionTimeoutMs == 0)
-            return 0;
-        return electionTimeoutMs + random.nextInt(electionTimeoutMs);
-    }
-
+    // TODO: Let's move this into QuorumState
     private int binaryExponentialElectionBackoffMs(int retries) {
         if (retries <= 0) {
             throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
@@ -598,7 +550,8 @@ public class KafkaRaftClient implements RaftClient {
      * - {@link Errors#FENCED_LEADER_EPOCH} if the epoch is smaller than this node's epoch
      */
     private BeginQuorumEpochResponseData handleBeginQuorumEpochRequest(
-        RaftRequest.Inbound requestMetadata
+        RaftRequest.Inbound requestMetadata,
+        long currentTimeMs
     ) throws IOException {
         BeginQuorumEpochRequestData request = (BeginQuorumEpochRequestData) requestMetadata.data;
 
@@ -610,20 +563,21 @@ public class KafkaRaftClient implements RaftClient {
         BeginQuorumEpochRequestData.PartitionData partitionRequest =
             request.topics().get(0).partitions().get(0);
 
-        Optional<Errors> errorOpt = validateVoterOnlyRequest(
-            partitionRequest.leaderId(), partitionRequest.leaderEpoch());
+        int requestLeaderId = partitionRequest.leaderId();
+        int requestEpoch = partitionRequest.leaderEpoch();
+
+        Optional<Errors> errorOpt = validateVoterOnlyRequest(requestLeaderId, requestEpoch);
         if (errorOpt.isPresent()) {
             return buildBeginQuorumEpochResponse(errorOpt.get());
-        } else {
-            int requestLeaderId = partitionRequest.leaderId();
-            int requestEpoch = partitionRequest.leaderEpoch();
-            becomeFetchingFollower(requestLeaderId, requestEpoch);
-            return buildBeginQuorumEpochResponse(Errors.NONE);
         }
+
+        maybeTransition(OptionalInt.of(requestLeaderId), requestEpoch, currentTimeMs);
+        return buildBeginQuorumEpochResponse(Errors.NONE);
     }
 
     private boolean handleBeginQuorumEpochResponse(
-        RaftResponse.Inbound responseMetadata
+        RaftResponse.Inbound responseMetadata,
+        long currentTimeMs
     ) throws IOException {
         int remoteNodeId = responseMetadata.sourceId();
         BeginQuorumEpochResponseData response = (BeginQuorumEpochResponseData) responseMetadata.data;
@@ -643,12 +597,18 @@ public class KafkaRaftClient implements RaftClient {
         OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
         int responseEpoch = partitionResponse.leaderEpoch();
 
-        Optional<Boolean> handled = maybeHandleCommonResponse(partitionError, responseLeaderId, responseEpoch);
+        Optional<Boolean> handled = maybeHandleCommonResponse(responseMetadata.sourceId(),
+            partitionError, responseLeaderId, responseEpoch, currentTimeMs);
         if (handled.isPresent()) {
             return handled.get();
         } else if (partitionError == Errors.NONE) {
-            LeaderState state = quorum.leaderStateOrThrow();
-            state.addEndorsementFrom(remoteNodeId);
+            if (quorum.isLeader()) {
+                LeaderState state = quorum.leaderStateOrThrow();
+                state.addEndorsementFrom(remoteNodeId);
+            } else {
+                logger.debug("Ignoring BeginQuorumEpoch response {} since " +
+                    "this node is not the leader anymore", response);
+            }
             return true;
         } else {
             return handleUnexpectedError(partitionError, responseMetadata);
@@ -673,7 +633,8 @@ public class KafkaRaftClient implements RaftClient {
      * - {@link Errors#FENCED_LEADER_EPOCH} if the epoch is smaller than this node's epoch
      */
     private EndQuorumEpochResponseData handleEndQuorumEpochRequest(
-        RaftRequest.Inbound requestMetadata
+        RaftRequest.Inbound requestMetadata,
+        long currentTimeMs
     ) throws IOException {
         EndQuorumEpochRequestData request = (EndQuorumEpochRequestData) requestMetadata.data;
 
@@ -693,39 +654,45 @@ public class KafkaRaftClient implements RaftClient {
             return buildEndQuorumEpochResponse(errorOpt.get());
         }
 
-        // We still update our state if the request indicates a larger epoch
         OptionalInt requestLeaderId = optionalLeaderId(partitionRequest.leaderId());
-        maybeBecomeFollower(requestLeaderId, requestEpoch);
+        maybeTransition(requestLeaderId, requestEpoch, currentTimeMs);
 
         if (quorum.isFollower()) {
             FollowerState state = quorum.followerStateOrThrow();
-            if (state.isUnattached()
-                || state.hasLeader(requestReplicaId)
-                || state.hasVotedFor(requestReplicaId)) {
+            if (state.leaderId() == requestReplicaId) {
                 List<Integer> preferredSuccessors = partitionRequest.preferredSuccessors();
-                // We didn't find the corresponding voters inside the request.
                 if (!preferredSuccessors.contains(quorum.localId)) {
                     return buildEndQuorumEpochResponse(Errors.INCONSISTENT_VOTER_SET);
                 }
-                final int position = preferredSuccessors.indexOf(quorum.localId);
-                // Based on the priority inside the preferred successors, choose the corresponding delayed
-                // election backoff time based on strict exponential mechanism so that the most up-to-date voter
-                // has a higher chance to be elected. If the node's priority is highest, become candidate immediately
-                // instead of waiting for next poll.
-                if (position == 0) {
-                    becomeCandidate();
-                } else {
-                    timer.reset(strictExponentialElectionBackoffMs(position, preferredSuccessors.size()));
-                }
-
+                long electionBackoffMs = endEpochElectionBackoff(preferredSuccessors);
+                state.overrideFetchTimeout(currentTimeMs, electionBackoffMs);
             }
-        } // else if we are already leader or a candidate, then we take no action
-
+        } else if (quorum.isVoted()) {
+            VotedState state = quorum.votedStateOrThrow();
+            if (state.votedId() == requestReplicaId) {
+                long electionBackoffMs = binaryExponentialElectionBackoffMs(1);
+                state.overrideElectionTimeout(currentTimeMs, electionBackoffMs);
+            }
+        }
         return buildEndQuorumEpochResponse(Errors.NONE);
     }
 
+    private long endEpochElectionBackoff(List<Integer> preferredSuccessors) {
+        // Based on the priority inside the preferred successors, choose the corresponding delayed
+        // election backoff time based on strict exponential mechanism so that the most up-to-date
+        // voter has a higher chance to be elected. If the node's priority is highest, become
+        // candidate immediately instead of waiting for next poll.
+        int position = preferredSuccessors.indexOf(quorum.localId);
+        if (position == 0) {
+            return 0;
+        } else {
+            return strictExponentialElectionBackoffMs(position, preferredSuccessors.size());
+        }
+    }
+
     private boolean handleEndQuorumEpochResponse(
-        RaftResponse.Inbound responseMetadata
+        RaftResponse.Inbound responseMetadata,
+        long currentTimeMs
     ) throws IOException {
         EndQuorumEpochResponseData response = (EndQuorumEpochResponseData) responseMetadata.data;
         Errors topLevelError = Errors.forCode(response.errorCode());
@@ -739,12 +706,13 @@ public class KafkaRaftClient implements RaftClient {
 
         EndQuorumEpochResponseData.PartitionData partitionResponse =
             response.topics().get(0).partitions().get(0);
-        Errors partitionError = Errors.forCode(partitionResponse.errorCode());
 
+        Errors partitionError = Errors.forCode(partitionResponse.errorCode());
         OptionalInt responseLeaderId = optionalLeaderId(partitionResponse.leaderId());
         int responseEpoch = partitionResponse.leaderEpoch();
 
-        Optional<Boolean> handled = maybeHandleCommonResponse(partitionError, responseLeaderId, responseEpoch);
+        Optional<Boolean> handled = maybeHandleCommonResponse(responseMetadata.sourceId(),
+            partitionError, responseLeaderId, responseEpoch, currentTimeMs);
         if (handled.isPresent()) {
             return handled.get();
         } else if (partitionError == Errors.NONE) {
@@ -798,7 +766,8 @@ public class KafkaRaftClient implements RaftClient {
      *     or if either the fetch offset or the last fetched epoch is invalid
      */
     private CompletableFuture<FetchResponseData> handleFetchRequest(
-        RaftRequest.Inbound requestMetadata
+        RaftRequest.Inbound requestMetadata,
+        long currentTimeMs
     ) {
         FetchRequestData request = (FetchRequestData) requestMetadata.data;
 
@@ -816,7 +785,7 @@ public class KafkaRaftClient implements RaftClient {
                 Errors.INVALID_REQUEST, Optional.empty()));
         }
 
-        FetchResponseData response = tryCompleteFetchRequest(request.replicaId(), fetchPartition);
+        FetchResponseData response = tryCompleteFetchRequest(request.replicaId(), fetchPartition, currentTimeMs);
         FetchResponseData.FetchablePartitionResponse partitionResponse =
             response.responses().get(0).partitionResponses().get(0);
 
@@ -840,7 +809,7 @@ public class KafkaRaftClient implements RaftClient {
                 // any other error, we need to return it.
                 Errors error = Errors.forException(cause);
                 if (error != Errors.REQUEST_TIMED_OUT) {
-                    logger.error("Failed to handle fetch from {} at {} due to {}",
+                    logger.debug("Failed to handle fetch from {} at {} due to {}",
                         request.replicaId(), fetchPartition.fetchOffset(), error);
                     return buildEmptyFetchResponse(error, Optional.empty());
                 }
@@ -850,7 +819,7 @@ public class KafkaRaftClient implements RaftClient {
                 request.replicaId(), fetchPartition.fetchOffset(), completionTimeMs);
 
             try {
-                return tryCompleteFetchRequest(request.replicaId(), fetchPartition);
+                return tryCompleteFetchRequest(request.replicaId(), fetchPartition, time.milliseconds());
             } catch (Exception e) {
                 logger.error("Caught unexpected error in fetch completion of request {}", request, e);
                 return buildEmptyFetchResponse(Errors.UNKNOWN_SERVER_ERROR, Optional.empty());
@@ -910,7 +879,8 @@ public class KafkaRaftClient implements RaftClient {
 
     private FetchResponseData tryCompleteFetchRequest(
         int replicaId,
-        FetchRequestData.FetchPartition request
+        FetchRequestData.FetchPartition request,
+        long currentTimeMs
     ) {
         Optional<Errors> errorOpt = validateLeaderOnlyRequest(request.currentLeaderEpoch());
         if (errorOpt.isPresent()) {
@@ -931,7 +901,7 @@ public class KafkaRaftClient implements RaftClient {
             return buildFetchResponse(Errors.NONE, MemoryRecords.EMPTY, nextOffsetAndEpoch, state.highWatermark());
         } else {
             LogFetchInfo info = log.read(fetchOffset, Isolation.UNCOMMITTED);
-            updateReplicaEndOffsetAndTimestamp(state, replicaId, info.startOffsetMetadata);
+            updateReplicaEndOffsetAndTimestamp(state, replicaId, info.startOffsetMetadata, currentTimeMs);
             return buildFetchResponse(Errors.NONE, info.records, Optional.empty(), state.highWatermark());
         }
     }
@@ -961,7 +931,8 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     private boolean handleFetchResponse(
-        RaftResponse.Inbound responseMetadata
+        RaftResponse.Inbound responseMetadata,
+        long currentTimeMs
     ) throws IOException {
         FetchResponseData response = (FetchResponseData) responseMetadata.data;
         Errors topLevelError = Errors.forCode(response.errorCode());
@@ -981,13 +952,10 @@ public class KafkaRaftClient implements RaftClient {
         int responseEpoch = currentLeaderIdAndEpoch.leaderEpoch();
         Errors error = Errors.forCode(partitionResponse.errorCode());
 
-        Optional<Boolean> handled = maybeHandleCommonResponse(error, responseLeaderId, responseEpoch);
+        Optional<Boolean> handled = maybeHandleCommonResponse(responseMetadata.sourceId(),
+            error, responseLeaderId, responseEpoch, currentTimeMs);
         if (handled.isPresent()) {
             return handled.get();
-        }
-
-        if (!quorum.hasLeader()) {
-            maybeBecomeFollower(responseLeaderId, responseEpoch);
         }
 
         FollowerState state = quorum.followerStateOrThrow();
@@ -1007,7 +975,7 @@ public class KafkaRaftClient implements RaftClient {
                 });
 
                 log.truncateToEndOffset(nextFetchOffsetAndEpoch).ifPresent(truncationOffset -> {
-                    logger.info("Truncated to offset {} after out of range error from leader {}",
+                    logger.info("Truncated to offset {} from Fetch response from leader {}",
                         truncationOffset, quorum.leaderIdOrNil());
 
                     // Since the end offset has been updated, we should complete any delayed
@@ -1016,7 +984,7 @@ public class KafkaRaftClient implements RaftClient {
                     // FIXME: Come up with a better solution for completing all
                     fetchPurgatory.maybeComplete(
                         new LogOffset(Long.MAX_VALUE, Isolation.UNCOMMITTED),
-                        time.milliseconds());
+                        currentTimeMs);
                 });
             } else {
                 Records records = (Records) partitionResponse.recordSet();
@@ -1029,20 +997,24 @@ public class KafkaRaftClient implements RaftClient {
                 }
                 OptionalLong highWatermark = partitionResponse.highWatermark() < 0 ?
                     OptionalLong.empty() : OptionalLong.of(partitionResponse.highWatermark());
-                updateFollowerHighWatermark(state, highWatermark);
+                updateFollowerHighWatermark(state, highWatermark, currentTimeMs);
             }
 
-            timer.reset(fetchTimeoutMs);
+            state.resetFetchTimeout(currentTimeMs);
             return true;
         } else {
             return handleUnexpectedError(error, responseMetadata);
         }
     }
 
-    private LogAppendInfo appendAsLeader(LeaderState state, Records records) {
+    private LogAppendInfo appendAsLeader(
+        LeaderState state,
+        Records records,
+        long currentTimeMs
+    ) {
         LogAppendInfo info = log.appendAsLeader(records, quorum.epoch());
         OffsetAndEpoch endOffset = endOffset();
-        updateLeaderEndOffsetAndTimestamp(state);
+        updateLeaderEndOffsetAndTimestamp(state, currentTimeMs);
         kafkaRaftMetrics.updateAppendRecords(info.lastOffset - info.firstOffset + 1);
         kafkaRaftMetrics.updateLogEnd(endOffset);
         logger.trace("Leader appended records at base offset {}, new end offset is {}", info.firstOffset, endOffset);
@@ -1050,7 +1022,8 @@ public class KafkaRaftClient implements RaftClient {
     }
 
     private DescribeQuorumResponseData handleDescribeQuorumRequest(
-        RaftRequest.Inbound requestMetadata
+        RaftRequest.Inbound requestMetadata,
+        long currentTimeMs
     ) {
         DescribeQuorumRequestData describeQuorumRequestData = (DescribeQuorumRequestData) requestMetadata.data;
         if (!hasValidTopicPartition(describeQuorumRequestData, log.topicPartition())) {
@@ -1068,7 +1041,7 @@ public class KafkaRaftClient implements RaftClient {
             leaderState.epoch(),
             leaderState.highWatermark().isPresent() ? leaderState.highWatermark().get().offset : -1,
             convertToReplicaStates(leaderState.getVoterEndOffsets()),
-            convertToReplicaStates(leaderState.getObserverStates(time.milliseconds()))
+            convertToReplicaStates(leaderState.getObserverStates(currentTimeMs))
         );
     }
 
@@ -1097,9 +1070,11 @@ public class KafkaRaftClient implements RaftClient {
     /**
      * Handle response errors that are common across request types.
      *
+     * @param sourceId The source of the response (i.e. the destination of the corresponding request)
      * @param error Error from the received response
      * @param leaderId Optional leaderId from the response
      * @param epoch Epoch received from the response
+     * @param currentTimeMs Current epoch time in milliseconds
      * @return Optional value indicating whether the error was handled here and the outcome of
      *    that handling. Specifically:
      *
@@ -1111,22 +1086,39 @@ public class KafkaRaftClient implements RaftClient {
      *        will need to be retried
      */
     private Optional<Boolean> maybeHandleCommonResponse(
+        int sourceId,
         Errors error,
         OptionalInt leaderId,
-        int epoch
+        int epoch,
+        long currentTimeMs
     ) throws IOException {
-        if (epoch < quorum.epoch()) {
+        if (epoch < quorum.epoch() || error == Errors.UNKNOWN_LEADER_EPOCH) {
             // We have a larger epoch, so the response is no longer relevant
             return Optional.of(true);
-        } else if (error == Errors.FENCED_LEADER_EPOCH || error == Errors.NOT_LEADER_OR_FOLLOWER) {
+        } else if (epoch > quorum.epoch()
+            || error == Errors.FENCED_LEADER_EPOCH
+            || error == Errors.NOT_LEADER_OR_FOLLOWER) {
+
             // The response indicates that the request had a stale epoch, but we need
             // to validate the epoch from the response against our current state.
-            maybeBecomeFollower(leaderId, epoch);
+            maybeTransition(leaderId, epoch, currentTimeMs);
             return Optional.of(true);
-        } else if (error == Errors.BROKER_NOT_AVAILABLE) {
-            if (quorum.isObserver()) {
-                becomeUnattachedFollower(epoch);
+        } else if (epoch == quorum.epoch()
+            && leaderId.isPresent()
+            && !quorum.hasLeader()) {
+
+            // Since we are transitioning to Follower, we will only forward the
+            // request to the handler if there is no error. Otherwise, we will let
+            // the request be retried immediately (if needed) after the transition.
+            // This handling allows an observer to discover the leader and append
+            // to the log in the same Fetch request.
+            transitionToFollower(epoch, leaderId.getAsInt(), currentTimeMs);
+            if (error == Errors.NONE) {
+                return Optional.empty();
+            } else {
+                return Optional.of(true);
             }
+        } else if (error == Errors.BROKER_NOT_AVAILABLE) {
             return Optional.of(false);
         } else if (error == Errors.INCONSISTENT_GROUP_PROTOCOL) {
             // For now we treat this as a fatal error. Once we have support for quorum
@@ -1141,22 +1133,25 @@ public class KafkaRaftClient implements RaftClient {
         return Optional.empty();
     }
 
-    private void maybeBecomeFollower(
+    private void maybeTransition(
         OptionalInt leaderId,
-        int epoch
+        int epoch,
+        long currentTimeMs
     ) throws IOException {
         if (!hasConsistentLeader(epoch, leaderId)) {
             throw new IllegalStateException("Received request or response with leader " + leaderId +
                 " and epoch " + epoch + " which is inconsistent with current leader " +
                 quorum.leaderId() + " and epoch " + quorum.epoch());
         } else if (epoch > quorum.epoch()) {
-            // If the request or response indicates a higher epoch, we bump our local
-            // epoch and become a follower.
-            becomeFollower(leaderId, epoch);
+            if (leaderId.isPresent()) {
+                transitionToFollower(epoch, leaderId.getAsInt(), currentTimeMs);
+            } else {
+                transitionToUnattached(epoch);
+            }
         } else if (leaderId.isPresent() && !quorum.hasLeader()) {
             // The request or response indicates the leader of the current epoch,
             // which is currently unknown
-            becomeFetchingFollower(leaderId.getAsInt(), epoch);
+            transitionToFollower(epoch, leaderId.getAsInt(), currentTimeMs);
         }
     }
 
@@ -1183,26 +1178,26 @@ public class KafkaRaftClient implements RaftClient {
 
         switch (apiKey) {
             case FETCH:
-                handledSuccessfully = handleFetchResponse(response);
+                handledSuccessfully = handleFetchResponse(response, currentTimeMs);
                 break;
 
             case VOTE:
-                handledSuccessfully = handleVoteResponse(response);
+                handledSuccessfully = handleVoteResponse(response, currentTimeMs);
                 break;
 
             case BEGIN_QUORUM_EPOCH:
-                handledSuccessfully = handleBeginQuorumEpochResponse(response);
+                handledSuccessfully = handleBeginQuorumEpochResponse(response, currentTimeMs);
                 break;
 
             case END_QUORUM_EPOCH:
-                handledSuccessfully = handleEndQuorumEpochResponse(response);
+                handledSuccessfully = handleEndQuorumEpochResponse(response, currentTimeMs);
                 break;
 
             default:
                 throw new IllegalArgumentException("Received unexpected response type: " + apiKey);
         }
 
-        ConnectionState connection = connections.getOrCreate(response.sourceId());
+        ConnectionState connection = requestManager.getOrCreate(response.sourceId());
         if (handledSuccessfully) {
             connection.onResponseReceived(response.correlationId, currentTimeMs);
         } else {
@@ -1220,10 +1215,6 @@ public class KafkaRaftClient implements RaftClient {
         } else if (remoteNodeId < 0) {
             return Optional.of(Errors.INVALID_REQUEST);
         } else if (quorum.isObserver() || !quorum.isVoter(remoteNodeId)) {
-            // Inconsistent voter state could be the result of an active
-            // reassignment which has not been propagated to all of the
-            // expected voters. We generally expect this to be a transient
-            // error until all voters have replicated the reassignment record.
             return Optional.of(Errors.INCONSISTENT_VOTER_SET);
         } else {
             return Optional.empty();
@@ -1252,13 +1243,13 @@ public class KafkaRaftClient implements RaftClient {
         }
     }
 
-    private void handleRequest(RaftRequest.Inbound request) throws IOException {
+    private void handleRequest(RaftRequest.Inbound request, long currentTimeMs) throws IOException {
         ApiKeys apiKey = ApiKeys.forId(request.data.apiKey());
         final CompletableFuture<? extends ApiMessage> responseFuture;
 
         switch (apiKey) {
             case FETCH:
-                responseFuture = handleFetchRequest(request);
+                responseFuture = handleFetchRequest(request, currentTimeMs);
                 break;
 
             case VOTE:
@@ -1266,15 +1257,15 @@ public class KafkaRaftClient implements RaftClient {
                 break;
 
             case BEGIN_QUORUM_EPOCH:
-                responseFuture = completedFuture(handleBeginQuorumEpochRequest(request));
+                responseFuture = completedFuture(handleBeginQuorumEpochRequest(request, currentTimeMs));
                 break;
 
             case END_QUORUM_EPOCH:
-                responseFuture = completedFuture(handleEndQuorumEpochRequest(request));
+                responseFuture = completedFuture(handleEndQuorumEpochRequest(request, currentTimeMs));
                 break;
 
             case DESCRIBE_QUORUM:
-                responseFuture = completedFuture(handleDescribeQuorumRequest(request));
+                responseFuture = completedFuture(handleDescribeQuorumRequest(request, currentTimeMs));
                 break;
 
             default:
@@ -1297,7 +1288,7 @@ public class KafkaRaftClient implements RaftClient {
 
         if (message instanceof RaftRequest.Inbound) {
             RaftRequest.Inbound request = (RaftRequest.Inbound) message;
-            handleRequest(request);
+            handleRequest(request, currentTimeMs);
         } else if (message instanceof RaftResponse.Inbound) {
             RaftResponse.Inbound response = (RaftResponse.Inbound) message;
             handleResponse(response, currentTimeMs);
@@ -1311,39 +1302,58 @@ public class KafkaRaftClient implements RaftClient {
         logger.trace("Sent outbound message: {}", message);
     }
 
-    private void maybeSendRequest(
+    /**
+     * Attempt to send a request. Return the time to wait before the request can be retried.
+     */
+    private long maybeSendRequest(
         long currentTimeMs,
         int destinationId,
-        Supplier<ApiMessage> requestData
-    ) throws IOException {
-        ConnectionState connection = connections.getOrCreate(destinationId);
-        if (quorum.isObserver() && connection.hasRequestTimedOut(currentTimeMs)) {
-            // Observers need to proactively find the leader if there is a request timeout
-            becomeUnattachedFollower(quorum.epoch());
-        } else if (connection.isReady(currentTimeMs)) {
-            int correlationId = channel.newCorrelationId();
-            ApiMessage request = requestData.get();
-            sendOutboundMessage(new RaftRequest.Outbound(correlationId, request, destinationId, currentTimeMs));
-            connection.onRequestSent(correlationId, time.milliseconds());
-        } else {
-            logger.trace("Connection {} is not ready for sending", connection);
+        Supplier<ApiMessage> requestSupplier
+    )  {
+        ConnectionState connection = requestManager.getOrCreate(destinationId);
+
+        if (connection.isBackingOff(currentTimeMs)) {
+            return connection.remainingBackoffMs(currentTimeMs);
         }
+
+        if (connection.isReady(currentTimeMs)) {
+            int correlationId = channel.newCorrelationId();
+            ApiMessage request = requestSupplier.get();
+            sendOutboundMessage(new RaftRequest.Outbound(correlationId, request, destinationId, currentTimeMs));
+            connection.onRequestSent(correlationId, currentTimeMs);
+            return Long.MAX_VALUE;
+        }
+
+        return connection.remainingRequestTimeMs(currentTimeMs);
     }
 
     private EndQuorumEpochRequestData buildEndQuorumEpochRequest() {
+        List<Integer> preferredSuccessors = quorum.isLeader() ?
+            quorum.leaderStateOrThrow().nonLeaderVotersByDescendingFetchOffset() :
+            Collections.emptyList();
+
         return EndQuorumEpochRequest.singletonRequest(
             log.topicPartition(),
             quorum.localId,
             quorum.epoch(),
             quorum.leaderIdOrNil(),
-            quorum.leaderStateOrThrow().nonLeaderVotersByDescendingFetchOffset()
+            preferredSuccessors
         );
     }
 
-    private void maybeSendEndQuorumEpoch(long currentTimeMs) throws IOException {
-        for (Integer voterId : quorum.remoteVoters()) {
-            maybeSendRequest(currentTimeMs, voterId, this::buildEndQuorumEpochRequest);
+    private long maybeSendRequests(
+        long currentTimeMs,
+        Set<Integer> destinationIds,
+        Supplier<ApiMessage> requestSupplier
+    ) {
+        long minBackoffMs = Long.MAX_VALUE;
+        for (Integer destinationId : destinationIds) {
+            long backoffMs = maybeSendRequest(currentTimeMs, destinationId, requestSupplier);
+            if (backoffMs < minBackoffMs) {
+                minBackoffMs = backoffMs;
+            }
         }
+        return minBackoffMs;
     }
 
     private BeginQuorumEpochRequestData buildBeginQuorumEpochRequest() {
@@ -1352,12 +1362,6 @@ public class KafkaRaftClient implements RaftClient {
             quorum.epoch(),
             quorum.localId
         );
-    }
-
-    private void maybeSendBeginQuorumEpochToFollowers(long currentTimeMs, LeaderState state) throws IOException {
-        for (Integer followerId : state.nonEndorsingFollowers()) {
-            maybeSendRequest(currentTimeMs, followerId, this::buildBeginQuorumEpochRequest);
-        }
     }
 
     private VoteRequestData buildVoteRequest() {
@@ -1369,12 +1373,6 @@ public class KafkaRaftClient implements RaftClient {
             endOffset.epoch,
             endOffset.offset
         );
-    }
-
-    private void maybeSendVoteRequestToVoters(long currentTimeMs, CandidateState state) throws IOException {
-        for (Integer voterId : state.unrecordedVoters()) {
-            maybeSendRequest(currentTimeMs, voterId, this::buildVoteRequest);
-        }
     }
 
     private FetchRequestData buildFetchRequest() {
@@ -1389,32 +1387,16 @@ public class KafkaRaftClient implements RaftClient {
             .setReplicaId(quorum.localId);
     }
 
-    private void maybeSendLeaderFetch(long currentTimeMs, int leaderId) throws IOException {
-        maybeSendRequest(currentTimeMs, leaderId, this::buildFetchRequest);
-    }
-
-    private void maybeSendVoterFetch(long currentTimeMs) throws IOException {
-        OptionalInt readyVoterIdOpt = connections.findReadyVoter(currentTimeMs);
+    private long maybeSendAnyVoterFetch(long currentTimeMs) {
+        OptionalInt readyVoterIdOpt = requestManager.findReadyVoter(currentTimeMs);
         if (readyVoterIdOpt.isPresent()) {
-            maybeSendRequest(currentTimeMs, readyVoterIdOpt.getAsInt(), this::buildFetchRequest);
-        }
-    }
-
-    private void maybeSendRequests(long currentTimeMs) throws IOException {
-        if (quorum.isLeader()) {
-            LeaderState state = quorum.leaderStateOrThrow();
-            maybeSendBeginQuorumEpochToFollowers(currentTimeMs, state);
-        } else if (quorum.isCandidate()) {
-            CandidateState state = quorum.candidateStateOrThrow();
-            maybeSendVoteRequestToVoters(currentTimeMs, state);
+            return maybeSendRequest(
+                currentTimeMs,
+                readyVoterIdOpt.getAsInt(),
+                this::buildFetchRequest
+            );
         } else {
-            FollowerState state = quorum.followerStateOrThrow();
-            if (quorum.isObserver() && (!state.hasLeader() || timer.isExpired())) {
-                maybeSendVoterFetch(currentTimeMs);
-            } else if (state.hasLeader()) {
-                int leaderId = state.leaderId();
-                maybeSendLeaderFetch(currentTimeMs, leaderId);
-            }
+            return requestManager.backoffBeforeAvailableVoter(currentTimeMs);
         }
     }
 
@@ -1443,13 +1425,169 @@ public class KafkaRaftClient implements RaftClient {
         if (quorum.remoteVoters().isEmpty() || quorum.hasRemoteLeader()) {
             shutdown.complete();
             return;
-        } else if (quorum.isLeader()) {
-            maybeSendEndQuorumEpoch(currentTimeMs);
         }
 
-        List<RaftMessage> inboundMessages = channel.receive(shutdown.finishTimer.remainingMs());
-        for (RaftMessage message : inboundMessages)
+        long pollTimeoutMs = shutdown.finishTimer.remainingMs();
+        if (quorum.isLeader() || quorum.isCandidate()) {
+            long backoffMs = maybeSendRequests(
+                currentTimeMs,
+                quorum.remoteVoters(),
+                this::buildEndQuorumEpochRequest
+            );
+            pollTimeoutMs = Math.min(backoffMs, pollTimeoutMs);
+        }
+
+        List<RaftMessage> inboundMessages = channel.receive(pollTimeoutMs);
+        for (RaftMessage message : inboundMessages) {
             handleInboundMessage(message, currentTimeMs);
+            currentTimeMs = time.milliseconds();
+        }
+    }
+
+    private long pollLeader(long currentTimeMs) {
+        LeaderState state = quorum.leaderStateOrThrow();
+
+        pollPendingAppends(currentTimeMs);
+
+        return maybeSendRequests(
+            currentTimeMs,
+            state.nonEndorsingFollowers(),
+            this::buildBeginQuorumEpochRequest
+        );
+    }
+
+    private long pollCandidate(long currentTimeMs) throws IOException {
+        CandidateState state = quorum.candidateStateOrThrow();
+        if (state.isBackingOff()) {
+            if (state.isBackoffComplete(currentTimeMs)) {
+                logger.info("Re-elect as candidate after election backoff has completed");
+                transitionToCandidate(currentTimeMs);
+                return 0L;
+            }
+            return state.remainingBackoffMs(currentTimeMs);
+        } else if (state.hasElectionTimeoutExpired(currentTimeMs)) {
+            long backoffDurationMs = binaryExponentialElectionBackoffMs(state.retries());
+            logger.debug("Election has timed out, backing off for {}ms before becoming a candidate again",
+                backoffDurationMs);
+            state.startBackingOff(currentTimeMs, backoffDurationMs);
+            return backoffDurationMs;
+        } else if (!state.isVoteRejected()) {
+            // Continue sending Vote requests as long as we still have a chance to win the election
+            long minRequestBackoffMs = maybeSendRequests(
+                currentTimeMs,
+                state.unrecordedVoters(),
+                this::buildVoteRequest
+            );
+            return Math.min(minRequestBackoffMs, state.remainingElectionTimeMs(currentTimeMs));
+        } else {
+            return state.remainingElectionTimeMs(currentTimeMs);
+        }
+    }
+
+    private long pollFollower(long currentTimeMs) throws IOException {
+        FollowerState state = quorum.followerStateOrThrow();
+        if (quorum.isVoter()) {
+            return pollFollowerAsVoter(state, currentTimeMs);
+        } else {
+            return pollFollowerAsObserver(state, currentTimeMs);
+        }
+    }
+
+    private long pollFollowerAsVoter(FollowerState state, long currentTimeMs) throws IOException {
+        failPendingAppends(new NotLeaderOrFollowerException("Failing append " +
+            "since this node is not the current leader"));
+
+        if (state.hasFetchTimeoutExpired(currentTimeMs)) {
+            logger.info("Become candidate due to fetch timeout");
+            transitionToCandidate(currentTimeMs);
+            return 0L;
+        } else {
+            long backoffMs = maybeSendRequest(
+                currentTimeMs,
+                state.leaderId(),
+                this::buildFetchRequest
+            );
+            return Math.min(backoffMs, state.remainingFetchTimeMs(currentTimeMs));
+        }
+
+    }
+
+    private long pollFollowerAsObserver(FollowerState state, long currentTimeMs) {
+        if (state.hasFetchTimeoutExpired(currentTimeMs)) {
+            return maybeSendAnyVoterFetch(currentTimeMs);
+        } else {
+            final long backoffMs;
+
+            // If the current leader is backing off due to some failure or if the
+            // request has timed out, then we attempt to send the Fetch to another
+            // voter in order to discover if there has been a leader change.
+
+            ConnectionState connection = requestManager.getOrCreate(state.leaderId());
+            if (connection.hasRequestTimedOut(currentTimeMs)) {
+                backoffMs = maybeSendAnyVoterFetch(currentTimeMs);
+                connection.reset();
+            } else if (connection.isBackingOff(currentTimeMs)) {
+                backoffMs = maybeSendAnyVoterFetch(currentTimeMs);
+            } else {
+                backoffMs = maybeSendRequest(
+                    currentTimeMs,
+                    state.leaderId(),
+                    this::buildFetchRequest
+                );
+
+            }
+            return Math.min(backoffMs, state.remainingFetchTimeMs(currentTimeMs));
+        }
+    }
+
+    private long pollVoted(long currentTimeMs) throws IOException {
+        VotedState state = quorum.votedStateOrThrow();
+        if (state.hasElectionTimeoutExpired(currentTimeMs)) {
+            transitionToCandidate(currentTimeMs);
+            return 0L;
+        } else {
+            return state.remainingElectionTimeMs(currentTimeMs);
+        }
+    }
+
+    private long pollUnattached(long currentTimeMs) throws IOException {
+        UnattachedState state = quorum.unattachedStateOrThrow();
+        if (quorum.isVoter()) {
+            return pollUnattachedAsVoter(state, currentTimeMs);
+        } else {
+            return pollUnattachedAsObserver(state, currentTimeMs);
+        }
+    }
+
+    private long pollUnattachedAsVoter(UnattachedState state, long currentTimeMs) throws IOException {
+        if (state.hasElectionTimeoutExpired(currentTimeMs)) {
+            transitionToCandidate(currentTimeMs);
+            return 0L;
+        } else {
+            return state.remainingElectionTimeMs(currentTimeMs);
+        }
+    }
+
+    private long pollUnattachedAsObserver(UnattachedState state, long currentTimeMs) {
+        long fetchBackoffMs = maybeSendAnyVoterFetch(currentTimeMs);
+        return Math.min(fetchBackoffMs, state.remainingElectionTimeMs(currentTimeMs));
+    }
+
+
+    private long pollCurrentState(long currentTimeMs) throws IOException {
+        if (quorum.isLeader()) {
+            return pollLeader(currentTimeMs);
+        } else if (quorum.isCandidate()) {
+            return pollCandidate(currentTimeMs);
+        } else if (quorum.isFollower()) {
+            return pollFollower(currentTimeMs);
+        } else if (quorum.isVoted()) {
+            return pollVoted(currentTimeMs);
+        } else if (quorum.isUnattached()) {
+            return pollUnattached(currentTimeMs);
+        } else {
+            throw new IllegalStateException("Unexpected quorum state " + quorum);
+        }
     }
 
     public void poll() throws IOException {
@@ -1457,97 +1595,75 @@ public class KafkaRaftClient implements RaftClient {
         if (gracefulShutdown != null) {
             pollShutdown(gracefulShutdown);
         } else {
-            timer.update();
+            long currentTimeMs = time.milliseconds();
+            long pollTimeoutMs = pollCurrentState(currentTimeMs);
 
-            if (quorum.isVoter() && !quorum.isLeader() && timer.isExpired()) {
-                logger.info("Become candidate due to fetch timeout");
-                becomeCandidate();
-            } else if (quorum.isCandidate() && timer.isExpired()) {
-                CandidateState state = quorum.candidateStateOrThrow();
-                if (state.isBackingOff()) {
-                    logger.info("Re-elect as candidate after election backoff has completed");
-                    becomeCandidate();
-                } else {
-                    logger.debug("Election has timed out, backing off before re-elect again");
-                    state.startBackingOff();
-                    timer.reset(binaryExponentialElectionBackoffMs(state.retries()));
-                }
-            }
-
-            timer.update();
-            long currentTimeMs = timer.currentTimeMs();
-
-            maybeSendRequests(currentTimeMs);
-            handlePendingAppends(currentTimeMs);
-
-            timer.update();
-            currentTimeMs = timer.currentTimeMs();
             kafkaRaftMetrics.updatePollStart(currentTimeMs);
-            // TODO: Receive time needs to take into account backing off operations that still need doing
-            List<RaftMessage> inboundMessages = channel.receive(timer.remainingMs());
-            timer.update();
-            currentTimeMs = timer.currentTimeMs();
+            List<RaftMessage> inboundMessages = channel.receive(pollTimeoutMs);
+
+            currentTimeMs = time.milliseconds();
             kafkaRaftMetrics.updatePollEnd(currentTimeMs);
 
-            for (RaftMessage message : inboundMessages)
+            for (RaftMessage message : inboundMessages) {
                 handleInboundMessage(message, currentTimeMs);
+                currentTimeMs = time.milliseconds();
+            }
         }
     }
 
-    private void handlePendingAppends(long currentTimeMs) {
-        if (quorum.isLeader()) {
-            int numAppends = 0;
-            int maxNumAppends = unwrittenAppends.size();
+    private void failPendingAppends(KafkaException exception) {
+        for (UnwrittenAppend unwrittenAppend : unwrittenAppends) {
+            unwrittenAppend.fail(exception);
+        }
+        unwrittenAppends.clear();
+    }
 
-            while (!unwrittenAppends.isEmpty() && numAppends < maxNumAppends) {
-                final UnwrittenAppend unwrittenAppend = unwrittenAppends.poll();
+    private void pollPendingAppends(long currentTimeMs) {
+        int numAppends = 0;
+        int maxNumAppends = unwrittenAppends.size();
 
-                if (unwrittenAppend.future.isDone())
-                    continue;
+        while (!unwrittenAppends.isEmpty() && numAppends < maxNumAppends) {
+            final UnwrittenAppend unwrittenAppend = unwrittenAppends.poll();
 
-                if (unwrittenAppend.isTimedOut(currentTimeMs)) {
-                    unwrittenAppend.fail(new TimeoutException("Request timeout " + unwrittenAppend.requestTimeoutMs
-                        + " expired before the records could be appended to the log"));
-                } else {
-                    LeaderState leaderState = quorum.leaderStateOrThrow();
-                    int epoch = quorum.epoch();
-                    LogAppendInfo info = appendAsLeader(leaderState, unwrittenAppend.records);
-                    OffsetAndEpoch offsetAndEpoch = new OffsetAndEpoch(info.lastOffset, epoch);
+            if (unwrittenAppend.future.isDone())
+                continue;
 
-                    if (unwrittenAppend.ackMode == AckMode.LEADER) {
-                        unwrittenAppend.complete(offsetAndEpoch);
-                    } else if (unwrittenAppend.ackMode == AckMode.QUORUM) {
-                        CompletableFuture<Long> future = appendPurgatory.await(
-                            LogOffset.awaitCommitted(offsetAndEpoch.offset),
-                            unwrittenAppend.requestTimeoutMs);
+            if (unwrittenAppend.isTimedOut(currentTimeMs)) {
+                unwrittenAppend.fail(new TimeoutException("Request timeout " + unwrittenAppend.requestTimeoutMs
+                    + " expired before the records could be appended to the log"));
+            } else {
+                LeaderState leaderState = quorum.leaderStateOrThrow();
+                int epoch = quorum.epoch();
+                LogAppendInfo info = appendAsLeader(leaderState, unwrittenAppend.records, currentTimeMs);
+                OffsetAndEpoch offsetAndEpoch = new OffsetAndEpoch(info.lastOffset, epoch);
 
-                        future.whenComplete((completionTimeMs, exception) -> {
-                            if (exception != null) {
-                                logger.error("Failed to commit append at {} due to {}", offsetAndEpoch, exception);
+                if (unwrittenAppend.ackMode == AckMode.LEADER) {
+                    unwrittenAppend.complete(offsetAndEpoch);
+                } else if (unwrittenAppend.ackMode == AckMode.QUORUM) {
+                    CompletableFuture<Long> future = appendPurgatory.await(
+                        LogOffset.awaitCommitted(offsetAndEpoch.offset),
+                        unwrittenAppend.requestTimeoutMs);
 
-                                unwrittenAppend.fail(exception);
-                            } else {
-                                long elapsedTime = Math.max(0, completionTimeMs - currentTimeMs);
-                                long numCommittedRecords = info.lastOffset - info.firstOffset + 1;
-                                double elapsedTimePerRecord = (double) elapsedTime / numCommittedRecords;
-                                kafkaRaftMetrics.updateCommitLatency(elapsedTimePerRecord, currentTimeMs);
-                                unwrittenAppend.complete(offsetAndEpoch);
+                    future.whenComplete((completionTimeMs, exception) -> {
+                        if (exception != null) {
+                            logger.error("Failed to commit append at {} due to {}", offsetAndEpoch, exception);
 
-                                logger.debug("Completed committing append with {} records at {}",
-                                    numCommittedRecords, offsetAndEpoch);
-                            }
-                        });
-                    }
+                            unwrittenAppend.fail(exception);
+                        } else {
+                            long elapsedTime = Math.max(0, completionTimeMs - currentTimeMs);
+                            long numCommittedRecords = info.lastOffset - info.firstOffset + 1;
+                            double elapsedTimePerRecord = (double) elapsedTime / numCommittedRecords;
+                            kafkaRaftMetrics.updateCommitLatency(elapsedTimePerRecord, currentTimeMs);
+                            unwrittenAppend.complete(offsetAndEpoch);
+
+                            logger.debug("Completed committing append with {} records at {}",
+                                numCommittedRecords, offsetAndEpoch);
+                        }
+                    });
                 }
+            }
 
-                numAppends++;
-            }
-        } else {
-            for (UnwrittenAppend unwrittenAppend : unwrittenAppends) {
-                unwrittenAppend.fail(new NotLeaderOrFollowerException(
-                    "Append refused since this node is no longer the leader"));
-            }
-            unwrittenAppends.clear();
+            numAppends++;
         }
     }
 
@@ -1562,12 +1678,19 @@ public class KafkaRaftClient implements RaftClient {
      * @return The uncommitted base offset and epoch of the appended records
      */
     @Override
-    public CompletableFuture<OffsetAndEpoch> append(Records records, AckMode ackMode, long timeoutMs) {
+    public CompletableFuture<OffsetAndEpoch> append(
+        Records records,
+        AckMode ackMode,
+        long timeoutMs
+    ) {
         if (records.sizeInBytes() == 0)
             throw new IllegalArgumentException("Attempt to append empty record set");
 
         if (shutdown.get() != null)
             throw new IllegalStateException("Cannot append records while we are shutting down");
+
+        if (quorum.isObserver())
+            throw new IllegalStateException("Illegal attempt to write to an observer");
 
         CompletableFuture<OffsetAndEpoch> future = new CompletableFuture<>();
         UnwrittenAppend unwrittenAppend = new UnwrittenAppend(
@@ -1612,7 +1735,7 @@ public class KafkaRaftClient implements RaftClient {
             finishTimer.update();
             if (finishTimer.isExpired()) {
                 close();
-                logger.warn("Graceful shutdown timed out after {}ms", timer.timeoutMs());
+                logger.warn("Graceful shutdown timed out after {}ms", finishTimer.timeoutMs());
                 completeFuture.completeExceptionally(
                     new TimeoutException("Timeout expired before shutdown completed"));
             }

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -17,35 +17,85 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Random;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
  * This class is responsible for managing the current state of this node and ensuring only
  * valid state transitions.
+ *
+ * Unattached =>
+ *    Unattached: After learning of a new election with a higher epoch
+ *    Voted: After granting a vote to a candidate
+ *    Candidate: After expiration of the election timeout
+ *    Follower: After discovering a leader with an equal or larger epoch
+ *
+ * Voted =>
+ *    Unattached: After learning of a new election with a higher epoch
+ *    Candidate: After expiration of the election timeout
+ *
+ * Candidate =>
+ *    Unattached: After learning of a new election with a higher epoch
+ *    Candidate: After expiration of the election timeout
+ *    Leader: After receiving a majority of votes
+ *
+ * Leader =>
+ *    Unattached: After learning of a new election with a higher epoch
+ *
+ * Follower =>
+ *    Unattached: After learning of a new election with a higher epoch
+ *    Candidate: After expiration of the fetch timeout
+ *    Follower: After discovering a leader with a larger epoch
+ *
+ * Observers follow a simpler state machine. The Voted/Candidate/Leader states
+ * are not possible for observers, so the only transitions that are possible are
+ * between Unattached and Follower.
+ *
+ * Unattached =>
+ *    Unattached: After learning of a new election with a higher epoch
+ *    Follower: After discovering a leader with an equal or larger epoch
+ *
+ * Follower =>
+ *    Unattached: After learning of a new election with a higher epoch
+ *    Follower: After discovering a leader with a larger epoch
+ *
  */
 public class QuorumState {
     public final int localId;
+    private final Time time;
     private final Logger log;
     private final QuorumStateStore store;
     private final Set<Integer> voters;
+    private final Random random;
+    private final int electionTimeoutMs;
+    private final int fetchTimeoutMs;
+
     private volatile EpochState state;
 
     public QuorumState(int localId,
                        Set<Integer> voters,
+                       int electionTimeoutMs,
+                       int fetchTimeoutMs,
                        QuorumStateStore store,
-                       LogContext logContext) {
+                       Time time,
+                       LogContext logContext,
+                       Random random) {
         this.localId = localId;
         this.voters = new HashSet<>(voters);
+        this.electionTimeoutMs = electionTimeoutMs;
+        this.fetchTimeoutMs = fetchTimeoutMs;
         this.store = store;
+        this.time = time;
         this.log = logContext.logger(QuorumState.class);
+        this.random = random;
     }
 
     public void initialize(OffsetAndEpoch logEndOffsetAndEpoch) throws IOException, IllegalStateException {
@@ -62,11 +112,13 @@ public class QuorumState {
         } catch (final IOException e) {
             // For exceptions during state file loading (missing or not readable),
             // we could assume the file is corrupted already and should be cleaned up.
-            log.warn("Clear local quorum state store {}", store.toString(), e);
+            log.warn("Clearing local quorum state store after error loading state {}",
+                store.toString(), e);
             store.clear();
             election = ElectionState.withUnknownLeader(0, voters);
         }
 
+        final EpochState initialState;
         if (!election.voters().isEmpty() && !voters.equals(election.voters())) {
             throw new IllegalStateException("Configured voter set: " + voters
                 + " is different from the voter set read from the state file: " + election.voters() +
@@ -76,30 +128,58 @@ public class QuorumState {
             log.warn("Epoch from quorum-state file is {}, which is " +
                 "smaller than last written epoch {} in the log",
                 election.epoch, logEndOffsetAndEpoch.epoch);
-            state = new FollowerState(election.epoch, voters);
-            becomeUnattachedFollower(logEndOffsetAndEpoch.epoch);
+            initialState = new UnattachedState(
+                time,
+                logEndOffsetAndEpoch.epoch,
+                voters,
+                randomElectionTimeoutMs()
+            );
         } else if (election.isLeader(localId)) {
-            becomeLeader(new LeaderState(localId, election.epoch, logEndOffsetAndEpoch.offset, voters));
+            initialState = new LeaderState(
+                localId,
+                election.epoch,
+                logEndOffsetAndEpoch.offset,
+                voters
+            );
         } else if (election.isCandidate(localId)) {
-            becomeCandidate(new CandidateState(localId, election.epoch, voters, 1));
+            initialState = new CandidateState(
+                time,
+                localId,
+                election.epoch,
+                voters,
+                1,
+                randomElectionTimeoutMs()
+            );
+        } else if (election.hasVoted()) {
+            initialState = new VotedState(
+                time,
+                election.epoch,
+                election.votedId(),
+                voters,
+                randomElectionTimeoutMs()
+            );
+        } else if (election.hasLeader()) {
+            initialState = new FollowerState(
+                time,
+                election.epoch,
+                election.leaderId(),
+                voters,
+                fetchTimeoutMs
+            );
         } else {
-            state = new FollowerState(election.epoch, voters);
-            if (election.hasLeader()) {
-                becomeFetchingFollower(election.epoch, election.leaderId());
-            } else if (election.hasVoted()) {
-                becomeVotedFollower(election.epoch, election.votedId());
-            } else {
-                becomeUnattachedFollower(election.epoch);
-            }
+            initialState = new UnattachedState(
+                time,
+                election.epoch,
+                voters,
+                randomElectionTimeoutMs()
+            );
         }
+
+        transitionTo(initialState);
     }
 
     public Set<Integer> remoteVoters() {
         return voters.stream().filter(voterId -> voterId != localId).collect(Collectors.toSet());
-    }
-
-    public Set<Integer> allVoters() {
-        return voters;
     }
 
     public int epoch() {
@@ -130,18 +210,6 @@ public class QuorumState {
         return hasLeader() && leaderIdOrNil() != localId;
     }
 
-    public boolean isLeader() {
-        return state instanceof LeaderState;
-    }
-
-    public boolean isCandidate() {
-        return state instanceof CandidateState;
-    }
-
-    public boolean isFollower() {
-        return state instanceof FollowerState;
-    }
-
     public boolean isVoter() {
         return voters.contains(localId);
     }
@@ -154,107 +222,167 @@ public class QuorumState {
         return !isVoter();
     }
 
-    public boolean becomeUnattachedFollower(int epoch) throws IOException {
-        if (isObserver())
-            return becomeFollower(epoch, FollowerState::detachLeader);
+    /**
+     * Transition to the "unattached" state. This means we have found an epoch strictly larger
+     * than what is currently known, but wo do not yet know of an elected leader.
+     */
+    public void transitionToUnattached(int epoch) throws IOException {
+        int currentEpoch = state.epoch();
+        if (epoch <= currentEpoch) {
+            throw new IllegalArgumentException("Cannot transition to Unattached with epoch= " + epoch +
+                " from current state " + state);
+        }
 
-        boolean transitioned = becomeFollower(epoch, FollowerState::assertNotAttached);
-        if (transitioned)
-            log.info("Become unattached follower in epoch {}", epoch);
-        return transitioned;
+        final long electionTimeoutMs;
+        if (isObserver()) {
+            electionTimeoutMs = Long.MAX_VALUE;
+        } else if (isCandidate()) {
+            electionTimeoutMs = candidateStateOrThrow().remainingElectionTimeMs(time.milliseconds());
+        } else if (isVoted()) {
+            electionTimeoutMs = votedStateOrThrow().remainingElectionTimeMs(time.milliseconds());
+        } else if (isUnattached()) {
+            electionTimeoutMs = unattachedStateOrThrow().remainingElectionTimeMs(time.milliseconds());
+        } else {
+            electionTimeoutMs = randomElectionTimeoutMs();
+        }
+
+        transitionTo(new UnattachedState(
+            time,
+            epoch,
+            voters,
+            electionTimeoutMs
+        ));
     }
 
     /**
      * Grant a vote to a candidate and become a follower for this epoch. We will remain in this
      * state until either the election timeout expires or a leader is elected. In particular,
-     * we do not begin fetching until the election has concluded and {@link #becomeFetchingFollower(int, int)}
+     * we do not begin fetching until the election has concluded and {@link #transitionToFollower(int, int)}
      * is invoked.
      */
-    public boolean becomeVotedFollower(int epoch, int candidateId) throws IOException {
-        if (candidateId == localId)
-            throw new IllegalArgumentException("Cannot become a follower of " + candidateId +
-                " since that matches the local `broker.id`");
-        if (!isVoter(candidateId))
-            throw new IllegalArgumentException("Cannot become follower of non-voter " + candidateId);
+    public void transitionToVoted(
+        int epoch,
+        int candidateId
+    ) throws IOException {
+        if (candidateId == localId) {
+            throw new IllegalArgumentException("Cannot transition to Voted with votedId=" + candidateId +
+                " and epoch=" + epoch + " since it matches the local broker.id");
+        } else if (isObserver()) {
+            throw new IllegalStateException("Cannot transition to Voted with votedId=" + candidateId +
+                " and epoch=" + epoch + " since the local broker.id=" + localId + " is not a voter");
+        } else if (!isVoter(candidateId)) {
+            throw new IllegalArgumentException("Cannot transition to Voted with voterId=" + candidateId +
+                " and epoch=" + epoch + " since it is not one of the voters " + voters);
+        }
 
-        boolean transitioned = becomeFollower(epoch, state -> state.grantVoteTo(candidateId));
-        if (transitioned)
-            log.info("Become voting follower of candidate {} in epoch {}", candidateId, epoch);
-        return transitioned;
+        int currentEpoch = state.epoch();
+        if (epoch < currentEpoch) {
+            throw new IllegalArgumentException("Cannot transition to Voted with votedId=" + candidateId +
+                " and epoch=" + epoch + " since the current epoch " + currentEpoch + " is larger");
+        } else if (epoch == currentEpoch && !isUnattached()) {
+            throw new IllegalArgumentException("Cannot transition to Voted with votedId=" + candidateId +
+                " and epoch=" + epoch + " from the current state " + state);
+        }
+
+        // Note that we reset the election timeout after voting for a candidate because we
+        // know that the candidate has at least as good of a chance of getting elected as us
+
+        transitionTo(new VotedState(
+            time,
+            epoch,
+            candidateId,
+            voters,
+            randomElectionTimeoutMs()
+        ));
     }
 
     /**
      * Become a follower of an elected leader so that we can begin fetching.
      */
-    public boolean becomeFetchingFollower(int epoch, int leaderId) throws IOException {
-        if (leaderId == localId)
-            throw new IllegalArgumentException("Cannot become a follower of " + leaderId +
-                " since that matches the local `broker.id`");
-        if (!isVoter(leaderId))
-            throw new IllegalArgumentException("Cannot become follower of non-voter " + leaderId);
-        boolean transitioned = becomeFollower(epoch, state -> state.acknowledgeLeader(leaderId));
-        if (transitioned) {
-            log.info("Become follower of leader {} in epoch {}", leaderId, epoch);
+    public void transitionToFollower(
+        int epoch,
+        int leaderId
+    ) throws IOException {
+        if (leaderId == localId) {
+            throw new IllegalArgumentException("Cannot transition to Follower with leaderId=" + leaderId +
+                " and epoch=" + epoch + " since it matches the local broker.id=" + localId);
+        } else if (!isVoter(leaderId)) {
+            throw new IllegalArgumentException("Cannot transition to Follower with leaderId=" + leaderId +
+                " and epoch=" + epoch + " since it is not one of the voters " + voters);
         }
 
-        return transitioned;
+        int currentEpoch = state.epoch();
+        if (epoch < currentEpoch) {
+            throw new IllegalArgumentException("Cannot transition to Follower with leaderId=" + leaderId +
+                " and epoch=" + epoch + " since the current epoch " + currentEpoch + " is larger");
+        } else if (epoch == currentEpoch
+            && (isFollower() || isLeader())) {
+            throw new IllegalArgumentException("Cannot transition to Follower with leaderId=" + leaderId +
+                " and epoch=" + epoch + " from state " + state);
+        }
+
+        transitionTo(new FollowerState(
+            time,
+            epoch,
+            leaderId,
+            voters,
+            fetchTimeoutMs
+        ));
     }
 
-    private boolean becomeFollower(int newEpoch, Function<FollowerState, Boolean> func) throws IOException {
-        int currentEpoch = epoch();
-        boolean stateChanged = false;
-
-        if (newEpoch < currentEpoch) {
-            throw new IllegalArgumentException("Cannot become follower in epoch " + newEpoch +
-                    " since it is smaller epoch than our current epoch " + currentEpoch);
-        } else if (newEpoch > currentEpoch || isCandidate()) {
-            state = new FollowerState(newEpoch, voters);
-            stateChanged = true;
+    public void transitionToCandidate() throws IOException {
+        if (isObserver()) {
+            throw new IllegalStateException("Cannot transition to Candidate since the local broker.id=" + localId +
+                " is not one of the voters " + voters);
         } else if (isLeader()) {
-            throw new IllegalArgumentException("Cannot become follower of epoch " + newEpoch +
-                    " since we are already the leader of this epoch");
+            throw new IllegalStateException("Cannot transition to Candidate since the local broker.id=" + localId +
+                " since this node is already a Leader with state " + state);
         }
-
-        FollowerState followerState = followerStateOrThrow();
-        if (func.apply(followerState) || stateChanged) {
-            store.writeElectionState(followerState.election());
-            return true;
-        }
-        return false;
-    }
-
-    public CandidateState becomeCandidate() throws IOException {
-        if (isObserver())
-            throw new IllegalStateException("Cannot become candidate since we are not a voter");
-        if (isLeader())
-            throw new IllegalStateException("Cannot become candidate after being leader");
 
         int retries = isCandidate() ? candidateStateOrThrow().retries() + 1 : 1;
-
         int newEpoch = epoch() + 1;
-        CandidateState state = new CandidateState(localId, newEpoch, voters, retries);
-        store.writeElectionState(state.election());
-        becomeCandidate(state);
-        return state;
+        int electionTimeoutMs = randomElectionTimeoutMs();
+
+        transitionTo(new CandidateState(
+            time,
+            localId,
+            newEpoch,
+            voters,
+            retries,
+            electionTimeoutMs
+        ));
     }
 
-    private void becomeCandidate(CandidateState state) {
-        this.state = state;
-        log.info("Become candidate in epoch {} to election (retry number {})", epoch(), state.retries());
-    }
-
-    public LeaderState becomeLeader(long epochStartOffset) throws IOException {
-        if (isObserver())
-            throw new IllegalStateException("Cannot become candidate since we are not a voter");
+    public void transitionToLeader(long epochStartOffset) throws IOException {
+        if (isObserver()) {
+            throw new IllegalStateException("Cannot transition to Leader since the local broker.id="  + localId +
+                " is not one of the voters " + voters);
+        } else if (!isCandidate()) {
+            throw new IllegalStateException("Cannot transition to Leader from current state " + state);
+        }
 
         CandidateState candidateState = candidateStateOrThrow();
         if (!candidateState.isVoteGranted())
             throw new IllegalStateException("Cannot become leader without majority votes granted");
 
-        LeaderState state = new LeaderState(localId, epoch(), epochStartOffset, voters);
-        store.writeElectionState(state.election());
-        becomeLeader(state);
-        return state;
+        transitionTo(new LeaderState(
+            localId,
+            epoch(),
+            epochStartOffset,
+            voters
+        ));
+    }
+
+    private void transitionTo(EpochState state) throws IOException {
+        this.store.writeElectionState(state.election());
+        this.state = state;
+        log.info("Completed transition to {}", state);
+    }
+
+    private int randomElectionTimeoutMs() {
+        if (electionTimeoutMs == 0)
+            return 0;
+        return electionTimeoutMs + random.nextInt(electionTimeoutMs);
     }
 
     private void becomeLeader(LeaderState state) {
@@ -265,7 +393,19 @@ public class QuorumState {
     public FollowerState followerStateOrThrow() {
         if (isFollower())
             return (FollowerState) state;
-        throw new IllegalStateException("Expected to be a follower, but current state is " + state);
+        throw new IllegalStateException("Expected to be Follower, but the current state is " + state);
+    }
+
+    public VotedState votedStateOrThrow() {
+        if (isVoted())
+            return (VotedState) state;
+        throw new IllegalStateException("Expected to be Voted, but current state is " + state);
+    }
+
+    public UnattachedState unattachedStateOrThrow() {
+        if (isUnattached())
+            return (UnattachedState) state;
+        throw new IllegalStateException("Expected to be Unattached, but current state is " + state);
     }
 
     public LeaderState leaderStateOrThrow() {
@@ -281,6 +421,28 @@ public class QuorumState {
     }
 
     public LeaderAndEpoch leaderAndEpoch() {
-        return state.leaderAndEpoch();
+        ElectionState election = state.election();
+        return new LeaderAndEpoch(election.leaderIdOpt, election.epoch);
     }
+
+    public boolean isFollower() {
+        return state instanceof FollowerState;
+    }
+
+    public boolean isVoted() {
+        return state instanceof VotedState;
+    }
+
+    public boolean isUnattached() {
+        return state instanceof UnattachedState;
+    }
+
+    public boolean isLeader() {
+        return state instanceof LeaderState;
+    }
+
+    public boolean isCandidate() {
+        return state instanceof CandidateState;
+    }
+
 }

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -229,7 +229,7 @@ public class QuorumState {
     public void transitionToUnattached(int epoch) throws IOException {
         int currentEpoch = state.epoch();
         if (epoch <= currentEpoch) {
-            throw new IllegalArgumentException("Cannot transition to Unattached with epoch= " + epoch +
+            throw new IllegalStateException("Cannot transition to Unattached with epoch= " + epoch +
                 " from current state " + state);
         }
 
@@ -265,22 +265,22 @@ public class QuorumState {
         int candidateId
     ) throws IOException {
         if (candidateId == localId) {
-            throw new IllegalArgumentException("Cannot transition to Voted with votedId=" + candidateId +
+            throw new IllegalStateException("Cannot transition to Voted with votedId=" + candidateId +
                 " and epoch=" + epoch + " since it matches the local broker.id");
         } else if (isObserver()) {
             throw new IllegalStateException("Cannot transition to Voted with votedId=" + candidateId +
                 " and epoch=" + epoch + " since the local broker.id=" + localId + " is not a voter");
         } else if (!isVoter(candidateId)) {
-            throw new IllegalArgumentException("Cannot transition to Voted with voterId=" + candidateId +
+            throw new IllegalStateException("Cannot transition to Voted with voterId=" + candidateId +
                 " and epoch=" + epoch + " since it is not one of the voters " + voters);
         }
 
         int currentEpoch = state.epoch();
         if (epoch < currentEpoch) {
-            throw new IllegalArgumentException("Cannot transition to Voted with votedId=" + candidateId +
+            throw new IllegalStateException("Cannot transition to Voted with votedId=" + candidateId +
                 " and epoch=" + epoch + " since the current epoch " + currentEpoch + " is larger");
         } else if (epoch == currentEpoch && !isUnattached()) {
-            throw new IllegalArgumentException("Cannot transition to Voted with votedId=" + candidateId +
+            throw new IllegalStateException("Cannot transition to Voted with votedId=" + candidateId +
                 " and epoch=" + epoch + " from the current state " + state);
         }
 
@@ -304,20 +304,20 @@ public class QuorumState {
         int leaderId
     ) throws IOException {
         if (leaderId == localId) {
-            throw new IllegalArgumentException("Cannot transition to Follower with leaderId=" + leaderId +
+            throw new IllegalStateException("Cannot transition to Follower with leaderId=" + leaderId +
                 " and epoch=" + epoch + " since it matches the local broker.id=" + localId);
         } else if (!isVoter(leaderId)) {
-            throw new IllegalArgumentException("Cannot transition to Follower with leaderId=" + leaderId +
+            throw new IllegalStateException("Cannot transition to Follower with leaderId=" + leaderId +
                 " and epoch=" + epoch + " since it is not one of the voters " + voters);
         }
 
         int currentEpoch = state.epoch();
         if (epoch < currentEpoch) {
-            throw new IllegalArgumentException("Cannot transition to Follower with leaderId=" + leaderId +
+            throw new IllegalStateException("Cannot transition to Follower with leaderId=" + leaderId +
                 " and epoch=" + epoch + " since the current epoch " + currentEpoch + " is larger");
         } else if (epoch == currentEpoch
             && (isFollower() || isLeader())) {
-            throw new IllegalArgumentException("Cannot transition to Follower with leaderId=" + leaderId +
+            throw new IllegalStateException("Cannot transition to Follower with leaderId=" + leaderId +
                 " and epoch=" + epoch + " from state " + state);
         }
 
@@ -385,11 +385,6 @@ public class QuorumState {
         return electionTimeoutMs + random.nextInt(electionTimeoutMs);
     }
 
-    private void becomeLeader(LeaderState state) {
-        this.state = state;
-        log.info("Become leader in epoch {}", epoch());
-    }
-
     public FollowerState followerStateOrThrow() {
         if (isFollower())
             return (FollowerState) state;
@@ -411,13 +406,13 @@ public class QuorumState {
     public LeaderState leaderStateOrThrow() {
         if (isLeader())
             return (LeaderState) state;
-        throw new IllegalStateException("Expected to be a leader, but current state is " + state);
+        throw new IllegalStateException("Expected to be Leader, but current state is " + state);
     }
 
     public CandidateState candidateStateOrThrow() {
         if (isCandidate())
             return (CandidateState) state;
-        throw new IllegalStateException("Expected to be a candidate, but current state is " + state);
+        throw new IllegalStateException("Expected to be Candidate, but current state is " + state);
     }
 
     public LeaderAndEpoch leaderAndEpoch() {

--- a/raft/src/main/java/org/apache/kafka/raft/UnattachedState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/UnattachedState.java
@@ -65,6 +65,10 @@ public class UnattachedState implements EpochState {
         return "Unattached";
     }
 
+    public long electionTimeoutMs() {
+        return electionTimeoutMs;
+    }
+
     public long remainingElectionTimeMs(long currentTimeMs) {
         electionTimer.update(currentTimeMs);
         return electionTimer.remainingMs();

--- a/raft/src/main/java/org/apache/kafka/raft/UnattachedState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/UnattachedState.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
+
+import java.util.OptionalInt;
+import java.util.Set;
+
+/**
+ * A voter is "unattached" when it learns of an ongoing election (typically
+ * by observing a bumped epoch), but has yet to cast its vote or become a
+ * candidate itself.
+ */
+public class UnattachedState implements EpochState {
+    private final int epoch;
+    private final Set<Integer> voters;
+    private final long electionTimeoutMs;
+    private final Timer electionTimer;
+
+    public UnattachedState(
+        Time time,
+        int epoch,
+        Set<Integer> voters,
+        long electionTimeoutMs
+    ) {
+        this.epoch = epoch;
+        this.voters = voters;
+        this.electionTimeoutMs = electionTimeoutMs;
+        this.electionTimer = time.timer(electionTimeoutMs);
+    }
+
+    @Override
+    public ElectionState election() {
+        return new ElectionState(
+            epoch,
+            OptionalInt.empty(),
+            OptionalInt.empty(),
+            voters
+        );
+    }
+
+    @Override
+    public int epoch() {
+        return epoch;
+    }
+
+    @Override
+    public String name() {
+        return "Unattached";
+    }
+
+    public long remainingElectionTimeMs(long currentTimeMs) {
+        electionTimer.update(currentTimeMs);
+        return electionTimer.remainingMs();
+    }
+
+    public boolean hasElectionTimeoutExpired(long currentTimeMs) {
+        electionTimer.update(currentTimeMs);
+        return electionTimer.isExpired();
+    }
+
+    @Override
+    public String toString() {
+        return "Unattached(" +
+            "epoch=" + epoch +
+            ", voters=" + voters +
+            ", electionTimeoutMs=" + electionTimeoutMs +
+            ')';
+    }
+
+}

--- a/raft/src/main/java/org/apache/kafka/raft/VotedState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/VotedState.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
+
+import java.util.OptionalInt;
+import java.util.Set;
+
+/**
+ * The "voted" state is for voters who have cast their vote for a
+ * specific candidate.
+ */
+public class VotedState implements EpochState {
+    private final int epoch;
+    private final int votedId;
+    private final Set<Integer> voters;
+    private final int electionTimeoutMs;
+    private final Timer electionTimer;
+
+    public VotedState(
+        Time time,
+        int epoch,
+        int votedId,
+        Set<Integer> voters,
+        int electionTimeoutMs
+    ) {
+        this.epoch = epoch;
+        this.votedId = votedId;
+        this.voters = voters;
+        this.electionTimeoutMs = electionTimeoutMs;
+        this.electionTimer = time.timer(electionTimeoutMs);
+    }
+
+    @Override
+    public ElectionState election() {
+        return new ElectionState(
+            epoch,
+            OptionalInt.empty(),
+            OptionalInt.of(votedId),
+            voters
+        );
+    }
+
+    public int votedId() {
+        return votedId;
+    }
+
+    @Override
+    public int epoch() {
+        return epoch;
+    }
+
+    @Override
+    public String name() {
+        return "Voted";
+    }
+
+    public long remainingElectionTimeMs(long currentTimeMs) {
+        electionTimer.update(currentTimeMs);
+        return electionTimer.remainingMs();
+    }
+
+    public boolean hasElectionTimeoutExpired(long currentTimeMs) {
+        electionTimer.update(currentTimeMs);
+        return electionTimer.isExpired();
+    }
+
+    public void overrideElectionTimeout(long currentTimeMs, long timeoutMs) {
+        electionTimer.update(currentTimeMs);
+        electionTimer.reset(timeoutMs);
+    }
+
+    @Override
+    public String toString() {
+        return "Voted(" +
+            "epoch=" + epoch +
+            ", votedId=" + votedId +
+            ", voters=" + voters +
+            ", electionTimeoutMs=" + electionTimeoutMs +
+            ')';
+    }
+
+}

--- a/raft/src/test/java/org/apache/kafka/raft/CandidateStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/CandidateStateTest.java
@@ -108,6 +108,14 @@ public class CandidateStateTest {
     }
 
     @Test
+    public void testCannotRejectVoteFromLocalId() {
+        int otherNodeId = 1;
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Utils.mkSet(localId, otherNodeId), 0, electionTimeoutMs);
+        assertThrows(IllegalArgumentException.class, () -> state.recordRejectedVote(localId));
+    }
+
+    @Test
     public void testCannotChangeVoteGrantedToRejected() {
         int otherNodeId = 1;
         CandidateState state = new CandidateState(time, localId, epoch,

--- a/raft/src/test/java/org/apache/kafka/raft/CandidateStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/CandidateStateTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.raft;
 
+import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.Test;
 
@@ -29,10 +30,13 @@ import static org.junit.Assert.assertTrue;
 public class CandidateStateTest {
     private final int localId = 0;
     private final int epoch = 5;
+    private final MockTime time = new MockTime();
+    private final int electionTimeoutMs = 5000;
 
     @Test
     public void testSingleNodeQuorum() {
-        CandidateState state = new CandidateState(localId, epoch, Collections.singleton(localId), 0);
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Collections.singleton(localId), 0, electionTimeoutMs);
         assertTrue(state.isVoteGranted());
         assertFalse(state.isVoteRejected());
         assertEquals(Collections.emptySet(), state.unrecordedVoters());
@@ -41,7 +45,8 @@ public class CandidateStateTest {
     @Test
     public void testTwoNodeQuorumVoteRejected() {
         int otherNodeId = 1;
-        CandidateState state = new CandidateState(localId, epoch, Utils.mkSet(localId, otherNodeId), 0);
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Utils.mkSet(localId, otherNodeId), 0, electionTimeoutMs);
         assertFalse(state.isVoteGranted());
         assertFalse(state.isVoteRejected());
         assertEquals(Collections.singleton(otherNodeId), state.unrecordedVoters());
@@ -53,7 +58,8 @@ public class CandidateStateTest {
     @Test
     public void testTwoNodeQuorumVoteGranted() {
         int otherNodeId = 1;
-        CandidateState state = new CandidateState(localId, epoch, Utils.mkSet(localId, otherNodeId), 0);
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Utils.mkSet(localId, otherNodeId), 0, electionTimeoutMs);
         assertFalse(state.isVoteGranted());
         assertFalse(state.isVoteRejected());
         assertEquals(Collections.singleton(otherNodeId), state.unrecordedVoters());
@@ -67,7 +73,8 @@ public class CandidateStateTest {
     public void testThreeNodeQuorumVoteGranted() {
         int node1 = 1;
         int node2 = 2;
-        CandidateState state = new CandidateState(localId, epoch, Utils.mkSet(localId, node1, node2), 0);
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Utils.mkSet(localId, node1, node2), 0, electionTimeoutMs);
         assertFalse(state.isVoteGranted());
         assertFalse(state.isVoteRejected());
         assertEquals(Utils.mkSet(node1, node2), state.unrecordedVoters());
@@ -85,7 +92,8 @@ public class CandidateStateTest {
     public void testThreeNodeQuorumVoteRejected() {
         int node1 = 1;
         int node2 = 2;
-        CandidateState state = new CandidateState(localId, epoch, Utils.mkSet(localId, node1, node2), 0);
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Utils.mkSet(localId, node1, node2), 0, electionTimeoutMs);
         assertFalse(state.isVoteGranted());
         assertFalse(state.isVoteRejected());
         assertEquals(Utils.mkSet(node1, node2), state.unrecordedVoters());
@@ -102,7 +110,8 @@ public class CandidateStateTest {
     @Test
     public void testCannotChangeVoteGrantedToRejected() {
         int otherNodeId = 1;
-        CandidateState state = new CandidateState(localId, epoch, Utils.mkSet(localId, otherNodeId), 0);
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Utils.mkSet(localId, otherNodeId), 0, electionTimeoutMs);
         assertTrue(state.recordGrantedVote(otherNodeId));
         assertThrows(IllegalArgumentException.class, () -> state.recordRejectedVote(otherNodeId));
         assertTrue(state.isVoteGranted());
@@ -111,7 +120,8 @@ public class CandidateStateTest {
     @Test
     public void testCannotChangeVoteRejectedToGranted() {
         int otherNodeId = 1;
-        CandidateState state = new CandidateState(localId, epoch, Utils.mkSet(localId, otherNodeId), 0);
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Utils.mkSet(localId, otherNodeId), 0, electionTimeoutMs);
         assertTrue(state.recordRejectedVote(otherNodeId));
         assertThrows(IllegalArgumentException.class, () -> state.recordGrantedVote(otherNodeId));
         assertTrue(state.isVoteRejected());
@@ -120,7 +130,8 @@ public class CandidateStateTest {
     @Test
     public void testCannotGrantOrRejectNonVoters() {
         int nonVoterId = 1;
-        CandidateState state = new CandidateState(localId, epoch, Collections.singleton(localId), 0);
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Collections.singleton(localId), 0, electionTimeoutMs);
         assertThrows(IllegalArgumentException.class, () -> state.recordGrantedVote(nonVoterId));
         assertThrows(IllegalArgumentException.class, () -> state.recordRejectedVote(nonVoterId));
     }
@@ -128,7 +139,8 @@ public class CandidateStateTest {
     @Test
     public void testIdempotentGrant() {
         int otherNodeId = 1;
-        CandidateState state = new CandidateState(localId, epoch, Utils.mkSet(localId, otherNodeId), 0);
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Utils.mkSet(localId, otherNodeId), 0, electionTimeoutMs);
         assertTrue(state.recordGrantedVote(otherNodeId));
         assertFalse(state.recordGrantedVote(otherNodeId));
     }
@@ -136,7 +148,8 @@ public class CandidateStateTest {
     @Test
     public void testIdempotentReject() {
         int otherNodeId = 1;
-        CandidateState state = new CandidateState(localId, epoch, Utils.mkSet(localId, otherNodeId), 0);
+        CandidateState state = new CandidateState(time, localId, epoch,
+            Utils.mkSet(localId, otherNodeId), 0, electionTimeoutMs);
         assertTrue(state.recordRejectedVote(otherNodeId));
         assertFalse(state.recordRejectedVote(otherNodeId));
     }

--- a/raft/src/test/java/org/apache/kafka/raft/FollowerStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/FollowerStateTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.raft;
 
+import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.Test;
 
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -29,119 +29,54 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class FollowerStateTest {
-    private final int epoch = 5;
-    private final Set<Integer> voters = Utils.mkSet(1, 2);
+    private final MockTime time = new MockTime();
 
     @Test
-    public void testVoteForCandidate() {
-        FollowerState state = new FollowerState(epoch, voters);
-        assertTrue(state.assertNotAttached());
-        assertFalse(state.hasVoted());
+    public void testFetchTimeoutExpiration() {
+        int epoch = 5;
+        int leaderId = 3;
+        int fetchTimeoutMs = 15000;
 
-        int votedId = 1;
-        assertTrue(state.grantVoteTo(votedId));
-        assertTrue(state.hasVoted());
-        assertTrue(state.hasVotedFor(votedId));
-    }
+        FollowerState state = new FollowerState(
+            time,
+            epoch,
+            leaderId,
+            Utils.mkSet(1, 2, 3),
+            fetchTimeoutMs
+        );
 
-    @Test
-    public void testCannotChangeVote() {
-        FollowerState state = new FollowerState(epoch, voters);
-        int votedId = 1;
-        int otherCandidateId = 2;
-        assertTrue(state.grantVoteTo(votedId));
-        assertThrows(IllegalArgumentException.class, () -> state.grantVoteTo(otherCandidateId));
-    }
+        assertFalse(state.hasFetchTimeoutExpired(time.milliseconds()));
+        assertEquals(fetchTimeoutMs, state.remainingFetchTimeMs(time.milliseconds()));
 
-    @Test
-    public void testIdempotentVote() {
-        FollowerState state = new FollowerState(epoch, voters);
-        int votedId = 1;
-        assertTrue(state.grantVoteTo(votedId));
-        assertFalse(state.grantVoteTo(votedId));
-        assertTrue(state.hasVoted());
-        assertTrue(state.hasVotedFor(votedId));
-    }
+        time.sleep(5000);
+        assertFalse(state.hasFetchTimeoutExpired(time.milliseconds()));
+        assertEquals(fetchTimeoutMs - 5000, state.remainingFetchTimeMs(time.milliseconds()));
 
-    @Test
-    public void testCannotVoteIfLeaderIsKnown() {
-        FollowerState state = new FollowerState(epoch, voters);
-        int leaderId = 1;
-        int candidateId = 2;
-        state.acknowledgeLeader(leaderId);
-        assertFalse(state.hasVoted());
-        assertThrows(IllegalArgumentException.class, () -> state.grantVoteTo(candidateId));
-        assertFalse(state.hasVoted());
-        assertEquals(leaderId, state.leaderId());
-    }
-
-    @Test
-    public void testAckLeaderWithoutVoting() {
-        FollowerState state = new FollowerState(epoch, voters);
-        int leaderId = 1;
-        state.acknowledgeLeader(leaderId);
-        assertTrue(state.hasLeader());
-        assertEquals(leaderId, state.leaderId());
-    }
-
-    @Test
-    public void testAckLeaderAfterVoting() {
-        FollowerState state = new FollowerState(epoch, voters);
-        int candidateId = 1;
-        int leaderId = 2;
-        assertTrue(state.grantVoteTo(candidateId));
-        assertTrue(state.acknowledgeLeader(leaderId));
-        assertFalse(state.hasVotedFor(candidateId));
-        assertFalse(state.hasVoted());
-        assertTrue(state.hasLeader());
-        assertEquals(leaderId, state.leaderId());
-    }
-
-    @Test
-    public void testCannotChangeLeader() {
-        FollowerState state = new FollowerState(epoch, voters);
-        int leaderId = 1;
-        int otherLeaderId = 2;
-        assertTrue(state.acknowledgeLeader(leaderId));
-        assertThrows(IllegalArgumentException.class, () -> state.acknowledgeLeader(otherLeaderId));
-        assertTrue(state.hasLeader());
-        assertEquals(leaderId, state.leaderId());
-    }
-
-    @Test
-    public void testIdempotentLeaderAcknowledgement() {
-        FollowerState state = new FollowerState(epoch, voters);
-        int leaderId = 1;
-        assertTrue(state.acknowledgeLeader(leaderId));
-        assertFalse(state.acknowledgeLeader(leaderId));
-        assertTrue(state.hasLeader());
-        assertEquals(leaderId, state.leaderId());
-    }
-
-    @Test
-    public void testUpdateHighWatermarkOnlyPermittedWithLeader() {
-        OptionalLong highWatermark = OptionalLong.of(15L);
-        FollowerState state = new FollowerState(epoch, voters);
-        assertThrows(IllegalArgumentException.class, () -> state.updateHighWatermark(highWatermark));
-        int candidateId = 1;
-        assertTrue(state.grantVoteTo(candidateId));
-        assertThrows(IllegalArgumentException.class, () -> state.updateHighWatermark(highWatermark));
-        int leaderId = 2;
-        assertTrue(state.acknowledgeLeader(leaderId));
-        state.updateHighWatermark(highWatermark);
-        assertEquals(Optional.of(new LogOffsetMetadata(15L)), state.highWatermark());
+        time.sleep(10000);
+        assertTrue(state.hasFetchTimeoutExpired(time.milliseconds()));
+        assertEquals(0, state.remainingFetchTimeMs(time.milliseconds()));
     }
 
     @Test
     public void testMonotonicHighWatermark() {
+        int epoch = 5;
+        int leaderId = 3;
+        int fetchTimeoutMs = 15000;
+
+        FollowerState state = new FollowerState(
+            time,
+            epoch,
+            leaderId,
+            Utils.mkSet(1, 2, 3),
+            fetchTimeoutMs
+        );
+
         OptionalLong highWatermark = OptionalLong.of(15L);
-        FollowerState state = new FollowerState(epoch, voters);
-        int leaderId = 1;
-        assertTrue(state.acknowledgeLeader(leaderId));
         state.updateHighWatermark(highWatermark);
         assertThrows(IllegalArgumentException.class, () -> state.updateHighWatermark(OptionalLong.empty()));
         assertThrows(IllegalArgumentException.class, () -> state.updateHighWatermark(OptionalLong.of(14L)));
         state.updateHighWatermark(highWatermark);
         assertEquals(Optional.of(new LogOffsetMetadata(15L)), state.highWatermark());
     }
+
 }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -759,7 +759,8 @@ public class RaftEventSimulationTest {
             LogContext logContext = new LogContext("[Node " + nodeId + "] ");
             PersistentState persistentState = nodes.get(nodeId);
             MockNetworkChannel channel = new MockNetworkChannel(correlationIdCounter);
-            QuorumState quorum = new QuorumState(nodeId, voters(), persistentState.store, logContext);
+            QuorumState quorum = new QuorumState(nodeId, voters(), ELECTION_TIMEOUT_MS,
+                FETCH_TIMEOUT_MS, persistentState.store, time, logContext, random);
             MockFuturePurgatory<LogOffset> fetchPurgatory = new MockFuturePurgatory<>(time);
             MockFuturePurgatory<LogOffset> appendPurgatory = new MockFuturePurgatory<>(time);
             Metrics metrics = new Metrics(time);
@@ -771,8 +772,8 @@ public class RaftEventSimulationTest {
                 ));
 
             KafkaRaftClient client = new KafkaRaftClient(channel, persistentState.log, quorum, time, metrics,
-                fetchPurgatory, appendPurgatory, voterConnectionMap, ELECTION_TIMEOUT_MS, ELECTION_JITTER_MS,
-                FETCH_TIMEOUT_MS, RETRY_BACKOFF_MS, REQUEST_TIMEOUT_MS, FETCH_MAX_WAIT_MS, logContext, random);
+                fetchPurgatory, appendPurgatory, voterConnectionMap, ELECTION_JITTER_MS,
+                RETRY_BACKOFF_MS, REQUEST_TIMEOUT_MS, FETCH_MAX_WAIT_MS, logContext, random);
             RaftNode node = new RaftNode(nodeId, client, persistentState.log, channel,
                     persistentState.store, quorum, logContext);
             node.initialize();

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -25,7 +25,7 @@ import java.util.Random;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class ConnectionCacheTest {
+public class RequestManagerTest {
     private final MockTime time = new MockTime();
     private final int requestTimeoutMs = 30000;
     private final int retryBackoffMs = 100;
@@ -33,19 +33,19 @@ public class ConnectionCacheTest {
 
     @Test
     public void testResetAllConnections() {
-        ConnectionCache cache = new ConnectionCache(
+        RequestManager cache = new RequestManager(
             Utils.mkSet(1, 2, 3),
             retryBackoffMs,
             requestTimeoutMs,
             random);
 
         // One host has an inflight request
-        ConnectionCache.ConnectionState connectionState1 = cache.getOrCreate(1);
+        RequestManager.ConnectionState connectionState1 = cache.getOrCreate(1);
         connectionState1.onRequestSent(1, time.milliseconds());
         assertFalse(connectionState1.isReady(time.milliseconds()));
 
         // Another is backing off
-        ConnectionCache.ConnectionState connectionState2 = cache.getOrCreate(2);
+        RequestManager.ConnectionState connectionState2 = cache.getOrCreate(2);
         connectionState2.onRequestSent(2, time.milliseconds());
         connectionState2.onResponseError(2, time.milliseconds());
         assertFalse(connectionState2.isReady(time.milliseconds()));
@@ -59,13 +59,13 @@ public class ConnectionCacheTest {
 
     @Test
     public void testBackoffAfterFailure() {
-        ConnectionCache cache = new ConnectionCache(
+        RequestManager cache = new RequestManager(
             Utils.mkSet(1, 2, 3),
             retryBackoffMs,
             requestTimeoutMs,
             random);
 
-        ConnectionCache.ConnectionState connectionState = cache.getOrCreate(1);
+        RequestManager.ConnectionState connectionState = cache.getOrCreate(1);
         assertTrue(connectionState.isReady(time.milliseconds()));
 
         long correlationId = 1;
@@ -81,13 +81,13 @@ public class ConnectionCacheTest {
 
     @Test
     public void testSuccessfulResponse() {
-        ConnectionCache cache = new ConnectionCache(
+        RequestManager cache = new RequestManager(
             Utils.mkSet(1, 2, 3),
             retryBackoffMs,
             requestTimeoutMs,
             random);
 
-        ConnectionCache.ConnectionState connectionState = cache.getOrCreate(1);
+        RequestManager.ConnectionState connectionState = cache.getOrCreate(1);
 
         long correlationId = 1;
         connectionState.onRequestSent(correlationId, time.milliseconds());
@@ -98,13 +98,13 @@ public class ConnectionCacheTest {
 
     @Test
     public void testIgnoreUnexpectedResponse() {
-        ConnectionCache cache = new ConnectionCache(
+        RequestManager cache = new RequestManager(
             Utils.mkSet(1, 2, 3),
             retryBackoffMs,
             requestTimeoutMs,
             random);
 
-        ConnectionCache.ConnectionState connectionState = cache.getOrCreate(1);
+        RequestManager.ConnectionState connectionState = cache.getOrCreate(1);
 
         long correlationId = 1;
         connectionState.onRequestSent(correlationId, time.milliseconds());
@@ -115,14 +115,14 @@ public class ConnectionCacheTest {
 
     @Test
     public void testRequestTimeout() {
-        ConnectionCache cache = new ConnectionCache(
+        RequestManager cache = new RequestManager(
             Utils.mkSet(1, 2, 3),
             retryBackoffMs,
             requestTimeoutMs,
             random);
 
 
-        ConnectionCache.ConnectionState connectionState = cache.getOrCreate(1);
+        RequestManager.ConnectionState connectionState = cache.getOrCreate(1);
 
         long correlationId = 1;
         connectionState.onRequestSent(correlationId, time.milliseconds());

--- a/raft/src/test/java/org/apache/kafka/raft/VotedStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/VotedStateTest.java
@@ -16,27 +16,13 @@
  */
 package org.apache.kafka.raft;
 
-import java.util.Optional;
+import org.junit.Test;
 
-public interface EpochState {
+public class VotedStateTest {
 
-    default Optional<LogOffsetMetadata> highWatermark() {
-        return Optional.empty();
+    @Test
+    public void testElectionTimeout() {
+        // TODO:
     }
-
-    /**
-     * Get the current election state, which is guaranteed to be immutable.
-     */
-    ElectionState election();
-
-    /**
-     * Get the current (immutable) epoch.
-     */
-    int epoch();
-
-    /**
-     * User-friendly description of the state
-     */
-    String name();
 
 }


### PR DESCRIPTION
This PR attempts to improve timeout/backoff logic in the raft client. It does the following:

- Split the Follower state into three separates and document all state transitions 
- Move fetch/election timer into respective `EpochState` implementations
- Take into account backoffs when setting poll timeout

Plus a bunch of small fixes. Note that this builds off #390. I will rebase after it is merged.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
