### PR TITLE
SEC-1883: Upgrade Netty version to 4.1.61.Final

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -103,7 +103,7 @@ versions += [
   mavenArtifact: "3.6.3",
   metrics: "2.2.0",
   mockito: "3.2.4",
-  netty: "4.1.50.Final",
+  netty: "4.1.62.Final",
   owaspDepCheckPlugin: "5.2.4",
   powermock: "2.0.5",
   reflections: "0.9.12",


### PR DESCRIPTION


This will fix the following three CVEs brought by io.netty:netty-codec-http2 and io.netty:netty-codec-http.
https://confluentinc.atlassian.net/browse/SEC-1883
https://confluentinc.atlassian.net/browse/SEC-2016
https://confluentinc.atlassian.net/browse/SEC-2022


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
