### PR TITLE
MINOR: call super.close() when closing RocksDB options (#9498)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ def retryFlagsString(jobConfig) {
 def downstreamBuildFailureOutput = ""
 def publishStep(String vaultSecret) {
     withDockerServer([uri: dockerHost()]) {
-        withVaultFile([["gradle/artifactory_hotfix_settings", "settings_file", "${env.WORKSPACE}/init.gradle", "GRADLE_NEXUS_SETTINGS"]]) {
+        withVaultFile([["gradle/artifactory_hotfix_settings_6.1.0-beta201006024150", "settings_file", "${env.WORKSPACE}/init.gradle", "GRADLE_NEXUS_SETTINGS"]]) {
             writeFile file:'.ci/extract-iam-credential.sh', text:libraryResource('scripts/extract-iam-credential.sh')
             sh """
                 bash .ci/extract-iam-credential.sh && rm .ci/extract-iam-credential.sh
@@ -83,7 +83,7 @@ def job = {
             ciTool("ci-push-tag ${env.WORKSPACE} kafka")
         }
 
-        publishStep('artifactory_hotfix_settings')
+        publishStep('artifactory_hotfix_settings_6.1.0-beta201006024150')
       }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
-version=6.1.0-beta200916191548-hf-1
+version=6.1.0-beta200916191548-hf-2
 scalaVersion=2.13.3
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC --add-modules=java.xml.bind -XX:+IgnoreUnrecognizedVMOptions

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -1393,8 +1393,10 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
 
     @Override
     public void close() {
-        // ColumnFamilyOptions should be closed last
+        // ColumnFamilyOptions should be closed after DBOptions
         dbOptions.close();
         columnFamilyOptions.close();
+        // close super last since we initialized it first
+        super.close();
     }
 }


### PR DESCRIPTION
Cherry-picks https://github.com/confluentinc/kafka/commit/35deb2f7c4a735924b6452c6c60016fbe7dc54e0
to the v6.1.0-beta200916191548 hotfix branch and bumps the hotfix version.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
