### PR TITLE
Upgrade org.reflections:reflections to 0.9.12

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -104,7 +104,7 @@ versions += [
   netty: "4.1.62.Final",
   owaspDepCheckPlugin: "5.2.1",
   powermock: "2.0.2",
-  reflections: "0.9.11",
+  reflections: "0.9.12",
   rocksDB: "5.18.3",
   scalaCollectionCompat: "2.1.2",
   scalafmt: "1.5.1",


### PR DESCRIPTION
Guava 20 has CVE:  https://nvd.nist.gov/vuln/detail/CVE-2018-10237
This was introduced through transitive dependency:

+--- org.reflections:reflections:0.9.11
|    +--- com.google.guava:guava:20.0
|    \--- org.javassist:javassist:3.21.0-GA -> 3.25.0-GA

After the change 

|    +--- org.reflections:reflections:0.9.12
|    |    \--- org.javassist:javassist:3.26.0-GA


Our tooling is good. I missed this when reviewing the scan result. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
