### PR TITLE
Hook up MetaLogManager.Listener to broker and simplify event processing loop

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServerManager.scala
+++ b/core/src/main/scala/kafka/server/KafkaServerManager.scala
@@ -46,16 +46,16 @@ object KafkaServerManager extends Logging {
       if (config.controllerConnect.isEmpty) {
         throw new RuntimeException(s"You must specify a value for ${KafkaConfig.ControllerConnectProp}")
       }
-      roles.asScala.foreach(role => role match {
+      roles.asScala.foreach {
         case "broker" =>
           kip500Broker = Some(new Kip500Broker(config, time,
             threadNamePrefix, kafkaMetricsReporters))
         case "controller" =>
           controller = Some(new Kip500Controller(config, time, threadNamePrefix,
             kafkaMetricsReporters, CompletableFuture.completedFuture(config.controllerConnect)))
-        case _ =>
+        case role =>
           throw new RuntimeException("Unknown process role " + role)
-      })
+      }
       val bld = new StringBuilder
       var prefix = ""
       bld.append("Starting ")

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -18,19 +18,16 @@
 package kafka.server.metadata
 
 import java.util
-import java.util.concurrent.locks.ReentrantLock
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.LinkedBlockingQueue
 
 import kafka.coordinator.group.GroupCoordinator
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.{KafkaConfig, MetadataCache, QuotaFactory, ReplicaManager}
 import kafka.utils.ShutdownableThread
-import org.apache.kafka.common.internals.FatalExitError
 import org.apache.kafka.common.protocol.ApiMessage
 import org.apache.kafka.common.utils.Time
-
-import scala.collection.mutable.ListBuffer
+import org.apache.kafka.controller.MetaLogManager
 
 object BrokerMetadataListener {
   val ThreadNamePrefix = "broker-"
@@ -54,17 +51,15 @@ object BrokerMetadataListener {
 /**
  * A metadata event appearing either in the metadata log or originating out-of-band from the broker's heartbeat
  */
-sealed trait BrokerMetadataEvent {}
-
-final case object StartupEvent extends BrokerMetadataEvent
+sealed trait BrokerMetadataEvent
 
 /**
  * A batch of messages from the metadata log
  *
  * @param apiMessages the batch of messages
- * @param lastMetadataOffset the metadata offset of the last message in the batch
+ * @param lastOffset the metadata offset of the last message in the batch
  */
-final case class MetadataLogEvent(apiMessages: List[ApiMessage], lastMetadataOffset: Long) extends BrokerMetadataEvent
+final case class MetadataLogEvent(apiMessages: util.List[ApiMessage], lastOffset: Long) extends BrokerMetadataEvent
 
 /**
  * A register-broker event that occurs when the broker heartbeat receives a successful registration response.
@@ -74,7 +69,7 @@ final case class MetadataLogEvent(apiMessages: List[ApiMessage], lastMetadataOff
  *
  * @param brokerEpoch the epoch assigned to the broker by the active controller
  */
-final case class OutOfBandRegisterLocalBrokerEvent(brokerEpoch: Long) extends BrokerMetadataEvent
+final case class RegisterBrokerEvent(brokerEpoch: Long) extends BrokerMetadataEvent
 
 /**
  * A fence-broker event that occurs when either:
@@ -88,63 +83,58 @@ final case class OutOfBandRegisterLocalBrokerEvent(brokerEpoch: Long) extends Br
  *
  * @param brokerEpoch the broker epoch that was fenced
  */
-final case class OutOfBandFenceLocalBrokerEvent(brokerEpoch: Long) extends BrokerMetadataEvent
+final case class FenceBrokerEvent(brokerEpoch: Long) extends BrokerMetadataEvent
 
-/*
- * WakeupEvent is necessary for the case when the event thread is blocked in queue.take() and we need to wake it up.
- * This event has no other semantic meaning and should be ignored when seen.  It is useful in two specific situations:
- * 1) when an out-of-band message is available; and 2) when shutdown needs to occur.  The presence of this message
- * ensures these other messages are seen quickly when no other messages are in the queue.
+/**
+ * Used to wakeup the polling thread in order to shutdown.
  */
-final case object WakeupEvent extends BrokerMetadataEvent
+case object ShutdownEvent extends BrokerMetadataEvent
 
-class QueuedEvent(val event: BrokerMetadataEvent, val enqueueTimeNanos: Long) {
+class QueuedEvent(val event: BrokerMetadataEvent, val enqueueTimeMs: Long) {
   override def toString: String = {
-    s"QueuedEvent(event=$event, enqueueTimeNanos=$enqueueTimeNanos)"
+    s"QueuedEvent(event=$event, enqueueTimeMs=$enqueueTimeMs)"
   }
 }
 
 trait BrokerMetadataProcessor {
-  def processStartup(): Unit
-  def process(metadataLogEvent: MetadataLogEvent): Unit
-  def process(outOfBandRegisterLocalBrokerEvent: OutOfBandRegisterLocalBrokerEvent): Unit
-  def process(outOfBandFenceLocalBrokerEvent: OutOfBandFenceLocalBrokerEvent): Unit
+  def process(event: BrokerMetadataEvent): Unit
 }
 
-class BrokerMetadataListener(config: KafkaConfig,
-                             time: Time,
-                             processors: List[BrokerMetadataProcessor],
-                             eventQueueTimeHistogramTimeoutMs: Long = 300000) extends KafkaMetricsGroup {
+class BrokerMetadataListener(
+  config: KafkaConfig,
+  time: Time,
+  processors: List[BrokerMetadataProcessor],
+) extends MetaLogManager.Listener with KafkaMetricsGroup  {
+
   if (processors.isEmpty) {
     throw new IllegalArgumentException(s"Empty processors list!")
   }
 
-  private val deque = new util.LinkedList[QueuedEvent]
-  private val dequeLock = new ReentrantLock()
-  private val dequeNonEmptyCondition = dequeLock.newCondition()
-
-  @volatile private var dequeSize: Int = 0
-  @volatile private var errorCount: Int = 0
-
+  private val queue = new LinkedBlockingQueue[QueuedEvent]()
   private val thread = new BrokerMetadataEventThread(
     s"${BrokerMetadataListener.ThreadNamePrefix}${config.brokerId}${BrokerMetadataListener.ThreadNameSuffix}")
 
   // metrics
   private val eventQueueTimeHist = newHistogram(BrokerMetadataListener.EventQueueTimeMetricName)
-  newGauge(BrokerMetadataListener.EventQueueSizeMetricName, () => dequeSize)
-  newGauge(BrokerMetadataListener.ErrorCountMetricName, () => errorCount)
+  newGauge(BrokerMetadataListener.EventQueueSizeMetricName, () => queue.size)
 
   @volatile private var _currentMetadataOffset: Long = -1
 
   def start(): Unit = {
-    put(StartupEvent)
     thread.start()
+  }
+
+  // For testing, it is useful to be able to drain all events synchronously
+  def drain(): Unit = {
+    while (!queue.isEmpty) {
+      thread.doWork()
+    }
   }
 
   def close(): Unit = {
     try {
       thread.initiateShutdown()
-      put(WakeupEvent) // wake up the thread in case it is blocked on queue.take()
+      put(ShutdownEvent) // wake up the thread in case it is blocked on queue.take()
       thread.awaitShutdown()
     } finally {
       removeMetric(BrokerMetadataListener.EventQueueTimeMetricName)
@@ -153,40 +143,13 @@ class BrokerMetadataListener(config: KafkaConfig,
     }
   }
 
+  override def handleCommits(lastOffset: Long, messages: util.List[ApiMessage]): Unit = {
+    put(MetadataLogEvent(messages, lastOffset))
+  }
+
   def put(event: BrokerMetadataEvent): QueuedEvent = {
-    val queuedEvent = new QueuedEvent(event, time.nanoseconds())
-    dequeLock.lock()
-    try {
-      event match {
-        case _: OutOfBandRegisterLocalBrokerEvent |
-             _: OutOfBandFenceLocalBrokerEvent =>
-          // we have to check to see if any out-of-band events are already at the front of the deque;
-          // if so, then we need to add this event after those
-          val listBuffer: ListBuffer[QueuedEvent] = new ListBuffer()
-          var nextEvent = deque.peekFirst()
-          while (nextEvent != null && {
-            nextEvent.event match {
-              case _: OutOfBandRegisterLocalBrokerEvent |
-                   _: OutOfBandFenceLocalBrokerEvent => true
-              case _ => false
-            }}) {
-            listBuffer += deque.pollFirst()
-            nextEvent = deque.peekFirst()
-          }
-          // we've removed any out-of-band events that were there
-          // so now add the one we want to add
-          deque.addFirst(queuedEvent)
-          // and then put back any out-of-band events that were there before (keeping their order unchanged)
-          listBuffer.reverseIterator.foreach(eventAlreadyThere => deque.addFirst(eventAlreadyThere))
-        case _ =>
-          // add this non-out-of-band message to the end of the deque
-          deque.addLast(queuedEvent)
-      }
-      dequeNonEmptyCondition.signal()
-      dequeSize += 1
-    } finally {
-      dequeLock.unlock()
-    }
+    val queuedEvent = new QueuedEvent(event, time.milliseconds())
+    queue.offer(queuedEvent)
     queuedEvent
   }
 
@@ -195,105 +158,33 @@ class BrokerMetadataListener(config: KafkaConfig,
   private class BrokerMetadataEventThread(name: String) extends ShutdownableThread(name = name, isInterruptible = false) {
     logIdent = s"[BrokerMetadataEventThread] "
 
-    override def doWork(): Unit = {
-      val dequeued: QueuedEvent = pollFromEventQueue()
-      try {
-        dequeued.event match {
-          case StartupEvent =>
-            processors.foreach(processor =>
-              try {
-                processor.processStartup()
-              } catch {
-                case e: FatalExitError => throw e
-                case e: Exception =>
-                  error(s"Uncaught error when processor $processor processed startup event", e)
-                  errorCount += 1
-              })
-          case WakeupEvent => // Ignore since it serves solely to wake us up
-          case metadataLogEvent: MetadataLogEvent =>
-            eventQueueTimeHist.update(TimeUnit.MILLISECONDS.convert(time.nanoseconds() - dequeued.enqueueTimeNanos, TimeUnit.NANOSECONDS))
-
-            val currentOffset = currentMetadataOffset()
-            if (metadataLogEvent.lastMetadataOffset < currentOffset + metadataLogEvent.apiMessages.size) {
-              error(s"Metadata offset of last message in batch of size ${metadataLogEvent.apiMessages.size}" +
-                s" is too small for current metadata offset $currentOffset: ${metadataLogEvent.lastMetadataOffset}")
-              errorCount += 1
-            } else {
-              // Give each processor an opportunity to process the batch.
-
-              // We could introduce queues, run each processor in a separate thread, and pipeline message batches to them.
-              // If we pipeline, then we would probably add a CompletableFuture to the process() method
-              // and we would have a separate thread/queue waiting on each batch's futures to complete before applying the
-              // corresponding metadata offset.
-              processors.foreach(processor =>
-                try {
-                  processor.process(metadataLogEvent) // synchronous, see above for an alternative
-                } catch {
-                  case e: FatalExitError => throw e
-                  case e: Exception =>
-                    error(s"Uncaught error when processor $processor processed metadata log event: $metadataLogEvent", e)
-                    errorCount += 1
-                })
-              // set the new offset now that all processors have processed the metadata log event
-              if (isTraceEnabled) {
-                trace(s"Setting current metadata offset to ${metadataLogEvent.lastMetadataOffset} after processing metadata log messages: ${metadataLogEvent.apiMessages}")
-              }
-              _currentMetadataOffset = metadataLogEvent.lastMetadataOffset
-            }
-          case outOfBandRegisterLocalBrokerEvent: OutOfBandRegisterLocalBrokerEvent =>
-            processors.foreach(processor =>
-              try {
-                processor.process(outOfBandRegisterLocalBrokerEvent)
-              } catch {
-                case e: FatalExitError => throw e
-                case e: Exception =>
-                  error(s"Uncaught error when processor $processor processed out-of-band register-broker event: $outOfBandRegisterLocalBrokerEvent", e)
-                  errorCount += 1
-              })
-          case outOfBandFenceLocalBrokerEvent: OutOfBandFenceLocalBrokerEvent =>
-            processors.foreach(processor =>
-              try {
-                processor.process(outOfBandFenceLocalBrokerEvent)
-              } catch {
-                case e: FatalExitError => throw e
-                case e: Exception =>
-                  error(s"Uncaught error when processor $processor processed out-of-band fence-broker event: $outOfBandFenceLocalBrokerEvent", e)
-                  errorCount += 1
-              })
-        }
-      } catch {
-        case e: FatalExitError => throw e
-        case e: Exception =>
-          error(s"Uncaught error when processing dequeued event: $dequeued", e)
-          errorCount += 1
-      }
+    private def process(event: BrokerMetadataEvent): Unit = {
+      processors.foreach(_.process(event))
     }
 
-    private def pollFromEventQueue(): QueuedEvent = {
-      dequeLock.lock()
-      try {
-        var nanosRemaining = TimeUnit.NANOSECONDS.convert(eventQueueTimeHistogramTimeoutMs, TimeUnit.MILLISECONDS)
-        while (deque.isEmpty()) { // takes care of spurious wakeups
-          val hasRecordedValue = eventQueueTimeHist.count() > 0
-          if (!hasRecordedValue) {
-            // wait indefinitely for something to appear
-            dequeNonEmptyCondition.await()
-          } else {
-            if (nanosRemaining <= 0) {
-              // no time left, so clear the histogram and wait indefinitely
-              eventQueueTimeHist.clear()
-              dequeNonEmptyCondition.await()
-            } else {
-              // wait only up until the timeout so we can clear the histogram if nothing appears
-              nanosRemaining = dequeNonEmptyCondition.awaitNanos(nanosRemaining)
-            }
+    override def doWork(): Unit = {
+      val dequeued = queue.poll()
+      val currentTimeMs = time.milliseconds()
+      eventQueueTimeHist.update(math.max(0, currentTimeMs - dequeued.enqueueTimeMs))
+
+      trace(s"Processing event ${dequeued.event}")
+      dequeued.event match {
+        case ShutdownEvent =>
+          // Do nothing since we are shutting down
+
+        case logEvent: MetadataLogEvent =>
+          if (logEvent.lastOffset < _currentMetadataOffset + logEvent.apiMessages.size) {
+            throw new IllegalStateException(s"Non-monotonic offset found in $logEvent. Our " +
+              s"current offset is $_currentMetadataOffset.")
           }
-        }
-        dequeSize -= 1
-        deque.poll()
-      } finally {
-        dequeLock.unlock()
+
+          process(logEvent)
+          _currentMetadataOffset = logEvent.lastOffset
+
+        case event =>
+          process(event)
       }
     }
   }
+
 }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -175,7 +175,7 @@ class BrokerMetadataListener(
         case logEvent: MetadataLogEvent =>
           if (logEvent.lastOffset < _currentMetadataOffset + logEvent.apiMessages.size) {
             throw new IllegalStateException(s"Non-monotonic offset found in $logEvent. Our " +
-              s"current offset is $_currentMetadataOffset.")
+              s"current offset is ${_currentMetadataOffset}.")
           }
 
           process(logEvent)

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -125,7 +125,7 @@ class BrokerMetadataListener(
   }
 
   // For testing, it is useful to be able to drain all events synchronously
-  def drain(): Unit = {
+  private[metadata] def drain(): Unit = {
     while (!queue.isEmpty) {
       thread.doWork()
     }

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -4,7 +4,7 @@ import java.io.IOException
 import java.util.Properties
 import java.util.concurrent.{Executors, TimeUnit}
 
-import kafka.server.metadata.{BrokerMetadataEvent, BrokerMetadataListener, OutOfBandFenceLocalBrokerEvent, OutOfBandRegisterLocalBrokerEvent, QueuedEvent}
+import kafka.server.metadata.{BrokerMetadataEvent, BrokerMetadataListener, FenceBrokerEvent, RegisterBrokerEvent, QueuedEvent}
 import org.apache.kafka.common.KafkaException
 import kafka.server.{BrokerLifecycleManagerImpl, BrokerToControllerChannelManager, Defaults, KafkaConfig}
 import kafka.utils.{MockTime, TestUtils}
@@ -110,7 +110,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     // Setup mock heartbeat response
@@ -151,8 +151,8 @@ class BrokerLifecycleManagerTest {
 
     // Verify BrokerMetadataListener notification
     assert(capturedMetadataEvent.hasCaptured)
-    assert(capturedMetadataEvent.getValue.isInstanceOf[OutOfBandRegisterLocalBrokerEvent])
-    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[OutOfBandRegisterLocalBrokerEvent].brokerEpoch, registrationEpoch)
+    assert(capturedMetadataEvent.getValue.isInstanceOf[RegisterBrokerEvent])
+    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[RegisterBrokerEvent].brokerEpoch, registrationEpoch)
 
     // Verify that only a single request was processed per scheduler tick
     EasyMock.verify(brokerToControllerChannel, brokerMetadataListener)
@@ -173,7 +173,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     // Setup mock heartbeat response
@@ -220,8 +220,8 @@ class BrokerLifecycleManagerTest {
 
     // Verify BrokerMetadataListener notification
     assert(capturedMetadataEvent.hasCaptured)
-    assert(capturedMetadataEvent.getValue.isInstanceOf[OutOfBandRegisterLocalBrokerEvent])
-    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[OutOfBandRegisterLocalBrokerEvent].brokerEpoch, registrationEpoch)
+    assert(capturedMetadataEvent.getValue.isInstanceOf[RegisterBrokerEvent])
+    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[RegisterBrokerEvent].brokerEpoch, registrationEpoch)
 
     // Verify that only a single request was processed per scheduler tick
     EasyMock.verify(brokerToControllerChannel, brokerMetadataListener)
@@ -241,7 +241,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     // Setup mock heartbeat response
@@ -291,8 +291,8 @@ class BrokerLifecycleManagerTest {
 
     // Verify BrokerMetadataListener notification
     assert(capturedMetadataEvent.hasCaptured)
-    assert(capturedMetadataEvent.getValue.isInstanceOf[OutOfBandRegisterLocalBrokerEvent])
-    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[OutOfBandRegisterLocalBrokerEvent].brokerEpoch, registrationEpoch)
+    assert(capturedMetadataEvent.getValue.isInstanceOf[RegisterBrokerEvent])
+    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[RegisterBrokerEvent].brokerEpoch, registrationEpoch)
 
     // Verify that only a single request was processed per scheduler tick
     EasyMock.verify(brokerToControllerChannel, brokerMetadataListener)
@@ -319,7 +319,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     // Setup mock heartbeat response
@@ -377,8 +377,8 @@ class BrokerLifecycleManagerTest {
 
     // Verify BrokerMetadataListener notification
     assert(capturedMetadataEvent.hasCaptured)
-    assert(capturedMetadataEvent.getValue.isInstanceOf[OutOfBandRegisterLocalBrokerEvent])
-    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[OutOfBandRegisterLocalBrokerEvent].brokerEpoch, registrationEpoch)
+    assert(capturedMetadataEvent.getValue.isInstanceOf[RegisterBrokerEvent])
+    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[RegisterBrokerEvent].brokerEpoch, registrationEpoch)
 
     // Verify that only a single request was processed per scheduler tick
     EasyMock.verify(brokerToControllerChannel, brokerMetadataListener)
@@ -400,7 +400,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     // Setup mock heartbeat response
@@ -448,8 +448,8 @@ class BrokerLifecycleManagerTest {
 
     // Verify BrokerMetadataListener notification
     assert(capturedMetadataEvent.hasCaptured)
-    assert(capturedMetadataEvent.getValue.isInstanceOf[OutOfBandRegisterLocalBrokerEvent])
-    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[OutOfBandRegisterLocalBrokerEvent].brokerEpoch, registrationEpoch)
+    assert(capturedMetadataEvent.getValue.isInstanceOf[RegisterBrokerEvent])
+    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[RegisterBrokerEvent].brokerEpoch, registrationEpoch)
 
     // Verify that only a single request was processed per scheduler tick
     EasyMock.verify(brokerToControllerChannel, brokerMetadataListener)
@@ -479,7 +479,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     // Setup mock heartbeat response
@@ -531,8 +531,8 @@ class BrokerLifecycleManagerTest {
 
     // Verify BrokerMetadataListener notification
     assert(capturedMetadataEvent.hasCaptured)
-    assert(capturedMetadataEvent.getValue.isInstanceOf[OutOfBandRegisterLocalBrokerEvent])
-    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[OutOfBandRegisterLocalBrokerEvent].brokerEpoch, registrationEpoch)
+    assert(capturedMetadataEvent.getValue.isInstanceOf[RegisterBrokerEvent])
+    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[RegisterBrokerEvent].brokerEpoch, registrationEpoch)
 
     // Verify that only a single request was processed per scheduler tick
     EasyMock.verify(brokerToControllerChannel, brokerMetadataListener)
@@ -571,7 +571,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     // Setup mock heartbeat response
@@ -646,8 +646,8 @@ class BrokerLifecycleManagerTest {
 
     // Verify BrokerMetadataListener notification
     assert(capturedMetadataEvent.hasCaptured)
-    assert(capturedMetadataEvent.getValue.isInstanceOf[OutOfBandFenceLocalBrokerEvent])
-    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[OutOfBandFenceLocalBrokerEvent].brokerEpoch, brokerEpochProvider())
+    assert(capturedMetadataEvent.getValue.isInstanceOf[FenceBrokerEvent])
+    assertEquals(capturedMetadataEvent.getValue.asInstanceOf[FenceBrokerEvent].brokerEpoch, brokerEpochProvider())
 
     // Verify that only a single request was processed per scheduler tick
     EasyMock.verify(brokerToControllerChannel)
@@ -683,7 +683,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     EasyMock.replay(brokerToControllerChannel, brokerMetadataListener)
@@ -735,7 +735,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     EasyMock.replay(brokerToControllerChannel, brokerMetadataListener)
@@ -786,7 +786,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     EasyMock.replay(brokerToControllerChannel, brokerMetadataListener)
@@ -831,7 +831,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     EasyMock.replay(brokerToControllerChannel, brokerMetadataListener)
@@ -882,7 +882,7 @@ class BrokerLifecycleManagerTest {
 
     val capturedMetadataEvent = EasyMock.newCapture[BrokerMetadataEvent]()
     EasyMock.expect(brokerMetadataListener.put(EasyMock.capture(capturedMetadataEvent))).andStubReturn(
-      new QueuedEvent(OutOfBandRegisterLocalBrokerEvent(registrationEpoch), time.nanoseconds)
+      new QueuedEvent(RegisterBrokerEvent(registrationEpoch), time.nanoseconds)
     )
 
     EasyMock.replay(brokerToControllerChannel, brokerMetadataListener)

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -17,35 +17,27 @@
 
 package kafka.server.metadata
 
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicInteger
-
 import com.yammer.metrics.core.{Gauge, Histogram, MetricName}
 import kafka.metrics.KafkaYammerMetrics
 import kafka.server.KafkaConfig
-import kafka.utils.TestUtils
+import org.apache.kafka.common.metadata.BrokerRecord
 import org.apache.kafka.common.protocol.ApiMessage
 import org.apache.kafka.common.utils.MockTime
 import org.junit.Assert.{assertEquals, assertTrue, fail}
-import org.junit.{After, Before, Test}
+import org.junit.Test
 import org.mockito.Mockito.mock
+import org.scalatest.Assertions.intercept
 
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 
 class BrokerMetadataListenerTest {
   val expectedMetricMBeanPrefix = "kafka.server.metadata:type=BrokerMetadataListener"
   val expectedEventQueueTimeMsMetricName = "EventQueueTimeMs"
-  val expectedErrorCountMetricName = "ErrorCount"
   val expectedEventQueueSizeMetricName = "EventQueueSize"
-  val errorCountMetricMBeanName = s"$expectedMetricMBeanPrefix,name=$expectedErrorCountMetricName"
   val eventQueueSizeMetricMBeanName = s"$expectedMetricMBeanPrefix,name=$expectedEventQueueSizeMetricName"
   val eventQueueTimeMsMetricMBeanName = s"$expectedMetricMBeanPrefix,name=$expectedEventQueueTimeMsMetricName"
 
-  def errorCountGauge() = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.filter {
-    case (k, _) => k.getMBeanName == errorCountMetricMBeanName
-  }.values.headOption.getOrElse(fail(s"Unable to find metric $errorCountMetricMBeanName")).asInstanceOf[Gauge[Int]]
   def eventQueueSizeGauge() = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.filter {
     case (k, _) => k.getMBeanName == eventQueueSizeMetricMBeanName
   }.values.headOption.getOrElse(fail(s"Unable to find metric $eventQueueSizeMetricMBeanName")).asInstanceOf[Gauge[Int]]
@@ -58,34 +50,7 @@ class BrokerMetadataListenerTest {
       .toSet
   }
 
-  var brokerMetadataListener: Option[BrokerMetadataListener] = None
   val expectedInitialMetadataOffset = -1
-
-  val processor1Key = "processor1"
-  val processor2Key = "processor2"
-  val processorKeys = List(processor1Key, processor2Key)
-  val metadataLogEventInvocations = mutable.Map[String, ListBuffer[MetadataLogEvent]]()
-  val outOfBandRegisterLocalBrokerInvocations = mutable.Map[String, ListBuffer[OutOfBandRegisterLocalBrokerEvent]]()
-  val outOfbandFenceLocalBrokerInvocations = mutable.Map[String, ListBuffer[OutOfBandFenceLocalBrokerEvent]]()
-  val numStartupEventsProcessed = mutable.Map[String, Int]()
-  var numEventsProcessed = 0
-
-  @Before
-  def setUp(): Unit = {
-    brokerMetadataListener = None
-    processorKeys.foreach(key => {
-      metadataLogEventInvocations.put(key, ListBuffer.empty)
-      outOfBandRegisterLocalBrokerInvocations.put(key, ListBuffer.empty)
-      outOfbandFenceLocalBrokerInvocations.put(key, ListBuffer.empty)
-      numStartupEventsProcessed.put(key, 0)
-      numEventsProcessed = 0
-    })
-  }
-
-  @After
-  def tearDown(): Unit = {
-    brokerMetadataListener.foreach(_.close())
-  }
 
   @Test(expected = classOf[IllegalArgumentException])
   def testEmptyBrokerMetadataProcessors(): Unit = {
@@ -94,123 +59,74 @@ class BrokerMetadataListenerTest {
 
   @Test
   def testEventIsProcessedAfterStartup(): Unit = {
-    val processedEvents = mutable.Buffer.empty[List[ApiMessage]]
-    val metadataLogEventIndicator = List(mock(classOf[ApiMessage]))
-    val startupEventIndicator = mock(classOf[ApiMessage]) :: metadataLogEventIndicator
+    val processor = new MockMetadataProcessor
+    val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List(processor))
 
-    val brokerMetadataProcessor = new BrokerMetadataProcessor {
-      override def processStartup(): Unit = {
-        processedEvents += startupEventIndicator
-      }
-      override def process(metadataLogEvent: MetadataLogEvent): Unit = {
-        processedEvents += metadataLogEvent.apiMessages
-      }
-      def process(outOfBandFenceLocalBrokerEvent: OutOfBandFenceLocalBrokerEvent): Unit = {}
-      def process(outOfBandRegisterLocalBrokerEvent: OutOfBandRegisterLocalBrokerEvent): Unit = {}
-    }
-
-    val listener = start(new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List(brokerMetadataProcessor)))
-
-    listener.put(MetadataLogEvent(metadataLogEventIndicator, 1))
-    TestUtils.waitUntilTrue(() => processedEvents.size == 2,
-      s"Failed to process expected event before timing out; processed events = ${processedEvents.size}", 5000)
-    assertEquals(startupEventIndicator, processedEvents(0))
-    assertEquals(metadataLogEventIndicator, processedEvents(1))
+    val metadataLogEvent = MetadataLogEvent(List[ApiMessage](new BrokerRecord()).asJava, 1)
+    listener.put(metadataLogEvent)
+    listener.drain()
+    assertEquals(List(metadataLogEvent), processor.processed.toList)
   }
 
   @Test
   def testInitialAndSubsequentMetadataOffsets(): Unit = {
-    val listener = start(new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(),
-      twoProcessorsCountingInvocations(processorKeys)))
+    val processor = new MockMetadataProcessor
+    val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List(processor))
     assertEquals(expectedInitialMetadataOffset, listener.currentMetadataOffset())
 
     val nextMetadataOffset = expectedInitialMetadataOffset + 2
     val msg0 = mock(classOf[ApiMessage])
     val msg1 = mock(classOf[ApiMessage])
     val apiMessages = List(msg0, msg1)
-    val event = MetadataLogEvent(apiMessages, nextMetadataOffset)
+    val event = MetadataLogEvent(apiMessages.asJava, nextMetadataOffset)
     listener.put(event)
-
-    val expectedNumEventsProcessedPerKey = 2 // 1 successful message + 1 startup
-    TestUtils.waitUntilTrue(() => numEventsProcessed == processorKeys.size * expectedNumEventsProcessedPerKey,
-      s"Failed to process expected event before timing out; processed events = $numEventsProcessed", 5000)
-
-    // offset should be updated
+    listener.drain()
+    assertEquals(List(event), processor.processed.toList)
     assertEquals(nextMetadataOffset, listener.currentMetadataOffset())
-
-    // record should be processed
-    processorKeys.foreach(key => {
-      assertEquals(1, numStartupEventsProcessed.get(key).get)
-      assertEquals(1, metadataLogEventInvocations.get(key).get.size)
-      assertEquals(metadataLogEventInvocations.get(key).get.head, event)
-      assertEquals(0, outOfBandRegisterLocalBrokerInvocations.get(key).get.size)
-      assertEquals(0, outOfbandFenceLocalBrokerInvocations.get(key).get.size)
-    })
-    // there should be no errors
-    assertEquals(0, errorCountGauge().value())
   }
 
   @Test
   def testOutOfBandHeartbeatMessages(): Unit = {
-    val listener = start(new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(),
-      twoProcessorsCountingInvocations(processorKeys)))
+    val processor = new MockMetadataProcessor
+    val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List(processor))
     assertEquals(expectedInitialMetadataOffset, listener.currentMetadataOffset())
 
-    val msg0 = OutOfBandRegisterLocalBrokerEvent(1)
-    val msg1 = OutOfBandFenceLocalBrokerEvent(1)
+    val msg0 = RegisterBrokerEvent(1)
+    val msg1 = FenceBrokerEvent(1)
     listener.put(msg0)
     listener.put(msg1)
-
-    val expectedNumEventsProcessedPerKey = 3 // 2 successful messages + 1 startup
-    TestUtils.waitUntilTrue(() => numEventsProcessed == processorKeys.size * expectedNumEventsProcessedPerKey,
-      s"Failed to process expected event before timing out; processed events = $numEventsProcessed", 5000)
+    listener.drain()
+    assertEquals(List(msg0, msg1), processor.processed.toList)
 
     // offset should not be updated
     assertEquals(expectedInitialMetadataOffset, listener.currentMetadataOffset())
-
-    // out-of-band records should be processed
-    processorKeys.foreach(key => {
-      assertEquals(0, metadataLogEventInvocations.get(key).get.size)
-      assertEquals(1, outOfBandRegisterLocalBrokerInvocations.get(key).get.size)
-      assertEquals(outOfBandRegisterLocalBrokerInvocations.get(key).get.head, msg0)
-      assertEquals(1, outOfbandFenceLocalBrokerInvocations.get(key).get.size)
-      assertEquals(outOfbandFenceLocalBrokerInvocations.get(key).get.head, msg1)
-    })
   }
 
   @Test
   def testBadMetadataOffset(): Unit = {
-    val listener = start(new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(),
-      twoProcessorsCountingInvocations(processorKeys)))
+    val processor = new MockMetadataProcessor
+    val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List(processor))
     assertEquals(expectedInitialMetadataOffset, listener.currentMetadataOffset())
 
-    val badMetadataOffset = listener.currentMetadataOffset() - 1 // too low
-    listener.put(MetadataLogEvent(List(mock(classOf[ApiMessage])), badMetadataOffset))
+    val metadataLogEvent = MetadataLogEvent(List[ApiMessage](new BrokerRecord()).asJava, -1)
+    listener.put(metadataLogEvent)
 
-    val expectedNumEventsProcessedPerKey = 1 // 0 successful messages + 1 startup
-    TestUtils.waitUntilTrue(() => numEventsProcessed == processorKeys.size * expectedNumEventsProcessedPerKey,
-      s"Failed to process expected event before timing out; processed events = $numEventsProcessed", 5000)
-
-    // error count metric should increase by 1 since it is a badd metadata offset and therefore no processors see it
-    // we have to wait for it to occur since it is the last event and the wait above only waits for the startup events
-    TestUtils.waitUntilTrue(() => errorCountGauge().value() == 1,
-      s"Failed to see error count gauge increase when there was an error; error count = ${errorCountGauge().value()}", 5000)
+    intercept[IllegalStateException] {
+      listener.drain()
+    }
 
     // offset should be unchanged
     assertEquals(expectedInitialMetadataOffset, listener.currentMetadataOffset())
 
     // record should not be processed
-    processorKeys.foreach(key => {
-      assertEquals(0, metadataLogEventInvocations.get(key).get.size)
-      assertEquals(0, outOfBandRegisterLocalBrokerInvocations.get(key).get.size)
-      assertEquals(0, outOfbandFenceLocalBrokerInvocations.get(key).get.size)
-    })
+    assertEquals(List.empty, processor.processed.toList)
   }
 
   @Test
   def testMetricsCleanedOnClose(): Unit = {
-    val listener = start(new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(),
-      twoProcessorsCountingInvocations(processorKeys)))
+    val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(),
+      List(new MockMetadataProcessor))
+    listener.start()
     assertTrue(allRegisteredMetricNames.nonEmpty)
 
     listener.close()
@@ -219,79 +135,42 @@ class BrokerMetadataListenerTest {
 
   @Test
   def testOutOfBandEventIsProcessed(): Unit = {
-    val processedEvents = mutable.Buffer.empty[List[ApiMessage]]
-    val outOfBandRegisterLocalBrokerEventIndicator = List(mock(classOf[ApiMessage]), mock(classOf[ApiMessage]))
-    val outOfBandFenceLocalBrokerEventIndicator = List(mock(classOf[ApiMessage]), mock(classOf[ApiMessage]), mock(classOf[ApiMessage]))
-    val countDownLatch = new CountDownLatch(1)
+    val processor = new MockMetadataProcessor
+    val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List(processor))
+    val logEvent1 = MetadataLogEvent(List(mock(classOf[ApiMessage])).asJava, 1)
+    val logEvent2 = MetadataLogEvent(List(mock(classOf[ApiMessage])).asJava, 2)
+    val registerEvent = RegisterBrokerEvent(1)
+    val fenceEvent = FenceBrokerEvent(1)
 
-    val brokerMetadataProcessor = new BrokerMetadataProcessor {
-      override def processStartup(): Unit = {}
-      override def process(metadataLogEvent: MetadataLogEvent): Unit = {
-        processedEvents += metadataLogEvent.apiMessages
-        countDownLatch.await()
-      }
-
-      override def process(outOfBandRegisterLocalBrokerEvent: OutOfBandRegisterLocalBrokerEvent): Unit = {
-        processedEvents += outOfBandRegisterLocalBrokerEventIndicator
-      }
-
-      override def process(outOfBandFenceLocalBrokerEvent: OutOfBandFenceLocalBrokerEvent): Unit = {
-        processedEvents += outOfBandFenceLocalBrokerEventIndicator
-      }
-    }
-
-    val listener = start(new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(),
-      List(brokerMetadataProcessor)))
-
-    val apiMessagesEvent1 = List(mock(classOf[ApiMessage]))
-    val apiMessagesEvent2 = List(mock(classOf[ApiMessage]))
     // add the out-of-band messages after the batches
-    listener.put(MetadataLogEvent(apiMessagesEvent1, 1))
-    listener.put(MetadataLogEvent(apiMessagesEvent2, 2))
-    listener.put(OutOfBandRegisterLocalBrokerEvent(1))
-    listener.put(OutOfBandFenceLocalBrokerEvent(1))
-    countDownLatch.countDown()
-    TestUtils.waitUntilTrue(() => processedEvents.size == 4,
-      s"Failed to process expected event before timing out; processed events = ${processedEvents.size}", 5000)
-    // make sure out-of-band messages processed before the second batch
-    assertEquals(apiMessagesEvent1, processedEvents(0))
-    assertEquals(outOfBandRegisterLocalBrokerEventIndicator, processedEvents(1))
-    assertEquals(outOfBandFenceLocalBrokerEventIndicator, processedEvents(2))
-    assertEquals(apiMessagesEvent2, processedEvents(3))
+    listener.put(logEvent1)
+    listener.put(logEvent2)
+    listener.put(registerEvent)
+    listener.put(fenceEvent)
+    listener.drain()
+
+    // make sure events are handled in order
+    assertEquals(List(logEvent1, logEvent2, registerEvent, fenceEvent), processor.processed.toList)
   }
 
   @Test
   def testEventQueueTime(): Unit = {
     val time = new MockTime()
-    val latch = new CountDownLatch(1)
-    val processedEvents = new AtomicInteger()
-
-    val brokerMetadataProcessor = new BrokerMetadataProcessor {
-      override def processStartup(): Unit = {}
-      override def process(metadataLogEvent: MetadataLogEvent): Unit = {
-        latch.await()
-        time.sleep(500)
-        processedEvents.incrementAndGet()
-      }
-      def process(outOfBandFenceLocalBrokerEvent: kafka.server.metadata.OutOfBandFenceLocalBrokerEvent): Unit = {}
-      def process(outOfBandRegisterLocalBrokerEvent: kafka.server.metadata.OutOfBandRegisterLocalBrokerEvent): Unit = {}
-    }
+    val brokerMetadataProcessor = new MockMetadataProcessor
 
     // The metric should not already exist
     assertTrue(KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.filter { case (k, _) =>
       k.getMBeanName == eventQueueTimeMsMetricMBeanName
     }.values.isEmpty)
 
-    val listener = start(new BrokerMetadataListener(mock(classOf[KafkaConfig]), time,
-      List(brokerMetadataProcessor)))
-
+    val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), time, List(brokerMetadataProcessor))
     val apiMessagesEvent = List(mock(classOf[ApiMessage]))
