### PR TITLE
Enable downstream validation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ def config = jobConfig {
     runMergeCheck = false
     downStreamValidate = true
     downStreamRepos = ["common",]
+    nanoVersion = true
     disableConcurrentBuilds = true
 }
 
@@ -122,7 +123,7 @@ def job = {
             echo "Building cp-downstream-builds"
             stage('Downstream validation') {
                 if (config.isPrJob && config.downStreamValidate) {
-                    downStreamValidation(true, true)
+                    downStreamValidation(nanoVersion, true, true)
                 } else {
                     return "skip downStreamValidation"
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,8 +53,8 @@ def job = {
             "master": "master"
     ]
 
-    if (!config.isReleaseJob) {
-        ciTool("ci-update-version ${env.WORKSPACE} kafka")
+    if (config.nanoVersion && !config.isReleaseJob) {
+        ciTool("ci-update-version ${env.WORKSPACE} kafka", config.isPrJob)
     }
 
     stage("Check compilation compatibility with Scala 2.12") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ def config = jobConfig {
     slackChannel = '#kafka-warn'
     timeoutHours = 4
     runMergeCheck = false
-    downStreamValidate = false
+    downStreamValidate = true
     downStreamRepos = ["common",]
     disableConcurrentBuilds = true
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ def job = {
             echo "Building cp-downstream-builds"
             stage('Downstream validation') {
                 if (config.isPrJob && config.downStreamValidate) {
-                    downStreamValidation(nanoVersion, true, true)
+                    downStreamValidation(config.nanoVersion, true, true)
                 } else {
                     return "skip downStreamValidation"
                 }


### PR DESCRIPTION
*More detailed description of your change,
Re-enable downstream validation on kafka PR. The current build order will be 
```
[["common","master","common-7.0.0"],["common-docker","master","common-docker-7.0.0"],["newwave","master","newwave-7.0.0"],["cc-docker-schema-registry","master","cc-docker-schema-registry-7.0.0"],["hub-client","master","hub-client-7.0.0"],["confluent-rebalancer","master","confluent-rebalancer-7.0.0"],["rest-utils","master","rest-utils-7.0.0"],["schema-registry","master","schema-registry-7.0.0"],["kafka-rest","master","kafka-rest-7.0.0"],["kafka-connect-replicator","master","kafka-connect-replicator-7.0.0"],["ksql","master","ksql-7.0.0"],["ce-kafka-http-server","master","ce-kafka-http-server-7.0.0"],["schema-registry-plugins","master","schema-registry-plugins-7.0.0"],["secret-registry","master","secret-registry-7.0.0"],["confluent-security-plugins","master","confluent-security-plugins-7.0.0"],["metadata-service","master","metadata-service-7.0.0"],["blueway","master","blueway-7.0.0"],["kafka-streams-examples","master","kafka-streams-examples-7.0.0"],["confluent-cloud-plugins","master","confluent-cloud-plugins-7.0.0"],["ce-kafka-rest","master","ce-kafka-rest-7.0.0"]
```

*Summary of testing strategy (including rationale)
Testing in CI, I plan to cherry pick the same change to 6.1.x and 6.2.x after this PR get approved.
