### PR TITLE
CONFLUENT: Fix GssapiAuthenticationTest to work with scala 2.11

### DIFF
--- a/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
@@ -112,8 +112,12 @@ class GssapiAuthenticationTest extends IntegrationTestHarness with SaslSetup {
       val login = TestableKerberosLogin.instance
       assertNotNull(login)
       login.loginException = Some(new RuntimeException("Test exception to fail login"))
-      executor.submit(() => login.reLogin(), 0)
-      executor.submit(() => login.reLogin(), 0)
+      executor.submit(new Runnable {
+        override def run(): Unit = login.reLogin()
+      })
+      executor.submit(new Runnable {
+        override def run(): Unit = login.reLogin()
+      })
 
       verifyRelogin(selector, login)
       assertEquals(2, login.loginAttempts)
@@ -134,7 +138,9 @@ class GssapiAuthenticationTest extends IntegrationTestHarness with SaslSetup {
     try {
       val login = TestableKerberosLogin.instance
       assertNotNull(login)
-      executor.submit(() => login.reLogin(), 0)
+      executor.submit(new Runnable {
+        override def run(): Unit = login.reLogin()
+      })
       verifyRelogin(selector, login)
     } finally {
       selector.close()


### PR DESCRIPTION

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
