### PR TITLE
Delay partition changes until after log recovery

### DIFF
--- a/core/src/main/scala/kafka/server/Kip500Broker.scala
+++ b/core/src/main/scala/kafka/server/Kip500Broker.scala
@@ -163,8 +163,10 @@ class Kip500Broker(
 
       // Create log manager, but don't start it because we need to delay any potential unclean shutdown log recovery
       // until we catch up on the metadata log and have up-to-date topic and broker configs.
+      val recoveryDoneFutureToComplete: CompletableFuture[Void] = new CompletableFuture[Void]()
+      recoveryDoneFutureToComplete.thenApply(_ => brokerMetadataListener.handleLogRecoveryDone())
       logManager = LogManager(config, initialOfflineDirs, kafkaScheduler, time,
-        brokerTopicStats, logDirFailureChannel)
+        brokerTopicStats, logDirFailureChannel, recoveryDoneFutureToComplete)
 
       metadataCache = new MetadataCache(config.brokerId)
       // Enable delegation token cache for all SCRAM mechanisms to simplify dynamic update.

--- a/core/src/main/scala/kafka/server/LegacyBroker.scala
+++ b/core/src/main/scala/kafka/server/LegacyBroker.scala
@@ -242,7 +242,8 @@ class LegacyBroker(val config: KafkaConfig,
 
         /* start log manager */
         brokerState.set(BrokerState.RECOVERY)
-        logManager = LogManager(config, initialOfflineDirs, kafkaScheduler, time, brokerTopicStats, logDirFailureChannel)
+        logManager = LogManager(config, initialOfflineDirs, kafkaScheduler, time, brokerTopicStats, logDirFailureChannel,
+          new CompletableFuture[Void]())
         logManager.startup()
         brokerState.set(BrokerState.RUNNING)
 

--- a/core/src/main/scala/kafka/server/metadata/MetadataImage.scala
+++ b/core/src/main/scala/kafka/server/metadata/MetadataImage.scala
@@ -86,12 +86,15 @@ case class MetadataImageBuilder(brokerId: Int,
     } else {
       _partitionsBuilder.build()
     }
-    val nextBrokers = if (_brokersBuilder == null) {
+    MetadataImage(nextPartitions, _controllerId, nextBrokers())
+  }
+
+  def nextBrokers(): MetadataBrokers = {
+    if(_brokersBuilder == null) {
       prevImage.brokers
     } else {
       _brokersBuilder.build()
     }
-    MetadataImage(nextPartitions, _controllerId, nextBrokers)
   }
 }
 

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -20,7 +20,7 @@ package kafka.log
 import java.io._
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
-import java.util.concurrent.{Callable, Executors}
+import java.util.concurrent.{Callable, CompletableFuture, Executors}
 import java.util.regex.Pattern
 import java.util.{Collections, Optional, Properties}
 
@@ -99,7 +99,8 @@ class LogTest {
         initialDefaultConfig = logConfig, cleanerConfig = CleanerConfig(enableCleaner = false), recoveryThreadsPerDataDir = 4,
         flushCheckMs = 1000L, flushRecoveryOffsetCheckpointMs = 10000L, flushStartOffsetCheckpointMs = 10000L,
         retentionCheckMs = 1000L, maxPidExpirationMs = 60 * 60 * 1000, scheduler = time.scheduler, time = time,
-        brokerTopicStats = new BrokerTopicStats, logDirFailureChannel = new LogDirFailureChannel(logDirs.size)) {
+        brokerTopicStats = new BrokerTopicStats, logDirFailureChannel = new LogDirFailureChannel(logDirs.size),
+        recoveryDoneFutureToComplete = new CompletableFuture[Void]()) {
 
          override def loadLog(logDir: File, hadCleanShutdown: Boolean, recoveryPoints: Map[TopicPartition, Long],
                      logStartOffsets: Map[TopicPartition, Long]): Log = {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -25,7 +25,7 @@ import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.{Arrays, Collections, Properties}
-import java.util.concurrent.{Callable, ExecutionException, Executors, TimeUnit}
+import java.util.concurrent.{Callable, CompletableFuture, ExecutionException, Executors, TimeUnit}
 
 import javax.net.ssl.X509TrustManager
 import kafka.api._
@@ -1072,7 +1072,8 @@ object TestUtils extends Logging {
                    scheduler = time.scheduler,
                    time = time,
                    brokerTopicStats = new BrokerTopicStats,
-                   logDirFailureChannel = new LogDirFailureChannel(logDirs.size))
+                   logDirFailureChannel = new LogDirFailureChannel(logDirs.size),
+                   recoveryDoneFutureToComplete = new CompletableFuture[Void]())
   }
 
   class MockAlterIsrManager extends AlterIsrManager {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -87,6 +87,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -134,7 +135,8 @@ public class ReplicaFetcherThreadBenchmark {
                 scheduler,
                 brokerTopicStats,
                 logDirFailureChannel,
-                Time.SYSTEM);
+                Time.SYSTEM,
+                new CompletableFuture<>());
 
         LinkedHashMap<TopicPartition, FetchResponse.PartitionData<BaseRecords>> initialFetched = new LinkedHashMap<>();
         scala.collection.mutable.Map<TopicPartition, InitialFetchState> initialFetchStates = new scala.collection.mutable.HashMap<>();

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -64,6 +64,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -110,7 +111,8 @@ public class PartitionMakeFollowerBenchmark {
             scheduler,
             brokerTopicStats,
             logDirFailureChannel,
-            Time.SYSTEM);
+            Time.SYSTEM,
+            new CompletableFuture<>());
 
         TopicPartition tp = new TopicPartition("topic", 0);
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -58,6 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -95,7 +96,8 @@ public class UpdateFollowerFetchStateBenchmark {
                 scheduler,
                 brokerTopicStats,
                 logDirFailureChannel,
-                Time.SYSTEM);
+                Time.SYSTEM,
+                new CompletableFuture<>());
         OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
         Mockito.when(offsetCheckpoints.fetch(logDir.getAbsolutePath(), topicPartition)).thenReturn(Option.apply(0L));
         DelayedOperations delayedOperations = new DelayedOperationsMock();


### PR DESCRIPTION
Allows KIP-500 brokers to successfully roll.

KIP-500 broker rolls without this change were generating the following broker error:

```
java.lang.IllegalStateException: Duplicate log directories for topic-0 are found in both /mnt/kafka/kafka-data-logs-1/topic-0 and /mnt/kafka/kafka-data-logs-1/topic-0. It is likely because log directory failure happened while broker was replacing current replica with future replica. Recover broker from this failure by manually deleting one of the two directories for this partition. It is recommended to delete the partition in the log directory that is known to have failed recently.
at kafka.log.LogManager.loadLog(LogManager.scala:291)
at kafka.log.LogManager.$anonfun$loadLogs$13(LogManager.scala:357)
```

The root cause of this is that we are causing `Log` instances to be created when catching up on the metadata log by sending the make leader/follower requests to `ReplicaManager`, and then later, once we’ve caught up and we are performing log recovery, the `LogManager` is getting confused.  One would think that just allowing `LogManager` to not throw the exception would solve the issue, but when the original `Log` instance is created it performs log recovery but assumes the shutdown was clean.  Basically, with both of these issues, we are seeing an assumption in the code that we have performed log recovery already.   These are perhaps not the only places where this assumption exists.  The right solution seems to be to remember all of the partition changes up until log recovery is complete and only then send them to `ReplicaManager`.  This PR implements this, and the bounce test now passes.