### PR TITLE
Add support for auto topic creation in KIP-500

### DIFF
--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.utils.{LogContext, Time}
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.TimeoutException
 
-class ForwardingManager(channelManager: BrokerToControllerChannelManager,
+class ForwardingManager(val channelManager: BrokerToControllerChannelManager,
                         time: Time,
                         retryTimeoutMs: Long,
                         logContext: LogContext) extends Logging {


### PR DESCRIPTION
Adds support for auto topic creation in KIP-500.  This implementation is a quick-and-dirty one that should be jettisoned in favor of https://github.com/apache/kafka/pull/9579 when that is merged to `trunk` and then to `kip-500`.  In the meantime, this PR allows KIP-500 system tests as implemented in https://github.com/confluentinc/kafka/pull/480 to pass.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
