### PR TITLE
SEC-2022: Upgrade netty to 4.1.62.Final

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -101,7 +101,7 @@ versions += [
   mavenArtifact: "3.6.1",
   metrics: "2.2.0",
   mockito: "3.0.0",
-  netty: "4.1.50.Final",
+  netty: "4.1.62.Final",
   owaspDepCheckPlugin: "5.2.1",
   powermock: "2.0.2",
   reflections: "0.9.11",


### PR DESCRIPTION
This will fix the following three CVEs brought by io.netty:netty-codec-http2 and io.netty:netty-codec-http.
https://confluentinc.atlassian.net/browse/SEC-1883
https://confluentinc.atlassian.net/browse/SEC-2016
https://confluentinc.atlassian.net/browse/SEC-2022

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
