### PR TITLE
MINOR: Codify version bumps and bump 2.6 to 6.0.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.0.1-ccs-SNAPSHOT
+current_version = 6.0.2-ccs-SNAPSHOT
 commit = true
 message = Bump Version: {current_version} → {new_version}
 tag = false

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,33 @@
+[bumpversion]
+current_version = 6.0.1-ccs-SNAPSHOT
+commit = true
+message = Bump Version: {current_version} → {new_version}
+tag = false
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)-ccs(-(?P<release>[A-Za-z0-9]+))?
+serialize = 
+	{major}.{minor}.{patch}-ccs-{release}
+	{major}.{minor}.{patch}-ccs
+
+[bumpversion:part:release]
+optional_value = RELEASE_EMPTY
+values = 
+	SNAPSHOT
+	RELEASE_EMPTY
+
+[bumpversion:file:streams/quickstart/java/src/main/resources/archetype-resources/pom.xml]
+
+[bumpversion:file:streams/quickstart/pom.xml]
+
+[bumpversion:file:gradle.properties]
+
+[bumpversion:file:tests/kafkatest/version.py]
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>[A-Za-z0-9]+))?
+serialize = 
+	{major}.{minor}.{patch}-{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:tests/kafkatest/__init__.py]
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+).dev0
+serialize = 
+	{major}.{minor}.{patch}.dev0
+	{major}.{minor}.{patch}

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ group=org.apache.kafka
 #  - streams/quickstart/pom.xml
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - .bumpversion.cfg (current_version needs to be "in sync" with the logical version)
-version=6.0.1-ccs-SNAPSHOT
+version=6.0.2-ccs-SNAPSHOT
 scalaVersion=2.13.2
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,14 +14,18 @@
 # limitations under the License.
 
 group=org.apache.kafka
-# NOTE: When you change this version number, you should also make sure to update
-# the version numbers in
+# NOTE: When you need to bump versions, please use the bump2version python project
+# to bump the part (major, minor, patch, release), as it contains "codified"
+# rules in .bumpversion.cfg to bump values in all files. Eg:
+# bump2version [major|minor|patch|release]
+# If you need to perform a manual bump, ensure these files are updated:
 #  - docs/js/templateData.js
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 #  - streams/quickstart/pom.xml
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+#  - .bumpversion.cfg (current_version needs to be "in sync" with the logical version)
 version=6.0.1-ccs-SNAPSHOT
 scalaVersion=2.13.2
 task=build

--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>6.0.1-ccs-SNAPSHOT</kafka.version>
+        <kafka.version>6.0.2-ccs-SNAPSHOT</kafka.version>
         <slf4j.version>1.7.7</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
     </properties>

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>6.0.1-ccs-SNAPSHOT</version>
+    <version>6.0.2-ccs-SNAPSHOT</version>
 
     <name>Kafka Streams :: Quickstart</name>
 

--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -22,4 +22,4 @@
 # Instead, in development branches, the version should have a suffix of the form ".devN"
 #
 # For example, when Kafka is at version 1.0.0-SNAPSHOT, this should be something like "1.0.0.dev0"
-__version__ = '6.0.1.dev0'
+__version__ = '6.0.2.dev0'

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -69,7 +69,7 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("6.0.1-SNAPSHOT")
+DEV_VERSION = KafkaVersion("6.0.2-SNAPSHOT")
 
 # 0.8.2.x versions
 V_0_8_2_1 = KafkaVersion("0.8.2.1")


### PR DESCRIPTION
This PR has two goals:

* Codify version bumps using the bump2version project - Thats what https://github.com/confluentinc/kafka/commit/a8f047d7b5ab8da735be31025276a1b2edeb4d28 did, initially with the current logical value of 6.0.1-ccs-SNAPSHOT
* Now that 6.0.1 is released, we need to update this project to the "next" version of 6.0.2, which was done by executing `bump2version patch`, which resulted in this commit https://github.com/confluentinc/kafka/commit/2f75e8c7287fe9d9f0b9ba6d416c1671a749c0d1

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
