### PR TITLE
APPSEC-96: Fix jetty, zookeeper, jersey, mvn-artifact

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -102,7 +102,7 @@ versions += [
   spotbugsPlugin: "1.6.9",
   spotlessPlugin: "3.23.0",
   zkclient: "0.11",
-  zookeeper: "3.5.9",
+  zookeeper: "3.4.14",
   zstd: "1.4.0-1"
 ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -102,7 +102,7 @@ versions += [
   spotbugsPlugin: "1.6.9",
   spotlessPlugin: "3.23.0",
   zkclient: "0.11",
-  zookeeper: "3.5.8",
+  zookeeper: "3.5.9",
   zstd: "1.4.0-1"
 ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -63,8 +63,8 @@ versions += [
   jackson: "2.10.5",
   jacksonDatabind: "2.10.5.1",
   jacoco: "0.8.3",
-  jetty: "9.4.18.v20190429",
-  jersey: "2.28",
+  jetty: "9.4.39.v20210325",
+  jersey: "2.34",
   jmh: "1.21",
   hamcrest: "2.1",
   log4j: "1.2.17",
@@ -84,7 +84,7 @@ versions += [
   kafka_21: "2.1.1",
   kafka_22: "2.2.0",
   lz4: "1.6.0",
-  mavenArtifact: "3.6.1",
+  mavenArtifact: "3.8.1",
   metrics: "2.2.0",
   mockito: "2.27.0",
   owaspDepCheckPlugin: "4.0.2",
@@ -102,7 +102,7 @@ versions += [
   spotbugsPlugin: "1.6.9",
   spotlessPlugin: "3.23.0",
   zkclient: "0.11",
-  zookeeper: "3.4.14",
+  zookeeper: "3.5.8",
   zstd: "1.4.0-1"
 ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -63,7 +63,7 @@ versions += [
   jackson: "2.10.5",
   jacksonDatabind: "2.10.5.1",
   jacoco: "0.8.3",
-  jetty: "9.4.39.v20210325",
+  jetty: "9.4.40.v20210413",
   jersey: "2.34",
   jmh: "1.21",
   hamcrest: "2.1",


### PR DESCRIPTION
There are more to be upgraded:
- commons-beanutils_commons-beanutils to 1.9.4
- com.google.guava_guava to be 30.0
- org.codehaus.jackson:jackson-mapper-asl seems to have no fixed version. https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSJACKSON-534878

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
