### PR TITLE
Bump CCS kafka to AK 2.9 CP 7.0

### DIFF
--- a/docs/js/templateData.js
+++ b/docs/js/templateData.js
@@ -17,8 +17,8 @@ limitations under the License.
 
 // Define variables for doc templates
 var context={
-    "version": "28",
-    "dotVersion": "2.8",
-    "fullDotVersion": "2.8.0",
+    "version": "29",
+    "dotVersion": "2.9",
+    "fullDotVersion": "2.9.0",
     "scalaVersion": "2.13"
 };

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
-version=6.2.0-0-ccs
+version=7.0.0-0-ccs
 scalaVersion=2.13.4
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/kafka-merge-pr.py
+++ b/kafka-merge-pr.py
@@ -70,7 +70,7 @@ TEMP_BRANCH_PREFIX = "PR_TOOL"
 
 DEV_BRANCH_NAME = "trunk"
 
-DEFAULT_FIX_VERSION = os.environ.get("DEFAULT_FIX_VERSION", "2.8.0")
+DEFAULT_FIX_VERSION = os.environ.get("DEFAULT_FIX_VERSION", "2.9.0")
 
 def get_json(url):
     try:

--- a/streams/quickstart/java/pom.xml
+++ b/streams/quickstart/java/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.kafka</groupId>
         <artifactId>streams-quickstart</artifactId>
-        <version>6.2.0-0-ccs</version>
+        <version>7.0.0-0-ccs</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>6.2.0-0-ccs</kafka.version>
+        <kafka.version>7.0.0-0-ccs</kafka.version>
         <slf4j.version>1.7.7</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
     </properties>

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>6.2.0-0-ccs</version>
+    <version>7.0.0-0-ccs</version>
 
     <name>Kafka Streams :: Quickstart</name>
 

--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -23,5 +23,5 @@
 #
 
 # For example, when Kafka is at version 1.0.0-0, this should be something like "1.0.0-0.dev0"
-__version__ = '6.2.0-0.dev0'
+__version__ = '7.0.0-0.dev0'
 

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -103,7 +103,7 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("6.2.0-0")
+DEV_VERSION = KafkaVersion("7.0.0-0")
 
 # 0.8.2.x versions
 V_0_8_2_1 = KafkaVersion("0.8.2.1")
@@ -195,3 +195,7 @@ LATEST_2_7 = V_2_7_0
 # 2.8.x versions
 V_2_8_0 = KafkaVersion("2.8.0")
 LATEST_2_8 = V_2_8_0
+
+# 2.9.x versions
+V_2_9_0 = KafkaVersion("2.9.0")
+LATEST_2_9 = V_2_9_0


### PR DESCRIPTION
For now AK's version will be 2.9. CP will be 7.0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
