### PR TITLE
MINOR: Bump CCS streams version to 6.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,8 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
+#  - streams/quickstart/pom.xml
+#  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 version=6.0.1-ccs-SNAPSHOT
 scalaVersion=2.13.2
 task=build

--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>6.0.0-ccs-SNAPSHOT</kafka.version>
+        <kafka.version>6.0.1-ccs-SNAPSHOT</kafka.version>
         <slf4j.version>1.7.7</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
     </properties>


### PR DESCRIPTION
I missed bumping the version in this file from https://github.com/confluentinc/kafka/commit/16373a23d9fafe20113dbceea3f9f5db1c8b3478

I've added notes about these files in gradle.properties.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
