### PR TITLE
Get Kip500Broker into startable state

### DIFF
--- a/config/kip500-broker-node.properties
+++ b/config/kip500-broker-node.properties
@@ -1,0 +1,126 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# see kafka.server.KafkaConfig for additional details and defaults
+
+############################# Server Basics #############################
+
+# The role of this server. Setting this puts us in kip-500 mode
+process.roles=broker
+
+# The connect string for the controller quorum
+controller.connect=3000@localhost:9093
+
+# The id of the controller. This must be different than the broker id.
+#controller.id=3000
+broker.id=0
+
+############################# Socket Server Settings #############################
+
+# The address the socket server listens on. It will get the value returned from 
+# java.net.InetAddress.getCanonicalHostName() if not configured.
+#   FORMAT:
+#     listeners = listener_name://host_name:port
+#   EXAMPLE:
+#     listeners = PLAINTEXT://your.host.name:9092
+listeners=PLAINTEXT://localhost:9092
+inter.broker.listener.name=PLAINTEXT
+
+# Hostname and port the broker will advertise to producers and consumers. If not set, 
+# it uses the value for "listeners" if configured.  Otherwise, it will use the value
+# returned from java.net.InetAddress.getCanonicalHostName().
+advertised.listeners=PLAINTEXT://localhost:9092
+
+# Listener, host name, and port for the controller to advertise to the brokers. If 
+# this server is a controller, this listener must be configured.
+controller.listener.names=CONTROLLER
+
+# Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
+listener.security.protocol.map=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+
+# The number of threads that the server uses for receiving requests from the network and sending responses to the network
+num.network.threads=3
+
+# The number of threads that the server uses for processing requests, which may include disk I/O
+num.io.threads=8
+
+# The send buffer (SO_SNDBUF) used by the socket server
+socket.send.buffer.bytes=102400
+
+# The receive buffer (SO_RCVBUF) used by the socket server
+socket.receive.buffer.bytes=102400
+
+# The maximum size of a request that the socket server will accept (protection against OOM)
+socket.request.max.bytes=104857600
+
+
+############################# Log Basics #############################
+
+# A comma separated list of directories under which to store log files
+log.dirs=/tmp/kafka-broker-logs
+
+# The default number of log partitions per topic. More partitions allow greater
+# parallelism for consumption, but this will also result in more files across
+# the brokers.
+num.partitions=1
+
+# The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
+# This value is recommended to be increased for installations with data dirs located in RAID array.
+num.recovery.threads.per.data.dir=1
+
+############################# Internal Topic Settings  #############################
+# The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+# For anything other than development testing, a value greater than 1 is recommended to ensure availability such as 3.
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
+
+############################# Log Flush Policy #############################
+
+# Messages are immediately written to the filesystem but by default we only fsync() to sync
+# the OS cache lazily. The following configurations control the flush of data to disk.
+# There are a few important trade-offs here:
+#    1. Durability: Unflushed data may be lost if you are not using replication.
+#    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
+#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to excessive seeks.
+# The settings below allow one to configure the flush policy to flush data after a period of time or
+# every N messages (or both). This can be done globally and overridden on a per-topic basis.
+
+# The number of messages to accept before forcing a flush of data to disk
+#log.flush.interval.messages=10000
+
+# The maximum amount of time a message can sit in a log before we force a flush
+#log.flush.interval.ms=1000
+
+############################# Log Retention Policy #############################
+
+# The following configurations control the disposal of log segments. The policy can
+# be set to delete segments after a period of time, or after a given size has accumulated.
+# A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
+# from the end of the log.
+
+# The minimum age of a log file to be eligible for deletion due to age
+log.retention.hours=168
+
+# A size-based retention policy for logs. Segments are pruned from the log unless the remaining
+# segments drop below log.retention.bytes. Functions independently of log.retention.hours.
+#log.retention.bytes=1073741824
+
+# The maximum size of a log segment file. When this size is reached a new log segment will be created.
+log.segment.bytes=1073741824
+
+# The interval at which log segments are checked to see if they can be deleted according
+# to the retention policies
+log.retention.check.interval.ms=300000

--- a/config/kip500-broker-node.properties
+++ b/config/kip500-broker-node.properties
@@ -23,8 +23,7 @@ process.roles=broker
 # The connect string for the controller quorum
 controller.connect=3000@localhost:9093
 
