### PR TITLE
Revert "Upgrade org.reflections:reflections to 0.9.12 (#551)"

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -47,6 +47,7 @@ import java.sql.Driver;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -342,7 +343,14 @@ public class DelegatingClassLoader extends URLClassLoader {
             Class<T> klass,
             ClassLoader loader
     ) throws InstantiationException, IllegalAccessException {
-        Set<Class<? extends T>> plugins = reflections.getSubTypesOf(klass);
+        Set<Class<? extends T>> plugins;
+        try {
+            plugins = reflections.getSubTypesOf(klass);
+        } catch (ReflectionsException e) {
+            log.debug("Reflections scanner could not find any classes for URLs: " +
+                    reflections.getConfiguration().getUrls(), e);
+            return Collections.emptyList();
+        }
 
         Collection<PluginDesc<T>> result = new ArrayList<>();
         for (Class<? extends T> plugin : plugins) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
@@ -17,14 +17,23 @@
 
 package org.apache.kafka.connect.runtime.isolation;
 
-import java.util.Collections;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import static org.junit.Assert.assertNotNull;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class DelegatingClassLoaderTest {
+
+    @Rule
+    public TemporaryFolder pluginDir = new TemporaryFolder();
 
     @Test
     public void testWhiteListedManifestResources() {
@@ -55,6 +64,64 @@ public class DelegatingClassLoaderTest {
     public void testLoadingPluginClass() throws ClassNotFoundException {
         TestPlugins.assertAvailable();
         DelegatingClassLoader classLoader = new DelegatingClassLoader(TestPlugins.pluginPath());
+        classLoader.initLoaders();
+        for (String pluginClassName : TestPlugins.pluginClasses()) {
+            assertNotNull(classLoader.loadClass(pluginClassName));
+            assertNotNull(classLoader.pluginClassLoader(pluginClassName));
+        }
+    }
+
+    @Test
+    public void testLoadingInvalidUberJar() throws Exception {
+        pluginDir.newFile("invalid.jar");
+
+        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+            Collections.singletonList(pluginDir.getRoot().getAbsolutePath()));
+        classLoader.initLoaders();
+    }
+
+    @Test
+    public void testLoadingPluginDirContainsInvalidJarsOnly() throws Exception {
+        pluginDir.newFolder("my-plugin");
+        pluginDir.newFile("my-plugin/invalid.jar");
+
+        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+            Collections.singletonList(pluginDir.getRoot().getAbsolutePath()));
+        classLoader.initLoaders();
+    }
+
+    @Test
+    public void testLoadingNoPlugins() throws Exception {
+        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+            Collections.singletonList(pluginDir.getRoot().getAbsolutePath()));
+        classLoader.initLoaders();
+    }
+
+    @Test
+    public void testLoadingPluginDirEmpty() throws Exception {
+        pluginDir.newFolder("my-plugin");
+
+        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+            Collections.singletonList(pluginDir.getRoot().getAbsolutePath()));
+        classLoader.initLoaders();
+    }
+
+    @Test
+    public void testLoadingMixOfValidAndInvalidPlugins() throws Exception {
+        TestPlugins.assertAvailable();
+
+        pluginDir.newFile("invalid.jar");
+        pluginDir.newFolder("my-plugin");
+        pluginDir.newFile("my-plugin/invalid.jar");
+        Path pluginPath = this.pluginDir.getRoot().toPath();
+
+        for (String sourceJar : TestPlugins.pluginPath()) {
+            Path source = new File(sourceJar).toPath();
+            Files.copy(source, pluginPath.resolve(source.getFileName()));
+        }
+
+        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+            Collections.singletonList(pluginDir.getRoot().getAbsolutePath()));
         classLoader.initLoaders();
         for (String pluginClassName : TestPlugins.pluginClasses()) {
             assertNotNull(classLoader.loadClass(pluginClassName));


### PR DESCRIPTION
This reverts commit c836096b103026055c6d81aef710eea916c1e1a8.

Due to https://github.com/ronmamo/reflections/issues/273

This is the full stack trace I'm seeing in the JDBC connector

```
[2021-04-28 20:42:40,669] INFO Loading plugin from: /usr/share/java/wagon-file.jar (org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader:241)
[2021-04-28 20:42:40,669] DEBUG Loading plugin urls: [file:/usr/share/java/wagon-file.jar] (org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader:248)
[2021-04-28 20:42:40,669] DEBUG going to scan these urls: [file:/usr/share/java/wagon-file.jar] (org.reflections.Reflections:198)
[2021-04-28 20:42:40,670] DEBUG [Thread[org.reflections-scanner-1,5,main]] scanning file:/usr/share/java/wagon-file.jar (org.reflections.Reflections:211)
[2021-04-28 20:42:40,671] INFO Reflections took 1 ms to scan 1 urls, producing 1 keys and 1 values [using 4 cores] (org.reflections.Reflections:239)
[2021-04-28 20:42:40,671] WARN could not get type for name org.apache.maven.wagon.StreamWagon from any class loader (org.reflections.Reflections:318)
org.reflections.ReflectionsException: could not get type for name org.apache.maven.wagon.StreamWagon
        at org.reflections.ReflectionUtils.forName(ReflectionUtils.java:312)
        at org.reflections.Reflections.expandSuperTypes(Reflections.java:382)
        at org.reflections.Reflections.<init>(Reflections.java:140)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader$InternalReflections.<init>(DelegatingClassLoader.java:428)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.scanPluginPath(DelegatingClassLoader.java:327)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.scanUrlsAndAddPlugins(DelegatingClassLoader.java:263)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.registerPlugin(DelegatingClassLoader.java:255)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.initPluginLoader(DelegatingClassLoader.java:224)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.initLoaders(DelegatingClassLoader.java:201)
        at org.apache.kafka.connect.runtime.isolation.Plugins.<init>(Plugins.java:60)
        at org.apache.kafka.connect.cli.ConnectStandalone.main(ConnectStandalone.java:79)
Caused by: java.lang.ClassNotFoundException: org.apache.maven.wagon.StreamWagon
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at org.apache.kafka.connect.runtime.isolation.PluginClassLoader.loadClass(PluginClassLoader.java:104)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at org.reflections.ReflectionUtils.forName(ReflectionUtils.java:310)
        ... 10 more
[2021-04-28 20:42:40,672] INFO Registered loader: PluginClassLoader{pluginLocation=file:/usr/share/java/wagon-file.jar} (org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader:264)
[2021-04-28 20:42:40,672] INFO Loading plugin from: /usr/share/java/maven-compat.jar (org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader:241)
[2021-04-28 20:42:40,672] DEBUG Loading plugin urls: [file:/usr/share/java/maven-compat.jar] (org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader:248)
[2021-04-28 20:42:40,672] DEBUG going to scan these urls: [file:/usr/share/java/maven-compat.jar] (org.reflections.Reflections:198)
[2021-04-28 20:42:40,673] DEBUG [Thread[org.reflections-scanner-1,5,main]] scanning file:/usr/share/java/maven-compat.jar (org.reflections.Reflections:211)
[2021-04-28 20:42:40,673] INFO Reflections took 1 ms to scan 1 urls, producing 0 keys and 0 values [using 4 cores] (org.reflections.Reflections:239)
[2021-04-28 20:42:40,674] ERROR Stopping due to error (org.apache.kafka.connect.cli.ConnectStandalone:130)
org.reflections.ReflectionsException: Scanner SubTypesScanner was not configured
        at org.reflections.Store.get(Store.java:39)
        at org.reflections.Store.get(Store.java:61)
        at org.reflections.Store.get(Store.java:46)
        at org.reflections.Store.getAll(Store.java:93)
        at org.reflections.Reflections.getSubTypesOf(Reflections.java:404)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.getPluginDesc(DelegatingClassLoader.java:345)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.scanPluginPath(DelegatingClassLoader.java:330)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.scanUrlsAndAddPlugins(DelegatingClassLoader.java:263)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.registerPlugin(DelegatingClassLoader.java:255)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.initPluginLoader(DelegatingClassLoader.java:224)
        at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.initLoaders(DelegatingClassLoader.java:201)
        at org.apache.kafka.connect.runtime.isolation.Plugins.<init>(Plugins.java:60)
        at org.apache.kafka.connect.cli.ConnectStandalone.main(ConnectStandalone.java:79)
```

Its my understanding this was to address a Guava CVE that was a LOW - This is not something to block the 5.4.4 release on.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
