### PR TITLE
Avoid duplicate topic creation

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -381,6 +381,10 @@ public class ReplicationControlManager {
         // Check the topic names.
         validateNewTopicNames(topicErrors, request.topics());
 
+        // Identify topics that already exist and mark them with the appropriate error
+        request.topics().stream().filter(creatableTopic -> topicsByName.containsKey(creatableTopic.name()))
+                .forEach(t -> topicErrors.put(t.name(), new ApiError(Errors.TOPIC_ALREADY_EXISTS)));
+
         // Verify that the configurations for the new topics are OK, and figure out what
         // ConfigRecords should be created.
         Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges =

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -109,6 +109,13 @@ public class ReplicationControlManagerTest {
         assertEquals(new PartitionControlInfo(new int[] {1, 2, 0},
             new int[] {1, 2, 0}, null, null, 1, 0),
             replicationControl.getPartition(Uuid.fromString("5sxVbzQc-jzRErUhNcPf0Q"), 0));
+        ControllerResult<CreateTopicsResponseData> result3 =
+                replicationControl.createTopics(request);
+        CreateTopicsResponseData expectedResponse3 = new CreateTopicsResponseData();
+        expectedResponse3.topics().add(new CreatableTopicResult().setName("foo").
+                setErrorCode(Errors.TOPIC_ALREADY_EXISTS.code()).
+                setErrorMessage(Errors.TOPIC_ALREADY_EXISTS.exception().getMessage()));
+        assertEquals(expectedResponse3, result3.response());
     }
 
     @Test

--- a/tests/kafkatest/tests/streams/streams_smoke_test.py
+++ b/tests/kafkatest/tests/streams/streams_smoke_test.py
@@ -16,6 +16,7 @@
 from ducktape.mark import matrix
 from ducktape.mark.resource import cluster
 
+from kafkatest.services.kafka import quorum
 from kafkatest.tests.kafka_test import KafkaTest
 from kafkatest.services.streams import StreamsSmokeTestDriverService, StreamsSmokeTestJobRunnerService
 
@@ -46,8 +47,8 @@ class StreamsSmokeTest(KafkaTest):
         self.driver = StreamsSmokeTestDriverService(test_context, self.kafka)
 
     @cluster(num_nodes=8)
-    @matrix(processing_guarantee=['at_least_once', 'exactly_once', 'exactly_once_beta'], crash=[True, False])
-    def test_streams(self, processing_guarantee, crash):
+    @matrix(processing_guarantee=['at_least_once', 'exactly_once', 'exactly_once_beta'], crash=[True, False], metadata_quorum=quorum.all_non_upgrade)
+    def test_streams(self, processing_guarantee, crash, metadata_quorum=quorum.zk):
         processor1 = StreamsSmokeTestJobRunnerService(self.test_context, self.kafka, processing_guarantee)
         processor2 = StreamsSmokeTestJobRunnerService(self.test_context, self.kafka, processing_guarantee)
         processor3 = StreamsSmokeTestJobRunnerService(self.test_context, self.kafka, processing_guarantee)


### PR DESCRIPTION
Return `TOPIC_ALREADY_EXISTS` if an attempt is made to create a topic with a name that already exists.

Appended a few lines to existing create-topic test to try creating the same topic a second time and confirming that we get the expected error; the test failed prior to the fix and succeeded with it.  Augmented `streams_smoke_test.py` system test to use both Zookeeper and Raft quorums; the Raft quorum cases were flaky before the fix and reliably passed with the fix.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