-    listener.put(MetadataLogEvent(apiMessagesEvent, 1))
-    listener.put(MetadataLogEvent(apiMessagesEvent, 2))
-    latch.countDown()
+    listener.put(MetadataLogEvent(apiMessagesEvent.asJava, 1))
+    listener.drain()
 
-    TestUtils.waitUntilTrue(() => processedEvents.get() == 2,
-      s"Timed out waiting for processing of all events; processed events = ${processedEvents.get()}", 5000)
+    listener.put(MetadataLogEvent(apiMessagesEvent.asJava, 2))
+    time.sleep(500)
+    listener.drain()
 
     val histogram = queueTimeHistogram()
     assertEquals(2, histogram.count)
@@ -299,68 +178,12 @@ class BrokerMetadataListenerTest {
     assertEquals(500, histogram.max, 0.01)
   }
 
-  @Test
-  def testEventQueueTimeResetOnTimeout(): Unit = {
-    val time = new MockTime()
-    val processedEvents = new AtomicInteger()
+  private class MockMetadataProcessor extends BrokerMetadataProcessor {
+    val processed: mutable.Buffer[BrokerMetadataEvent] = mutable.Buffer.empty
 
-    val brokerMetadataProcessor = new BrokerMetadataProcessor {
-      override def processStartup(): Unit = {}
-      override def process(metadataLogEvent: MetadataLogEvent): Unit = {
-        processedEvents.incrementAndGet()
-      }
-      def process(outOfBandFenceLocalBrokerEvent: kafka.server.metadata.OutOfBandFenceLocalBrokerEvent): Unit = {}
-      def process(outOfBandRegisterLocalBrokerEvent: kafka.server.metadata.OutOfBandRegisterLocalBrokerEvent): Unit = {}
+    override def process(event: BrokerMetadataEvent): Unit = {
+      processed += event
     }
-
-    // set a short histogram timeout of 1 ms
-    val listener = start(new BrokerMetadataListener(mock(classOf[KafkaConfig]), time,
-      List(brokerMetadataProcessor), 1))
-
-    val apiMessagesEvent = List(mock(classOf[ApiMessage]))
-    listener.put(MetadataLogEvent(apiMessagesEvent, 1))
-    listener.put(MetadataLogEvent(apiMessagesEvent, 2))
-
-    TestUtils.waitUntilTrue(() => processedEvents.get() == 2,
-      s"Timed out waiting for processing of all events; processed eents = ${processedEvents.get()}", 5000)
-
-    // we know from previous tests that the histogram count at this point will be 2
-
-    // wait for the timeout/reset
-    val histogram = queueTimeHistogram()
-    TestUtils.waitUntilTrue(() => histogram.count == 0,
-      s"Timed out on resetting $expectedEventQueueTimeMsMetricName Histogram; count=${histogram.count}", 5000)
-    assertEquals(0, histogram.min, 0.1)
-    assertEquals(0, histogram.max, 0.1)
   }
 
-  def start(brokerMetadataListener: BrokerMetadataListener): BrokerMetadataListener = {
-    this.brokerMetadataListener = Some(brokerMetadataListener)
-    this.brokerMetadataListener.get.start()
-    brokerMetadataListener
-  }
-
-  def twoProcessorsCountingInvocations(processorKeys: List[String]): List[BrokerMetadataProcessor] = {
-    processorKeys.map(key => new BrokerMetadataProcessor {
-      override def process(metadataLogEvent: MetadataLogEvent): Unit = {
-        metadataLogEventInvocations.get(key).get += metadataLogEvent
-        numEventsProcessed += 1
-      }
-
-      override def process(outOfBandRegisterLocalBrokerEvent: OutOfBandRegisterLocalBrokerEvent): Unit = {
-        outOfBandRegisterLocalBrokerInvocations.get(key).get += outOfBandRegisterLocalBrokerEvent
-        numEventsProcessed += 1
-      }
-
-      override def process(outOfBandFenceLocalBrokerEvent: OutOfBandFenceLocalBrokerEvent): Unit = {
-        outOfbandFenceLocalBrokerInvocations.get(key).get += outOfBandFenceLocalBrokerEvent
-        numEventsProcessed += 1
-      }
-
-      override def processStartup(): Unit = {
-        numStartupEventsProcessed(key) = numStartupEventsProcessed.get(key).get + 1
-        numEventsProcessed += 1
-      }
-    })
-  }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/MetaLogManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/MetaLogManager.java
@@ -43,26 +43,28 @@ public interface MetaLogManager extends AutoCloseable {
          *
          * @param epoch         The controller epoch that is starting.
          */
-        void handleClaim(long epoch);
+        default void handleClaim(long epoch) {}
 
         /**
          * Called when the MetaLogManager has renounced the leadership.
          *
          * @param epoch         The controller epoch that has ended.
          */
-        void handleRenounce(long epoch);
+        default void handleRenounce(long epoch) {}
 
         /**
          * Called when the MetaLogManager has finished shutting down, and wants to tell its
          * listener that it is safe to shut down as well.
          */
-        void beginShutdown();
+        default void beginShutdown() {}
 
         /**
          * If this listener is currently active, return the controller epoch it is active
          * for.  Otherwise, return -1.
          */
-        long currentClaimEpoch();
+        default long currentClaimEpoch() {
+            return -1L;
+        }
     }
 
     /**


### PR DESCRIPTION
This patch does the following:

1) Events are handled in order. The previous logic attempted to route the out-of-band registration/fencing messages to the front of the queue, but it seems simpler to let them be handled in order. I am not sure it is worthwhile optimizing for the case when there is a backlog of events to be processed.
2) Event failures are propagated. Previously we incremented an error counter, but an event failure leaves the broker state machine in an indeterminate state and it seems dangerous to try and continue. 
3) Simplify processor API. Rather than overloading `process`, we can use a single method and let the processor `match` on the events it wants to handle.
4) Hook up `MetaLogManager.Listener`. The only real change here is that I preferred to retain the java List type since it awkwardly converts to the `Buffer` type with the scala collection converters.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
