### PR TITLE
Config file renames/changes

### DIFF
--- a/config/kip500-broker.properties
+++ b/config/kip500-broker.properties
@@ -21,7 +21,7 @@
 process.roles=broker
 
 # The connect string for the controller quorum
-controller.quorum.voters=3000@localhost:9093
+controller.connect=3000@localhost:9093
 
 # The id of the broker. This must be set to a unique integer for each broker.
 broker.id=0

--- a/config/kip500-broker.properties
+++ b/config/kip500-broker.properties
@@ -21,7 +21,7 @@
 process.roles=broker
 
 # The connect string for the controller quorum
-controller.connect=3000@localhost:9093
+controller.quorum.voters=3000@localhost:9093
 
 # The id of the broker. This must be set to a unique integer for each broker.
 broker.id=0
@@ -123,8 +123,3 @@ log.segment.bytes=1073741824
 # The interval at which log segments are checked to see if they can be deleted according
 # to the retention policies
 log.retention.check.interval.ms=300000
-
-############################# Log Basics #############################
-
-# The directory in which the metadata log is kept. If not set, we default to the first directory given by log.dirs
-metadata.log.dir=/tmp/kafka-metadata-log

--- a/config/kip500-combined.properties
+++ b/config/kip500-combined.properties
@@ -21,7 +21,7 @@
 process.roles=broker,controller
 
 # The connect string for the controller quorum
-controller.quorum.voters=3000@localhost:9092
+controller.connect=3000@localhost:9092
 
 # The id of the controller. This must be different than the broker id.
 controller.id=3000

--- a/config/kip500-combined.properties
+++ b/config/kip500-combined.properties
@@ -18,16 +18,16 @@
 ############################# Server Basics #############################
 
 # The role of this server. Setting this puts us in kip-500 mode
-process.roles=controller
-
-# The id of the broker. This must be set to a unique integer for each broker.
-broker.id=0
+process.roles=broker,controller
 
 # The connect string for the controller quorum
-controller.connect=3000@localhost:9092
+controller.quorum.voters=3000@localhost:9092
 
 # The id of the controller. This must be different than the broker id.
 controller.id=3000
+
+# The id of the broker. This must be set to a unique integer for each broker.
+broker.id=0
 
 ############################# Socket Server Settings #############################
 
@@ -38,18 +38,19 @@ controller.id=3000
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
 listeners=PLAINTEXT://:9092,CONTROLLER://:9093
+inter.broker.listener.name=PLAINTEXT
 
 # Hostname and port the broker will advertise to producers and consumers. If not set, 
 # it uses the value for "listeners" if configured.  Otherwise, it will use the value
 # returned from java.net.InetAddress.getCanonicalHostName().
-#advertised.listeners=PLAINTEXT://your.host.name:9092
+advertised.listeners=PLAINTEXT://localhost:9092
 
 # Listener, host name, and port for the controller to advertise to the brokers. If 
 # this server is a controller, this listener must be configured.
-controller.listeners.names=CONTROLLER
+controller.listener.names=CONTROLLER
 
 # Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
-#listener.security.protocol.map=PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+listener.security.protocol.map=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
 
 # The number of threads that the server uses for receiving requests from the network and sending responses to the network
 num.network.threads=3
@@ -70,7 +71,7 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma separated list of directories under which to store log files
-log.dirs=/tmp/kafka-logs
+log.dirs=/tmp/kafka-combined-logs
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across
@@ -125,25 +126,3 @@ log.segment.bytes=1073741824
 # The interval at which log segments are checked to see if they can be deleted according
 # to the retention policies
 log.retention.check.interval.ms=300000
-
-############################# Zookeeper #############################
-
-# Zookeeper connection string (see zookeeper docs for details).
-# This is a comma separated host:port pairs, each corresponding to a zk
-# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
-# You can also append an optional chroot string to the urls to specify the
-# root directory for all kafka znodes.
-zookeeper.connect=localhost:2181
-
-# Timeout in ms for connecting to zookeeper
-zookeeper.connection.timeout.ms=18000
-
-
-############################# Group Coordinator Settings #############################
-
-# The following configuration specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance.
-# The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of max.poll.interval.ms.
-# The default value for this is 3 seconds.
-# We override this to 0 here as it makes for a better out-of-the-box experience for development and testing.
-# However, in production environments the default value of 3 seconds is more suitable as this will help to avoid unnecessary, and potentially expensive, rebalances during application startup.
-group.initial.rebalance.delay.ms=0

--- a/config/kip500-controller.properties
+++ b/config/kip500-controller.properties
@@ -35,7 +35,6 @@ controller.id=3000
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
 listeners=PLAINTEXT://:9093
-inter.broker.listener.name=PLAINTEXT
 
 # Hostname and port the broker will advertise to producers and consumers. If not set, 
 # it uses the value for "listeners" if configured.  Otherwise, it will use the value

--- a/config/kip500-controller.properties
+++ b/config/kip500-controller.properties
@@ -21,7 +21,7 @@
 process.roles=controller
 
 # The connect string for the controller quorum
-controller.connect=3000@localhost:9093
+controller.quorum.voters=3000@localhost:9093
 
 # The id of the controller. This must be different than the broker id.
 controller.id=3000
@@ -35,6 +35,7 @@ controller.id=3000
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
 listeners=PLAINTEXT://:9093
+inter.broker.listener.name=PLAINTEXT
 
 # Hostname and port the broker will advertise to producers and consumers. If not set, 
 # it uses the value for "listeners" if configured.  Otherwise, it will use the value
@@ -67,7 +68,7 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma separated list of directories under which to store log files
-log.dirs=/tmp/kafka-logs
+log.dirs=/tmp/kafka-controller-logs
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across
@@ -122,20 +123,3 @@ log.segment.bytes=1073741824
 # The interval at which log segments are checked to see if they can be deleted according
 # to the retention policies
 log.retention.check.interval.ms=300000
-
-############################# Zookeeper #############################
-
-# Zookeeper connection string (see zookeeper docs for details).
-# This is a comma separated host:port pairs, each corresponding to a zk
-# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
-# You can also append an optional chroot string to the urls to specify the
-# root directory for all kafka znodes.
-zookeeper.connect=localhost:2181
-
-# Timeout in ms for connecting to zookeeper
-zookeeper.connection.timeout.ms=18000
-
-############################# Log Basics #############################
-
-# The directory in which the metadata log is kept. If not set, we default to the first directory given by log.dirs
-metadata.log.dir=/tmp/kafka-metadata-log

--- a/config/kip500-controller.properties
+++ b/config/kip500-controller.properties
@@ -21,7 +21,7 @@
 process.roles=controller
 
 # The connect string for the controller quorum
-controller.quorum.voters=3000@localhost:9093
+controller.connect=3000@localhost:9093
 
 # The id of the controller. This must be different than the broker id.
 controller.id=3000


### PR DESCRIPTION
Rename 3 config files more intuitively
Remove metadata.log.dir so it defaults to log.dir
Make sure log.dir never overlaps across the 3 configs

Was able to format log dirs in both `kip-500` branch on on https://github.com/confluentinc/kafka/pull/467 (with fixes applied as mentioned in that PR).  On that PR branch I was able to start with `kip500-controller.properties`; I was unable to successfully start with `kip500-{broker,combined}.properties` but it was not a config issue -- more a PR issue.