### PR TITLE
MINOR: CCS Version Bump to 5.5.3-ccs-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
-version=5.5.2-ccs-SNAPSHOT
+version=5.5.3-ccs-SNAPSHOT
 scalaVersion=2.12.10
 task=build
 org.gradle.jvmargs=-Xmx1024m -Xss2m

--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>2.5.2-SNAPSHOT</kafka.version>
+        <kafka.version>5.5.3-ccs-SNAPSHOT</kafka.version>
         <slf4j.version>1.7.7</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
     </properties>

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>5.5.3-ce-SNAPSHOT</version>
 
     <name>Kafka Streams :: Quickstart</name>
 

--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -22,4 +22,4 @@
 # Instead, in development branches, the version should have a suffix of the form ".devN"
 #
 # For example, when Kafka is at version 1.0.0-SNAPSHOT, this should be something like "1.0.0.dev0"
-__version__ = '5.5.2.dev0'
+__version__ = '5.5.3.dev0'

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -65,7 +65,7 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("5.5.2-SNAPSHOT")
+DEV_VERSION = KafkaVersion("5.5.3-SNAPSHOT")
 
 # 0.8.2.x versions
 V_0_8_2_1 = KafkaVersion("0.8.2.1")


### PR DESCRIPTION
With 5.5.2 out the door, its time to bump the versions in CCS Kafka to 5.5.3


- In the past we've not bumped the streams versions from AK to CCS
versions, but we should begin.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