-# The id of the controller. This must be different than the broker id.
-#controller.id=3000
+# The id of the broker. This must be set to a unique integer for each broker.
 broker.id=0
 
 ############################# Socket Server Settings #############################

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1328,9 +1328,7 @@ object GroupCoordinator {
             replicaManager: ReplicaManager,
             time: Time,
             metrics: Metrics): GroupCoordinator = {
-    val heartbeatPurgatory = DelayedOperationPurgatory[DelayedHeartbeat]("Heartbeat", config.brokerId)
-    val joinPurgatory = DelayedOperationPurgatory[DelayedJoin]("Rebalance", config.brokerId)
-    apply(config, zkClient, replicaManager, heartbeatPurgatory, joinPurgatory, time, metrics)
+    apply(config, Some(zkClient), None, replicaManager, time, metrics)
   }
 
   def apply(config: KafkaConfig,
@@ -1338,9 +1336,28 @@ object GroupCoordinator {
             replicaManager: ReplicaManager,
             time: Time,
             metrics: Metrics): GroupCoordinator = {
+    apply(config, None, Some(groupMetadataTopicPartitionCountFunc), replicaManager, time, metrics)
+  }
+
+  def apply(config: KafkaConfig,
+            zkClient: Option[KafkaZkClient],
+            groupMetadataTopicPartitionCountFunc: Option[() => Int],
+            replicaManager: ReplicaManager,
+            time: Time,
+            metrics: Metrics): GroupCoordinator = {
     val heartbeatPurgatory = DelayedOperationPurgatory[DelayedHeartbeat]("Heartbeat", config.brokerId)
     val joinPurgatory = DelayedOperationPurgatory[DelayedJoin]("Rebalance", config.brokerId)
-    apply(config, groupMetadataTopicPartitionCountFunc, replicaManager, heartbeatPurgatory, joinPurgatory, time, metrics)
+    apply(config, zkClient, groupMetadataTopicPartitionCountFunc, replicaManager, heartbeatPurgatory, joinPurgatory, time, metrics)
+  }
+
+  def apply(config: KafkaConfig,
+            zkClient: KafkaZkClient,
+            replicaManager: ReplicaManager,
+            heartbeatPurgatory: DelayedOperationPurgatory[DelayedHeartbeat],
+            joinPurgatory: DelayedOperationPurgatory[DelayedJoin],
+            time: Time,
+            metrics: Metrics): GroupCoordinator = {
+    apply(config, Some(zkClient), None, replicaManager, heartbeatPurgatory, joinPurgatory, time, metrics)
   }
 
   def apply(config: KafkaConfig,
@@ -1350,14 +1367,35 @@ object GroupCoordinator {
             joinPurgatory: DelayedOperationPurgatory[DelayedJoin],
             time: Time,
             metrics: Metrics): GroupCoordinator = {
+    apply(config, None, Some(groupMetadataTopicPartitionCountFunc), replicaManager, heartbeatPurgatory, joinPurgatory, time, metrics)
+  }
+
+  def apply(config: KafkaConfig,
+            zkClient: Option[KafkaZkClient],
+            groupMetadataTopicPartitionCountFunc: Option[() => Int],
+            replicaManager: ReplicaManager,
+            heartbeatPurgatory: DelayedOperationPurgatory[DelayedHeartbeat],
+            joinPurgatory: DelayedOperationPurgatory[DelayedJoin],
+            time: Time,
+            metrics: Metrics): GroupCoordinator = {
+    if (zkClient.isEmpty && groupMetadataTopicPartitionCountFunc.isEmpty) {
+      throw new IllegalArgumentException("Must supply either a ZK Client or a topic partition count function")
+    }
+    if (zkClient.nonEmpty && groupMetadataTopicPartitionCountFunc.nonEmpty) {
+      throw new IllegalArgumentException("Cannot supply both a ZK Client and a topic partition count function")
+    }
     val offsetConfig = this.offsetConfig(config)
     val groupConfig = GroupConfig(groupMinSessionTimeoutMs = config.groupMinSessionTimeoutMs,
       groupMaxSessionTimeoutMs = config.groupMaxSessionTimeoutMs,
       groupMaxSize = config.groupMaxSize,
       groupInitialRebalanceDelayMs = config.groupInitialRebalanceDelay)
-
-    val groupMetadataManager = new GroupMetadataManager(config.brokerId, config.interBrokerProtocolVersion,
-      offsetConfig, replicaManager, groupMetadataTopicPartitionCountFunc, time, metrics)
+    val groupMetadataManager = if (zkClient.nonEmpty) {
+      new GroupMetadataManager(config.brokerId, config.interBrokerProtocolVersion, offsetConfig, replicaManager,
+        zkClient.get, time, metrics)
+    } else {
+      new GroupMetadataManager(config.brokerId, config.interBrokerProtocolVersion, offsetConfig, replicaManager,
+        groupMetadataTopicPartitionCountFunc.get, time, metrics)
+    }
     new GroupCoordinator(config.brokerId, groupConfig, offsetConfig, groupMetadataManager, heartbeatPurgatory, joinPurgatory, time, metrics)
   }
 
@@ -1373,24 +1411,6 @@ object GroupCoordinator {
     offsetCommitTimeoutMs = config.offsetCommitTimeoutMs,
     offsetCommitRequiredAcks = config.offsetCommitRequiredAcks
   )
-
-  def apply(config: KafkaConfig,
-            zkClient: KafkaZkClient,
-            replicaManager: ReplicaManager,
-            heartbeatPurgatory: DelayedOperationPurgatory[DelayedHeartbeat],
-            joinPurgatory: DelayedOperationPurgatory[DelayedJoin],
-            time: Time,
-            metrics: Metrics): GroupCoordinator = {
-    val offsetConfig = this.offsetConfig(config)
-    val groupConfig = GroupConfig(groupMinSessionTimeoutMs = config.groupMinSessionTimeoutMs,
-      groupMaxSessionTimeoutMs = config.groupMaxSessionTimeoutMs,
-      groupMaxSize = config.groupMaxSize,
-      groupInitialRebalanceDelayMs = config.groupInitialRebalanceDelay)
-
-    val groupMetadataManager = new GroupMetadataManager(config.brokerId, config.interBrokerProtocolVersion,
-      offsetConfig, replicaManager, zkClient, time, metrics)
-    new GroupCoordinator(config.brokerId, groupConfig, offsetConfig, groupMetadataManager, heartbeatPurgatory, joinPurgatory, time, metrics)
-  }
 
   private def memberLeaveError(memberIdentity: MemberIdentity,
                                error: Errors): LeaveMemberResponse = {

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -58,9 +58,19 @@ class GroupMetadataManager(brokerId: Int,
                            interBrokerProtocolVersion: ApiVersion,
                            config: OffsetConfig,
                            val replicaManager: ReplicaManager,
-                           zkClient: KafkaZkClient,
+                           groupMetadataTopicPartitionCountFunc: () => Int,
                            time: Time,
                            metrics: Metrics) extends Logging with KafkaMetricsGroup {
+
+  def this(brokerId: Int,
+           interBrokerProtocolVersion: ApiVersion,
+           config: OffsetConfig,
+           replicaManager: ReplicaManager,
+           zkClient: KafkaZkClient,
+           time: Time,
+           metrics: Metrics) = this(brokerId, interBrokerProtocolVersion, config, replicaManager,
+    () => zkClient.getTopicPartitionCount(Topic.GROUP_METADATA_TOPIC_NAME).getOrElse(config.offsetsTopicNumPartitions),
+    time, metrics)
 
   private val compressionType: CompressionType = CompressionType.forId(config.offsetsTopicCompressionCodec.codec)
 
@@ -79,7 +89,7 @@ class GroupMetadataManager(brokerId: Int,
   private val shuttingDown = new AtomicBoolean(false)
 
   /* number of partitions for the consumer metadata topic */
-  private val groupMetadataTopicPartitionCount = getGroupMetadataTopicPartitionCount
+  private val groupMetadataTopicPartitionCount = groupMetadataTopicPartitionCountFunc()
 
   /* single-thread scheduler to handle offset/group metadata cache loading and unloading */
   private val scheduler = new KafkaScheduler(threads = 1, threadNamePrefix = "group-metadata-manager-")
@@ -933,14 +943,6 @@ class GroupMetadataManager(brokerId: Int,
       scheduler.shutdown()
 
     // TODO: clear the caches
-  }
-
-  /**
-   * Gets the partition count of the group metadata topic from ZooKeeper.
-   * If the topic does not exist, the configured partition count is returned.
-   */
-  private def getGroupMetadataTopicPartitionCount: Int = {
-    zkClient.getTopicPartitionCount(Topic.GROUP_METADATA_TOPIC_NAME).getOrElse(config.offsetsTopicNumPartitions)
   }
 
   /**

--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -70,7 +70,7 @@ case class ProducerIdBlock(brokerId: Int, blockStartId: Long, blockEndId: Long) 
   }
 }
 
-class ProducerIdManager(val brokerId: Int, val zkClient: KafkaZkClient) extends Logging {
+class ProducerIdManager(val brokerId: Int, val zkClient: KafkaZkClient) extends ProducerIdMgr with Logging {
 
   this.logIdent = "[ProducerId Manager " + brokerId + "]: "
 
@@ -150,7 +150,7 @@ class ProducerIdManager(val brokerId: Int, val zkClient: KafkaZkClient) extends 
     }
   }
 
-  def shutdown(): Unit = {
+  override def shutdown(): Unit = {
     info(s"Shutdown complete: last producerId assigned $nextProducerId")
   }
 }

--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -70,7 +70,12 @@ case class ProducerIdBlock(brokerId: Int, blockStartId: Long, blockEndId: Long) 
   }
 }
 
-class ProducerIdManager(val brokerId: Int, val zkClient: KafkaZkClient) extends ProducerIdMgr with Logging {
+trait ProducerIdGenerator {
+  def generateProducerId(): Long
+  def shutdown() : Unit = {}
+}
+
+class ProducerIdManager(val brokerId: Int, val zkClient: KafkaZkClient) extends ProducerIdGenerator with Logging {
 
   this.logIdent = "[ProducerId Manager " + brokerId + "]: "
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -30,11 +30,6 @@ import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests.TransactionResult
 import org.apache.kafka.common.utils.{LogContext, ProducerIdAndEpoch, Time}
 
-trait ProducerIdMgr {
-  def generateProducerId(): Long
-  def shutdown() : Unit = {}
-}
-
 object TransactionCoordinator {
 
   def apply(config: KafkaConfig,
@@ -52,7 +47,7 @@ object TransactionCoordinator {
   def apply(config: KafkaConfig,
             replicaManager: ReplicaManager,
             scheduler: Scheduler,
-            producerIdMgr: ProducerIdMgr,
+            producerIdGenerator: ProducerIdGenerator,
             transactionTopicPartitionCountFunc: () => Int,
             metrics: Metrics,
             metadataCache: MetadataCache,
@@ -76,7 +71,7 @@ object TransactionCoordinator {
     val txnMarkerChannelManager = TransactionMarkerChannelManager(config, metrics, metadataCache, txnStateManager,
       time, logContext)
 
-    new TransactionCoordinator(txnConfig, scheduler, producerIdMgr, txnStateManager, txnMarkerChannelManager,
+    new TransactionCoordinator(txnConfig, scheduler, producerIdGenerator, txnStateManager, txnMarkerChannelManager,
       time, logContext)
   }
 
@@ -99,7 +94,7 @@ object TransactionCoordinator {
  */
 class TransactionCoordinator(txnConfig: TransactionConfig,
                              scheduler: Scheduler,
-                             producerIdManager: ProducerIdMgr,
+                             producerIdManager: ProducerIdGenerator,
                              txnManager: TransactionStateManager,
                              txnMarkerChannelManager: TransactionMarkerChannelManager,
                              time: Time,

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -487,9 +487,10 @@ class TransactionStateManager(brokerId: Int,
   }
 
   private def validateTransactionTopicPartitionCountIsStable(): Unit = {
+    val alreadyDeterminedPartitionCount = transactionTopicPartitionCount
     val curTransactionTopicPartitionCount = transactionTopicPartitionCountFunc()
-    if (transactionTopicPartitionCount != curTransactionTopicPartitionCount)
-      throw new KafkaException(s"Transaction topic number of partitions has changed from $transactionTopicPartitionCount to $curTransactionTopicPartitionCount")
+    if (alreadyDeterminedPartitionCount != curTransactionTopicPartitionCount)
+      throw new KafkaException(s"Transaction topic number of partitions has changed from $alreadyDeterminedPartitionCount to $curTransactionTopicPartitionCount")
   }
 
   def appendTransactionToLog(transactionalId: String,

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -60,7 +60,7 @@ class LogManager(logDirs: Seq[File],
                  val retentionCheckMs: Long,
                  val maxPidExpirationMs: Int,
                  scheduler: Scheduler,
-                 val brokerState: AtomicReference[BrokerState],
+                 val cleanShutdownFunc: Boolean => Unit, // we send true if the shutdown was clean, otherwise false
                  brokerTopicStats: BrokerTopicStats,
                  logDirFailureChannel: LogDirFailureChannel,
                  time: Time) extends Logging with KafkaMetricsGroup {
@@ -68,7 +68,7 @@ class LogManager(logDirs: Seq[File],
   import LogManager._
 
   val LockFile = ".lock"
-  val InitialTaskDelayMs = 30 * 1000
+  val InitialTaskDelayMs: Int = 30 * 1000
 
   private val logCreationOrDeletionLock = new Object
   private val currentLogs = new Pool[TopicPartition, Log]()
@@ -323,10 +323,11 @@ class LogManager(logDirs: Seq[File],
           // so that if broker crashes while loading the log, it is considered hard shutdown during the next boot up. KAFKA-10471
           cleanShutdownFile.delete()
           hadCleanShutdown = true
+          cleanShutdownFunc(true)
         } else {
           // log recovery itself is being performed by `Log` class during initialization
           info(s"Attempting recovery for all logs in $logDirAbsolutePath since no clean shutdown file was found")
-          brokerState.set(BrokerState.RECOVERING_FROM_UNCLEAN_SHUTDOWN)
+          cleanShutdownFunc(false)
         }
 
         var recoveryPoints = Map[TopicPartition, Long]()
@@ -1167,6 +1168,10 @@ object LogManager {
   val LogStartOffsetCheckpointFile = "log-start-offset-checkpoint"
   val ProducerIdExpirationCheckIntervalMs = 10 * 60 * 1000
 
+  def mutateBrokerStateForUncleanShutdown(brokerState: AtomicReference[BrokerState]): Boolean => Unit = {
+    cleanShutdown => if (!cleanShutdown) brokerState.set(BrokerState.RECOVERING_FROM_UNCLEAN_SHUTDOWN)
+  }
+
   def apply(config: KafkaConfig,
             initialOfflineDirs: Seq[String],
             zkClient: KafkaZkClient,
@@ -1175,7 +1180,9 @@ object LogManager {
             time: Time,
             brokerTopicStats: BrokerTopicStats,
             logDirFailureChannel: LogDirFailureChannel): LogManager = {
-    this(config, initialOfflineDirs, Some(zkClient), brokerState, kafkaScheduler, time, brokerTopicStats, logDirFailureChannel)
+    this(config, initialOfflineDirs, Some(zkClient),
+      mutateBrokerStateForUncleanShutdown(brokerState),
+      kafkaScheduler, time, brokerTopicStats, logDirFailureChannel)
   }
 
   def apply(config: KafkaConfig,
@@ -1185,13 +1192,25 @@ object LogManager {
             time: Time,
             brokerTopicStats: BrokerTopicStats,
             logDirFailureChannel: LogDirFailureChannel): LogManager = {
-    this(config, initialOfflineDirs, None, brokerState, kafkaScheduler, time, brokerTopicStats, logDirFailureChannel)
+    this(config, initialOfflineDirs, None,
+      mutateBrokerStateForUncleanShutdown(brokerState),
+      kafkaScheduler, time, brokerTopicStats, logDirFailureChannel)
+  }
+
+  def apply(config: KafkaConfig,
+            initialOfflineDirs: Seq[String],
+            cleanShutdownFunc: Boolean => Unit, // we send true if the shutdown was clean, otherwise false,
+            kafkaScheduler: KafkaScheduler,
+            time: Time,
+            brokerTopicStats: BrokerTopicStats,
+            logDirFailureChannel: LogDirFailureChannel): LogManager = {
+    this(config, initialOfflineDirs, None, cleanShutdownFunc, kafkaScheduler, time, brokerTopicStats, logDirFailureChannel)
   }
 
   def apply(config: KafkaConfig,
             initialOfflineDirs: Seq[String],
             maybeZkClient: Option[KafkaZkClient],
-            brokerState: AtomicReference[BrokerState],
+            cleanShutdownFunc: Boolean => Unit, // we send true if the shutdown was clean, otherwise false
             kafkaScheduler: KafkaScheduler,
             time: Time,
             brokerTopicStats: BrokerTopicStats,
@@ -1203,12 +1222,14 @@ object LogManager {
 
     val topicConfigs: Map[String, LogConfig] =
       if (maybeZkClient.isDefined) {
+        // do this to get rid of a spotbugs error in Scala 2.12
+        val zkClient: KafkaZkClient = maybeZkClient.iterator.next()
         // read the log configurations from zookeeper
-        val (topicConfigs, failed) = maybeZkClient.get.getLogConfigs(
-          maybeZkClient.get.getAllTopicsInCluster(),
+        val (topicConfigs, failed) = zkClient.getLogConfigs(
+          zkClient.getAllTopicsInCluster(),
           defaultProps
         )
-        if (!failed.isEmpty) throw failed.head._2
+        if (failed.nonEmpty) throw failed.head._2
         topicConfigs
       } else {
         Map.empty
@@ -1227,7 +1248,7 @@ object LogManager {
       retentionCheckMs = config.logCleanupIntervalMs,
       maxPidExpirationMs = config.transactionalIdExpirationMs,
       scheduler = kafkaScheduler,
-      brokerState = brokerState,
+      cleanShutdownFunc = cleanShutdownFunc,
       brokerTopicStats = brokerTopicStats,
       logDirFailureChannel = logDirFailureChannel,
       time = time)

--- a/core/src/main/scala/kafka/server/AbstractBrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractBrokerToControllerChannelManager.scala
@@ -17,7 +17,7 @@
 
 package kafka.server
 
-import java.util.concurrent.{LinkedBlockingDeque, TimeUnit}
+import java.util.concurrent.{Future, LinkedBlockingDeque, TimeUnit}
 
 import kafka.common.{InterBrokerSendThread, RequestAndCompletionHandler}
 import kafka.utils.Logging
@@ -29,6 +29,7 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network._
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.security.JaasContext
+import org.apache.kafka.common.security.auth.SecurityProtocol
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -38,6 +39,8 @@ trait BrokerToControllerChannelManager {
   def sendRequest(request: AbstractRequest.Builder[_ <: AbstractRequest],
                   callback: RequestCompletionHandler): Unit
 
+  def clusterId(): Future[String]
+
   def start(): Unit
 
   def shutdown(): Unit
@@ -45,21 +48,27 @@ trait BrokerToControllerChannelManager {
 
 
 /**
- * This class manages the connection between a broker and the controller. It runs a single
- * {@link BrokerToControllerRequestThread} which uses the broker's metadata cache as its own metadata to find
- * and connect to the controller. The channel is async and runs the network connection in the background.
- * The maximum number of in-flight requests are set to one to ensure orderly response from the controller, therefore
- * care must be taken to not block on outstanding requests for too long.
+ * This abstract class manages the connection between a broker and the controller. It runs a single
+ * {@link BrokerToControllerRequestThread} which finds and connects to the controller. The channel is async and runs
+ * the network connection in the background. The maximum number of in-flight requests are set to one to ensure orderly
+ * response from the controller, therefore care must be taken to not block on outstanding requests for too long.
  */
-class BrokerToControllerChannelManagerImpl(metadataCache: kafka.server.MetadataCache,
-                                           time: Time,
-                                           metrics: Metrics,
-                                           config: KafkaConfig,
-                                           threadNamePrefix: Option[String] = None) extends BrokerToControllerChannelManager with Logging {
-  private val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]
-  private val logContext = new LogContext(s"[broker-${config.brokerId}-to-controller] ")
-  private val manualMetadataUpdater = new ManualMetadataUpdater()
-  private val requestThread = newRequestThread
+abstract class AbstractBrokerToControllerChannelManager(time: Time,
+                                                        metrics: Metrics,
+                                                        config: KafkaConfig,
+                                                        threadNamePrefix: Option[String] = None) extends BrokerToControllerChannelManager with Logging {
+  protected val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]
+  protected val logContext = new LogContext(s"[broker-${config.brokerId}-to-controller] ")
+  protected val manualMetadataUpdater = new ManualMetadataUpdater()
+
+  protected def requestThread: BrokerToControllerRequestThread
+  protected def brokerToControllerListenerName: ListenerName
+  protected def brokerToControllerSecurityProtocol: SecurityProtocol
+  protected def brokerToControllerSaslMechanism: String
+
+  protected def instantiateRequestThread(networkClient: NetworkClient,
+                                         brokerToControllerListenerName: ListenerName,
+                                         threadName: String): BrokerToControllerRequestThread
 
   override def start(): Unit = {
     requestThread.start()
@@ -71,16 +80,13 @@ class BrokerToControllerChannelManagerImpl(metadataCache: kafka.server.MetadataC
   }
 
   private[server] def newRequestThread = {
-    val brokerToControllerListenerName = config.controlPlaneListenerName.getOrElse(config.interBrokerListenerName)
-    val brokerToControllerSecurityProtocol = config.controlPlaneSecurityProtocol.getOrElse(config.interBrokerSecurityProtocol)
-
     val networkClient = {
       val channelBuilder = ChannelBuilders.clientChannelBuilder(
         brokerToControllerSecurityProtocol,
         JaasContext.Type.SERVER,
         config,
         brokerToControllerListenerName,
-        config.saslMechanismInterBrokerProtocol,
+        brokerToControllerSaslMechanism,
         time,
         config.saslInterBrokerHandshakeRequestEnable,
         logContext
@@ -120,8 +126,7 @@ class BrokerToControllerChannelManagerImpl(metadataCache: kafka.server.MetadataC
       case Some(name) => s"$name:broker-${config.brokerId}-to-controller-send-thread"
     }
 
-    new BrokerToControllerRequestThread(networkClient, manualMetadataUpdater, requestQueue, metadataCache, config,
-      brokerToControllerListenerName, time, threadName)
+    instantiateRequestThread(networkClient, brokerToControllerListenerName, threadName)
   }
 
   override def sendRequest(request: AbstractRequest.Builder[_ <: AbstractRequest],
@@ -134,17 +139,14 @@ class BrokerToControllerChannelManagerImpl(metadataCache: kafka.server.MetadataC
 case class BrokerToControllerQueueItem(request: AbstractRequest.Builder[_ <: AbstractRequest],
                                        callback: RequestCompletionHandler)
 
-class BrokerToControllerRequestThread(networkClient: KafkaClient,
-                                      metadataUpdater: ManualMetadataUpdater,
-                                      requestQueue: LinkedBlockingDeque[BrokerToControllerQueueItem],
-                                      metadataCache: kafka.server.MetadataCache,
-                                      config: KafkaConfig,
-                                      listenerName: ListenerName,
-                                      time: Time,
-                                      threadName: String)
+abstract class BrokerToControllerRequestThread(networkClient: KafkaClient,
+                                               requestQueue: LinkedBlockingDeque[BrokerToControllerQueueItem],
+                                               config: KafkaConfig,
+                                               time: Time,
+                                               threadName: String)
   extends InterBrokerSendThread(threadName, networkClient, time, isInterruptible = false) {
 
-  private var activeController: Option[Node] = None
+  protected var activeController: Option[Node] = None
 
   override def requestTimeoutMs: Int = config.controllerSocketTimeoutMs
 
@@ -177,23 +179,4 @@ class BrokerToControllerRequestThread(networkClient: KafkaClient,
   }
 
   private[server] def backoff(): Unit = pause(100, TimeUnit.MILLISECONDS)
-
-  override def doWork(): Unit = {
-    if (activeController.isDefined) {
-      super.doWork()
-    } else {
-      debug("Controller isn't cached, looking for local metadata changes")
-      val controllerOpt = metadataCache.getControllerId.flatMap(metadataCache.getAliveBroker)
-      if (controllerOpt.isDefined) {
-        if (activeController.isEmpty || activeController.exists(_.id != controllerOpt.get.id))
-          info(s"Recorded new controller, from now on will use broker ${controllerOpt.get.id}")
-        activeController = Option(controllerOpt.get.node(listenerName))
-        metadataUpdater.setNodes(metadataCache.getAliveBrokers.map(_.node(listenerName)).asJava)
-      } else {
-        // need to backoff to avoid tight loops
-        debug("No controller defined in metadata cache, retrying after backoff")
-        backoff()
-      }
-    }
-  }
 }

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -207,13 +207,23 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
   private var currentConfig = kafkaConfig
   private val dynamicConfigPasswordEncoder = maybeCreatePasswordEncoder(kafkaConfig.passwordEncoderSecret)
 
+  private[server] def initialize(): Unit = {
+    initialize(None)
+  }
+
   private[server] def initialize(zkClient: KafkaZkClient): Unit = {
+    initialize(Some(zkClient))
+  }
+
+  private def initialize(maybeZkClient: Option[KafkaZkClient]): Unit = {
     currentConfig = new KafkaConfig(kafkaConfig.props, false, None)
-    val adminZkClient = new AdminZkClient(zkClient)
-    updateDefaultConfig(adminZkClient.fetchEntityConfig(ConfigType.Broker, ConfigEntityName.Default))
-    val props = adminZkClient.fetchEntityConfig(ConfigType.Broker, kafkaConfig.brokerId.toString)
-    val brokerConfig = maybeReEncodePasswords(props, adminZkClient)
-    updateBrokerConfig(kafkaConfig.brokerId, brokerConfig)
+    maybeZkClient.foreach { zkClient =>
+      val adminZkClient = new AdminZkClient(zkClient)
+      updateDefaultConfig(adminZkClient.fetchEntityConfig(ConfigType.Broker, ConfigEntityName.Default))
+      val props = adminZkClient.fetchEntityConfig(ConfigType.Broker, kafkaConfig.brokerId.toString)
+      val brokerConfig = maybeReEncodePasswords(props, adminZkClient)
+      updateBrokerConfig(kafkaConfig.brokerId, brokerConfig)
+    }
   }
 
   /**
@@ -239,21 +249,21 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
    * reconfigured after `KafkaConfig` is updated so that they can access `KafkaConfig`
    * directly. They are provided both old and new configs.
    */
-  def addReconfigurables(kafkaServer: LegacyBroker): Unit = {
-    kafkaServer.authorizer match {
+  def addReconfigurables(kafkaServer: KafkaBroker): Unit = {
+    kafkaServer.getAuthorizer() match {
       case Some(authz: Reconfigurable) => addReconfigurable(authz)
       case _ =>
     }
-    addReconfigurable(kafkaServer.kafkaYammerMetrics)
+    addReconfigurable(kafkaServer.getKafkaYammerMetrics())
     addReconfigurable(new DynamicMetricsReporters(kafkaConfig.brokerId, kafkaServer))
     addReconfigurable(new DynamicClientQuotaCallback(kafkaConfig.brokerId, kafkaServer))
 
     addBrokerReconfigurable(new DynamicThreadPool(kafkaServer))
-    if (kafkaServer.logManager.cleaner != null)
-      addBrokerReconfigurable(kafkaServer.logManager.cleaner)
-    addBrokerReconfigurable(new DynamicLogConfig(kafkaServer.logManager, kafkaServer))
+    if (kafkaServer.getLogManager().cleaner != null)
+      addBrokerReconfigurable(kafkaServer.getLogManager().cleaner)
+    addBrokerReconfigurable(new DynamicLogConfig(kafkaServer.getLogManager(), kafkaServer))
     addBrokerReconfigurable(new DynamicListenerConfig(kafkaServer))
-    addBrokerReconfigurable(kafkaServer.socketServer)
+    addBrokerReconfigurable(kafkaServer.getSocketServer())
   }
 
   def addReconfigurable(reconfigurable: Reconfigurable): Unit = CoreUtils.inWriteLock(lock) {
@@ -625,7 +635,7 @@ object DynamicLogConfig {
   val KafkaConfigToLogConfigName = LogConfig.TopicConfigSynonyms.map { case (k, v) => (v, k) }
 }
 
-class DynamicLogConfig(logManager: LogManager, server: LegacyBroker) extends BrokerReconfigurable with Logging {
+class DynamicLogConfig(logManager: LogManager, server: KafkaBroker) extends BrokerReconfigurable with Logging {
 
   override def reconfigurableConfigs: Set[String] = {
     DynamicLogConfig.ReconfigurableConfigs
@@ -669,7 +679,7 @@ class DynamicLogConfig(logManager: LogManager, server: LegacyBroker) extends Bro
     updateLogsConfig(newBrokerDefaults.asScala)
 
     if (logManager.currentDefaultConfig.uncleanLeaderElectionEnable && !origUncleanLeaderElectionEnable) {
-      server.kafkaController.enableDefaultUncleanLeaderElection()
+      server.getKafkaController().foreach { _.enableDefaultUncleanLeaderElection() }
     }
   }
 }
@@ -683,7 +693,7 @@ object DynamicThreadPool {
     KafkaConfig.BackgroundThreadsProp)
 }
 
-class DynamicThreadPool(server: LegacyBroker) extends BrokerReconfigurable {
+class DynamicThreadPool(server: KafkaBroker) extends BrokerReconfigurable {
 
   override def reconfigurableConfigs: Set[String] = {
     DynamicThreadPool.ReconfigurableConfigs
@@ -709,33 +719,33 @@ class DynamicThreadPool(server: LegacyBroker) extends BrokerReconfigurable {
 
   override def reconfigure(oldConfig: KafkaConfig, newConfig: KafkaConfig): Unit = {
     if (newConfig.numIoThreads != oldConfig.numIoThreads)
-      server.dataPlaneRequestHandlerPool.resizeThreadPool(newConfig.numIoThreads)
+      server.getDataPlaneRequestHandlerPool().resizeThreadPool(newConfig.numIoThreads)
     if (newConfig.numNetworkThreads != oldConfig.numNetworkThreads)
-      server.socketServer.resizeThreadPool(oldConfig.numNetworkThreads, newConfig.numNetworkThreads)
+      server.getSocketServer().resizeThreadPool(oldConfig.numNetworkThreads, newConfig.numNetworkThreads)
     if (newConfig.numReplicaFetchers != oldConfig.numReplicaFetchers)
-      server.replicaManager.replicaFetcherManager.resizeThreadPool(newConfig.numReplicaFetchers)
+      server.getReplicaManager().replicaFetcherManager.resizeThreadPool(newConfig.numReplicaFetchers)
     if (newConfig.numRecoveryThreadsPerDataDir != oldConfig.numRecoveryThreadsPerDataDir)
-      server.getLogManager.resizeRecoveryThreadPool(newConfig.numRecoveryThreadsPerDataDir)
+      server.getLogManager().resizeRecoveryThreadPool(newConfig.numRecoveryThreadsPerDataDir)
     if (newConfig.backgroundThreads != oldConfig.backgroundThreads)
-      server.kafkaScheduler.resizeThreadPool(newConfig.backgroundThreads)
+      server.getKafkaScheduler().resizeThreadPool(newConfig.backgroundThreads)
   }
 
   private def currentValue(name: String): Int = {
     name match {
-      case KafkaConfig.NumIoThreadsProp => server.config.numIoThreads
-      case KafkaConfig.NumNetworkThreadsProp => server.config.numNetworkThreads
-      case KafkaConfig.NumReplicaFetchersProp => server.config.numReplicaFetchers
-      case KafkaConfig.NumRecoveryThreadsPerDataDirProp => server.config.numRecoveryThreadsPerDataDir
-      case KafkaConfig.BackgroundThreadsProp => server.config.backgroundThreads
+      case KafkaConfig.NumIoThreadsProp => server.getConfig().numIoThreads
+      case KafkaConfig.NumNetworkThreadsProp => server.getConfig().numNetworkThreads
+      case KafkaConfig.NumReplicaFetchersProp => server.getConfig().numReplicaFetchers
+      case KafkaConfig.NumRecoveryThreadsPerDataDirProp => server.getConfig().numRecoveryThreadsPerDataDir
+      case KafkaConfig.BackgroundThreadsProp => server.getConfig().backgroundThreads
       case n => throw new IllegalStateException(s"Unexpected config $n")
     }
   }
 }
 
-class DynamicMetricsReporters(brokerId: Int, server: LegacyBroker) extends Reconfigurable {
+class DynamicMetricsReporters(brokerId: Int, server: KafkaBroker) extends Reconfigurable {
 
-  private val dynamicConfig = server.config.dynamicConfig
-  private val metrics = server.metrics
+  private val dynamicConfig = server.getConfig().dynamicConfig
+  private val metrics = server.metrics()
   private val propsOverride = Map[String, AnyRef](KafkaConfig.BrokerIdProp -> brokerId.toString)
   private val currentReporters = mutable.Map[String, MetricsReporter]()
 
@@ -797,7 +807,7 @@ class DynamicMetricsReporters(brokerId: Int, server: LegacyBroker) extends Recon
       currentReporters += reporter.getClass.getName -> reporter
     }
     KafkaBroker.notifyClusterListeners(server.clusterId(), reporters.asScala)
-    KafkaBroker.notifyMetricsReporters(server.clusterId(), server.config, reporters.asScala)
+    KafkaBroker.notifyMetricsReporters(server.clusterId(), server.getConfig(), reporters.asScala)
   }
 
   private def removeReporter(className: String): Unit = {
@@ -808,6 +818,7 @@ class DynamicMetricsReporters(brokerId: Int, server: LegacyBroker) extends Recon
     configs.get(KafkaConfig.MetricReporterClassesProp).asInstanceOf[util.List[String]].asScala
   }
 }
+
 object DynamicListenerConfig {
 
   val ReconfigurableConfigs = Set(
@@ -857,13 +868,13 @@ object DynamicListenerConfig {
   )
 }
 
-class DynamicClientQuotaCallback(brokerId: Int, server: LegacyBroker) extends Reconfigurable {
+class DynamicClientQuotaCallback(brokerId: Int, server: KafkaBroker) extends Reconfigurable {
 
   override def configure(configs: util.Map[String, _]): Unit = {}
 
   override def reconfigurableConfigs(): util.Set[String] = {
     val configs = new util.HashSet[String]()
-    server.quotaManagers.clientQuotaCallback.foreach {
+    server.getQuotaManagers().clientQuotaCallback.foreach {
       case callback: Reconfigurable => configs.addAll(callback.reconfigurableConfigs)
       case _ =>
     }
@@ -871,15 +882,15 @@ class DynamicClientQuotaCallback(brokerId: Int, server: LegacyBroker) extends Re
   }
 
   override def validateReconfiguration(configs: util.Map[String, _]): Unit = {
-    server.quotaManagers.clientQuotaCallback.foreach {
+    server.getQuotaManagers().clientQuotaCallback.foreach {
       case callback: Reconfigurable => callback.validateReconfiguration(configs)
       case _ =>
     }
   }
 
   override def reconfigure(configs: util.Map[String, _]): Unit = {
-    val config = server.config
-    server.quotaManagers.clientQuotaCallback.foreach {
+    val config = server.getConfig()
+    server.getQuotaManagers().clientQuotaCallback.foreach {
       case callback: Reconfigurable =>
         config.dynamicConfig.maybeReconfigure(callback, config.dynamicConfig.currentKafkaConfig, configs)
         true
@@ -888,14 +899,14 @@ class DynamicClientQuotaCallback(brokerId: Int, server: LegacyBroker) extends Re
   }
 }
 
-class DynamicListenerConfig(server: LegacyBroker) extends BrokerReconfigurable with Logging {
+class DynamicListenerConfig(server: KafkaBroker) extends BrokerReconfigurable with Logging {
 
   override def reconfigurableConfigs: Set[String] = {
     DynamicListenerConfig.ReconfigurableConfigs
   }
 
   def validateReconfiguration(newConfig: KafkaConfig): Unit = {
-    val oldConfig = server.config
+    val oldConfig = server.getConfig()
     val newListeners = listenersToMap(newConfig.listeners)
     val newAdvertisedListeners = listenersToMap(newConfig.advertisedListeners)
     val oldListeners = listenersToMap(oldConfig.listeners)
@@ -932,17 +943,14 @@ class DynamicListenerConfig(server: LegacyBroker) extends BrokerReconfigurable w
     if (listenersAdded.nonEmpty || listenersRemoved.nonEmpty)
       LoginManager.closeAll()
 
-    server.socketServer.removeListeners(listenersRemoved)
+    server.getSocketServer().removeListeners(listenersRemoved)
     if (listenersAdded.nonEmpty)
-      server.socketServer.addListeners(listenersAdded)
+      server.getSocketServer().addListeners(listenersAdded)
 
-    server.kafkaController.updateBrokerInfo(server.createBrokerInfo)
+    server.getKafkaController().foreach { _.updateBrokerInfo(server.createBrokerInfo()) }
   }
 
   private def listenersToMap(listeners: Seq[EndPoint]): Map[ListenerName, EndPoint] =
     listeners.map(e => (e.listenerName, e)).toMap
 
 }
-
-
-

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -225,7 +225,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     apisUtils.authorizeClusterOperation(request, CLUSTER_ACTION)
     if (legacyController == null) {
-      throw new ClusterAuthorizationException(s"Request $request should never happen in KIP-500 mode.")
+      throw new UnsupportedVersionException(s"Request $request should never happen in KIP-500 mode.")
     }
     if (isBrokerEpochStale(leaderAndIsrRequest.brokerEpoch)) {
       // When the broker restarts very quickly, it is possible for this broker to receive request intended
@@ -246,7 +246,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val stopReplicaRequest = request.body[StopReplicaRequest]
     apisUtils.authorizeClusterOperation(request, CLUSTER_ACTION)
     if (legacyController == null) {
-      throw new ClusterAuthorizationException(s"Request $request should never happen in KIP-500 mode.")
+      throw new UnsupportedVersionException(s"Request $request should never happen in KIP-500 mode.")
     }
     if (isBrokerEpochStale(stopReplicaRequest.brokerEpoch)) {
       // When the broker restarts very quickly, it is possible for this broker to receive request intended
@@ -304,7 +304,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     apisUtils.authorizeClusterOperation(request, CLUSTER_ACTION)
     if (legacyController == null) {
-      throw new ClusterAuthorizationException(s"Request $request should never happen in KIP-500 mode.")
+      throw new UnsupportedVersionException(s"Request $request should never happen in KIP-500 mode.")
     }
     if (isBrokerEpochStale(updateMetadataRequest.brokerEpoch)) {
       // When the broker restarts very quickly, it is possible for this broker to receive request intended
@@ -349,7 +349,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val controlledShutdownRequest = request.body[ControlledShutdownRequest]
     apisUtils.authorizeClusterOperation(request, CLUSTER_ACTION)
     if (legacyController == null) {
-      throw new ClusterAuthorizationException(s"Request $request should never happen in KIP-500 mode.")
+      throw new UnsupportedVersionException(s"Request $request should never happen in KIP-500 mode.")
     }
 
     def controlledShutdownCallback(controlledShutdownResult: Try[Set[TopicPartition]]): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -20,7 +20,7 @@ package kafka.server
 import java.lang.{Long => JLong}
 import java.nio.ByteBuffer
 import java.util
-import java.util.{Collections, Optional}
+import java.util.{Collections, Optional, Properties}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -31,19 +31,19 @@ import kafka.common.OffsetAndMetadata
 import kafka.controller.{KafkaController, ReplicaAssignment}
 import kafka.coordinator.group.{GroupCoordinator, JoinGroupResult, LeaveGroupResult, SyncGroupResult}
 import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinator}
-import kafka.log.AppendOrigin
+import kafka.log.{AppendOrigin, LogConfig}
 import kafka.message.ZStdCompressionCodec
 import kafka.network.RequestChannel
 import kafka.security.authorizer.AuthorizerUtils
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
-import kafka.utils.{CoreUtils, Logging}
+import kafka.utils.{CoreUtils, Log4jController, Logging}
 import kafka.utils.Implicits._
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.common.acl.{AclBinding, AclOperation}
 import org.apache.kafka.common.acl.AclOperation._
-import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.config.{AbstractConfig, ConfigDef, ConfigResource}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.{FatalExitError, Topic}
 import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME, isInternal}
@@ -88,6 +88,9 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.{Map, Seq, Set, immutable, mutable}
 import scala.util.{Failure, Success, Try}
 import kafka.coordinator.group.GroupOverview
+import kafka.server.metadata.BrokerMetadataListener
+import org.apache.kafka.common.message.DescribeConfigsRequestData.DescribeConfigsResource
+import org.apache.kafka.common.requests.DescribeConfigsResponse.ConfigSource
 
 /**
  * Logic to handle the various Kafka requests
@@ -111,13 +114,14 @@ class KafkaApis(val requestChannel: RequestChannel,
                 time: Time,
                 val tokenManager: DelegationTokenManager,
                 val brokerFeatures: BrokerFeatures,
-                val finalizedFeatureCache: FinalizedFeatureCache) extends ApiRequestHandler with Logging {
+                val finalizedFeatureCache: FinalizedFeatureCache,
+                brokerMetadataListener: BrokerMetadataListener) extends ApiRequestHandler with Logging {
 
   val apisUtils = new ApisUtils(requestChannel, authorizer, quotas, time, Some(groupCoordinator), Some(txnCoordinator))
 
   type FetchResponseStats = Map[TopicPartition, RecordConversionStats]
   this.logIdent = "[KafkaApi-%d] ".format(brokerId)
-  val adminZkClient = new AdminZkClient(zkClient)
+  val adminZkClient = if (zkClient == null) null else new AdminZkClient(zkClient)
   private val alterAclsPurgatory = new DelayedFuturePurgatory(purgatoryName = "AlterAcls", brokerId = config.brokerId)
 
   def close(): Unit = {
@@ -220,6 +224,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     val leaderAndIsrRequest = request.body[LeaderAndIsrRequest]
 
     apisUtils.authorizeClusterOperation(request, CLUSTER_ACTION)
+    if (controller == null) {
+      throw new ClusterAuthorizationException(s"Request $request should never happen in KIP-500 mode.")
+    }
     if (isBrokerEpochStale(leaderAndIsrRequest.brokerEpoch)) {
       // When the broker restarts very quickly, it is possible for this broker to receive request intended
       // for its previous generation so the broker should skip the stale request.
@@ -238,6 +245,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     // stop serving data to clients for the topic being deleted
     val stopReplicaRequest = request.body[StopReplicaRequest]
     apisUtils.authorizeClusterOperation(request, CLUSTER_ACTION)
+    if (controller == null) {
+      throw new ClusterAuthorizationException(s"Request $request should never happen in KIP-500 mode.")
+    }
     if (isBrokerEpochStale(stopReplicaRequest.brokerEpoch)) {
       // When the broker restarts very quickly, it is possible for this broker to receive request intended
       // for its previous generation so the broker should skip the stale request.
@@ -293,6 +303,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     val updateMetadataRequest = request.body[UpdateMetadataRequest]
 
     apisUtils.authorizeClusterOperation(request, CLUSTER_ACTION)
+    if (controller == null) {
+      throw new ClusterAuthorizationException(s"Request $request should never happen in KIP-500 mode.")
+    }
     if (isBrokerEpochStale(updateMetadataRequest.brokerEpoch)) {
       // When the broker restarts very quickly, it is possible for this broker to receive request intended
       // for its previous generation so the broker should skip the stale request.
@@ -335,6 +348,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     // stop serving data to clients for the topic being deleted
     val controlledShutdownRequest = request.body[ControlledShutdownRequest]
     apisUtils.authorizeClusterOperation(request, CLUSTER_ACTION)
+    if (controller == null) {
+      throw new ClusterAuthorizationException(s"Request $request should never happen in KIP-500 mode.")
+    }
 
     def controlledShutdownCallback(controlledShutdownResult: Try[Set[TopicPartition]]): Unit = {
       val response = controlledShutdownResult match {
@@ -418,6 +434,9 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (authorizedTopicRequestInfo.isEmpty)
         sendResponseCallback(Map.empty)
       else if (header.apiVersion == 0) {
+        if (zkClient == null) {
+          throw new UnsupportedOperationException("Storing offsets in ZooKeeper is unsupported in KIP-500 mode")
+        }
         // for version 0 always store offsets to ZK
         val responseInfo = authorizedTopicRequestInfo.map {
           case (topicPartition, partitionData) =>
@@ -1085,6 +1104,9 @@ class KafkaApis(val requestChannel: RequestChannel,
                           replicationFactor: Int,
                           properties: util.Properties = new util.Properties()): MetadataResponseTopic = {
     try {
+      if (adminZkClient == null) {
+        throw new UnsupportedOperationException("Auto topic creation is not yet supported in KIP-500 mode")
+      }
       adminZkClient.createTopic(topic, numPartitions, replicationFactor, properties, RackAwareMode.Safe)
       info("Auto creation of topic %s with %d partitions and replication factor %d is successful"
         .format(topic, numPartitions, replicationFactor))
@@ -1282,6 +1304,9 @@ class KafkaApis(val requestChannel: RequestChannel,
               offsetFetchRequest.partitions.asScala)
 
             // version 0 reads offsets from ZK
+            if (zkClient == null) {
+              throw new UnsupportedOperationException("Reading offsets from ZooKeeper is unsupported in KIP-500 mode")
+            }
             val authorizedPartitionData = authorizedPartitions.map { topicPartition =>
               try {
                 if (!metadataCache.contains(topicPartition))
@@ -1756,7 +1781,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     val createTopicsRequest = request.body[CreateTopicsRequest]
     val results = new CreatableTopicResultCollection(createTopicsRequest.data.topics.size)
-    if (!controller.isActive) {
+    if (controller == null || !controller.isActive) {
       createTopicsRequest.data.topics.forEach { topic =>
         results.add(new CreatableTopicResult().setName(topic.name)
           .setErrorCode(Errors.NOT_CONTROLLER.code))
@@ -1840,7 +1865,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       apisUtils.sendResponseMaybeThrottle(controllerMutationQuota, request, createResponse, onComplete = None)
     }
 
-    if (!controller.isActive) {
+    if (controller == null || !controller.isActive) {
       val result = createPartitionsRequest.data.topics.asScala.map { topic =>
         (topic.name, new ApiError(Errors.NOT_CONTROLLER, null))
       }.toMap
@@ -1890,7 +1915,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val deleteTopicRequest = request.body[DeleteTopicsRequest]
     val results = new DeletableTopicResultCollection(deleteTopicRequest.data.topicNames.size)
     val toDelete = mutable.Set[String]()
-    if (!controller.isActive) {
+    if (controller == null || !controller.isActive) {
       deleteTopicRequest.data.topicNames.forEach { topic =>
         results.add(new DeletableTopicResult()
           .setName(topic)
@@ -2536,9 +2561,17 @@ class KafkaApis(val requestChannel: RequestChannel,
         case rt => throw new InvalidRequestException(s"Unexpected resource type $rt")
       }
     }
-    val authorizedResult = adminManager.alterConfigs(authorizedResources, alterConfigsRequest.validateOnly)
-    val unauthorizedResult = unauthorizedResources.keys.map { resource =>
-      resource -> configsAuthorizationApiError(resource)
+    // unsupported in KIP-500 mode until forwarding is available
+    val authorizedResult: Map[ConfigResource, ApiError] = if (adminManager == null) {
+      Map.empty
+    } else {
+      adminManager.alterConfigs(authorizedResources, alterConfigsRequest.validateOnly)
+    }
+    val unauthorizedResult = if (adminManager == null) {
+      unauthorizedResources.keys.map { resource => resource -> configsAuthorizationApiError(resource) } ++
+        authorizedResources.keys.map { resource => resource -> configsAuthorizationApiError(resource) }
+    } else {
+      unauthorizedResources.keys.map { resource => resource -> configsAuthorizationApiError(resource) }
     }
     def responseCallback(requestThrottleMs: Int): AlterConfigsResponse = {
       val data = new AlterConfigsResponseData()
@@ -2557,6 +2590,9 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleAlterPartitionReassignmentsRequest(request: RequestChannel.Request): Unit = {
     apisUtils.authorizeClusterOperation(request, ALTER)
+    if (controller == null) {
+      throw new ClusterAuthorizationException(s"Request $request is not authorized in KIP-500 mode.")
+    }
     val alterPartitionReassignmentsRequest = request.body[AlterPartitionReassignmentsRequest]
 
     def sendResponseCallback(result: Either[Map[TopicPartition, ApiError], ApiError]): Unit = {
@@ -2598,6 +2634,9 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleListPartitionReassignmentsRequest(request: RequestChannel.Request): Unit = {
     apisUtils.authorizeClusterOperation(request, DESCRIBE)
+    if (controller == null) {
+      throw new ClusterAuthorizationException(s"Request $request is not authorized in KIP-500 mode.")
+    }
     val listPartitionReassignmentsRequest = request.body[ListPartitionReassignmentsRequest]
 
     def sendResponseCallback(result: Either[Map[TopicPartition, ReplicaAssignment], ApiError]): Unit = {
@@ -2671,9 +2710,17 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
     }
 
-    val authorizedResult = adminManager.incrementalAlterConfigs(authorizedResources, alterConfigsRequest.data.validateOnly)
-    val unauthorizedResult = unauthorizedResources.keys.map { resource =>
-      resource -> configsAuthorizationApiError(resource)
+    // unsupported in KIP-500 mode until forwarding is available
+    val authorizedResult: Map[ConfigResource, ApiError] = if (adminManager == null) {
+      Map.empty
+    } else {
+      adminManager.incrementalAlterConfigs(authorizedResources, alterConfigsRequest.data.validateOnly)
+    }
+    val unauthorizedResult = if (adminManager == null) {
+      unauthorizedResources.keys.map { resource => resource -> configsAuthorizationApiError(resource) } ++
+        authorizedResources.keys.map { resource => resource -> configsAuthorizationApiError(resource) }
+    } else {
+      unauthorizedResources.keys.map { resource => resource -> configsAuthorizationApiError(resource) }
     }
     apisUtils.sendResponseMaybeThrottle(request, requestThrottleMs =>
       new IncrementalAlterConfigsResponse(IncrementalAlterConfigsResponse.toResponseData(requestThrottleMs,
@@ -2691,7 +2738,11 @@ class KafkaApis(val requestChannel: RequestChannel,
         case rt => throw new InvalidRequestException(s"Unexpected resource type $rt for resource ${resource.resourceName}")
       }
     }
-    val authorizedConfigs = adminManager.describeConfigs(authorizedResources.toList, describeConfigsRequest.data.includeSynonyms, describeConfigsRequest.data.includeDocumentation)
+    val authorizedConfigs: List[DescribeConfigsResponseData.DescribeConfigsResult] = if (adminManager == null) {
+      describeConfigs(authorizedResources.toList, describeConfigsRequest.data.includeSynonyms, describeConfigsRequest.data.includeDocumentation)
+    } else {
+      adminManager.describeConfigs(authorizedResources.toList, describeConfigsRequest.data.includeSynonyms, describeConfigsRequest.data.includeDocumentation)
+    }
     val unauthorizedConfigs = unauthorizedResources.map { resource =>
       val error = ConfigResource.Type.forId(resource.resourceType) match {
         case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER => Errors.CLUSTER_AUTHORIZATION_FAILED
@@ -2935,7 +2986,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       })
     }
 
-    if (!apisUtils.authorize(request.context, ALTER, CLUSTER, CLUSTER_NAME)) {
+    if (controller == null || !apisUtils.authorize(request.context, ALTER, CLUSTER, CLUSTER_NAME)) {
       val error = new ApiError(Errors.CLUSTER_AUTHORIZATION_FAILED, null)
       val partitionErrors: Map[TopicPartition, ApiError] =
         electionRequest.topicPartitions.iterator.map(partition => partition -> error).toMap
@@ -3019,7 +3070,8 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleDescribeClientQuotasRequest(request: RequestChannel.Request): Unit = {
     val describeClientQuotasRequest = request.body[DescribeClientQuotasRequest]
 
-    if (apisUtils.authorize(request.context, DESCRIBE_CONFIGS, CLUSTER, CLUSTER_NAME)) {
+    // unsupported in KIP-500 mode until we implement client quotas
+    if (adminManager != null && apisUtils.authorize(request.context, DESCRIBE_CONFIGS, CLUSTER, CLUSTER_NAME)) {
       val result = adminManager.describeClientQuotas(describeClientQuotasRequest.filter).map { case (quotaEntity, quotaConfigs) =>
         quotaEntity -> quotaConfigs.map { case (key, value) => key -> Double.box(value) }.asJava
       }.asJava
@@ -3034,7 +3086,8 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleAlterClientQuotasRequest(request: RequestChannel.Request): Unit = {
     val alterClientQuotasRequest = request.body[AlterClientQuotasRequest]
 
-    if (apisUtils.authorize(request.context, ALTER_CONFIGS, CLUSTER, CLUSTER_NAME)) {
+    // unsupported in KIP-500 mode until we implement client quotas
+    if (adminManager != null && apisUtils.authorize(request.context, ALTER_CONFIGS, CLUSTER, CLUSTER_NAME)) {
       val result = adminManager.alterClientQuotas(alterClientQuotasRequest.entries().asScala.toSeq,
         alterClientQuotasRequest.validateOnly()).asJava
       apisUtils.sendResponseMaybeThrottle(request, requestThrottleMs =>
@@ -3048,7 +3101,8 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleDescribeUserScramCredentialsRequest(request: RequestChannel.Request): Unit = {
     val describeUserScramCredentialsRequest = request.body[DescribeUserScramCredentialsRequest]
 
-    if (apisUtils.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME)) {
+    // unsupported in KIP-500 mode until we implement user SCRAM credentials
+    if (adminManager != null && apisUtils.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME)) {
       val result = adminManager.describeUserScramCredentials(
         Option(describeUserScramCredentialsRequest.data.users).map(_.asScala.map(_.name).toList))
       apisUtils.sendResponseMaybeThrottle(request, requestThrottleMs =>
@@ -3062,7 +3116,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleAlterUserScramCredentialsRequest(request: RequestChannel.Request): Unit = {
     val alterUserScramCredentialsRequest = request.body[AlterUserScramCredentialsRequest]
 
-    if (!controller.isActive) {
+    if (controller == null || !controller.isActive) {
       apisUtils.sendResponseMaybeThrottle(request, requestThrottleMs =>
         alterUserScramCredentialsRequest.getErrorResponse(requestThrottleMs, Errors.NOT_CONTROLLER.exception))
     } else if (apisUtils.authorize(request.context, ALTER, CLUSTER, CLUSTER_NAME)) {
@@ -3082,7 +3136,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     if (!apisUtils.authorize(request.context, CLUSTER_ACTION, CLUSTER, CLUSTER_NAME)) {
       apisUtils.sendResponseMaybeThrottle(request, requestThrottleMs =>
         alterIsrRequest.getErrorResponse(requestThrottleMs, Errors.CLUSTER_AUTHORIZATION_FAILED.exception))
-    } else if (!controller.isActive) {
+    } else if (controller == null || !controller.isActive) {
       apisUtils.sendResponseMaybeThrottle(request, requestThrottleMs =>
         alterIsrRequest.getErrorResponse(requestThrottleMs, Errors.NOT_CONTROLLER.exception()))
     } else {
@@ -3117,7 +3171,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     if (!apisUtils.authorize(request.context, ALTER, CLUSTER, CLUSTER_NAME)) {
       sendResponseCallback(Left(new ApiError(Errors.CLUSTER_AUTHORIZATION_FAILED)))
-    } else if (!controller.isActive) {
+    } else if (controller == null || !controller.isActive) {
       sendResponseCallback(Left(new ApiError(Errors.NOT_CONTROLLER)))
     } else if (!config.isFeatureVersioningSupported) {
       sendResponseCallback(Left(new ApiError(Errors.INVALID_REQUEST, "Feature versioning system is disabled.")))
@@ -3226,4 +3280,182 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
   }
 
+  // visible for testing
+  private[server] def describeConfigs(resourceToConfigNames: List[DescribeConfigsResource],
+                              includeSynonyms: Boolean,
+                              includeDocumentation: Boolean): List[DescribeConfigsResponseData.DescribeConfigsResult] = {
+    resourceToConfigNames.map { case resource =>
+
+      def allConfigs(config: AbstractConfig) = {
+        config.originals.asScala.filter(_._2 != null) ++ config.values.asScala
+      }
+
+      def createResponseConfig(configs: Map[String, Any],
+                               createConfigEntry: (String, Any) => DescribeConfigsResponseData.DescribeConfigsResourceResult): DescribeConfigsResponseData.DescribeConfigsResult = {
+        val filteredConfigPairs = if (resource.configurationKeys == null)
+          configs.toBuffer
+        else
+          configs.filter { case (configName, _) =>
+            resource.configurationKeys.asScala.forall(_.contains(configName))
+          }.toBuffer
+
+        val configEntries = filteredConfigPairs.map { case (name, value) => createConfigEntry(name, value) }
+        new DescribeConfigsResponseData.DescribeConfigsResult().setErrorCode(Errors.NONE.code)
+          .setConfigs(configEntries.asJava)
+      }
+
+      try {
+        val configResult = ConfigResource.Type.forId(resource.resourceType) match {
+          case ConfigResource.Type.TOPIC =>
+            val topic = resource.resourceName
+            Topic.validate(topic)
+            if (metadataCache.contains(topic)) {
+              val topicProps = brokerMetadataListener.initiallyCaughtUpFuture.get.configProperties(new ConfigResource(ConfigResource.Type.TOPIC, topic))
+              val logConfig = LogConfig.fromProps(KafkaBroker.copyKafkaConfigToLog(config), topicProps)
+              createResponseConfig(allConfigs(logConfig), createTopicConfigEntry(logConfig, topicProps, includeSynonyms, includeDocumentation))
+            } else {
+              new DescribeConfigsResponseData.DescribeConfigsResult().setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code)
+                .setConfigs(Collections.emptyList[DescribeConfigsResponseData.DescribeConfigsResourceResult])
+            }
+
+          case ConfigResource.Type.BROKER =>
+            if (resource.resourceName == null || resource.resourceName.isEmpty)
+              createResponseConfig(config.dynamicConfig.currentDynamicDefaultConfigs,
+                createBrokerConfigEntry(perBrokerConfig = false, includeSynonyms, includeDocumentation))
+            else if (resourceNameToBrokerId(resource.resourceName) == config.brokerId)
+              createResponseConfig(allConfigs(config),
+                createBrokerConfigEntry(perBrokerConfig = true, includeSynonyms, includeDocumentation))
+            else
+              throw new InvalidRequestException(s"Unexpected broker id, expected ${config.brokerId} or empty string, but received ${resource.resourceName}")
+
+          case ConfigResource.Type.BROKER_LOGGER =>
+            if (resource.resourceName == null || resource.resourceName.isEmpty)
+              throw new InvalidRequestException("Broker id must not be empty")
+            else if (resourceNameToBrokerId(resource.resourceName) != config.brokerId)
+              throw new InvalidRequestException(s"Unexpected broker id, expected ${config.brokerId} but received ${resource.resourceName}")
+            else
+              createResponseConfig(Log4jController.loggers,
+                (name, value) => new DescribeConfigsResponseData.DescribeConfigsResourceResult().setName(name)
+                  .setValue(value.toString).setConfigSource(ConfigSource.DYNAMIC_BROKER_LOGGER_CONFIG.id)
+                  .setIsSensitive(false).setReadOnly(false).setSynonyms(List.empty.asJava))
+          case resourceType => throw new InvalidRequestException(s"Unsupported resource type: $resourceType")
+        }
+        configResult.setResourceName(resource.resourceName).setResourceType(resource.resourceType)
+      } catch {
+        case e: Throwable =>
+          // Log client errors at a lower level than unexpected exceptions
+          val message = s"Error processing describe configs request for resource $resource"
+          if (e.isInstanceOf[ApiException])
+            info(message, e)
+          else
+            error(message, e)
+          val err = ApiError.fromThrowable(e)
+          new DescribeConfigsResponseData.DescribeConfigsResult()
+            .setResourceName(resource.resourceName)
+            .setResourceType(resource.resourceType)
+            .setErrorMessage(err.message)
+            .setErrorCode(err.error.code)
+            .setConfigs(Collections.emptyList[DescribeConfigsResponseData.DescribeConfigsResourceResult])
+      }
+    }
+  }
+
+  private def createTopicConfigEntry(logConfig: LogConfig, topicProps: Properties, includeSynonyms: Boolean, includeDocumentation: Boolean)
+                                    (name: String, value: Any): DescribeConfigsResponseData.DescribeConfigsResourceResult = {
+    val configEntryType = LogConfig.configType(name)
+    val isSensitive = KafkaConfig.maybeSensitive(configEntryType)
+    val valueAsString = if (isSensitive) null else ConfigDef.convertToString(value, configEntryType.orNull)
+    val allSynonyms = {
+      val list = LogConfig.TopicConfigSynonyms.get(name)
+        .map(s => configSynonyms(s, brokerSynonyms(s), isSensitive))
+        .getOrElse(List.empty)
+      if (!topicProps.containsKey(name))
+        list
+      else
+        new DescribeConfigsResponseData.DescribeConfigsSynonym().setName(name).setValue(valueAsString)
+          .setSource(ConfigSource.TOPIC_CONFIG.id) +: list
+    }
+    val source = if (allSynonyms.isEmpty) ConfigSource.DEFAULT_CONFIG.id else allSynonyms.head.source
+    val synonyms = if (!includeSynonyms) List.empty else allSynonyms
+    val dataType = configResponseType(configEntryType)
+    val configDocumentation = if (includeDocumentation) logConfig.documentationOf(name) else null
+    new DescribeConfigsResponseData.DescribeConfigsResourceResult()
+      .setName(name).setValue(valueAsString).setConfigSource(source)
+      .setIsSensitive(isSensitive).setReadOnly(false).setSynonyms(synonyms.asJava)
+      .setDocumentation(configDocumentation).setConfigType(dataType.id)
+  }
+
+  private def createBrokerConfigEntry(perBrokerConfig: Boolean, includeSynonyms: Boolean, includeDocumentation: Boolean)
+                                     (name: String, value: Any): DescribeConfigsResponseData.DescribeConfigsResourceResult = {
+    val allNames = brokerSynonyms(name)
+    val configEntryType = KafkaConfig.configType(name)
+    val isSensitive = KafkaConfig.maybeSensitive(configEntryType)
+    val valueAsString = if (isSensitive)
+      null
+    else value match {
+      case v: String => v
+      case _ => ConfigDef.convertToString(value, configEntryType.orNull)
+    }
+    val allSynonyms = configSynonyms(name, allNames, isSensitive)
+      .filter(perBrokerConfig || _.source == ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG.id)
+    val synonyms = if (!includeSynonyms) List.empty else allSynonyms
+    val source = if (allSynonyms.isEmpty) ConfigSource.DEFAULT_CONFIG.id else allSynonyms.head.source
+    val readOnly = !DynamicBrokerConfig.AllDynamicConfigs.contains(name)
+
+    val dataType = configResponseType(configEntryType)
+    val configDocumentation = if (includeDocumentation) brokerDocumentation(name) else null
+    new DescribeConfigsResponseData.DescribeConfigsResourceResult().setName(name).setValue(valueAsString).setConfigSource(source)
+      .setIsSensitive(isSensitive).setReadOnly(readOnly).setSynonyms(synonyms.asJava)
+      .setDocumentation(configDocumentation).setConfigType(dataType.id)
+  }
+
+  private def configSynonyms(name: String, synonyms: List[String], isSensitive: Boolean): List[DescribeConfigsResponseData.DescribeConfigsSynonym] = {
+    val dynamicConfig = config.dynamicConfig
+    val allSynonyms = mutable.Buffer[DescribeConfigsResponseData.DescribeConfigsSynonym]()
+
+    def maybeAddSynonym(map: Map[String, String], source: ConfigSource)(name: String): Unit = {
+      map.get(name).map { value =>
+        val configValue = if (isSensitive) null else value
+        allSynonyms += new DescribeConfigsResponseData.DescribeConfigsSynonym().setName(name).setValue(configValue).setSource(source.id)
+      }
+    }
+
+    synonyms.foreach(maybeAddSynonym(dynamicConfig.currentDynamicBrokerConfigs, ConfigSource.DYNAMIC_BROKER_CONFIG))
+    synonyms.foreach(maybeAddSynonym(dynamicConfig.currentDynamicDefaultConfigs, ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG))
+    synonyms.foreach(maybeAddSynonym(dynamicConfig.staticBrokerConfigs, ConfigSource.STATIC_BROKER_CONFIG))
+    synonyms.foreach(maybeAddSynonym(dynamicConfig.staticDefaultConfigs, ConfigSource.DEFAULT_CONFIG))
+    allSynonyms.dropWhile(s => s.name != name).toList // e.g. drop listener overrides when describing base config
+  }
+
+  private def brokerSynonyms(name: String): List[String] = {
+    DynamicBrokerConfig.brokerConfigSynonyms(name, matchListenerOverride = true)
+  }
+
+  private def brokerDocumentation(name: String): String = {
+    config.documentationOf(name)
+  }
+
+  private def configResponseType(configType: Option[ConfigDef.Type]): DescribeConfigsResponse.ConfigType = {
+    if (configType.isEmpty)
+      DescribeConfigsResponse.ConfigType.UNKNOWN
+    else configType.get match {
+      case ConfigDef.Type.BOOLEAN => DescribeConfigsResponse.ConfigType.BOOLEAN
+      case ConfigDef.Type.STRING => DescribeConfigsResponse.ConfigType.STRING
+      case ConfigDef.Type.INT => DescribeConfigsResponse.ConfigType.INT
+      case ConfigDef.Type.SHORT => DescribeConfigsResponse.ConfigType.SHORT
+      case ConfigDef.Type.LONG => DescribeConfigsResponse.ConfigType.LONG
+      case ConfigDef.Type.DOUBLE => DescribeConfigsResponse.ConfigType.DOUBLE
+      case ConfigDef.Type.LIST => DescribeConfigsResponse.ConfigType.LIST
+      case ConfigDef.Type.CLASS => DescribeConfigsResponse.ConfigType.CLASS
+      case ConfigDef.Type.PASSWORD => DescribeConfigsResponse.ConfigType.PASSWORD
+      case _ => DescribeConfigsResponse.ConfigType.UNKNOWN
+    }
+  }
+
+  private def resourceNameToBrokerId(resourceName: String): Int = {
+    try resourceName.toInt catch {
+      case _: NumberFormatException =>
+        throw new InvalidRequestException(s"Broker id must be an integer, but it is: $resourceName")
+    }
+  }
 }

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -126,17 +126,17 @@ trait KafkaBroker extends Logging with KafkaMetricsGroup {
   def clusterId(): String
 
   // methods required for legacy/kip500-agnostic dynamic configuration
-  def getConfig(): KafkaConfig
-  def getAuthorizer(): Option[Authorizer]
-  def getKafkaYammerMetrics(): KafkaYammerMetrics
-  def getQuotaManagers(): QuotaFactory.QuotaManagers
-  def getDataPlaneRequestHandlerPool(): KafkaRequestHandlerPool
-  def getSocketServer(): SocketServer
-  def getReplicaManager(): ReplicaManager
-  def getLogManager(): LogManager
-  def getKafkaScheduler(): KafkaScheduler
-  def getKafkaController(): Option[KafkaController] = None // must override in legacy broker
-  def createBrokerInfo(): BrokerInfo = throw new UnsupportedOperationException("Unsupported in KIP-500 mode") // must override in legacy broker
+  def config: KafkaConfig
+  def authorizer: Option[Authorizer]
+  def kafkaYammerMetrics: KafkaYammerMetrics
+  def quotaManagers: QuotaFactory.QuotaManagers
+  def dataPlaneRequestHandlerPool: KafkaRequestHandlerPool
+  def socketServer: SocketServer
+  def replicaManager: ReplicaManager
+  def logManager: LogManager
+  def kafkaScheduler: KafkaScheduler
+  def legacyController: Option[KafkaController] = None // must override in legacy broker
+  def createBrokerInfo: BrokerInfo = throw new UnsupportedOperationException("Unsupported in KIP-500 mode") // must override in legacy broker
 
   newKafkaServerGauge("BrokerState", () => currentState().value())
   newKafkaServerGauge("ClusterId", () => clusterId())

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -21,15 +21,19 @@ import java.util
 import java.util.concurrent._
 
 import com.yammer.metrics.{core => yammer}
-import kafka.log.LogConfig
+import kafka.controller.KafkaController
+import kafka.log.{LogConfig, LogManager}
 import kafka.metrics.{KafkaMetricsGroup, KafkaYammerMetrics, LinuxIoMetricsCollector}
-import kafka.utils.Logging
+import kafka.network.SocketServer
+import kafka.utils.{KafkaScheduler, Logging}
+import kafka.zk.BrokerInfo
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.common.internals.ClusterResourceListeners
 import org.apache.kafka.common.metrics.{KafkaMetricsContext, MetricConfig, Metrics, MetricsReporter, Sensor}
 import org.apache.kafka.common.ClusterResource
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.metadata.BrokerState
+import org.apache.kafka.server.authorizer.Authorizer
 
 import scala.jdk.CollectionConverters._
 import scala.collection.Seq
@@ -120,6 +124,19 @@ trait KafkaBroker extends Logging with KafkaMetricsGroup {
   def metrics(): Metrics
   def currentState(): BrokerState
   def clusterId(): String
+
+  // methods required for legacy/kip500-agnostic dynamic configuration
+  def getConfig(): KafkaConfig
+  def getAuthorizer(): Option[Authorizer]
+  def getKafkaYammerMetrics(): KafkaYammerMetrics
+  def getQuotaManagers(): QuotaFactory.QuotaManagers
+  def getDataPlaneRequestHandlerPool(): KafkaRequestHandlerPool
+  def getSocketServer(): SocketServer
+  def getReplicaManager(): ReplicaManager
+  def getLogManager(): LogManager
+  def getKafkaScheduler(): KafkaScheduler
+  def getKafkaController(): Option[KafkaController] = None // must override in legacy broker
+  def createBrokerInfo(): BrokerInfo = throw new UnsupportedOperationException("Unsupported in KIP-500 mode") // must override in legacy broker
 
   newKafkaServerGauge("BrokerState", () => currentState().value())
   newKafkaServerGauge("ClusterId", () => clusterId())

--- a/core/src/main/scala/kafka/server/KafkaServerManager.scala
+++ b/core/src/main/scala/kafka/server/KafkaServerManager.scala
@@ -43,7 +43,7 @@ object KafkaServerManager extends Logging {
       if (roles.asScala.distinct.length != roles.size()) {
         throw new RuntimeException(s"Duplicate role names found in roles config ${roles}")
       }
-      if (config.controllerConnect.isEmpty) {
+      if (config.controllerConnect == null || config.controllerConnect.isEmpty) {
         throw new RuntimeException(s"You must specify a value for ${KafkaConfig.ControllerConnectProp}")
       }
       roles.asScala.foreach {

--- a/core/src/main/scala/kafka/server/Kip500Broker.scala
+++ b/core/src/main/scala/kafka/server/Kip500Broker.scala
@@ -17,35 +17,136 @@
 
 package kafka.server
 
+import java.io.{File, IOException}
+import java.util
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 
-import kafka.metrics.KafkaMetricsReporter
-import kafka.server.metadata.BrokerMetadataListener
-import org.apache.kafka.common.utils.{LogContext, Time}
+import kafka.cluster.{Broker, EndPoint}
+import kafka.common.InconsistentBrokerMetadataException
+import kafka.controller.KafkaController
+import kafka.coordinator.group.GroupCoordinator
+import kafka.coordinator.transaction.{ProducerIdMgr, TransactionCoordinator}
+import kafka.log.LogManager
+import kafka.metrics.{KafkaMetricsReporter, KafkaYammerMetrics}
+import kafka.network.SocketServer
+import kafka.security.CredentialProvider
+import kafka.server.KafkaBroker.{metricsPrefix, notifyClusterListeners}
+import kafka.server.metadata.{BrokerMetadataListener}
+import kafka.utils.{CoreUtils, KafkaScheduler, Mx4jLoader}
+import kafka.zk.KafkaZkClient
+import org.apache.kafka.common.feature.{Features, SupportedVersionRange}
+import org.apache.kafka.common.message.BrokerRegistrationRequestData.{FeatureCollection, Listener, ListenerCollection}
+import org.apache.kafka.common.{Endpoint, KafkaException}
+import org.apache.kafka.common.internals.Topic
+import org.apache.kafka.common.metrics.{JmxReporter, Metrics, MetricsReporter}
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.common.security.scram.internals.ScramMechanism
+import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
+import org.apache.kafka.common.utils.{AppInfoParser, LogContext, Time}
 import org.apache.kafka.controller.{LocalLogManager, MetaLogManager}
 import org.apache.kafka.metadata.BrokerState
+import org.apache.kafka.server.authorizer.Authorizer
+
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.{Map, Seq, mutable}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success}
 
 /**
  * A KIP-500 Kafka broker.
  */
-class Kip500Broker(config: KafkaConfig,
+class Kip500Broker(val config: KafkaConfig,
                    time: Time,
                    threadNamePrefix: Option[String],
                    kafkaMetricsReporters: Seq[KafkaMetricsReporter]) extends KafkaBroker {
   import kafka.server.KafkaServerManager._
 
+  private val isShuttingDown = new AtomicBoolean(false)
+
   val lock = new ReentrantLock()
   val awaitShutdownCond = lock.newCondition()
   var status: ProcessStatus = KafkaServerManager.SHUTDOWN
+
+  private var logContext: LogContext = null
+
+  var kafkaYammerMetrics: KafkaYammerMetrics = null
+  var metrics: Metrics = null
+
+  var dataPlaneRequestProcessor: KafkaApis = null
+  var controlPlaneRequestProcessor: KafkaApis = null
+
+  var authorizer: Option[Authorizer] = None
+  var socketServer: SocketServer = null
+  var dataPlaneRequestHandlerPool: KafkaRequestHandlerPool = null
+  var controlPlaneRequestHandlerPool: KafkaRequestHandlerPool = null
+
+  var logDirFailureChannel: LogDirFailureChannel = null
+  var logManager: LogManager = null
+  var cleanShutdown: Option[Boolean] = None
+
+  var tokenManager: DelegationTokenManager = null
+
+  var replicaManager: ReplicaManager = null
+
+  var credentialProvider: CredentialProvider = null
+  var tokenCache: DelegationTokenCache = null
+
+  var groupCoordinator: GroupCoordinator = null
+
+  var transactionCoordinator: TransactionCoordinator = null
+
+  var brokerToControllerChannelManager: Kip500BrokerToControllerChannelManager = null
+
+  var kafkaScheduler: KafkaScheduler = null
+
+  var metadataCache: MetadataCache = null
+  var quotaManagers: QuotaFactory.QuotaManagers = null
+
+  val brokerMetaPropsFile = "meta.properties"
+  val brokerMetadataCheckpoints = config.logDirs.map(logDir => (logDir, new BrokerMetadataCheckpoint(new File(logDir + File.separator + brokerMetaPropsFile)))).toMap
+
+  private var _clusterId: String = null
+  private var _brokerTopicStats: BrokerTopicStats = null
+
+  val brokerFeatures: BrokerFeatures = BrokerFeatures.createDefault()
+
+  val featureCache: FinalizedFeatureCache = new FinalizedFeatureCache(brokerFeatures)
+
+  def clusterId(): String = _clusterId
+
   var brokerMetadataListener: BrokerMetadataListener = null
+  val _brokerMetadataListenerFuture: CompletableFuture[BrokerMetadataListener] = new CompletableFuture[BrokerMetadataListener]()
+
+  var brokerLifecycleManager: BrokerLifecycleManager = null
+
   var metaLogManager: MetaLogManager = null
+
+  override def getConfig(): KafkaConfig = config
+  override def getAuthorizer(): Option[Authorizer] = authorizer
+  override def getKafkaYammerMetrics(): KafkaYammerMetrics = kafkaYammerMetrics
+  override def getQuotaManagers(): QuotaFactory.QuotaManagers = quotaManagers
+  override def getDataPlaneRequestHandlerPool(): KafkaRequestHandlerPool = dataPlaneRequestHandlerPool
+  override def getSocketServer(): SocketServer = socketServer
+  override def getReplicaManager(): ReplicaManager = replicaManager
+  override def getKafkaScheduler(): KafkaScheduler = kafkaScheduler
+
+  private[kafka] def brokerTopicStats = _brokerTopicStats
 
   private def maybeChangeStatus(from: ProcessStatus, to: ProcessStatus): Boolean = {
     lock.lock()
     try {
       if (status != from) return false
       status = to
-      if (to == SHUTDOWN) awaitShutdownCond.signalAll()
+      if (to == SHUTTING_DOWN) {
+        isShuttingDown.set(true)
+      } else if (to == SHUTDOWN) {
+        isShuttingDown.set(false)
+        awaitShutdownCond.signalAll()
+      }
     } finally {
       lock.unlock()
     }
@@ -55,22 +156,105 @@ class Kip500Broker(config: KafkaConfig,
   override def startup(): Unit = {
     if (!maybeChangeStatus(SHUTDOWN, STARTING)) return
     try {
-      // Start the broker metadata change listener
-      // FIXME: Replace placeholders w/ actual instances
-      //        Should be a merge conflict here for you @Ron
-      // DEPENDS ON: github.com/confluentinc/kafka/pull/44
+      val (loadedClusterId, loadedBrokerId, initialOfflineDirs) = loadClusterIdBrokerIdAndOfflineDirs
+      _clusterId = loadedClusterId
+      info(s"Cluster ID = ${_clusterId}")
+
+      config.brokerId = loadedBrokerId
+      logContext = new LogContext(s"[KafkaBroker id=${config.brokerId}] ")
+      this.logIdent = logContext.logPrefix
+
+      // initialize dynamic broker configs from static config. Any updates will be
+      // applied as we process the metadata log.
+      config.dynamicConfig.initialize() // Currently we don't wait for catch-up on the metadata log.  TODO?
+
+      /* start scheduler */
+      kafkaScheduler = new KafkaScheduler(config.backgroundThreads)
+      kafkaScheduler.startup()
+
+      /* create and configure metrics */
+      kafkaYammerMetrics = KafkaYammerMetrics.INSTANCE
+      kafkaYammerMetrics.configure(config.originals)
+
+      val jmxReporter = new JmxReporter()
+      jmxReporter.configure(config.originals)
+
+      val reporters = new util.ArrayList[MetricsReporter]
+      reporters.add(jmxReporter)
+
+      val metricConfig = KafkaBroker.metricConfig(config)
+      val metricsContext = KafkaBroker.createKafkaMetricsContext(_clusterId, config)
+      metrics = new Metrics(metricConfig, reporters, time, true, metricsContext)
+
+      /* register broker metrics */
+      _brokerTopicStats = new BrokerTopicStats
+
+      quotaManagers = QuotaFactory.instantiate(config, metrics, time, threadNamePrefix.getOrElse(""))
+      notifyClusterListeners(_clusterId, kafkaMetricsReporters ++ metrics.reporters.asScala)
+
+      logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size)
+
+      /* create log manager, which will perform recovery from unclean shutdown if necessary before returning */
+      logManager = LogManager(config, initialOfflineDirs, wasCleanShutdown => cleanShutdown = Some(wasCleanShutdown), kafkaScheduler, time, brokerTopicStats, logDirFailureChannel)
+      /* start log manager */
+      logManager.startup()
+
+      metadataCache = new MetadataCache(config.brokerId)
+      // Enable delegation token cache for all SCRAM mechanisms to simplify dynamic update.
+      // This keeps the cache up-to-date if new SCRAM mechanisms are enabled dynamically.
+      tokenCache = new DelegationTokenCache(ScramMechanism.mechanismNames)
+      credentialProvider = new CredentialProvider(ScramMechanism.mechanismNames, tokenCache)
+
+      // Create and start the socket server acceptor threads so that the bound port is known.
+      // Delay starting processors until the end of the initialization sequence to ensure
+      // that credentials have been loaded before processing authentications.
+      socketServer = new SocketServer(config, metrics, time, credentialProvider)
+      socketServer.startup(startProcessingRequests = false)
+
+      /* start replica manager */
+      replicaManager = createReplicaManager(isShuttingDown)
+      replicaManager.startup()
+
+      /* start broker-to-controller channel manager */
+      brokerToControllerChannelManager = new Kip500BrokerToControllerChannelManager(time, metrics, config, threadNamePrefix)
+      brokerToControllerChannelManager.start()
+
+      /* start token manager */
+      if (config.tokenAuthEnabled) {
+        throw new UnsupportedOperationException("Delegation tokens are not supported")
+      }
+      tokenManager = new DelegationTokenManager(config, tokenCache, time , null)
+      tokenManager.startup() // does nothing, we just need a token manager in order to compile right now...
+
+      /* start group coordinator */
+      // Hardcode Time.SYSTEM for now as some Streams tests fail otherwise, it would be good to fix the underlying issue
+      groupCoordinator = GroupCoordinator(config, () => getGroupMetadataTopicPartitionCount(), replicaManager, Time.SYSTEM, metrics)
+      groupCoordinator.startup()
+
+      /* start transaction coordinator, with a separate background thread scheduler for transaction expiration and log loading */
+      // Hardcode Time.SYSTEM for now as some Streams tests fail otherwise, it would be good to fix the underlying issue
+      transactionCoordinator = TransactionCoordinator(config, replicaManager, new KafkaScheduler(threads = 1, threadNamePrefix = "transaction-log-manager-"),
+        createTemporaryProducerIdManager(), getTransactionTopicPartitionCount,
+        metrics, metadataCache, Time.SYSTEM)
+      transactionCoordinator.startup()
+
+      /* Add all reconfigurables for config change notification before starting the metadata listener */
+      config.dynamicConfig.addReconfigurables(this.asInstanceOf[Kip500Broker])
+
       brokerMetadataListener = new BrokerMetadataListener(
         config, time,
         BrokerMetadataListener.defaultProcessors(
-          config,
-          "CLUSTER_ID_PLACEHOLDER",
-          null,
-          null,
-          null,
-          null,
-          null,
-          null))
+          config, _clusterId, metadataCache, groupCoordinator, quotaManagers, replicaManager, transactionCoordinator,
+          logManager))
+      _brokerMetadataListenerFuture.complete(brokerMetadataListener)
       brokerMetadataListener.start()
+
+      /* check local clusterId matches the controller quorum clusterId */
+      // TODO: decide if maybe this would be better to communicate in a registration request?
+      val controllerQuorumClusterId = brokerToControllerChannelManager.clusterId().get()
+      if (_clusterId != controllerQuorumClusterId) {
+        throw new IllegalStateException(s"Local clusterId ${_clusterId} does not match controller quorum clusterId $controllerQuorumClusterId")
+      }
 
       // Initialize the metadata log manager
       // TODO: Replace w/ the raft log implementation
@@ -78,6 +262,76 @@ class Kip500Broker(config: KafkaConfig,
         config.controllerId, config.metadataLogDir, "log-manager")
       metaLogManager.initialize(brokerMetadataListener)
 
+      brokerLifecycleManager = new BrokerLifecycleManagerImpl(brokerMetadataListener, config,
+        brokerToControllerChannelManager, kafkaScheduler, time, config.brokerId, config.rack.getOrElse(""),
+        brokerMetadataListener.currentMetadataOffset, brokerMetadataListener.brokerEpochNow)
+
+      val listeners = new ListenerCollection()
+      config.advertisedListeners.foreach { ep =>
+        listeners.add(new Listener().setHost(ep.host).setName(ep.listenerName.value()).setPort(ep.port.shortValue())
+          .setSecurityProtocol(ep.securityProtocol.id))
+      }
+      val features = new FeatureCollection()
+      brokerLifecycleManager.start(listeners, features)
+
+      val endPoints = new ArrayBuffer[EndPoint](listeners.size())
+      listeners.iterator().forEachRemaining(listener => {
+        endPoints += new EndPoint(listener.host(), listener.port(), new ListenerName(listener.name()),
+          SecurityProtocol.forId(listener.securityProtocol()))
+      })
+      val supportedFeaturesMap = mutable.Map[String, SupportedVersionRange]()
+      features.iterator().forEachRemaining(feature => {
+        supportedFeaturesMap(feature.name()) = new SupportedVersionRange(feature.minSupportedVersion(), feature.maxSupportedVersion())
+      })
+
+      val broker = Broker(config.brokerId, endPoints, config.rack, Features.supportedFeatures(supportedFeaturesMap.asJava))
+
+      /* Get the authorizer and initialize it if one is specified.*/
+      authorizer = config.authorizer
+      authorizer.foreach(_.configure(config.originals))
+      val authorizerFutures: Map[Endpoint, CompletableFuture[Void]] = authorizer match {
+        case Some(authZ) =>
+          authZ.start(broker.toServerInfo(_clusterId, config)).asScala.map { case (ep, cs) =>
+            ep -> cs.toCompletableFuture
+          }
+        case None =>
+          broker.endPoints.map { ep =>
+            ep.toJava -> CompletableFuture.completedFuture[Void](null)
+          }.toMap
+      }
+
+      val fetchManager = new FetchManager(Time.SYSTEM,
+        new FetchSessionCache(config.maxIncrementalFetchSessionCacheSlots,
+          KafkaBroker.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS))
+
+      /* start processing requests */
+      val adminManager: LegacyAdminManager = null
+      val zkClient: KafkaZkClient = null
+      val kafkaController: KafkaController = null
+      dataPlaneRequestProcessor = new KafkaApis(socketServer.dataPlaneRequestChannel,
+        replicaManager, adminManager, groupCoordinator, transactionCoordinator,
+        kafkaController, zkClient, config.brokerId, config, metadataCache, metrics, authorizer, quotaManagers,
+        fetchManager, brokerTopicStats, _clusterId, time, tokenManager, brokerFeatures, featureCache, brokerMetadataListener)
+
+      dataPlaneRequestHandlerPool = new KafkaRequestHandlerPool(config.brokerId, socketServer.dataPlaneRequestChannel, dataPlaneRequestProcessor, time,
+        config.numIoThreads, s"${SocketServer.DataPlaneMetricPrefix}RequestHandlerAvgIdlePercent", SocketServer.DataPlaneThreadPrefix)
+
+      socketServer.controlPlaneRequestChannelOpt.foreach { controlPlaneRequestChannel =>
+        controlPlaneRequestProcessor = new KafkaApis(controlPlaneRequestChannel,
+          replicaManager, adminManager, groupCoordinator, transactionCoordinator,
+          kafkaController, zkClient, config.brokerId, config, metadataCache, metrics, authorizer, quotaManagers,
+          fetchManager, brokerTopicStats, _clusterId, time, tokenManager, brokerFeatures, featureCache, brokerMetadataListener)
+
+        controlPlaneRequestHandlerPool = new KafkaRequestHandlerPool(config.brokerId, socketServer.controlPlaneRequestChannelOpt.get, controlPlaneRequestProcessor, time,
+          1, s"${SocketServer.ControlPlaneMetricPrefix}RequestHandlerAvgIdlePercent", SocketServer.ControlPlaneThreadPrefix)
+      }
+
+      Mx4jLoader.maybeLoad()
+
+      socketServer.startProcessingRequests(authorizerFutures)
+
+      AppInfoParser.registerAppInfo(metricsPrefix, config.brokerId.toString, metrics, time.milliseconds())
+      info("started")
       maybeChangeStatus(STARTING, STARTED)
     } catch {
       case e: Throwable =>
@@ -88,9 +342,140 @@ class Kip500Broker(config: KafkaConfig,
     }
   }
 
-  override def shutdown(): Unit = {
+  class TemporaryProducerIdManager() extends ProducerIdMgr {
+    val maxProducerIdsPerBrokerEpoch = 1000000
+    var currentOffset = -1
+    override def generateProducerId(): Long = {
+      currentOffset = currentOffset + 1
+      if (currentOffset >= maxProducerIdsPerBrokerEpoch) {
+        fatal(s"Exhausted all demo/temporary producerIds as the next one will has extend past the block size of $maxProducerIdsPerBrokerEpoch")
+        throw new KafkaException("Have exhausted all demo/temporary producerIds.")
+      }
+      _brokerMetadataListenerFuture.get.brokerEpochFuture().get() * maxProducerIdsPerBrokerEpoch + currentOffset
+    }
+  }
+
+  def createTemporaryProducerIdManager(): ProducerIdMgr = {
+    new TemporaryProducerIdManager()
+  }
+
+  protected def createReplicaManager(isShuttingDown: AtomicBoolean): ReplicaManager = {
+    val alterIsrManager = new AlterIsrManagerImpl(brokerToControllerChannelManager, kafkaScheduler,
+      time, config.brokerId, () => _brokerMetadataListenerFuture.get.brokerEpochFuture().get())
+    // explicitly declare to eliminate spotbugs error in Scala 2.12
+    val zkClient: Option[KafkaZkClient] = None
+    new ReplicaManager(config, metrics, time, zkClient, kafkaScheduler, logManager, isShuttingDown, quotaManagers,
+      brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager, None, Some(_brokerMetadataListenerFuture))
+  }
+
+  /**
+   * Gets the partition count of the group metadata topic from the metadata log.
+   * If the topic does not exist, the configured partition count is returned.
+   */
+  def getGroupMetadataTopicPartitionCount(): Int = {
+    // wait until we are caught up on the metadata log if necessary
+    val listener = _brokerMetadataListenerFuture.get()
+    listener.initiallyCaughtUpFuture.get()
+    // now return the number of partitions if the topic exists, otherwise the default
+    metadataCache.numPartitions(Topic.GROUP_METADATA_TOPIC_NAME).getOrElse(config.offsetsTopicPartitions)
+  }
+
+  /**
+   * Gets the partition count of the transaction log topic from the metadata log.
+   * If the topic does not exist, the default partition count is returned.
+   */
+  def getTransactionTopicPartitionCount(): Int = {
+    // wait until we are caught up on the metadata log if necessary
+    val listener = _brokerMetadataListenerFuture.get()
+    listener.initiallyCaughtUpFuture.get()
+    // now return the number of partitions if the topic exists, otherwise the default
+    metadataCache.numPartitions(Topic.TRANSACTION_STATE_TOPIC_NAME).getOrElse(config.transactionTopicPartitions)
+  }
+
+  /**
+   * Performs controlled shutdown
+   */
+  private def controlledShutdown(): Unit = {
+
+    if (config.controlledShutdownEnable) {
+      // We request the heartbeat to initiate a controlled shutdown.
+      info("Controlled shutdown requested")
+
+      if (brokerLifecycleManager != null) { // it's possible we haven't created it yet, in which case we do nothing
+        info("Requesting controlled shutdown via broker heartbeat")
+        brokerLifecycleManager.enqueue(BrokerState.PENDING_CONTROLLED_SHUTDOWN).future.onComplete {
+          case Success(_) => info("Controlled shutdown succeeded")
+          case Failure(_) => warn("Proceeding to do an unclean shutdown as all the controlled shutdown attempts failed")
+        }
+      }
+    }
+  }
+
+  def shutdown(): Unit = {
     if (!maybeChangeStatus(STARTED, SHUTTING_DOWN)) return
     try {
+      info("shutting down")
+
+      CoreUtils.swallow(controlledShutdown(), this)
+
+      // Stop socket server to stop accepting any more connections and requests.
+      // Socket server will be shutdown towards the end of the sequence.
+      if (socketServer != null)
+        CoreUtils.swallow(socketServer.stopProcessingRequests(), this)
+      if (dataPlaneRequestHandlerPool != null)
+        CoreUtils.swallow(dataPlaneRequestHandlerPool.shutdown(), this)
+      if (controlPlaneRequestHandlerPool != null)
+        CoreUtils.swallow(controlPlaneRequestHandlerPool.shutdown(), this)
+      if (kafkaScheduler != null)
+        CoreUtils.swallow(kafkaScheduler.shutdown(), this)
+
+      if (dataPlaneRequestProcessor != null)
+        CoreUtils.swallow(dataPlaneRequestProcessor.close(), this)
+      if (controlPlaneRequestProcessor != null)
+        CoreUtils.swallow(controlPlaneRequestProcessor.close(), this)
+      CoreUtils.swallow(authorizer.foreach(_.close()), this)
+
+      if (brokerLifecycleManager != null)
+        CoreUtils.swallow(brokerLifecycleManager.stop(), this)
+
+      if (brokerMetadataListener !=  null) {
+        CoreUtils.swallow(brokerMetadataListener.close(), this)
+      }
+      _brokerMetadataListenerFuture.cancel(true)
+
+      if (transactionCoordinator != null)
+        CoreUtils.swallow(transactionCoordinator.shutdown(), this)
+      if (groupCoordinator != null)
+        CoreUtils.swallow(groupCoordinator.shutdown(), this)
+
+      if (tokenManager != null)
+        CoreUtils.swallow(tokenManager.shutdown(), this)
+
+      if (replicaManager != null)
+        CoreUtils.swallow(replicaManager.shutdown(), this)
+
+      if (brokerToControllerChannelManager != null)
+        CoreUtils.swallow(brokerToControllerChannelManager.shutdown(), this)
+
+      if (logManager != null)
+        CoreUtils.swallow(logManager.shutdown(), this)
+
+      if (quotaManagers != null)
+        CoreUtils.swallow(quotaManagers.shutdown(), this)
+
+      if (socketServer != null)
+        CoreUtils.swallow(socketServer.shutdown(), this)
+      if (metrics != null)
+        CoreUtils.swallow(metrics.close(), this)
+      if (brokerTopicStats != null)
+        CoreUtils.swallow(brokerTopicStats.close(), this)
+
+      // Clear all reconfigurable instances stored in DynamicBrokerConfig
+      config.dynamicConfig.clear()
+
+      isShuttingDown.set(false)
+      CoreUtils.swallow(AppInfoParser.unregisterAppInfo(metricsPrefix, config.brokerId.toString, metrics), this)
+      info("shut down completed")
     } catch {
       case e: Throwable =>
         fatal("Fatal error during broker shutdown.", e)
@@ -112,9 +497,80 @@ class Kip500Broker(config: KafkaConfig,
     }
   }
 
-  override def metrics() = null
+  def getLogManager(): LogManager = logManager
 
-  override def currentState(): BrokerState = null
+  override def currentState(): BrokerState = {
+    if (logManager == null) {
+      // we haven't instantiated log manager yet, so we are either not running or recovering from unclean shutdown
+      if (cleanShutdown.isDefined && !cleanShutdown.get) {
+        BrokerState.RECOVERING_FROM_UNCLEAN_SHUTDOWN
+      } else {
+        BrokerState.NOT_RUNNING
+      }
+    } else if (brokerLifecycleManager == null) {
+      // we've instantiated our log manager but not yet our lifecycle manager, so we are not running
+      BrokerState.NOT_RUNNING
+    } else {
+      // we've instantiated everything, so the lifecycle manager has our current state
+      brokerLifecycleManager.brokerState
+    }
+  }
 
-  override def clusterId(): String = null
+  def loadClusterIdBrokerIdAndOfflineDirs: (String, Int, Seq[String]) = {
+    /* load metadata */
+    val (loadedBrokerMetadata, initialOfflineDirs) = getBrokerMetadataAndOfflineDirs
+
+    /* check brokerId */
+    val loadedBrokerId = config.brokerId // TODO: grab loadedBrokerMetadata.brokerId when available in meta.properties
+    if (config.brokerId != loadedBrokerId)
+      throw new InconsistentBrokerMetadataException(
+        s"The configured Broker ID ${config.brokerId} doesn't match stored broker.id ${loadedBrokerId} in meta.properties. " +
+          s"The broker is trying to use the wrong log directory. Configured log.dirs may be wrong.")
+
+    (loadedBrokerMetadata.clusterId.toString, loadedBrokerId, initialOfflineDirs)
+  }
+
+  /**
+   * Reads the BrokerMetadata. If the BrokerMetadata doesn't match in all the log.dirs, InconsistentBrokerMetadataException is
+   * thrown.
+   *
+   * The log directories whose meta.properties can not be accessed due to IOException will be returned to the caller
+   *
+   * @return A 2-tuple containing the brokerMetadata and a sequence of offline log directories.
+   */
+  private def getBrokerMetadataAndOfflineDirs: (MetaProperties, Seq[String]) = {
+    val brokerMetadataMap = mutable.HashMap[String, MetaProperties]()
+    val brokerMetadataSet = mutable.HashSet[MetaProperties]()
+    val offlineDirs = mutable.ArrayBuffer.empty[String]
+
+    for (logDir <- config.logDirs) {
+      try {
+        brokerMetadataCheckpoints(logDir).read().foreach(properties => {
+          val brokerMetadata = MetaProperties(properties)
+          brokerMetadataMap += (logDir -> brokerMetadata)
+          brokerMetadataSet += brokerMetadata
+        })
+      } catch {
+        case e: IOException =>
+          offlineDirs += logDir
+          error(s"Fail to read $brokerMetaPropsFile under log directory $logDir", e)
+      }
+    }
+
+    if (brokerMetadataSet.size > 1) {
+      val builder = new StringBuilder
+
+      for ((logDir, brokerMetadata) <- brokerMetadataMap)
+        builder ++= s"- $logDir -> $brokerMetadata\n"
+
+      throw new InconsistentBrokerMetadataException(
+        s"BrokerMetadata is not consistent across log.dirs. This could happen if multiple brokers shared a log directory (log.dirs) " +
+          s"or partial data was manually copied from another broker. Found:\n${builder.toString()}"
+      )
+    } else if (brokerMetadataSet.size == 1)
+      (brokerMetadataSet.last, offlineDirs)
+    else {
+      throw new IOException("All log dirs are offline; unable to read any meta.properties file.")
+    }
+  }
 }

--- a/core/src/main/scala/kafka/server/Kip500Broker.scala
+++ b/core/src/main/scala/kafka/server/Kip500Broker.scala
@@ -186,7 +186,9 @@ class Kip500Broker(val config: KafkaConfig,
       logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size)
 
       /* create log manager, which will perform recovery from unclean shutdown if necessary before returning */
-      logManager = LogManager(config, initialOfflineDirs, wasCleanShutdown => cleanShutdown = Some(wasCleanShutdown), kafkaScheduler, time, brokerTopicStats, logDirFailureChannel)
+      val cleanShutdownCompletableFuture = new CompletableFuture[Boolean]()
+      logManager = LogManager(config, initialOfflineDirs, cleanShutdownCompletableFuture, kafkaScheduler, time, brokerTopicStats, logDirFailureChannel)
+      cleanShutdown = Some(cleanShutdownCompletableFuture.get())
       /* start log manager */
       logManager.startup()
 

--- a/core/src/main/scala/kafka/server/Kip500Broker.scala
+++ b/core/src/main/scala/kafka/server/Kip500Broker.scala
@@ -125,15 +125,6 @@ class Kip500Broker(val config: KafkaConfig,
 
   var metaLogManager: MetaLogManager = null
 
-  override def getConfig(): KafkaConfig = config
-  override def getAuthorizer(): Option[Authorizer] = authorizer
-  override def getKafkaYammerMetrics(): KafkaYammerMetrics = kafkaYammerMetrics
-  override def getQuotaManagers(): QuotaFactory.QuotaManagers = quotaManagers
-  override def getDataPlaneRequestHandlerPool(): KafkaRequestHandlerPool = dataPlaneRequestHandlerPool
-  override def getSocketServer(): SocketServer = socketServer
-  override def getReplicaManager(): ReplicaManager = replicaManager
-  override def getKafkaScheduler(): KafkaScheduler = kafkaScheduler
-
   private[kafka] def brokerTopicStats = _brokerTopicStats
 
   private def maybeChangeStatus(from: ProcessStatus, to: ProcessStatus): Boolean = {
@@ -496,8 +487,6 @@ class Kip500Broker(val config: KafkaConfig,
       lock.unlock()
     }
   }
-
-  def getLogManager(): LogManager = logManager
 
   override def currentState(): BrokerState = {
     if (logManager == null) {

--- a/core/src/main/scala/kafka/server/Kip500Broker.scala
+++ b/core/src/main/scala/kafka/server/Kip500Broker.scala
@@ -27,7 +27,7 @@ import kafka.cluster.{Broker, EndPoint}
 import kafka.common.InconsistentBrokerMetadataException
 import kafka.controller.KafkaController
 import kafka.coordinator.group.GroupCoordinator
-import kafka.coordinator.transaction.{ProducerIdMgr, TransactionCoordinator}
+import kafka.coordinator.transaction.{ProducerIdGenerator, TransactionCoordinator}
 import kafka.log.LogManager
 import kafka.metrics.{KafkaMetricsReporter, KafkaYammerMetrics}
 import kafka.network.SocketServer
@@ -342,7 +342,7 @@ class Kip500Broker(val config: KafkaConfig,
     }
   }
 
-  class TemporaryProducerIdManager() extends ProducerIdMgr {
+  class TemporaryProducerIdManager() extends ProducerIdGenerator {
     val maxProducerIdsPerBrokerEpoch = 1000000
     var currentOffset = -1
     override def generateProducerId(): Long = {
@@ -355,7 +355,7 @@ class Kip500Broker(val config: KafkaConfig,
     }
   }
 
-  def createTemporaryProducerIdManager(): ProducerIdMgr = {
+  def createTemporaryProducerIdManager(): ProducerIdGenerator = {
     new TemporaryProducerIdManager()
   }
 

--- a/core/src/main/scala/kafka/server/Kip500BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/Kip500BrokerToControllerChannelManager.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.util.Collections
+import java.util.concurrent.{CompletableFuture, Future, LinkedBlockingDeque}
+
+import org.apache.kafka.clients.{KafkaClient, NetworkClient}
+import org.apache.kafka.common.Node
+import org.apache.kafka.common.message.MetadataRequestData
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
+import org.apache.kafka.common.utils.Time
+
+import scala.util.Random
+
+/**
+ * This class uses the controller.connect configuration to find and connect to the controller and uses
+ * MetadataRequest to identify the active one.
+ */
+class Kip500BrokerToControllerChannelManager(time: Time,
+                                             metrics: Metrics,
+                                             config: KafkaConfig,
+                                             threadNamePrefix: Option[String] = None) extends
+  AbstractBrokerToControllerChannelManager(time, metrics, config, threadNamePrefix) {
+
+  val clusterIdFuture = new CompletableFuture[String]()
+  override def clusterId(): Future[String] = clusterIdFuture
+
+  val _brokerToControllerListenerName = new ListenerName(config.controllerListenerNames.head)
+  if (_brokerToControllerListenerName.value().isEmpty) {
+    throw new IllegalStateException(s"Must set at least one value for ${KafkaConfig.ControllerListenerNamesProp}")
+  }
+  val _brokerToControllerSecurityProtocol =
+    config.listenerSecurityProtocolMap.get(_brokerToControllerListenerName).getOrElse(
+      throw new IllegalStateException(s"No mapping in ${KafkaConfig.ListenerSecurityProtocolMapProp} for ${_brokerToControllerListenerName.value()}"))
+  val _brokerToControllerSaslMechanism = null // TODO: where will we define this?
+
+  val _requestThread = newRequestThread
+  override protected def requestThread = _requestThread
+
+  override protected def brokerToControllerListenerName = _brokerToControllerListenerName
+
+  override protected def brokerToControllerSecurityProtocol = _brokerToControllerSecurityProtocol
+
+  override protected def brokerToControllerSaslMechanism = _brokerToControllerSaslMechanism
+
+  override protected def instantiateRequestThread(networkClient: NetworkClient,
+                                                  brokerToControllerListenerName: ListenerName,
+                                                  threadName: String) = {
+    new Kip500BrokerToControllerRequestThread(networkClient, requestQueue, config, time, threadName, clusterIdFuture)
+  }
+
+}
+
+class Kip500BrokerToControllerRequestThread(networkClient: KafkaClient,
+                                            requestQueue: LinkedBlockingDeque[BrokerToControllerQueueItem],
+                                            config: KafkaConfig,
+                                            time: Time,
+                                            threadName: String,
+                                            clusterIdFuture: CompletableFuture[String])
+  extends BrokerToControllerRequestThread(networkClient, requestQueue, config, time, threadName) {
+  private var lastTriedActiveController: Option[Node] = None
+  val random = new Random
+  val nodes = config.controllerConnectNodes.toList
+
+  override def shutdown(): Unit = {
+    if (!clusterIdFuture.isDone) {
+      clusterIdFuture.cancel(true)
+    }
+    super.shutdown()
+  }
+
+  override def doWork(): Unit = {
+    if (activeController.isDefined) {
+      trace(s"Active controller is defined: ${activeController.get}")
+      lastTriedActiveController = activeController
+      super.doWork()
+    } else {
+      val metadataRequestData = new MetadataRequestData()
+        .setAllowAutoTopicCreation(false)
+        .setIncludeClusterAuthorizedOperations(false)
+        .setIncludeTopicAuthorizedOperations(false)
+        .setTopics(Collections.emptyList())
+      // select a random node that is not the one we were previously using (if any)
+      val nodesToChooseFrom = nodes.filter {
+        lastTriedActiveController.isEmpty || _.id() != lastTriedActiveController.get.id()
+      }
+      val node = if(nodesToChooseFrom.isEmpty) {
+        nodes(0)
+      } else {
+        nodesToChooseFrom(random.nextInt(nodesToChooseFrom.length))
+      }
+      info(s"Active Controller isn't known, sending metadata request data $metadataRequestData to node $node")
+      // The base class implementation assumes the active controller is always set,
+      // so we have to set it to the chosen node in order for this request to succeed.
+      activeController = Some(node) // temporary for just this request
+      lastTriedActiveController = activeController
+      requestQueue.putFirst(BrokerToControllerQueueItem(new MetadataRequest.Builder(metadataRequestData),
+        response => {
+          val metadataResponse = response.responseBody().asInstanceOf[MetadataResponse]
+          if (metadataResponse.controller().id() > 0) {
+            activeController = Option(metadataResponse.controller())
+            lastTriedActiveController = activeController
+            if (!clusterIdFuture.isDone) {
+              clusterIdFuture.complete(metadataResponse.clusterId())
+            }
+          } else {
+            // need to backoff to avoid tight loops
+            info(s"No active Controller defined; retrying after backoff")
+            activeController = None // so we try again
+            backoff()
+          }
+        }
+      ))
+      super.doWork() // submit it!
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/LegacyBroker.scala
+++ b/core/src/main/scala/kafka/server/LegacyBroker.scala
@@ -33,7 +33,6 @@ import kafka.log.LogManager
 import kafka.metrics.{KafkaMetricsReporter, KafkaYammerMetrics}
 import kafka.network.SocketServer
 import kafka.security.CredentialProvider
-import kafka.server.metadata.BrokerMetadataListener
 import kafka.utils._
 import kafka.zk.{BrokerInfo, KafkaZkClient}
 import org.apache.kafka.clients.{ApiVersions, ClientDnsLookup, ManualMetadataUpdater, NetworkClient, NetworkClientUtils}
@@ -127,9 +126,7 @@ class LegacyBroker(val config: KafkaConfig,
 
   var kafkaController: KafkaController = null
 
-  var brokerMetadataListener: BrokerMetadataListener = null
-
-  var brokerToControllerChannelManager: BrokerToControllerChannelManager = null
+  var brokerToControllerChannelManager: LegacyBrokerToControllerChannelManager = null
 
   var kafkaScheduler: KafkaScheduler = null
 
@@ -156,6 +153,16 @@ class LegacyBroker(val config: KafkaConfig,
 
   // Visible for testing
   private[kafka] def zkClient = _zkClient
+
+  override def getConfig(): KafkaConfig = config
+  override def getAuthorizer(): Option[Authorizer] = authorizer
+  override def getKafkaYammerMetrics(): KafkaYammerMetrics = kafkaYammerMetrics
+  override def getQuotaManagers(): QuotaFactory.QuotaManagers = quotaManagers
+  override def getDataPlaneRequestHandlerPool(): KafkaRequestHandlerPool = dataPlaneRequestHandlerPool
+  override def getSocketServer(): SocketServer = socketServer
+  override def getReplicaManager(): ReplicaManager = replicaManager
+  override def getKafkaScheduler(): KafkaScheduler = kafkaScheduler
+  override def getKafkaController(): Option[KafkaController] = Some(kafkaController)
 
   private[kafka] def brokerTopicStats = _brokerTopicStats
 
@@ -253,12 +260,12 @@ class LegacyBroker(val config: KafkaConfig,
         socketServer.startup(startProcessingRequests = false)
 
         /* start replica manager */
-        brokerToControllerChannelManager = new BrokerToControllerChannelManagerImpl(metadataCache, time, metrics, config, threadNamePrefix)
+        brokerToControllerChannelManager = new LegacyBrokerToControllerChannelManager(metadataCache, time, metrics, config, _clusterId, threadNamePrefix)
         replicaManager = createReplicaManager(isShuttingDown)
         replicaManager.startup()
         brokerToControllerChannelManager.start()
 
-        val brokerInfo = createBrokerInfo
+        val brokerInfo = createBrokerInfo()
         val brokerEpoch = zkClient.registerBroker(brokerInfo)
 
         // Now that the broker is successfully registered, checkpoint its metadata
@@ -284,13 +291,6 @@ class LegacyBroker(val config: KafkaConfig,
         transactionCoordinator = TransactionCoordinator(config, replicaManager, new KafkaScheduler(threads = 1, threadNamePrefix = "transaction-log-manager-"), zkClient, metrics, metadataCache, Time.SYSTEM)
         transactionCoordinator.startup()
 
-        brokerMetadataListener = new BrokerMetadataListener(
-          config, time,
-          BrokerMetadataListener.defaultProcessors(
-            config, _clusterId, metadataCache, groupCoordinator, quotaManagers, replicaManager, transactionCoordinator,
-            logManager))
-        brokerMetadataListener.start()
-
         /* Get the authorizer and initialize it if one is specified.*/
         authorizer = config.authorizer
         authorizer.foreach(_.configure(config.originals))
@@ -313,7 +313,7 @@ class LegacyBroker(val config: KafkaConfig,
         dataPlaneRequestProcessor = new KafkaApis(socketServer.dataPlaneRequestChannel,
           replicaManager, adminManager, groupCoordinator, transactionCoordinator,
           kafkaController, zkClient, config.brokerId, config, metadataCache, metrics, authorizer, quotaManagers,
-          fetchManager, brokerTopicStats, _clusterId, time, tokenManager, brokerFeatures, featureCache)
+          fetchManager, brokerTopicStats, _clusterId, time, tokenManager, brokerFeatures, featureCache, null)
 
         dataPlaneRequestHandlerPool = new KafkaRequestHandlerPool(config.brokerId, socketServer.dataPlaneRequestChannel, dataPlaneRequestProcessor, time,
           config.numIoThreads, s"${SocketServer.DataPlaneMetricPrefix}RequestHandlerAvgIdlePercent", SocketServer.DataPlaneThreadPrefix)
@@ -322,7 +322,7 @@ class LegacyBroker(val config: KafkaConfig,
           controlPlaneRequestProcessor = new KafkaApis(controlPlaneRequestChannel,
             replicaManager, adminManager, groupCoordinator, transactionCoordinator,
             kafkaController, zkClient, config.brokerId, config, metadataCache, metrics, authorizer, quotaManagers,
-            fetchManager, brokerTopicStats, _clusterId, time, tokenManager, brokerFeatures, featureCache)
+            fetchManager, brokerTopicStats, _clusterId, time, tokenManager, brokerFeatures, featureCache, null)
 
           controlPlaneRequestHandlerPool = new KafkaRequestHandlerPool(config.brokerId, socketServer.controlPlaneRequestChannelOpt.get, controlPlaneRequestProcessor, time,
             1, s"${SocketServer.ControlPlaneMetricPrefix}RequestHandlerAvgIdlePercent", SocketServer.ControlPlaneThreadPrefix)
@@ -366,7 +366,7 @@ class LegacyBroker(val config: KafkaConfig,
     val alterIsrManager = new AlterIsrManagerImpl(brokerToControllerChannelManager, kafkaScheduler,
       time, config.brokerId, () => kafkaController.brokerEpoch)
     new ReplicaManager(config, metrics, time, zkClient, kafkaScheduler, logManager, isShuttingDown, quotaManagers,
-      brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager)
+      brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager, None)
   }
 
   private def initZkClient(time: Time): Unit = {
@@ -407,7 +407,7 @@ class LegacyBroker(val config: KafkaConfig,
     zkClient.getClusterId.getOrElse(zkClient.createOrGetClusterId(CoreUtils.generateUuidAsBase64()))
   }
 
-  def createBrokerInfo: BrokerInfo = {
+  override def createBrokerInfo(): BrokerInfo = {
     val endPoints = config.advertisedListeners.map(e => s"${e.host}:${e.port}")
     zkClient.getAllBrokersInCluster.filter(_.id != config.brokerId).foreach { broker =>
       val commonEndPoints = broker.endPoints.map(e => s"${e.host}:${e.port}").intersect(endPoints)
@@ -612,9 +612,6 @@ class LegacyBroker(val config: KafkaConfig,
         CoreUtils.swallow(controlledShutdown(), this)
         brokerState.set(BrokerState.SHUTTING_DOWN)
 
-        if (brokerMetadataListener != null)
-          brokerMetadataListener.close()
-
         if (dynamicConfigManager != null)
           CoreUtils.swallow(dynamicConfigManager.shutdown(), this)
 
@@ -701,7 +698,7 @@ class LegacyBroker(val config: KafkaConfig,
    */
   def awaitShutdown(): Unit = shutdownLatch.await()
 
-  def getLogManager: LogManager = logManager
+  def getLogManager(): LogManager = logManager
 
   def boundPort(listenerName: ListenerName): Int = socketServer.boundPort(listenerName)
 

--- a/core/src/main/scala/kafka/server/LegacyBrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/LegacyBrokerToControllerChannelManager.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.util.concurrent.{CompletableFuture, Future, LinkedBlockingDeque}
+
+import org.apache.kafka.clients.{KafkaClient, ManualMetadataUpdater, NetworkClient}
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.utils.Time
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * This class uses the broker's metadata cache as its own metadata to find and connect to the controller.
+ */
+class LegacyBrokerToControllerChannelManager(metadataCache: kafka.server.MetadataCache,
+                                             time: Time,
+                                             metrics: Metrics,
+                                             config: KafkaConfig,
+                                             clusterId: String,
+                                             threadNamePrefix: Option[String] = None) extends
+  AbstractBrokerToControllerChannelManager(time, metrics, config, threadNamePrefix) {
+  val _brokerToControllerListenerName = config.controlPlaneListenerName.getOrElse(config.interBrokerListenerName)
+  val _brokerToControllerSecurityProtocol = config.controlPlaneSecurityProtocol.getOrElse(config.interBrokerSecurityProtocol)
+  val _brokerToControllerSaslMechanism = config.saslMechanismInterBrokerProtocol
+
+  val _requestThread = newRequestThread
+  override protected def requestThread = _requestThread
+
+  override protected def brokerToControllerListenerName = _brokerToControllerListenerName
+
+  override protected def brokerToControllerSecurityProtocol = _brokerToControllerSecurityProtocol
+
+  override protected def brokerToControllerSaslMechanism = _brokerToControllerSaslMechanism
+
+  override protected def instantiateRequestThread(networkClient: NetworkClient,
+                                          brokerToControllerListenerName: ListenerName,
+                                          threadName: String) = {
+    new LegacyBrokerToControllerRequestThread(networkClient, manualMetadataUpdater, requestQueue, metadataCache, config,
+      brokerToControllerListenerName, time, threadName)
+  }
+
+  val clusterIdFuture = new CompletableFuture[String]()
+  clusterIdFuture.complete(clusterId)
+  override def clusterId(): Future[String] = clusterIdFuture
+}
+
+class LegacyBrokerToControllerRequestThread(networkClient: KafkaClient,
+                                            metadataUpdater: ManualMetadataUpdater,
+                                            requestQueue: LinkedBlockingDeque[BrokerToControllerQueueItem],
+                                            metadataCache: kafka.server.MetadataCache,
+                                            config: KafkaConfig,
+                                            listenerName: ListenerName,
+                                            time: Time,
+                                            threadName: String)
+  extends BrokerToControllerRequestThread(networkClient, requestQueue, config, time, threadName) {
+
+  override def doWork(): Unit = {
+    if (activeController.isDefined) {
+      super.doWork()
+    } else {
+      debug("Controller isn't cached, looking for local metadata changes")
+      val controllerOpt = metadataCache.getControllerId.flatMap(metadataCache.getAliveBroker)
+      if (controllerOpt.isDefined) {
+        if (activeController.isEmpty || activeController.exists(_.id != controllerOpt.get.id))
+          info(s"Recorded new controller, from now on will use broker ${controllerOpt.get.id}")
+        activeController = Option(controllerOpt.get.node(listenerName))
+        metadataUpdater.setNodes(metadataCache.getAliveBrokers.map(_.node(listenerName)).asJava)
+      } else {
+        // need to backoff to avoid tight loops
+        debug("No controller defined in metadata cache, retrying after backoff")
+        backoff()
+      }
+    }
+  }
+}

--- a/core/src/test/scala/integration/kafka/api/GroupCoordinatorIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/GroupCoordinatorIntegrationTest.scala
@@ -44,7 +44,7 @@ class GroupCoordinatorIntegrationTest extends KafkaServerTestHarness {
       new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0) -> new OffsetAndMetadata(10, "")
     ).asJava
     consumer.commitSync(offsetMap)
-    val logManager = servers.head.getLogManager
+    val logManager = servers.head.getLogManager()
     def getGroupMetadataLogOpt: Option[Log] =
       logManager.getLog(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0))
 

--- a/core/src/test/scala/integration/kafka/api/GroupCoordinatorIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/GroupCoordinatorIntegrationTest.scala
@@ -44,7 +44,7 @@ class GroupCoordinatorIntegrationTest extends KafkaServerTestHarness {
       new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0) -> new OffsetAndMetadata(10, "")
     ).asJava
     consumer.commitSync(offsetMap)
-    val logManager = servers.head.getLogManager()
+    val logManager = servers.head.logManager
     def getGroupMetadataLogOpt: Option[Log] =
       logManager.getLog(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0))
 

--- a/core/src/test/scala/kafka/server/LegacyBrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/LegacyBrokerToControllerRequestThreadTest.scala
@@ -36,7 +36,7 @@ import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.Test
 import org.mockito.Mockito._
 
-class BrokerToControllerRequestThreadTest {
+class LegacyBrokerToControllerRequestThreadTest {
 
   @Test
   def testRequestsSent(): Unit = {
@@ -59,7 +59,7 @@ class BrokerToControllerRequestThreadTest {
     when(metadataCache.getAliveBroker(controllerId)).thenReturn(Some(activeController))
 
     val expectedResponse = ClientsTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", new Integer(2)))
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
+    val testRequestThread = new LegacyBrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
       config, listenerName, time, "")
     mockClient.prepareResponse(expectedResponse)
 
@@ -104,7 +104,7 @@ class BrokerToControllerRequestThreadTest {
     when(metadataCache.getAliveBrokers).thenReturn(Seq(oldController, newController))
 
     val expectedResponse = ClientsTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", new Integer(2)))
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(),
+    val testRequestThread = new LegacyBrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(),
       requestQueue, metadataCache, config, listenerName, time, "")
 
     val responseLatch = new CountDownLatch(1)
@@ -163,7 +163,7 @@ class BrokerToControllerRequestThreadTest {
       Collections.singletonMap("a", Errors.NOT_CONTROLLER),
       Collections.singletonMap("a", new Integer(2)))
     val expectedResponse = ClientsTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", new Integer(2)))
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
+    val testRequestThread = new LegacyBrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
       config, listenerName, time, "")
 
     val responseLatch = new CountDownLatch(1)

--- a/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
@@ -175,7 +175,7 @@ object ReplicationQuotasTestRig {
       //Validate that offsets are correct in all brokers
       for (broker <- servers) {
         (0 until config.partitions).foreach { partitionId =>
-          val offset = broker.getLogManager().getLog(new TopicPartition(topicName, partitionId)).map(_.logEndOffset).getOrElse(-1L)
+          val offset = broker.logManager.getLog(new TopicPartition(topicName, partitionId)).map(_.logEndOffset).getOrElse(-1L)
           if (offset >= 0 && offset != config.msgsPerPartition) {
             throw new RuntimeException(s"Run failed as offsets did not match for partition $partitionId on broker ${broker.config.brokerId}. Expected ${config.msgsPerPartition} but was $offset.")
           }

--- a/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
@@ -175,7 +175,7 @@ object ReplicationQuotasTestRig {
       //Validate that offsets are correct in all brokers
       for (broker <- servers) {
         (0 until config.partitions).foreach { partitionId =>
-          val offset = broker.getLogManager.getLog(new TopicPartition(topicName, partitionId)).map(_.logEndOffset).getOrElse(-1L)
+          val offset = broker.getLogManager().getLog(new TopicPartition(topicName, partitionId)).map(_.logEndOffset).getOrElse(-1L)
           if (offset >= 0 && offset != config.msgsPerPartition) {
             throw new RuntimeException(s"Run failed as offsets did not match for partition $partitionId on broker ${broker.config.brokerId}. Expected ${config.msgsPerPartition} but was $offset.")
           }

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -74,7 +74,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // check if all replicas but the one that is shut down has deleted the log
     TestUtils.waitUntilTrue(() =>
       servers.filter(s => s.config.brokerId != follower.config.brokerId)
-        .forall(_.getLogManager.getLog(topicPartition).isEmpty), "Replicas 0,1 have not deleted log.")
+        .forall(_.getLogManager().getLog(topicPartition).isEmpty), "Replicas 0,1 have not deleted log.")
     // ensure topic deletion is halted
     TestUtils.waitUntilTrue(() => zkClient.isTopicMarkedForDeletion(topic),
       "Admin path /admin/delete_topics/test path deleted even when a follower replica is down")
@@ -122,7 +122,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // create the topic
     TestUtils.createTopic(zkClient, topic, expectedReplicaAssignment, servers)
     // wait until replica log is created on every broker
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager.getLog(topicPartition).isDefined),
+    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicPartition).isDefined),
       "Replicas for topic test not created.")
     val leaderIdOpt = zkClient.getLeaderForPartition(new TopicPartition(topic, 0))
     assertTrue("Leader should exist for partition [test,0]", leaderIdOpt.isDefined)
@@ -206,7 +206,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // create the topic
     TestUtils.createTopic(zkClient, topic, expectedReplicaAssignment, servers)
     // wait until replica log is created on every broker
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager.getLog(topicPartition).isDefined),
+    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicPartition).isDefined),
       "Replicas for topic test not created.")
     // shutdown a broker to make sure the following topic deletion will be suspended
     val leaderIdOpt = zkClient.getLeaderForPartition(topicPartition)
@@ -279,7 +279,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     TestUtils.verifyTopicDeletion(zkClient, topic, 1, servers)
     // verify that new partition doesn't exist on any broker either
     TestUtils.waitUntilTrue(() =>
-      servers.forall(_.getLogManager.getLog(newPartition).isEmpty),
+      servers.forall(_.getLogManager().getLog(newPartition).isEmpty),
       "Replica logs not for new partition [test,1] not deleted after delete topic is complete.")
   }
 
@@ -298,7 +298,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     TestUtils.verifyTopicDeletion(zkClient, topic, 1, servers)
     // verify that new partition doesn't exist on any broker either
     assertTrue("Replica logs not deleted after delete topic is complete",
-      servers.forall(_.getLogManager.getLog(newPartition).isEmpty))
+      servers.forall(_.getLogManager().getLog(newPartition).isEmpty))
   }
 
   @Test
@@ -313,7 +313,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // re-create topic on same replicas
     TestUtils.createTopic(zkClient, topic, expectedReplicaAssignment, servers)
     // check if all replica logs are created
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager.getLog(topicPartition).isDefined),
+    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicPartition).isDefined),
       "Replicas for topic test not created.")
   }
 
@@ -332,7 +332,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // verify delete topic path for test2 is removed from ZooKeeper
     TestUtils.verifyTopicDeletion(zkClient, "test2", 1, servers)
     // verify that topic test is untouched
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager.getLog(topicPartition).isDefined),
+    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicPartition).isDefined),
       "Replicas for topic test not created")
     // test the topic path exists
     assertTrue("Topic test mistakenly deleted", zkClient.topicExists(topic))
@@ -403,7 +403,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // create the topic
     TestUtils.createTopic(zkClient, topic, expectedReplicaAssignment, servers)
     // wait until replica log is created on every broker
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager.getLog(topicPartition).isDefined),
+    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicPartition).isDefined),
       "Replicas for topic test not created")
     servers
   }
@@ -428,7 +428,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     TestUtils.waitUntilTrue(() => !zkClient.isTopicMarkedForDeletion(topic),
       "Admin path /admin/delete_topics/%s path not deleted even if deleteTopic is disabled".format(topic))
     // verify that topic test is untouched
-    assertTrue(servers.forall(_.getLogManager.getLog(topicPartition).isDefined))
+    assertTrue(servers.forall(_.getLogManager().getLog(topicPartition).isDefined))
     // test the topic path exists
     assertTrue("Topic path disappeared", zkClient.topicExists(topic))
     // topic test should have a leader

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -74,7 +74,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // check if all replicas but the one that is shut down has deleted the log
     TestUtils.waitUntilTrue(() =>
       servers.filter(s => s.config.brokerId != follower.config.brokerId)
-        .forall(_.getLogManager().getLog(topicPartition).isEmpty), "Replicas 0,1 have not deleted log.")
+        .forall(_.logManager.getLog(topicPartition).isEmpty), "Replicas 0,1 have not deleted log.")
     // ensure topic deletion is halted
     TestUtils.waitUntilTrue(() => zkClient.isTopicMarkedForDeletion(topic),
       "Admin path /admin/delete_topics/test path deleted even when a follower replica is down")
@@ -122,7 +122,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // create the topic
     TestUtils.createTopic(zkClient, topic, expectedReplicaAssignment, servers)
     // wait until replica log is created on every broker
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicPartition).isDefined),
+    TestUtils.waitUntilTrue(() => servers.forall(_.logManager.getLog(topicPartition).isDefined),
       "Replicas for topic test not created.")
     val leaderIdOpt = zkClient.getLeaderForPartition(new TopicPartition(topic, 0))
     assertTrue("Leader should exist for partition [test,0]", leaderIdOpt.isDefined)
@@ -206,7 +206,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // create the topic
     TestUtils.createTopic(zkClient, topic, expectedReplicaAssignment, servers)
     // wait until replica log is created on every broker
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicPartition).isDefined),
+    TestUtils.waitUntilTrue(() => servers.forall(_.logManager.getLog(topicPartition).isDefined),
       "Replicas for topic test not created.")
     // shutdown a broker to make sure the following topic deletion will be suspended
     val leaderIdOpt = zkClient.getLeaderForPartition(topicPartition)
@@ -279,7 +279,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     TestUtils.verifyTopicDeletion(zkClient, topic, 1, servers)
     // verify that new partition doesn't exist on any broker either
     TestUtils.waitUntilTrue(() =>
-      servers.forall(_.getLogManager().getLog(newPartition).isEmpty),
+      servers.forall(_.logManager.getLog(newPartition).isEmpty),
       "Replica logs not for new partition [test,1] not deleted after delete topic is complete.")
   }
 
@@ -298,7 +298,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     TestUtils.verifyTopicDeletion(zkClient, topic, 1, servers)
     // verify that new partition doesn't exist on any broker either
     assertTrue("Replica logs not deleted after delete topic is complete",
-      servers.forall(_.getLogManager().getLog(newPartition).isEmpty))
+      servers.forall(_.logManager.getLog(newPartition).isEmpty))
   }
 
   @Test
@@ -313,7 +313,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // re-create topic on same replicas
     TestUtils.createTopic(zkClient, topic, expectedReplicaAssignment, servers)
     // check if all replica logs are created
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicPartition).isDefined),
+    TestUtils.waitUntilTrue(() => servers.forall(_.logManager.getLog(topicPartition).isDefined),
       "Replicas for topic test not created.")
   }
 
@@ -332,7 +332,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // verify delete topic path for test2 is removed from ZooKeeper
     TestUtils.verifyTopicDeletion(zkClient, "test2", 1, servers)
     // verify that topic test is untouched
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicPartition).isDefined),
+    TestUtils.waitUntilTrue(() => servers.forall(_.logManager.getLog(topicPartition).isDefined),
       "Replicas for topic test not created")
     // test the topic path exists
     assertTrue("Topic test mistakenly deleted", zkClient.topicExists(topic))
@@ -403,7 +403,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // create the topic
     TestUtils.createTopic(zkClient, topic, expectedReplicaAssignment, servers)
     // wait until replica log is created on every broker
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicPartition).isDefined),
+    TestUtils.waitUntilTrue(() => servers.forall(_.logManager.getLog(topicPartition).isDefined),
       "Replicas for topic test not created")
     servers
   }
@@ -428,7 +428,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     TestUtils.waitUntilTrue(() => !zkClient.isTopicMarkedForDeletion(topic),
       "Admin path /admin/delete_topics/%s path not deleted even if deleteTopic is disabled".format(topic))
     // verify that topic test is untouched
-    assertTrue(servers.forall(_.getLogManager().getLog(topicPartition).isDefined))
+    assertTrue(servers.forall(_.logManager.getLog(topicPartition).isDefined))
     // test the topic path exists
     assertTrue("Topic path disappeared", zkClient.topicExists(topic))
     // topic test should have a leader

--- a/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
@@ -44,7 +44,7 @@ class FeatureCommandTest extends BaseRequestTest {
                                       targetServers: Set[LegacyBroker]): Unit = {
     targetServers.foreach(s => {
       s.brokerFeatures.setSupportedFeatures(features)
-      s.zkClient.updateBrokerInfo(s.createBrokerInfo)
+      s.zkClient.updateBrokerInfo(s.createBrokerInfo())
     })
 
     // Wait until updates to all BrokerZNode supported features propagate to the controller.

--- a/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
@@ -44,7 +44,7 @@ class FeatureCommandTest extends BaseRequestTest {
                                       targetServers: Set[LegacyBroker]): Unit = {
     targetServers.foreach(s => {
       s.brokerFeatures.setSupportedFeatures(features)
-      s.zkClient.updateBrokerInfo(s.createBrokerInfo())
+      s.zkClient.updateBrokerInfo(s.createBrokerInfo)
     })
 
     // Wait until updates to all BrokerZNode supported features propagate to the controller.

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -79,7 +79,7 @@ class PreferredReplicaLeaderElectionCommandTest extends ZooKeeperTestHarness wit
       () =>
         servers.forall { server =>
           partitionsAndAssignments.forall { partitionAndAssignment =>
-            server.getLogManager.getLog(partitionAndAssignment._1).isDefined
+            server.getLogManager().getLog(partitionAndAssignment._1).isDefined
           }
         },
       "Replicas for topic test not created"

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -79,7 +79,7 @@ class PreferredReplicaLeaderElectionCommandTest extends ZooKeeperTestHarness wit
       () =>
         servers.forall { server =>
           partitionsAndAssignments.forall { partitionAndAssignment =>
-            server.getLogManager().getLog(partitionAndAssignment._1).isDefined
+            server.logManager.getLog(partitionAndAssignment._1).isDefined
           }
         },
       "Replicas for topic test not created"

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -95,7 +95,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
       txnStateManager,
       time)
 
-    transactionCoordinator = new TransactionCoordinator(brokerId = 0,
+    transactionCoordinator = new TransactionCoordinator(
       txnConfig,
       scheduler,
       pidManager,

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -49,7 +49,7 @@ class TransactionCoordinatorTest {
   private val partitions = mutable.Set[TopicPartition](new TopicPartition("topic1", 0))
   private val scheduler = new MockScheduler(time)
 
-  val coordinator = new TransactionCoordinator(brokerId,
+  val coordinator = new TransactionCoordinator(
     TransactionConfig(),
     scheduler,
     pidManager,

--- a/core/src/test/scala/unit/kafka/integration/MinIsrConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/MinIsrConfigTest.scala
@@ -31,7 +31,7 @@ class MinIsrConfigTest extends KafkaServerTestHarness {
 
   @Test
   def testDefaultKafkaConfig(): Unit = {
-    assert(servers.head.getLogManager().initialDefaultConfig.minInSyncReplicas == 5)
+    assert(servers.head.logManager.initialDefaultConfig.minInSyncReplicas == 5)
   }
 
 }

--- a/core/src/test/scala/unit/kafka/integration/MinIsrConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/MinIsrConfigTest.scala
@@ -31,7 +31,7 @@ class MinIsrConfigTest extends KafkaServerTestHarness {
 
   @Test
   def testDefaultKafkaConfig(): Unit = {
-    assert(servers.head.getLogManager.initialDefaultConfig.minInSyncReplicas == 5)
+    assert(servers.head.getLogManager().initialDefaultConfig.minInSyncReplicas == 5)
   }
 
 }

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -20,7 +20,6 @@ package kafka.log
 import java.io._
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
-import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{Callable, Executors}
 import java.util.regex.Pattern
 import java.util.{Collections, Optional, Properties}
@@ -42,7 +41,6 @@ import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.FetchResponse.AbortedTransaction
 import org.apache.kafka.common.requests.{ListOffsetRequest, ListOffsetResponse}
 import org.apache.kafka.common.utils.{Time, Utils}
-import org.apache.kafka.metadata.BrokerState
 import org.easymock.EasyMock
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
@@ -101,7 +99,7 @@ class LogTest {
         initialDefaultConfig = logConfig, cleanerConfig = CleanerConfig(enableCleaner = false), recoveryThreadsPerDataDir = 4,
         flushCheckMs = 1000L, flushRecoveryOffsetCheckpointMs = 10000L, flushStartOffsetCheckpointMs = 10000L,
         retentionCheckMs = 1000L, maxPidExpirationMs = 60 * 60 * 1000, scheduler = time.scheduler, time = time,
-        brokerState = new AtomicReference[BrokerState](BrokerState.NOT_RUNNING),
+        cleanShutdownFunc = _ => {},
         brokerTopicStats = new BrokerTopicStats, logDirFailureChannel = new LogDirFailureChannel(logDirs.size)) {
 
          override def loadLog(logDir: File, hadCleanShutdown: Boolean, recoveryPoints: Map[TopicPartition, Long],

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -20,7 +20,7 @@ package kafka.log
 import java.io._
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
-import java.util.concurrent.{Callable, Executors}
+import java.util.concurrent.{Callable, CompletableFuture, Executors}
 import java.util.regex.Pattern
 import java.util.{Collections, Optional, Properties}
 
@@ -99,7 +99,7 @@ class LogTest {
         initialDefaultConfig = logConfig, cleanerConfig = CleanerConfig(enableCleaner = false), recoveryThreadsPerDataDir = 4,
         flushCheckMs = 1000L, flushRecoveryOffsetCheckpointMs = 10000L, flushStartOffsetCheckpointMs = 10000L,
         retentionCheckMs = 1000L, maxPidExpirationMs = 60 * 60 * 1000, scheduler = time.scheduler, time = time,
-        cleanShutdownFunc = _ => {},
+        cleanShutdownCompletableFuture = new CompletableFuture[Boolean](),
         brokerTopicStats = new BrokerTopicStats, logDirFailureChannel = new LogDirFailureChannel(logDirs.size)) {
 
          override def loadLog(logDir: File, hadCleanShutdown: Boolean, recoveryPoints: Map[TopicPartition, Long],

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -21,7 +21,7 @@ import java.io.IOException
 import java.util.Properties
 import java.util.concurrent.{Executors, TimeUnit}
 
-import kafka.server.metadata.{BrokerMetadataEvent, BrokerMetadataListener, FenceBrokerEvent, RegisterBrokerEvent, QueuedEvent}
+import kafka.server.metadata.{BrokerMetadataEvent, BrokerMetadataListener, FenceBrokerEvent, QueuedEvent, RegisterBrokerEvent}
 import org.apache.kafka.common.KafkaException
 import kafka.server.{BrokerLifecycleManagerImpl, BrokerToControllerChannelManager, Defaults, KafkaConfig}
 import kafka.utils.{MockTime, TestUtils}

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -323,7 +323,7 @@ class DynamicBrokerConfigTest {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 9092)
     val oldConfig =  KafkaConfig.fromProps(props)
     val kafkaServer: KafkaBroker = EasyMock.createMock(classOf[kafka.server.KafkaBroker])
-    EasyMock.expect(kafkaServer.getConfig()).andReturn(oldConfig).anyTimes()
+    EasyMock.expect(kafkaServer.config).andReturn(oldConfig).anyTimes()
     EasyMock.replay(kafkaServer)
 
     props.put(KafkaConfig.ListenersProp, "PLAINTEXT://hostname:9092,SASL_PLAINTEXT://hostname:9093")
@@ -358,17 +358,17 @@ class DynamicBrokerConfigTest {
     }
 
     val authorizer = new TestAuthorizer
-    EasyMock.expect(kafkaServer.getConfig()).andReturn(oldConfig).anyTimes()
-    EasyMock.expect(kafkaServer.getAuthorizer()).andReturn(Some(authorizer)).anyTimes()
+    EasyMock.expect(kafkaServer.config).andReturn(oldConfig).anyTimes()
+    EasyMock.expect(kafkaServer.authorizer).andReturn(Some(authorizer)).anyTimes()
     EasyMock.replay(kafkaServer)
     try {
-      kafkaServer.getConfig().dynamicConfig.addReconfigurables(kafkaServer)
+      kafkaServer.config.dynamicConfig.addReconfigurables(kafkaServer)
     } catch {
       case _: Throwable => // We are only testing authorizer reconfiguration, ignore any exceptions due to incomplete mock
     }
 
     props.put("super.users", "User:admin")
-    kafkaServer.getConfig().dynamicConfig.updateBrokerConfig(0, props)
+    kafkaServer.config.dynamicConfig.updateBrokerConfig(0, props)
     assertEquals("User:admin", authorizer.superUsers)
   }
 

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -72,7 +72,7 @@ class LogOffsetTest extends BaseRequestTest {
 
     createTopic(topic, 1, 1)
 
-    val logManager = server.getLogManager()
+    val logManager = server.logManager
     TestUtils.waitUntilTrue(() => logManager.getLog(topicPartition).isDefined,
                   "Log for partition [topic,0] should be created")
     val log = logManager.getLog(topicPartition).get
@@ -103,7 +103,7 @@ class LogOffsetTest extends BaseRequestTest {
 
     createTopic(topic, 1, 1)
 
-    val logManager = server.getLogManager()
+    val logManager = server.logManager
     TestUtils.waitUntilTrue(() => logManager.getLog(topicPartition).isDefined,
       s"Log for partition $topicPartition should be created")
     val log = logManager.getLog(topicPartition).get
@@ -162,7 +162,7 @@ class LogOffsetTest extends BaseRequestTest {
 
     createTopic(topic, 3, 1)
 
-    val logManager = server.getLogManager()
+    val logManager = server.logManager
     val log = logManager.getOrCreateLog(topicPartition, () => logManager.initialDefaultConfig)
 
     for (_ <- 0 until 20)
@@ -191,7 +191,7 @@ class LogOffsetTest extends BaseRequestTest {
 
     createTopic(topic, 3, 1)
 
-    val logManager = server.getLogManager()
+    val logManager = server.logManager
     val log = logManager.getOrCreateLog(topicPartition, () => logManager.initialDefaultConfig)
     for (_ <- 0 until 20)
       log.appendAsLeader(TestUtils.singletonRecords(value = Integer.toString(42).getBytes()), leaderEpoch = 0)

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -72,7 +72,7 @@ class LogOffsetTest extends BaseRequestTest {
 
     createTopic(topic, 1, 1)
 
-    val logManager = server.getLogManager
+    val logManager = server.getLogManager()
     TestUtils.waitUntilTrue(() => logManager.getLog(topicPartition).isDefined,
                   "Log for partition [topic,0] should be created")
     val log = logManager.getLog(topicPartition).get
@@ -103,7 +103,7 @@ class LogOffsetTest extends BaseRequestTest {
 
     createTopic(topic, 1, 1)
 
-    val logManager = server.getLogManager
+    val logManager = server.getLogManager()
     TestUtils.waitUntilTrue(() => logManager.getLog(topicPartition).isDefined,
       s"Log for partition $topicPartition should be created")
     val log = logManager.getLog(topicPartition).get
@@ -162,7 +162,7 @@ class LogOffsetTest extends BaseRequestTest {
 
     createTopic(topic, 3, 1)
 
-    val logManager = server.getLogManager
+    val logManager = server.getLogManager()
     val log = logManager.getOrCreateLog(topicPartition, () => logManager.initialDefaultConfig)
 
     for (_ <- 0 until 20)
@@ -191,7 +191,7 @@ class LogOffsetTest extends BaseRequestTest {
 
     createTopic(topic, 3, 1)
 
-    val logManager = server.getLogManager
+    val logManager = server.getLogManager()
     val log = logManager.getOrCreateLog(topicPartition, () => logManager.initialDefaultConfig)
     for (_ <- 0 until 20)
       log.appendAsLeader(TestUtils.singletonRecords(value = Integer.toString(42).getBytes()), leaderEpoch = 0)

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetchTest.scala
@@ -69,9 +69,9 @@ class ReplicaFetchTest extends ZooKeeperTestHarness  {
       var result = true
       for (topic <- List(topic1, topic2)) {
         val tp = new TopicPartition(topic, partition)
-        val expectedOffset = brokers.head.getLogManager().getLog(tp).get.logEndOffset
+        val expectedOffset = brokers.head.logManager.getLog(tp).get.logEndOffset
         result = result && expectedOffset > 0 && brokers.forall { item =>
-          expectedOffset == item.getLogManager().getLog(tp).get.logEndOffset
+          expectedOffset == item.logManager.getLog(tp).get.logEndOffset
         }
       }
       result

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetchTest.scala
@@ -69,9 +69,9 @@ class ReplicaFetchTest extends ZooKeeperTestHarness  {
       var result = true
       for (topic <- List(topic1, topic2)) {
         val tp = new TopicPartition(topic, partition)
-        val expectedOffset = brokers.head.getLogManager.getLog(tp).get.logEndOffset
+        val expectedOffset = brokers.head.getLogManager().getLog(tp).get.logEndOffset
         result = result && expectedOffset > 0 && brokers.forall { item =>
-          expectedOffset == item.getLogManager.getLog(tp).get.logEndOffset
+          expectedOffset == item.getLogManager().getLog(tp).get.logEndOffset
         }
       }
       result

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1509,7 +1509,7 @@ class ReplicaManagerTest {
     val quota = QuotaFactory.instantiate(config, metrics, time, "")
     val blockingSend = new ReplicaFetcherMockBlockingSend(Map(topicPartitionObj ->
       new EpochEndOffset(leaderEpochFromLeader, offsetFromLeader)).asJava, BrokerEndPoint(1, "host1" ,1), time)
-    val replicaManager = new ReplicaManager(config, metrics, time, kafkaZkClient, mockScheduler, mockLogMgr,
+    val replicaManager = new ReplicaManager(config, metrics, time, Some(kafkaZkClient), mockScheduler, mockLogMgr,
       new AtomicBoolean(false), quota, mockBrokerTopicStats,
       metadataCache, mockLogDirFailureChannel, mockProducePurgatory, mockFetchPurgatory,
       mockDeleteRecordsPurgatory, mockElectLeaderPurgatory, Option(this.getClass.getName), alterIsrManager) {
@@ -1683,7 +1683,7 @@ class ReplicaManagerTest {
     val mockDelayedElectLeaderPurgatory = new DelayedOperationPurgatory[DelayedElectLeader](
       purgatoryName = "DelayedElectLeader", timer, reaperEnabled = false)
 
-    new ReplicaManager(config, metrics, time, kafkaZkClient, new MockScheduler(time), mockLogMgr,
+    new ReplicaManager(config, metrics, time, Some(kafkaZkClient), new MockScheduler(time), mockLogMgr,
       new AtomicBoolean(false), QuotaFactory.instantiate(config, metrics, time, ""), new BrokerTopicStats,
       metadataCache, new LogDirFailureChannel(config.logDirs.size), mockProducePurgatory, mockFetchPurgatory,
       mockDeleteRecordsPurgatory, mockDelayedElectLeaderPurgatory, Option(this.getClass.getName), alterIsrManager)

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -217,7 +217,7 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
 
   private def waitForOffsetsToMatch(offset: Int, partitionId: Int, brokerId: Int): Unit = {
     waitUntilTrue(() => {
-      offset == brokerFor(brokerId).getLogManager.getLog(new TopicPartition(topic, partitionId))
+      offset == brokerFor(brokerId).getLogManager().getLog(new TopicPartition(topic, partitionId))
         .map(_.logEndOffset).getOrElse(0)
     }, s"Offsets did not match for partition $partitionId on broker $brokerId", 60000)
   }

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -217,7 +217,7 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
 
   private def waitForOffsetsToMatch(offset: Int, partitionId: Int, brokerId: Int): Unit = {
     waitUntilTrue(() => {
-      offset == brokerFor(brokerId).getLogManager().getLog(new TopicPartition(topic, partitionId))
+      offset == brokerFor(brokerId).logManager.getLog(new TopicPartition(topic, partitionId))
         .map(_.logEndOffset).getOrElse(0)
     }, s"Offsets did not match for partition $partitionId on broker $brokerId", 60000)
   }

--- a/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
@@ -61,7 +61,7 @@ class UpdateFeaturesTest extends BaseRequestTest {
     features: Features[SupportedVersionRange], targetServers: Set[LegacyBroker]): Unit = {
     targetServers.foreach(s => {
       s.brokerFeatures.setSupportedFeatures(features)
-      s.zkClient.updateBrokerInfo(s.createBrokerInfo)
+      s.zkClient.updateBrokerInfo(s.createBrokerInfo())
     })
 
     // Wait until updates to all BrokerZNode supported features propagate to the controller.

--- a/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
@@ -61,7 +61,7 @@ class UpdateFeaturesTest extends BaseRequestTest {
     features: Features[SupportedVersionRange], targetServers: Set[LegacyBroker]): Unit = {
     targetServers.foreach(s => {
       s.brokerFeatures.setSupportedFeatures(features)
-      s.zkClient.updateBrokerInfo(s.createBrokerInfo())
+      s.zkClient.updateBrokerInfo(s.createBrokerInfo)
     })
 
     // Wait until updates to all BrokerZNode supported features propagate to the controller.

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
@@ -239,9 +239,9 @@ class LeaderEpochIntegrationTest extends ZooKeeperTestHarness with Logging {
     var result = true
     for (topic <- List(topic1, topic2)) {
       val tp = new TopicPartition(topic, 0)
-      val leo = broker.getLogManager().getLog(tp).get.logEndOffset
+      val leo = broker.logManager.getLog(tp).get.logEndOffset
       result = result && leo > 0 && brokers.forall { broker =>
-        broker.getLogManager().getLog(tp).get.logSegments.iterator.forall { segment =>
+        broker.logManager.getLog(tp).get.logSegments.iterator.forall { segment =>
           if (segment.read(minOffset, Integer.MAX_VALUE) == null) {
             false
           } else {

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
@@ -239,9 +239,9 @@ class LeaderEpochIntegrationTest extends ZooKeeperTestHarness with Logging {
     var result = true
     for (topic <- List(topic1, topic2)) {
       val tp = new TopicPartition(topic, 0)
-      val leo = broker.getLogManager.getLog(tp).get.logEndOffset
+      val leo = broker.getLogManager().getLog(tp).get.logEndOffset
       result = result && leo > 0 && brokers.forall { broker =>
-        broker.getLogManager.getLog(tp).get.logSegments.iterator.forall { segment =>
+        broker.getLogManager().getLog(tp).get.logSegments.iterator.forall { segment =>
           if (segment.read(minOffset, Integer.MAX_VALUE) == null) {
             false
           } else {

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -20,15 +20,16 @@ package kafka.server.metadata
 import com.yammer.metrics.core.{Gauge, Histogram, MetricName}
 import kafka.metrics.KafkaYammerMetrics
 import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.metadata.{FenceBrokerRecord, RegisterBrokerRecord}
 import org.apache.kafka.common.protocol.{ApiMessage, ApiMessageAndVersion}
 import org.apache.kafka.common.utils.{LogContext, MockTime, Utils}
 import org.apache.kafka.controller.LocalLogManager
 import org.apache.kafka.test.{TestCondition, TestUtils => KTestUtils}
-import kafka.utils.TestUtils
-import org.junit.Assert.{assertEquals, assertTrue, fail}
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue, fail}
 import org.junit.{After, Test}
-import org.mockito.Mockito.mock
+import org.mockito.Mockito.{mock, times, verify}
 import org.scalatest.Assertions.intercept
 
 import scala.collection.mutable
@@ -65,6 +66,32 @@ class BrokerMetadataListenerTest {
     new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List.empty)
   }
 
+  @Test(expected = classOf[IllegalStateException])
+  def testNoConfigMetadataProcessors(): Unit = {
+    val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List(mock(classOf[BrokerMetadataProcessor])))
+    listener.brokerConfigProperties(1)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testMultipleConfigMetadataProcessors(): Unit = {
+    trait ConfigRepositoryProcessor extends BrokerMetadataProcessor with ConfigRepository
+    new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(),
+      List(mock(classOf[ConfigRepositoryProcessor]), mock(classOf[ConfigRepositoryProcessor])))
+  }
+
+  @Test
+  def testConfigMetadataProcessor(): Unit = {
+    trait ConfigRepositoryProcessor extends BrokerMetadataProcessor with ConfigRepository
+    val configProcessor = mock(classOf[ConfigRepositoryProcessor])
+    val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List(configProcessor))
+    val brokerId = 0
+    listener.brokerConfigProperties(brokerId)
+    val topicName = "foo"
+    listener.topicConfigProperties(topicName)
+    verify(configProcessor, times(1)).configProperties(new ConfigResource(ConfigResource.Type.BROKER, brokerId.toString))
+    verify(configProcessor, times(1)).configProperties(new ConfigResource(ConfigResource.Type.TOPIC, topicName))
+  }
+
   @Test
   def testEventIsProcessedAfterStartup(): Unit = {
     val processor = new MockMetadataProcessor
@@ -99,15 +126,33 @@ class BrokerMetadataListenerTest {
     val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List(processor))
     assertEquals(expectedInitialMetadataOffset, listener.currentMetadataOffset())
 
-    val msg0 = RegisterBrokerEvent(1)
-    val msg1 = FenceBrokerEvent(1)
+    assertFalse(listener.initiallyCaughtUpFuture.isDone)
+    assertFalse(listener.brokerEpochFuture().isDone)
+    val brokerEpoch = 1
+    val msg0 = RegisterBrokerEvent(brokerEpoch)
+    val msg1 = FenceBrokerEvent(1, true)
     listener.put(msg0)
     listener.put(msg1)
     listener.drain()
     assertEquals(List(msg0, msg1), processor.processed.toList)
+    assertFalse(listener.initiallyCaughtUpFuture.isDone)
+    assertTrue(listener.brokerEpochFuture().isDone)
+    assertEquals(brokerEpoch, listener.brokerEpochFuture().get())
 
     // offset should not be updated
     assertEquals(expectedInitialMetadataOffset, listener.currentMetadataOffset())
+
+    processor.processed.clear()
+    val msg2 = FenceBrokerEvent(1, false)
+    listener.put(msg2)
+    listener.drain()
+    assertEquals(List(msg2), processor.processed.toList)
+
+    // offset should not be updated
+    assertEquals(expectedInitialMetadataOffset, listener.currentMetadataOffset())
+    // but we should now be "caught up"
+    assertTrue(listener.initiallyCaughtUpFuture.isDone)
+
   }
 
   @Test
@@ -142,23 +187,34 @@ class BrokerMetadataListenerTest {
   }
 
   @Test
+  def testFuturesCancelledOnClose(): Unit = {
+    val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(),
+      List(new MockMetadataProcessor))
+    listener.start()
+    assertFalse(listener.initiallyCaughtUpFuture.isDone)
+    assertFalse(listener.brokerEpochFuture().isDone)
+
+    listener.close()
+    assertTrue(listener.initiallyCaughtUpFuture.isCancelled)
+    assertTrue(listener.brokerEpochFuture().isCancelled)
+  }
+
+  @Test
   def testOutOfBandEventIsProcessed(): Unit = {
     val processor = new MockMetadataProcessor
     val listener = new BrokerMetadataListener(mock(classOf[KafkaConfig]), new MockTime(), List(processor))
     val logEvent1 = MetadataLogEvent(List(mock(classOf[ApiMessage])).asJava, 1)
     val logEvent2 = MetadataLogEvent(List(mock(classOf[ApiMessage])).asJava, 2)
     val registerEvent = RegisterBrokerEvent(1)
-    val fenceEvent = FenceBrokerEvent(1)
+    val fenceEvent = FenceBrokerEvent(1, true)
 
     // add the out-of-band messages after the batches
-    listener.put(logEvent1)
-    listener.put(logEvent2)
-    listener.put(registerEvent)
-    listener.put(fenceEvent)
+    val expected = List(logEvent1, logEvent2, registerEvent, fenceEvent)
+    expected.foreach { listener.put(_) }
     listener.drain()
 
     // make sure events are handled in order
-    assertEquals(List(logEvent1, logEvent2, registerEvent, fenceEvent), processor.processed.toList)
+    assertEquals(expected, processor.processed.toList)
   }
 
   @Test
@@ -231,7 +287,7 @@ class BrokerMetadataListenerTest {
       override def conditionMet(): Boolean = {
         listener.pendingEvents == eventsScheduled
       }
-    }, 1000, "Wait for all events to be queued")
+    }, 2000, "Wait for all events to be queued")
 
     // Process all events
     listener.drain()

--- a/core/src/test/scala/unit/kafka/utils/ReplicationUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ReplicationUtilsTest.scala
@@ -62,7 +62,7 @@ class ReplicationUtilsTest extends ZooKeeperTestHarness {
     EasyMock.expect(replicaManager.config).andReturn(configs.head)
     EasyMock.expect(replicaManager.logManager).andReturn(logManager)
     EasyMock.expect(replicaManager.replicaFetcherManager).andReturn(EasyMock.createMock(classOf[ReplicaFetcherManager]))
-    EasyMock.expect(replicaManager.zkClient).andReturn(zkClient)
+    EasyMock.expect(replicaManager.zkClient).andReturn(Some(zkClient))
     EasyMock.replay(replicaManager)
 
     zkClient.makeSurePersistentPathExists(IsrChangeNotificationZNode.path)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -23,7 +23,6 @@ import java.nio.charset.{Charset, StandardCharsets}
 import java.nio.file.{Files, StandardOpenOption}
 import java.security.cert.X509Certificate
 import java.time.Duration
-import java.util.concurrent.atomic.AtomicReference
 import java.util.{Arrays, Collections, Properties}
 import java.util.concurrent.{Callable, ExecutionException, Executors, TimeUnit}
 
@@ -57,7 +56,6 @@ import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySe
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.utils.Utils._
 import org.apache.kafka.common.{KafkaFuture, TopicPartition}
-import org.apache.kafka.metadata.BrokerState
 import org.apache.kafka.server.authorizer.{Authorizer => JAuthorizer}
 import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
 import org.apache.zookeeper.KeeperException.SessionExpiredException
@@ -1060,7 +1058,7 @@ object TestUtils extends Logging {
                    maxPidExpirationMs = 60 * 60 * 1000,
                    scheduler = time.scheduler,
                    time = time,
-                   brokerState = new AtomicReference[BrokerState](BrokerState.NOT_RUNNING),
+                   cleanShutdownFunc = _ => {},
                    brokerTopicStats = new BrokerTopicStats,
                    logDirFailureChannel = new LogDirFailureChannel(logDirs.size))
   }
@@ -1136,10 +1134,10 @@ object TestUtils extends Logging {
       "Replica manager's should have deleted all of this topic's partitions")
     // ensure that logs from all replicas are deleted if delete topic is marked successful in ZooKeeper
     assertTrue("Replica logs not deleted after delete topic is complete",
-      servers.forall(server => topicPartitions.forall(tp => server.getLogManager.getLog(tp).isEmpty)))
+      servers.forall(server => topicPartitions.forall(tp => server.getLogManager().getLog(tp).isEmpty)))
     // ensure that topic is removed from all cleaner offsets
     waitUntilTrue(() => servers.forall(server => topicPartitions.forall { tp =>
-      val checkpoints = server.getLogManager.liveLogDirs.map { logDir =>
+      val checkpoints = server.getLogManager().liveLogDirs.map { logDir =>
         new OffsetCheckpointFile(new File(logDir, "cleaner-offset-checkpoint")).read()
       }
       checkpoints.forall(checkpointsPerLogDir => !checkpointsPerLogDir.contains(tp))

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1134,10 +1134,10 @@ object TestUtils extends Logging {
       "Replica manager's should have deleted all of this topic's partitions")
     // ensure that logs from all replicas are deleted if delete topic is marked successful in ZooKeeper
     assertTrue("Replica logs not deleted after delete topic is complete",
-      servers.forall(server => topicPartitions.forall(tp => server.getLogManager().getLog(tp).isEmpty)))
+      servers.forall(server => topicPartitions.forall(tp => server.logManager.getLog(tp).isEmpty)))
     // ensure that topic is removed from all cleaner offsets
     waitUntilTrue(() => servers.forall(server => topicPartitions.forall { tp =>
-      val checkpoints = server.getLogManager().liveLogDirs.map { logDir =>
+      val checkpoints = server.logManager.liveLogDirs.map { logDir =>
         new OffsetCheckpointFile(new File(logDir, "cleaner-offset-checkpoint")).read()
       }
       checkpoints.forall(checkpointsPerLogDir => !checkpointsPerLogDir.contains(tp))

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -24,7 +24,7 @@ import java.nio.file.{Files, StandardOpenOption}
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.{Arrays, Collections, Properties}
-import java.util.concurrent.{Callable, ExecutionException, Executors, TimeUnit}
+import java.util.concurrent.{Callable, CompletableFuture, ExecutionException, Executors, TimeUnit}
 
 import javax.net.ssl.X509TrustManager
 import kafka.api._
@@ -1058,7 +1058,7 @@ object TestUtils extends Logging {
                    maxPidExpirationMs = 60 * 60 * 1000,
                    scheduler = time.scheduler,
                    time = time,
-                   cleanShutdownFunc = _ => {},
+                   cleanShutdownCompletableFuture = new CompletableFuture[Boolean](),
                    brokerTopicStats = new BrokerTopicStats,
                    logDirFailureChannel = new LogDirFailureChannel(logDirs.size))
   }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -54,7 +54,6 @@ import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.metadata.BrokerState;
 import org.mockito.Mockito;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -74,6 +73,8 @@ import scala.collection.Iterator;
 import scala.collection.JavaConverters;
 import scala.compat.java8.OptionConverters;
 import scala.collection.Map;
+import scala.runtime.AbstractFunction1;
+import scala.runtime.BoxedUnit;
 
 import java.io.File;
 import java.io.IOException;
@@ -87,7 +88,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 @State(Scope.Benchmark)
 @Fork(value = 1)
@@ -105,6 +105,13 @@ public class ReplicaFetcherThreadBenchmark {
     private File logDir = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
     private KafkaScheduler scheduler = new KafkaScheduler(1, "scheduler", true);
     private Pool<TopicPartition, Partition> pool = new Pool<TopicPartition, Partition>(Option.empty());
+
+    private AbstractFunction1<Object, BoxedUnit> cleanShutdownFunc = new AbstractFunction1<Object, BoxedUnit>() {
+        @Override
+        public BoxedUnit apply(Object v1) {
+            return null;
+        }
+    };
 
     @Setup(Level.Trial)
     public void setup() throws IOException {
@@ -132,7 +139,7 @@ public class ReplicaFetcherThreadBenchmark {
                 1000L,
                 60000,
                 scheduler,
-                new AtomicReference<BrokerState>(BrokerState.NOT_RUNNING),
+                cleanShutdownFunc,
                 brokerTopicStats,
                 logDirFailureChannel,
                 Time.SYSTEM);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -73,8 +73,6 @@ import scala.collection.Iterator;
 import scala.collection.JavaConverters;
 import scala.compat.java8.OptionConverters;
 import scala.collection.Map;
-import scala.runtime.AbstractFunction1;
-import scala.runtime.BoxedUnit;
 
 import java.io.File;
 import java.io.IOException;
@@ -87,6 +85,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -105,13 +104,6 @@ public class ReplicaFetcherThreadBenchmark {
     private File logDir = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
     private KafkaScheduler scheduler = new KafkaScheduler(1, "scheduler", true);
     private Pool<TopicPartition, Partition> pool = new Pool<TopicPartition, Partition>(Option.empty());
-
-    private AbstractFunction1<Object, BoxedUnit> cleanShutdownFunc = new AbstractFunction1<Object, BoxedUnit>() {
-        @Override
-        public BoxedUnit apply(Object v1) {
-            return null;
-        }
-    };
 
     @Setup(Level.Trial)
     public void setup() throws IOException {
@@ -139,7 +131,7 @@ public class ReplicaFetcherThreadBenchmark {
                 1000L,
                 60000,
                 scheduler,
-                cleanShutdownFunc,
+                new CompletableFuture<>(),
                 brokerTopicStats,
                 logDirFailureChannel,
                 Time.SYSTEM);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -188,7 +188,8 @@ public class MetadataRequestBenchmark {
             time,
             null,
             brokerFeatures,
-            new FinalizedFeatureCache(brokerFeatures));
+            new FinalizedFeatureCache(brokerFeatures),
+            null);
     }
 
     @TearDown(Level.Trial)

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -38,7 +38,6 @@ import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.metadata.BrokerState;
 import org.mockito.Mockito;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -54,6 +53,8 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.Option;
 import scala.collection.JavaConverters;
+import scala.runtime.AbstractFunction1;
+import scala.runtime.BoxedUnit;
 
 import java.io.File;
 import java.io.IOException;
@@ -67,7 +68,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 @State(Scope.Benchmark)
 @Fork(value = 1)
@@ -85,6 +85,13 @@ public class PartitionMakeFollowerBenchmark {
     private OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
     private DelayedOperations delayedOperations  = Mockito.mock(DelayedOperations.class);
     private ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    private AbstractFunction1<Object, BoxedUnit> cleanShutdownFunc = new AbstractFunction1<Object, BoxedUnit>() {
+        @Override
+        public BoxedUnit apply(Object v1) {
+            return null;
+        }
+    };
 
     @Setup(Level.Trial)
     public void setup() throws IOException {
@@ -109,7 +116,7 @@ public class PartitionMakeFollowerBenchmark {
             1000L,
             60000,
             scheduler,
-            new AtomicReference<BrokerState>(BrokerState.NOT_RUNNING),
+            cleanShutdownFunc,
             brokerTopicStats,
             logDirFailureChannel,
             Time.SYSTEM);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -53,8 +53,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.Option;
 import scala.collection.JavaConverters;
-import scala.runtime.AbstractFunction1;
-import scala.runtime.BoxedUnit;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,6 +63,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -85,13 +84,6 @@ public class PartitionMakeFollowerBenchmark {
     private OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
     private DelayedOperations delayedOperations  = Mockito.mock(DelayedOperations.class);
     private ExecutorService executorService = Executors.newSingleThreadExecutor();
-
-    private AbstractFunction1<Object, BoxedUnit> cleanShutdownFunc = new AbstractFunction1<Object, BoxedUnit>() {
-        @Override
-        public BoxedUnit apply(Object v1) {
-            return null;
-        }
-    };
 
     @Setup(Level.Trial)
     public void setup() throws IOException {
@@ -116,7 +108,7 @@ public class PartitionMakeFollowerBenchmark {
             1000L,
             60000,
             scheduler,
-            cleanShutdownFunc,
+            new CompletableFuture<>(),
             brokerTopicStats,
             logDirFailureChannel,
             Time.SYSTEM);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -35,7 +35,6 @@ import kafka.utils.KafkaScheduler;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.metadata.BrokerState;
 import org.mockito.Mockito;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -51,6 +50,8 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.Option;
 import scala.collection.JavaConverters;
+import scala.runtime.AbstractFunction1;
+import scala.runtime.BoxedUnit;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -59,7 +60,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 @State(Scope.Benchmark)
 @Fork(value = 1)
@@ -76,6 +76,13 @@ public class UpdateFollowerFetchStateBenchmark {
     private long nextOffset = 0;
     private LogManager logManager;
     private Partition partition;
+
+    private AbstractFunction1<Object, BoxedUnit> cleanShutdownFunc = new AbstractFunction1<Object, BoxedUnit>() {
+        @Override
+        public BoxedUnit apply(Object v1) {
+            return null;
+        }
+    };
 
     @Setup(Level.Trial)
     public void setUp() {
@@ -94,7 +101,7 @@ public class UpdateFollowerFetchStateBenchmark {
                 1000L,
                 60000,
                 scheduler,
-                new AtomicReference<BrokerState>(BrokerState.NOT_RUNNING),
+                cleanShutdownFunc,
                 brokerTopicStats,
                 logDirFailureChannel,
                 Time.SYSTEM);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -50,8 +50,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.Option;
 import scala.collection.JavaConverters;
-import scala.runtime.AbstractFunction1;
-import scala.runtime.BoxedUnit;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -59,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -77,13 +76,6 @@ public class UpdateFollowerFetchStateBenchmark {
     private LogManager logManager;
     private Partition partition;
 
-    private AbstractFunction1<Object, BoxedUnit> cleanShutdownFunc = new AbstractFunction1<Object, BoxedUnit>() {
-        @Override
-        public BoxedUnit apply(Object v1) {
-            return null;
-        }
-    };
-
     @Setup(Level.Trial)
     public void setUp() {
         scheduler.startup();
@@ -101,7 +93,7 @@ public class UpdateFollowerFetchStateBenchmark {
                 1000L,
                 60000,
                 scheduler,
-                cleanShutdownFunc,
+                new CompletableFuture<>(),
                 brokerTopicStats,
                 logDirFailureChannel,
                 Time.SYSTEM);


### PR DESCRIPTION
Broker (almost) starts.  I see the broker sending a metadata request to identify the active controller, and it gets the response and correctly identifies that controller as the active one:

Here's the broker sending it:

```
[2020-11-08 18:25:59,972] INFO [broker-0-to-controller-send-thread]: Starting (kafka.server.Kip500BrokerToControllerRequestThread)
[2020-11-08 18:25:59,973] INFO [broker-0-to-controller-send-thread]: Active Controller isn't known, making metadata request to a random controller node to identify it (kafka.server.Kip500BrokerToControllerRequestThread)
[2020-11-08 18:25:59,974] INFO [broker-0-to-controller-send-thread]: Sending metadata request data MetadataRequestData(topics=[], allowAutoTopicCreation=false, includeClusterAuthorizedOperations=false, includeTopicAuthorizedOperations=false) to node localhost:9093 (id: 3000 rack: null) (kafka.server.Kip500BrokerToControllerRequestThread)
```

Here's the controller processing it (I locally added some logging for this):

```
[2020-11-08 18:26:00,035] INFO Received request: Request(processor=0, connectionId=127.0.0.1:9093-127.0.0.1:60813-0, session=Session(User:ANONYMOUS,/127.0.0.1), listenerName=ListenerName(PLAINTEXT), securityProtocol=PLAINTEXT, buffer=null) (kafka.server.ControllerApis)
[2020-11-08 18:26:00,036] INFO Handling {topics=[],allow_auto_topic_creation=false,include_cluster_authorized_operations=false,include_topic_authorized_operations=false,_tagged_fields={}} (kafka.server.ControllerApis)
```

And here's the broker receiving and processing it correctly:

```
[2020-11-08 18:26:00,048] INFO [broker-0-to-controller-send-thread]: Received metadata response org.apache.kafka.common.requests.MetadataResponse@8e446d5 (kafka.server.Kip500BrokerToControllerRequestThread)
[2020-11-08 18:26:00,050] INFO [broker-0-to-controller-send-thread]: Active controller is defined: localhost:9093 (id: 3000 rack: null) (kafka.server.Kip500BrokerToControllerRequestThread)
```

Then the broker heartbeat sends the registration request:

```
[2020-11-08 18:26:00,053] INFO [broker-0-to-controller-send-thread]: top request=BrokerToControllerQueueItem(org.apache.kafka.common.requests.BrokerRegistrationRequest$Builder@139347c9,kafka.server.BrokerLifecycleManagerImpl$$Lambda$325/548482954@41029111) (kafka.server.Kip500BrokerToControllerRequestThread)
```

And the controller processes it:

```
[2020-11-08 18:26:00,054] INFO Received request: Request(processor=0, connectionId=127.0.0.1:9093-127.0.0.1:60813-0, session=Session(User:ANONYMOUS,/127.0.0.1), listenerName=ListenerName(PLAINTEXT), securityProtocol=PLAINTEXT, buffer=null) (kafka.server.ControllerApis)
[2020-11-08 18:26:00,055] INFO Handling {broker_id=0,listeners=[{name=PLAINTEXT,host=localhost,port=9092,security_protocol=0,_tagged_fields={}}],features=[],rack=,_tagged_fields={}} (kafka.server.ControllerApis)
[2020-11-08 18:26:00,058] INFO Done handling {broker_id=0,listeners=[{name=PLAINTEXT,host=localhost,port=9092,security_protocol=0,_tagged_fields={}}],features=[],rack=,_tagged_fields={}} (kafka.server.ControllerApis)
```

But unfortunately the broker's request still times out.  I'm not sure why since the heartbeat request/response worked fine -- I would assume the registration request/response would also work fine.

```
[2020-11-08 18:26:18,073] ERROR [KafkaBroker id=0] Fatal error during controller startup. Prepare to shutdown (kafka.server.Kip500Broker)
java.util.concurrent.TimeoutException: Future timed out after [18000 milliseconds]
	at scala.concurrent.impl.Promise$DefaultPromise.tryAwait0(Promise.scala:212)
	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:225)
	at scala.concurrent.Await$.$anonfun$result$1(package.scala:201)
	at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:62)
	at scala.concurrent.Await$.result(package.scala:124)
	at kafka.server.BrokerLifecycleManagerImpl.start(BrokerLifecycleManager.scala:179)
	at kafka.server.Kip500Broker.startup(Kip500Broker.scala:245)
	at kafka.server.KafkaServerManager.startup(KafkaServerManager.scala:110)
	at kafka.server.KafkaServerStartable.startup(KafkaServerStartable.scala:44)
	at kafka.Kafka$.main(Kafka.scala:82)
	at kafka.Kafka.main(Kafka.scala)
[2020-11-08 18:26:18,075] INFO [KafkaBroker id=0] shutting down (kafka.server.Kip500Broker)
```