### PR TITLE
Add KafkaEventQueue

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
@@ -36,7 +36,7 @@ public interface EventQueue extends AutoCloseable {
     }
 
     /**
-     * Add an element to the end of the queue.
+     * Add an element to the front of the queue.
      *
      * @param event             The event to append.
      *

--- a/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
@@ -38,7 +38,7 @@ public interface EventQueue extends AutoCloseable {
     /**
      * Add an element to the front of the queue.
      *
-     * @param event             The event to append.
+     * @param event             The mandatory event to prepend.
      *
      * @return                  A future which is completed with an exception or
      *                          with the result of Event#run.

--- a/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
@@ -159,8 +159,8 @@ public interface EventQueue extends AutoCloseable {
      * No new events will be accepted, and the timeout will be initiated
      * for all existing events.
      *
-     * @param cleanupEvent  The event to invoke after all other events have been
-     *                      processed.
+     * @param cleanupEvent  The mandatory event to invoke after all other events have
+     *                     been processed.
      * @param timeUnit      The time unit to use for the timeout.
      * @param timeSpan      The amount of time to use for the timeout.
      *                      Once the timeout elapses, any remaining queued

--- a/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
@@ -143,8 +143,11 @@ public interface EventQueue extends AutoCloseable {
     }
 
     /**
-     * Asynchronously shut down the event queue.
-     * See beginShutdown(Event<?>, TimeUnit, long);
+     * Asynchronously shut down the event queue with no unnecessary delay.
+     *
+     * @param cleanupEvent The mandatory event to invoke after all other events have
+     *                     been processed.
+     * @see #beginShutdown(Event, TimeUnit, long)
      */
     default void beginShutdown(Event<?> cleanupEvent) {
         beginShutdown(cleanupEvent, TimeUnit.SECONDS, 0);

--- a/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.utils;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+public interface EventQueue extends AutoCloseable {
+    interface Event<T> {
+        T run() throws Throwable;
+    }
+
+    class VoidEvent implements Event<Void> {
+        public final static VoidEvent INSTANCE = new VoidEvent();
+
+        @Override
+        public Void run() {
+            return null;
+        }
+    }
+
+    /**
+     * Add an element to the end of the queue.
+     *
+     * @param event             The event to append.
+     *
+     * @return                  A future which is completed with an exception or
+     *                          with the result of Event#run.
+     */
+    default <T> CompletableFuture<T> prepend(Event<T> event) {
+        return enqueue(EventInsertionType.PREPEND, null, null, event);
+    }
+
+    /**
+     * Add an element to the end of the queue.
+     *
+     * @param event             The event to append.
+     *
+     * @return                  A future which is completed with an exception or
+     *                          with the result of Event#run.
+     */
+    default <T> CompletableFuture<T> append(Event<T> event) {
+        return enqueue(EventInsertionType.APPEND, null, null, event);
+    }
+
+    /**
+     * Enqueue an event to be run in FIFO order.
+     *
+     * @param deadlineNs        The time in monotonic nanoseconds after which the future
+     *                          is completed with a
+     *                          @{org.apache.kafka.common.errors.TimeoutException},
+     *                          and the event is cancelled.
+     * @param event             The event to append.
+     *
+     * @return                  A future which is completed with an exception or
+     *                          with the result of Event#run.  If there was a
+     *                          timeout, the event will not be run.
+     */
+    default <T> CompletableFuture<T> appendWithDeadline(long deadlineNs, Event<T> event) {
+
+        return enqueue(EventInsertionType.APPEND, null, __ -> deadlineNs, event);
+    }
+
+    /**
+     * Schedule an event to be run at a specific time.
+     *
+     * @param tag                   If this is non-null, the unique tag to use for this
+     *                              event.  If an event with this tag already exists, it
+     *                              will be cancelled.
+     * @param deadlineNsCalculator  If this is non-null, it is a function which takes as
+     *                              an argument the existing deadline for the event with
+     *                              this tag (or null if the event has no tag, or if
+     *                              there is none such), and produces the deadline to use
+     *                              for this event (or null to use none.)
+     * @param event                 The event to schedule.
+     *
+     * @return                      A future which is completed with an exception or
+     *                              with the result of Event#run.  If there was a
+     *                              timeout, the event will not be run.
+     */
+    default <T> CompletableFuture<T> scheduleDeferred(String tag,
+                                                      Function<Long, Long> deadlineNsCalculator,
+                                                      Event<T> event) {
+        return enqueue(EventInsertionType.DEFERRED, tag, deadlineNsCalculator, event);
+    }
+
+    enum EventInsertionType {
+        PREPEND,
+        APPEND,
+        DEFERRED;
+    }
+
+    /**
+     * Enqueue an event to be run in FIFO order.
+     *
+     * @param insertionType         How to insert the event.
+     *                              PREPEND means insert the event as the first thing
+     *                              to run.  APPEND means insert the event as the last
+     *                              thing to run.  DEFERRED means insert the event to
+     *                              run after a delay.
+     * @param tag                   If this is non-null, the unique tag to use for
+     *                              this event.  If an event with this tag already
+     *                              exists, it will be cancelled.
+     * @param deadlineNsCalculator  If this is non-null, it is a function which takes
+     *                              as an argument the existing deadline for the
+     *                              event with this tag (or null if the event has no
+     *                              tag, or if there is none such), and produces the
+     *                              deadline to use for this event (or null to use
+     *                              none.)
+     * @param event                 The event to enqueue.
+     *
+     * @return                      A future which is completed with an exception or
+     *                              with the result of Event#run.  If there was a
+     *                              timeout or the event was cancelled, it will not run.
+     */
+    <T> CompletableFuture<T> enqueue(EventInsertionType insertionType,
+                                     String tag,
+                                     Function<Long, Long> deadlineNsCalculator,
+                                     Event<T> event);
+
+    /**
+     * Asynchronously shut down the event queue.
+     * See shutdown(Event<?>, TimeUnit, long);
+     */
+    default void beginShutdown() {
+        beginShutdown(new VoidEvent());
+    }
+
+    /**
+     * Asynchronously shut down the event queue.
+     * See beginShutdown(Event<?>, TimeUnit, long);
+     */
+    default void beginShutdown(Event<?> cleanupEvent) {
+        beginShutdown(cleanupEvent, TimeUnit.SECONDS, 0);
+    }
+
+    /**
+     * Asynchronously shut down the event queue.
+     *
+     * No new events will be accepted, and the timeout will be initiated
+     * for all existing events.
+     *
+     * @param cleanupEvent  The event to invoke after all other events have been
+     *                      processed.
+     * @param timeUnit      The time unit to use for the timeout.
+     * @param timeSpan      The amount of time to use for the timeout.
+     *                      Once the timeout elapses, any remaining queued
+     *                      events will get a
+     *                      @{org.apache.kafka.common.errors.TimeoutException}.
+     */
+    void beginShutdown(Event<?> cleanupEvent, TimeUnit timeUnit, long timeSpan);
+
+    /**
+     * Synchronously close the event queue and wait for any threads to be joined.
+     */
+    void close() throws InterruptedException;
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 
 public interface EventQueue extends AutoCloseable {
     interface Event<T> {
-        T run() throws Throwable;
+        T run() throws Exception;
     }
 
     class VoidEvent implements Event<Void> {

--- a/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
@@ -83,11 +83,10 @@ public interface EventQueue extends AutoCloseable {
      * @param tag                   If this is non-null, the unique tag to use for this
      *                              event.  If an event with this tag already exists, it
      *                              will be cancelled.
-     * @param deadlineNsCalculator  If this is non-null, it is a function which takes as
-     *                              an argument the existing deadline for the event with
-     *                              this tag (or null if the event has no tag, or if
-     *                              there is none such), and produces the deadline to use
-     *                              for this event (or null to use none.)
+     * @param deadlineNsCalculator  A function which takes as an argument the existing
+     *                              deadline for the event with this tag (or null if the
+     *                              event has no tag, or if there is none such), and
+     *                              produces the deadline to use for this event.
      * @param event                 The event to schedule.
      *
      * @return                      A future which is completed with an exception or

--- a/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/EventQueue.java
@@ -135,8 +135,8 @@ public interface EventQueue extends AutoCloseable {
                                      Event<T> event);
 
     /**
-     * Asynchronously shut down the event queue.
-     * See shutdown(Event<?>, TimeUnit, long);
+     * Asynchronously shut down the event queue with no unnecessary delay.
+     * @see #beginShutdown(Event, TimeUnit, long)
      */
     default void beginShutdown() {
         beginShutdown(new VoidEvent());

--- a/clients/src/main/java/org/apache/kafka/common/utils/KafkaEventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/KafkaEventQueue.java
@@ -1,0 +1,390 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.utils;
+
+import org.apache.kafka.common.errors.TimeoutException;
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class KafkaEventQueue implements EventQueue {
+    /**
+     * A context object that wraps events.
+     *
+     * @param <T>       The type parameter of the wrapped event.
+     */
+    private static class EventContext<T> {
+        /**
+         * The caller-supplied event.
+         */
+        private final Event<T> event;
+
+        /**
+         * How this event was inserted.
+         */
+        private final EventInsertionType insertionType;
+
+        /**
+         * The CompletableFuture that the caller can listen on.
+         */
+        private final CompletableFuture<T> future = new CompletableFuture<>();
+
+        /**
+         * The previous pointer of our circular doubly-linked list.
+         */
+        private EventContext<?> prev = this;
+
+        /**
+         * The next pointer in our circular doubly-linked list.
+         */
+        private EventContext<?> next = this;
+
+        /**
+         * If this event is in the delay map, this is the key it is there under.
+         * If it is not in the map, this is null.
+         */
+        private Long deadlineNs = null;
+
+        /**
+         * The tag associated with this event.
+         */
+        private String tag;
+
+        EventContext(Event<T> event, EventInsertionType insertionType, String tag) {
+            this.event = event;
+            this.insertionType = insertionType;
+            this.tag = tag;
+        }
+
+        /**
+         * Insert a new node in the circularly linked list after this node.
+         */
+        @SuppressWarnings("unchecked")
+        void insertAfter(EventContext other) {
+            this.next.prev = other;
+            other.next = this.next;
+            other.prev = this;
+            this.next = other;
+        }
+
+        /**
+         * Insert a new node in the circularly linked list before this node.
+         */
+        @SuppressWarnings("unchecked")
+        void insertBefore(EventContext other) {
+            this.prev.next = other;
+            other.prev = this.prev;
+            other.next = this;
+            this.prev = other;
+        }
+
+        /**
+         * Remove this node from the circularly linked list.
+         */
+        void remove() {
+            this.prev.next = this.next;
+            this.next.prev = this.prev;
+            this.prev = this;
+            this.next = this;
+        }
+
+        /**
+         * Returns true if this node is the only element in its list.
+         */
+        boolean isSingleton() {
+            return prev == this && next == this;
+        }
+
+        /**
+         * Run the event associated with this EventContext.
+         */
+        void run() throws Throwable {
+            try {
+                future.complete(event.run());
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        }
+
+        /**
+         * Complete the event associated with this EventContext with a timeout exception.
+         */
+        void completeWithTimeout() {
+            completeWithException(new TimeoutException());
+        }
+
+        /**
+         * Complete the event associated with this EventContext with a cancellation exception.
+         */
+        void cancel() {
+            future.cancel(false);
+        }
+
+        /**
+         * Complete the event associated with this EventContext with the specified
+         * exception.
+         */
+        void completeWithException(Throwable t) {
+            future.completeExceptionally(t);
+        }
+    }
+
+    private class EventHandler implements Runnable {
+        /**
+         * Event contexts indexed by tag.  Events without a tag are not included here.
+         */
+        private final Map<String, EventContext<?>> tagToEventContext = new HashMap<>();
+
+        /**
+         * The head of the event queue.
+         */
+        private final EventContext<Void> head = new EventContext<>(null, null, null);
+
+        /**
+         * An ordered map of times in monotonic nanoseconds to events to time out.
+         */
+        private final TreeMap<Long, EventContext<?>> delayMap = new TreeMap<>();
+
+        /**
+         * A condition variable for waking up the event handler thread.
+         */
+        private final Condition cond = lock.newCondition();
+
+        @Override
+        public void run() {
+            try {
+                handleEvents();
+                cleanupEvent.run();
+            } catch (Throwable e) {
+                log.warn("event handler thread exiting with exception", e);
+            }
+        }
+
+        private void remove(EventContext<?> eventContext) {
+            eventContext.remove();
+            if (eventContext.deadlineNs != null) {
+                delayMap.remove(eventContext.deadlineNs);
+                eventContext.deadlineNs = null;
+            }
+            if (eventContext.tag != null) {
+                tagToEventContext.remove(eventContext.tag, eventContext);
+                eventContext.tag = null;
+            }
+        }
+
+        private void handleEvents() throws Throwable {
+            EventContext<?> timedEventContext = null;
+            EventContext<?> queuedEventContext = null;
+            while (true) {
+                if (timedEventContext != null) {
+                    if (timedEventContext.insertionType == EventInsertionType.DEFERRED) {
+                        // The deferred event is ready to run.  Put it in the queue.
+                        head.insertBefore(timedEventContext);
+                    } else {
+                        timedEventContext.completeWithTimeout();
+                    }
+                    timedEventContext = null;
+                } else if (queuedEventContext != null) {
+                    queuedEventContext.run();
+                    queuedEventContext = null;
+                }
+                lock.lock();
+                try {
+                    long awaitNs = Long.MAX_VALUE;
+                    Map.Entry<Long, EventContext<?>> entry = delayMap.firstEntry();
+                    if (entry != null) {
+                        long now = SystemTime.SYSTEM.nanoseconds();
+                        if (entry.getKey() <= now || closingTimeNs <= now) {
+                            timedEventContext = entry.getValue();
+                            remove(timedEventContext);
+                            continue;
+                        }
+                        awaitNs = entry.getKey() - now;
+                    }
+                    if (head.next == head) {
+                        if (closingTimeNs != Long.MAX_VALUE) {
+                            // If there are no more entries to process, and the queue is
+                            // closing, exit the thread.
+                            return;
+                        }
+                    } else {
+                        queuedEventContext = head.next;
+                        remove(queuedEventContext);
+                        continue;
+                    }
+                    if (closingTimeNs != Long.MAX_VALUE) {
+                        long now = SystemTime.SYSTEM.nanoseconds();
+                        if (awaitNs > closingTimeNs - now) {
+                            awaitNs = closingTimeNs - now;
+                        }
+                    }
+                    if (awaitNs == Long.MAX_VALUE) {
+                        cond.await();
+                    } else {
+                        cond.awaitNanos(awaitNs);
+                    }
+                } finally {
+                    lock.unlock();
+                }
+            }
+        }
+
+        void enqueue(EventContext<?> eventContext,
+                     Function<Long, Long> deadlineNsCalculator) {
+            lock.lock();
+            try {
+                Long existingDeadlineNs = null;
+                if (eventContext.tag != null) {
+                    EventContext<?> toRemove =
+                        tagToEventContext.put(eventContext.tag, eventContext);
+                    if (toRemove != null) {
+                        existingDeadlineNs = toRemove.deadlineNs;
+                        remove(toRemove);
+                        toRemove.cancel();
+                    }
+                }
+                Long deadlineNs = deadlineNsCalculator.apply(existingDeadlineNs);
+                boolean queueWasEmpty = head.isSingleton();
+                boolean shouldSignal = false;
+                switch (eventContext.insertionType) {
+                    case APPEND:
+                        head.insertBefore(eventContext);
+                        if (queueWasEmpty) {
+                            shouldSignal = true;
+                        }
+                        break;
+                    case PREPEND:
+                        head.insertAfter(eventContext);
+                        if (queueWasEmpty) {
+                            shouldSignal = true;
+                        }
+                        break;
+                    case DEFERRED:
+                        if (deadlineNs == null) {
+                            throw new RuntimeException("Deferred event must have a deadline.");
+                        }
+                        break;
+                }
+                if (deadlineNs != null) {
+                    long insertNs =  deadlineNs;
+                    long prevStartNs = delayMap.isEmpty() ? Long.MAX_VALUE : delayMap.firstKey();
+                    // If the time in nanoseconds is already taken, take the next one.
+                    while (delayMap.putIfAbsent(insertNs, eventContext) != null) {
+                        insertNs++;
+                    }
+                    eventContext.deadlineNs = insertNs;
+                    // If the new timeout is before all the existing ones, wake up the
+                    // timeout thread.
+                    if (insertNs <= prevStartNs) {
+                        shouldSignal = true;
+                    }
+                }
+                if (shouldSignal) {
+                    cond.signal();
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    private final ReentrantLock lock;
+    private final Logger log;
+    private final Supplier<Throwable> closedExceptionSupplier;
+    private final EventHandler eventHandler;
+    private final Thread eventHandlerThread;
+    private long closingTimeNs;
+    private Event<?> cleanupEvent;
+
+    public KafkaEventQueue(LogContext logContext,
+                           String threadNamePrefix) {
+        this(logContext, threadNamePrefix, TimeoutException::new);
+    }
+
+    public KafkaEventQueue(LogContext logContext,
+                           String threadNamePrefix,
+                           Supplier<Throwable> closedExceptionSupplier) {
+        this.lock = new ReentrantLock();
+        this.log = logContext.logger(KafkaEventQueue.class);
+        this.closedExceptionSupplier = closedExceptionSupplier;
+        this.eventHandler = new EventHandler();
+        this.eventHandlerThread = new KafkaThread(threadNamePrefix + "EventHandler",
+            this.eventHandler, false);
+        this.closingTimeNs = Long.MAX_VALUE;
+        this.cleanupEvent = null;
+        this.eventHandlerThread.start();
+    }
+
+    @Override
+    public <T> CompletableFuture<T> enqueue(EventInsertionType insertionType,
+                                            String tag,
+                                            Function<Long, Long> deadlineNsCalculator,
+                                            Event<T> event) {
+        lock.lock();
+        try {
+            EventContext<T> eventContext = new EventContext<>(event, insertionType, tag);
+            if (closingTimeNs != Long.MAX_VALUE) {
+                eventContext.completeWithException(closedExceptionSupplier.get());
+                return eventContext.future;
+            }
+            eventHandler.enqueue(eventContext,
+                deadlineNsCalculator == null ? __ -> null : deadlineNsCalculator);
+            return eventContext.future;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void beginShutdown(Event<?> newCleanupEvent, TimeUnit timeUnit, long timeSpan) {
+        if (timeSpan < 0) {
+            throw new IllegalArgumentException("beginShutdown must be called with a " +
+                "non-negative timeout.");
+        }
+        Objects.requireNonNull(newCleanupEvent);
+        lock.lock();
+        try {
+            if (cleanupEvent != null) {
+                log.debug("Event queue is already shut down.");
+                return;
+            }
+            cleanupEvent = newCleanupEvent;
+            long newClosingTimeNs = Time.SYSTEM.nanoseconds() + timeUnit.toNanos(timeSpan);
+            if (closingTimeNs >= newClosingTimeNs)
+                closingTimeNs = newClosingTimeNs;
+            eventHandler.cond.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void close() throws InterruptedException {
+        beginShutdown();
+        eventHandlerThread.join();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/KafkaEventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/KafkaEventQueue.java
@@ -253,7 +253,7 @@ public final class KafkaEventQueue implements EventQueue {
             }
         }
 
-        void enqueue(EventContext<?> eventContext,
+        private void enqueue(EventContext<?> eventContext,
                      Function<Long, Long> deadlineNsCalculator) {
             lock.lock();
             try {

--- a/clients/src/test/java/org/apache/kafka/common/utils/KafkaEventQueueTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/KafkaEventQueueTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.utils;
+
+import org.apache.kafka.common.errors.TimeoutException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class KafkaEventQueueTest {
+    @Rule
+    final public Timeout globalTimeout = Timeout.millis(120000);
+
+    @Test
+    public void testCreateAndClose() throws Exception {
+        KafkaEventQueue queue =
+            new KafkaEventQueue(new LogContext(), "testCreateAndClose");
+        queue.close();
+    }
+
+    @Test
+    public void testHandleEvents() throws Exception {
+        KafkaEventQueue queue =
+            new KafkaEventQueue(new LogContext(), "testHandleEvents");
+        AtomicInteger numEventsExecuted = new AtomicInteger(0);
+        CompletableFuture<Integer> future1 = queue.prepend(
+            () -> {
+                assertEquals(1, numEventsExecuted.incrementAndGet());
+                return 1;
+            });
+        CompletableFuture<Integer> future2 = queue.appendWithDeadline(
+            Time.SYSTEM.nanoseconds() + TimeUnit.SECONDS.toNanos(30),
+            () -> {
+                assertEquals(2, numEventsExecuted.incrementAndGet());
+                return 2;
+            });
+        CompletableFuture<Integer> future3 = queue.append(
+            () -> {
+                assertEquals(3, numEventsExecuted.incrementAndGet());
+                return 3;
+            });
+        assertEquals(Integer.valueOf(1), future1.get());
+        assertEquals(Integer.valueOf(3), future3.get());
+        assertEquals(Integer.valueOf(2), future2.get());
+        queue.appendWithDeadline(
+            Time.SYSTEM.nanoseconds() + TimeUnit.SECONDS.toNanos(30),
+            () -> {
+                assertEquals(4, numEventsExecuted.incrementAndGet());
+                return 4;
+            }).get();
+        queue.beginShutdown();
+        queue.close();
+    }
+
+    @Test
+    public void testTimeouts() throws Exception {
+        KafkaEventQueue queue =
+            new KafkaEventQueue(new LogContext(), "testTimeouts");
+        AtomicInteger numEventsExecuted = new AtomicInteger(0);
+        CompletableFuture<Integer> future1 = queue.append(
+            () -> {
+                assertEquals(1, numEventsExecuted.incrementAndGet());
+                return 1;
+            });
+        CompletableFuture<Integer> future2 = queue.append(
+            () -> {
+                assertEquals(2, numEventsExecuted.incrementAndGet());
+                Time.SYSTEM.sleep(1);
+                return 2;
+            });
+        CompletableFuture<Integer> future3 = queue.appendWithDeadline(
+            Time.SYSTEM.nanoseconds() + 1,
+            () -> {
+                numEventsExecuted.incrementAndGet();
+                return 3;
+            });
+        CompletableFuture<Integer> future4 = queue.append(
+            () -> {
+                numEventsExecuted.incrementAndGet();
+                return 4;
+            });
+        assertEquals(Integer.valueOf(1), future1.get());
+        assertEquals(Integer.valueOf(2), future2.get());
+        assertEquals(Integer.valueOf(4), future4.get());
+        assertEquals(TimeoutException.class,
+            assertThrows(ExecutionException.class,
+                () -> future3.get()).getCause().getClass());
+        queue.close();
+        assertEquals(3, numEventsExecuted.get());
+    }
+
+    @Test
+    public void testScheduleDeferred() throws Exception {
+        KafkaEventQueue queue =
+            new KafkaEventQueue(new LogContext(), "testAppendDeferred");
+
+        // Wait for the deferred event to happen after the non-deferred event.
+        // It may not happpen every time, so we keep trying until it does.
+        AtomicLong counter = new AtomicLong(0);
+        CompletableFuture<Boolean> future1;
+        do {
+            counter.addAndGet(1);
+            future1 = queue.scheduleDeferred(null, __ -> Time.SYSTEM.nanoseconds() + 1000000,
+                () -> counter.get() % 2 == 0);
+            CompletableFuture<Long> future2 = queue.append(() -> counter.addAndGet(1));
+            future2.get();
+        } while (!future1.get());
+        queue.close();
+    }
+
+    private final static long ONE_HOUR_NS = TimeUnit.NANOSECONDS.convert(1, TimeUnit.HOURS);
+
+    @Test
+    public void testScheduleDeferredWithTagReplacement() throws Exception {
+        KafkaEventQueue queue =
+            new KafkaEventQueue(new LogContext(), "testScheduleDeferredWithTagReplacement");
+
+        AtomicInteger ai = new AtomicInteger(0);
+        CompletableFuture<Integer> future1 = queue.
+            scheduleDeferred("foo", __ -> Time.SYSTEM.nanoseconds() + ONE_HOUR_NS,
+                () -> ai.addAndGet(1000));
+        CompletableFuture<Integer> future2 = queue.
+            scheduleDeferred("foo", prev -> prev - ONE_HOUR_NS,
+                () -> ai.addAndGet(1));
+        assertThrows(CancellationException.class, () -> future1.get());
+        assertEquals(Integer.valueOf(1), future2.get());
+        assertEquals(1, ai.get());
+        queue.close();
+    }
+
+    @Test
+    public void testDeferredIsQueuedAfterTriggering() throws Exception {
+        KafkaEventQueue queue =
+            new KafkaEventQueue(new LogContext(), "testDeferredIsQueuedAfterTriggering");
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        AtomicInteger count = new AtomicInteger(0);
+        List<CompletableFuture<Integer>> futures = new ArrayList<>();
+        futures.add(queue.append(() -> {
+            latch.await();
+            return count.getAndAdd(1);
+        }));
+        futures.add(queue.append(() -> count.getAndAdd(1)));
+        futures.add(queue.append(() -> count.getAndAdd(1)));
+        futures.add(queue.scheduleDeferred("foo",
+            __ -> Time.SYSTEM.nanoseconds() + 1L,
+            () -> {
+                int value = count.getAndAdd(1);
+                if (value != 3) {
+                    throw new RuntimeException("invalid ordering.");
+                }
+                return value;
+            }));
+        latch.countDown();
+        int i = 0;
+        for (CompletableFuture<Integer> future : futures) {
+            assertEquals(Integer.valueOf(i++), future.get());
+        }
+        queue.close();
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/utils/KafkaEventQueueTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/KafkaEventQueueTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertThrows;
 
 public class KafkaEventQueueTest {
     @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
+    final public Timeout globalTimeout = Timeout.seconds(20);
 
     @Test
     public void testCreateAndClose() throws Exception {
@@ -168,7 +168,7 @@ public class KafkaEventQueueTest {
             latch.await();
             return count.getAndAdd(1);
         }));
-        futures.add(queue.append(() -> count.getAndAdd(1)));
+        futures.add(queue.append(() -> count.getAndAdd(1) ));
         futures.add(queue.append(() -> count.getAndAdd(1)));
         futures.add(queue.scheduleDeferred("foo",
             __ -> Time.SYSTEM.nanoseconds() + 1L,
@@ -180,10 +180,10 @@ public class KafkaEventQueueTest {
                 return value;
             }));
         latch.countDown();
-        int i = 0;
-        for (CompletableFuture<Integer> future : futures) {
-            assertEquals(Integer.valueOf(i++), future.get());
-        }
+        assertEquals(Integer.valueOf(0), futures.get(0).get());
+        assertEquals(Integer.valueOf(1), futures.get(1).get());
+        assertEquals(Integer.valueOf(2), futures.get(2).get());
+        assertEquals(Integer.valueOf(3), futures.get(3).get());
         queue.close();
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/KafkaEventQueueTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/KafkaEventQueueTest.java
@@ -168,7 +168,7 @@ public class KafkaEventQueueTest {
             latch.await();
             return count.getAndAdd(1);
         }));
-        futures.add(queue.append(() -> count.getAndAdd(1) ));
+        futures.add(queue.append(() -> count.getAndAdd(1)));
         futures.add(queue.append(() -> count.getAndAdd(1)));
         futures.add(queue.scheduleDeferred("foo",
             __ -> Time.SYSTEM.nanoseconds() + 1L,

--- a/clients/src/test/java/org/apache/kafka/common/utils/KafkaEventQueueTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/KafkaEventQueueTest.java
@@ -186,4 +186,18 @@ public class KafkaEventQueueTest {
         assertEquals(Integer.valueOf(3), futures.get(3).get());
         queue.close();
     }
+
+    @Test
+    public void testShutdownBeforeDeferred() throws Exception {
+        KafkaEventQueue queue =
+            new KafkaEventQueue(new LogContext(), "testShutdownBeforeDeferred");
+        final AtomicInteger count = new AtomicInteger(0);
+        CompletableFuture<Integer> future = queue.scheduleDeferred("myDeferred",
+            __ -> SystemTime.SYSTEM.nanoseconds() + TimeUnit.HOURS.toNanos(1),
+            () -> count.getAndAdd(1));
+        queue.beginShutdown();
+        assertThrows(ExecutionException.class, () -> future.get());
+        assertEquals(0, count.get());
+        queue.close();
+    }
 }

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -281,6 +281,15 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <!-- Suppress a warning about ignoring the return value of await.
+             This is done intentionally because we use other clues to determine
+             if the wait was cut short.  -->
+        <Package name="org.apache.kafka.common.utils"/>
+        <Source name="KafkaEventQueue.java"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED,RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+    </Match>
+
+    <Match>
         <!-- Suppress some warnings about intentional switch statement fallthrough. -->
         <Class name="org.apache.kafka.connect.runtime.WorkerConnector"/>
         <Or>


### PR DESCRIPTION
Add an event queue for use with the new Kafka Controller.  It supports
deferred operations, as well as timeouts on events.