### PR TITLE
KAFKA-9584: Fix Headers ConcurrentModificationException in Streams (#8181)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -68,7 +68,6 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
  */
 public class StreamTask extends AbstractTask implements ProcessorNodePunctuator {
 
-    private static final ConsumerRecord<Object, Object> DUMMY_RECORD = new ConsumerRecord<>(ProcessorContextImpl.NONEXIST_TOPIC, -1, -1L, null, null);
     // visible for testing
     static final byte LATEST_MAGIC_BYTE = 1;
 
@@ -435,7 +434,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             throw new IllegalStateException(String.format("%sCurrent node is not null", logPrefix));
         }
 
-        updateProcessorContext(new StampedRecord(DUMMY_RECORD, timestamp), node);
+        updateProcessorContext(new StampedRecord(new ConsumerRecord<>(ProcessorContextImpl.NONEXIST_TOPIC, -1, -1L, null, null),
+            timestamp), node);
 
         if (log.isTraceEnabled()) {
             log.trace("Punctuating processor {} with timestamp {} and punctuation type {}", node.name(), timestamp, type);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1132,6 +1132,20 @@ public class StreamTaskTest {
     }
 
     @Test
+    public void shouldNotShareHeadersBetweenPunctuateIterations() {
+        task = createStatelessTask(createConfig(false), StreamsConfig.METRICS_LATEST);
+        task.initializeMetadata();
+        task.initializeTopology();
+
+        task.punctuate(processorSystemTime, 1, PunctuationType.WALL_CLOCK_TIME, timestamp -> {
+            task.processorContext.recordContext().headers().add("dummy", (byte[]) null);
+        });
+        task.punctuate(processorSystemTime, 1, PunctuationType.WALL_CLOCK_TIME, timestamp -> {
+            assertFalse(task.processorContext.recordContext().headers().iterator().hasNext());
+        });
+    }
+
+    @Test
     public void shouldCheckpointOffsetsOnCommit() throws IOException {
         task = createStatefulTask(createConfig(false), true);
         task.initializeStateStores();


### PR DESCRIPTION
Avoid forwarding a shared reference to the record context in punctuate calls.
Note, this fix isn't airtight, since all processors triggered by a single punctuate
call will still see the same reference to the record context. It's also not a terribly
principled approach, since the context is still technically not defined, but this
is about the best we can do without significant refactoring. We will probably
follow up with a more comprehensive solution, but this should avoid the issue
for most programs.

Reviewers: Matthias J. Sax <mjsax@apache.org>, John Roesler <vvcephei@apache.org>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
