### PR TITLE
Upgrade Jetty to 9.4.39.v20210325

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -76,7 +76,7 @@ versions += [
   jackson: "2.10.5",
   jacksonDatabind: "2.10.5.1",
   jacoco: "0.8.3",
-  jetty: "9.4.36.v20210114",
+  jetty: "9.4.39.v20210325",
   jersey: "2.31",
   jmh: "1.21",
   hamcrest: "2.1",


### PR DESCRIPTION
Apply https://github.com/confluentinc/kafka/pull/547 on 2.4

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
