### PR TITLE
KC-1458: Update JacksonDatabind to "2.9.10.8"

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -56,7 +56,7 @@ versions += [
   gradle: "4.10.3",
   easymock: "4.0.1",
   jackson: "2.9.10",
-  jacksonDatabind: "2.9.10.3",
+  jacksonDatabind: "2.9.10.8",
   jetty: "9.4.12.v20180830",
   jersey: "2.27",
   jmh: "1.21",


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/KC-1458 :Update jackson databind to "2.9.10.8" to fix
https://nvd.nist.gov/vuln/detail/CVE-2020-25649 

Kafka System tests and Platform system tests look good. Test failures are not related to the changes. 
http://confluent-platform-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/2021-02-18--002.1613692326--omkreddy--HEAD--f41aae54/report.html

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
