### PR TITLE
KC-1456: Update jetty to 9.4.35.v2020112

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -69,7 +69,7 @@ versions += [
   jackson: "2.10.5",
   jacksonDatabind: "2.10.5.1",
   jacoco: "0.8.5",
-  jetty: "9.4.33.v20201020",
+  jetty: "9.4.35.v20201120",
   jersey: "2.31",
   jmh: "1.23",
   hamcrest: "2.2",


### PR DESCRIPTION
Update jetty to fix https://nvd.nist.gov/vuln/detail/CVE-2020-27218
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.35.v20201120

This can be backported up to 2.4 releases which are using recent version 9.4.33.v20201020.  This can be risky update for 2.3 and earlier releases. We also need to update common module. Ran Kafka System tests and Platform system tests  and results look good.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
