### PR TITLE
SEC-1883: Upgrade Netty version to 4.1.62.Final

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -97,7 +97,7 @@ versions += [
   mavenArtifact: "3.6.3",
   metrics: "2.2.0",
   mockito: "3.3.3",
-  netty: "4.1.59.Final",
+  netty: "4.1.62.Final",
   owaspDepCheckPlugin: "5.3.2.1",
   powermock: "2.0.7",
   reflections: "0.9.12",


### PR DESCRIPTION
This will fix the following three CVEs brought by io.netty:netty-codec-http2 and io.netty:netty-codec-http.
https://confluentinc.atlassian.net/browse/SEC-1883
https://confluentinc.atlassian.net/browse/SEC-2016
https://confluentinc.atlassian.net/browse/SEC-2022

Trying to pick the change on #538 and apply to 2.6

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
