### PR TITLE
CONFLUENT: Revert avro version to 1.8.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -51,7 +51,7 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  avro: "1.9.2",
+  avro: "1.8.1",
   avroPlugin: "0.10.0",
   bcpkix: "1.61",
   checkstyle: "8.20",


### PR DESCRIPTION
avro: "1.9.2" is breaking some of downstream projects. reverting the version to 1.8.1