### PR TITLE
Test kit sets wrong id for broker in MetaProperties

### DIFF
--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -218,8 +218,8 @@ public class KafkaClusterTestKit implements AutoCloseable {
 
                     String threadNamePrefix = String.format("broker%d_", node.id());
                     MetaProperties metaProperties = MetaProperties.apply(nodes.clusterId(),
-                            OptionConverters.toScala(Optional.empty()),
-                            OptionConverters.toScala(Optional.of(node.id())));
+                        OptionConverters.toScala(Optional.of(node.id())),
+                        OptionConverters.toScala(Optional.empty()));
                     TopicPartition metadataPartition = new TopicPartition(Server.metadataTopicName(), 0);
                     KafkaRaftManager raftManager = new KafkaRaftManager(metaProperties, metadataPartition, config,
                             Time.SYSTEM, new Metrics(), connectFutureManager.future, 0);


### PR DESCRIPTION
The test kit is setting the wrong id for brokers in `MetaProperties`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
