### PR TITLE
MINOR: Update Scala to 2.13.6 (#10711)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -248,9 +248,9 @@ netty-transport-native-unix-common-4.1.59.Final
 plexus-utils-3.2.1
 rocksdbjni-5.18.4
 scala-collection-compat_2.13-2.3.0
-scala-library-2.13.5
+scala-library-2.13.6
 scala-logging_2.13-3.9.2
-scala-reflect-2.13.5
+scala-reflect-2.13.6
 scala-java8-compat_2.13-0.9.1
 snappy-java-1.1.8.1
 zookeeper-3.5.9

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -48,7 +48,7 @@ should_include_file() {
 base_dir=$(dirname $0)/..
 
 if [ -z "$SCALA_VERSION" ]; then
-  SCALA_VERSION=2.13.5
+  SCALA_VERSION=2.13.6
   if [[ -f "$base_dir/gradle.properties" ]]; then
     SCALA_VERSION=`grep "^scalaVersion=" "$base_dir/gradle.properties" | cut -d= -f 2`
   fi

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -27,7 +27,7 @@ set BASE_DIR=%CD%
 popd
 
 IF ["%SCALA_VERSION%"] EQU [""] (
-  set SCALA_VERSION=2.13.5
+  set SCALA_VERSION=2.13.6
 )
 
 IF ["%SCALA_BINARY_VERSION%"] EQU [""] (

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 version=7.0.0-0-ccs
-scalaVersion=2.13.5
+scalaVersion=2.13.6
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,7 +28,7 @@ ext {
 
 // Add Scala version
 def defaultScala212Version = '2.12.13'
-def defaultScala213Version = '2.13.5'
+def defaultScala213Version = '2.13.6'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.12') {
     versions["scala"] = defaultScala212Version


### PR DESCRIPTION
This includes TASTy Reader support for Scala 3.0.0. This makes it easier
for Kafka libraries to be used in Scala 3.0 projects

Release notes: https://github.com/scala/scala/releases/tag/v2.13.6

Reviewers: Ismael Juma <ismael@juma.me.uk>

Cherry-picking https://github.com/apache/kafka/commit/a8bd649dbf940a41e94ee695d3ecec5b97566c2d to resolve merge conflict.