### PR TITLE
Upgrade Jetty to 9.4.39.v20210325

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -76,7 +76,7 @@ versions += [
   jackson: "2.10.5",
   jacksonDatabind: "2.10.5.1",
   jacoco: "0.8.3",
-  jetty: "9.4.36.v20210114",
+  jetty: "9.4.39.v20210325",
   jersey: "2.31",
   jmh: "1.23",
   hamcrest: "2.2",


### PR DESCRIPTION
This brings fix to 2.5 to CCS-Kafka: https://github.com/apache/kafka/pull/10526 
Ref: https://nvd.nist.gov/vuln/detail/CVE-2021-28165


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
