### PR TITLE
Recover logs after LogManager construction, upon startup()

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -116,8 +116,6 @@ class LogManager(logDirs: Seq[File],
     logDirsSet
   }
 
-  loadLogs()
-
   private[kafka] val cleaner: LogCleaner =
     if (cleanerConfig.enableCleaner)
       new LogCleaner(cleanerConfig, liveLogDirs, currentLogs, logDirFailureChannel, time = time)
@@ -405,6 +403,8 @@ class LogManager(logDirs: Seq[File],
    *  Start the background threads to flush logs and do log cleanup
    */
   def startup(): Unit = {
+    loadLogs() // this could take a while if shutdown was not clean
+
     /* Schedule the cleanup task to delete old logs */
     if (scheduler != null) {
       info("Starting log cleanup with a period of %d ms.".format(retentionCheckMs))

--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -44,6 +44,13 @@ import scala.concurrent.duration._
  * Explicit broker state transitions are performed by co-ordinating
  * with the controller through the heartbeats.
  *
+ * Expected state transitions when starting up are:
+ * SHUTDOWN => REGISTERING => FENCED [=> RECOVERING_FROM_UNCLEAN_SHUTDOWN] => RUNNING
+ *
+ * We potentially transition from RUNNING to FENCED and back to RUNNING
+ *
+ * We eventually shutdown:
+ * RUNNING [=> PENDING_CONTROLLED_SHUTDOWN] => SHUTDOWN
  */
 trait BrokerLifecycleManager {
 

--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -45,12 +45,12 @@ import scala.concurrent.duration._
  * with the controller through the heartbeats.
  *
  * Expected state transitions when starting up are:
- * SHUTDOWN => REGISTERING => FENCED [=> RECOVERING_FROM_UNCLEAN_SHUTDOWN] => RUNNING
+ * NOT_RUNNING => REGISTERING => FENCED [=> RECOVERING_FROM_UNCLEAN_SHUTDOWN] => RUNNING
  *
  * We potentially transition from RUNNING to FENCED and back to RUNNING
  *
  * We eventually shutdown:
- * RUNNING [=> PENDING_CONTROLLED_SHUTDOWN] => SHUTDOWN
+ * RUNNING [=> PENDING_CONTROLLED_SHUTDOWN] => NOT_RUNNING
  */
 trait BrokerLifecycleManager {
 

--- a/core/src/main/scala/kafka/server/LegacyBroker.scala
+++ b/core/src/main/scala/kafka/server/LegacyBroker.scala
@@ -344,7 +344,7 @@ class LegacyBroker(val config: KafkaConfig,
         Mx4jLoader.maybeLoad()
 
         /* Add all reconfigurables for config change notification before starting config handlers */
-        config.dynamicConfig.addReconfigurables(this.asInstanceOf[LegacyBroker])
+        config.dynamicConfig.addReconfigurables(this)
 
         /* start dynamic config manager */
         dynamicConfigHandlers = Map[String, ConfigHandler](ConfigType.Topic -> new TopicConfigHandler(logManager, config, quotaManagers, Some(kafkaController.enableTopicUncleanLeaderElection)),

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -145,9 +145,10 @@ class LogManagerTest {
       logManagerForTest1 = Some(createLogManager(Seq(logDir1, logDir2)))
       assertFalse(Files.exists(new File(logDir1, Log.CleanShutdownFile).toPath))
       assertFalse(Files.exists(new File(logDir2, Log.CleanShutdownFile).toPath))
+      assertFalse(logManagerForTest1.get.cleanShutdownCompletableFuture.isDone)
+      logManagerForTest1.get.startup()
       assertTrue(logManagerForTest1.get.cleanShutdownCompletableFuture.isDone)
       assertFalse(logManagerForTest1.get.cleanShutdownCompletableFuture.get())
-      logManagerForTest1.get.startup()
       val log1 = logManagerForTest1.get.getOrCreateLog(new TopicPartition(name, 0), () => logConfig)
       val log2 = logManagerForTest1.get.getOrCreateLog(new TopicPartition(name, 1), () => logConfig)
       val logFile1 = new File(logDir1, name + "-0")
@@ -168,16 +169,20 @@ class LogManagerTest {
       assertTrue(Files.exists(new File(logDir1, Log.CleanShutdownFile).toPath))
       assertTrue(Files.exists(new File(logDir2, Log.CleanShutdownFile).toPath))
       logManagerForTest2 = Some(createLogManager(Seq(logDir1, logDir2)))
+      assertFalse(logManagerForTest2.get.cleanShutdownCompletableFuture.isDone)
+      logManagerForTest2.get.startup()
       assertTrue(logManagerForTest2.get.cleanShutdownCompletableFuture.isDone)
       assertTrue(logManagerForTest2.get.cleanShutdownCompletableFuture.get())
-      logManagerForTest2.get.startup()
       logManagerForTest2.get.shutdown()
 
       // now delete the file indicating a clean shutdown and make sure we get false for completion on a new manager's future
       FileUtils.forceDelete(new File(logDir2, Log.CleanShutdownFile))
       logManagerForTest3 = Some(createLogManager(Seq(logDir1, logDir2)))
+      assertFalse(logManagerForTest3.get.cleanShutdownCompletableFuture.isDone)
+      logManagerForTest3.get.startup()
       assertTrue(logManagerForTest3.get.cleanShutdownCompletableFuture.isDone)
       assertFalse(logManagerForTest3.get.cleanShutdownCompletableFuture.get())
+      logManagerForTest3.get.shutdown()
     } finally {
       logManagerForTest1.foreach(manager => manager.liveLogDirs.foreach(Utils.delete))
     }


### PR DESCRIPTION
Moves log recovery out of LogManager constructor and into `startup()` so we can delay recovery until we have caught up on the metadata log.  This is necessary because topic configs are currently required for log recovery.  We may work to remove this dependency on configs later.

ReplicaManager, GroupCoordinator, and TransactionCoordinator al have their `startup()` delayed as well.

Note that this means the broker will transition between states upon startup as follows:

`SHUTDOWN => REGISTERING => FENCED [=> RECOVERING_FROM_UNCLEAN_SHUTDOWN] => RUNNING`

This differs from what is currently stated in KIP-631, which has `RECOVERING_FROM_UNCLEAN_SHUTDOWN` occurring **before** `REGISTERING`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
