### PR TITLE
MINOR: Fix a Scala 2.11 compile error in GroupMetadataManagerTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,6 +307,7 @@ subprojects {
 
   test {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+    ignoreFailures = userIgnoreFailures
 
     minHeapSize = "256m"
     maxHeapSize = "2048m"

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.common.requests.OffsetFetchResponse
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.KafkaException
 import org.easymock.{Capture, EasyMock, IAnswer}
-import org.junit.Assert.{assertEquals, assertFalse, assertNull, assertTrue, assertThrows}
+import org.junit.Assert.{assertEquals, assertFalse, assertNull, assertTrue}
 import org.junit.{Before, Test}
 import org.scalatest.Assertions.fail
 import java.nio.ByteBuffer
@@ -815,9 +815,13 @@ class GroupMetadataManagerTest {
     // reset the position to the starting position 0 so that it can read the data in correct order
     groupMetadataRecordValue.position(0)
 
-    val e = assertThrows(classOf[KafkaException],
-      () => GroupMetadataManager.readGroupMessageValue(groupId, groupMetadataRecordValue, time))
-    assertEquals(s"Unknown group metadata version ${unsupportedVersion}", e.getMessage)
+    try {
+      GroupMetadataManager.readGroupMessageValue(groupId, groupMetadataRecordValue, time)
+      fail("Expected KafkaException here")
+    } catch {
+      case e: KafkaException => assertEquals(s"Unknown group metadata version ${unsupportedVersion}", e.getMessage)
+      case _ => fail("Expected KafkaException here")
+    }
   }
 
   @Test


### PR DESCRIPTION
Seeing this build failure:

```
core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala:818: overloaded method value assertThrows with alternatives:
[T <: Throwable](x$1: String, x$2: Class[T], x$3: org.junit.function.ThrowingRunnable)T <and>
[T <: Throwable](x$1: Class[T], x$2: org.junit.function.ThrowingRunnable)T
cannot be applied to (Class[org.apache.kafka.common.KafkaException], () => kafka.coordinator.group.GroupMetadata)
val e = assertThrows(classOf[KafkaException],
```

So this is a backport of the `GroupMetadataManagerTest` test fix from here: https://github.com/apache/kafka/commit/63f3e1c33b03870c5d4fe2dba40cf385cfab6dca

Change applied cleanly except for the conflict in Jenkinsfile, but I just discarded that change.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
