### PR TITLE
Revert "MINOR: Upgrade Gradle to 7.1.1 and remove JDK 15 build (#10968)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ See our [web site](https://kafka.apache.org) for details on the project.
 
 You need to have [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
 
-We build and test Apache Kafka with Java 8, 11 and 16. We set the `release` parameter in javac and scalac
+We build and test Apache Kafka with Java 8, 11 and 15. We set the `release` parameter in javac and scalac
 to `8` to ensure the generated binaries are compatible with Java 8 or higher (independently of the Java version
 used for compilation).
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ plugins {
   id 'org.nosphere.apache.rat' version "0.7.0"
 
   id "com.github.spotbugs" version '4.7.1' apply false
-  id 'org.gradle.test-retry' version '1.3.1' apply false
+  id 'org.gradle.test-retry' version '1.2.1' apply false
   id 'org.scoverage' version '5.0.0' apply false
   id 'com.github.johnrengelman.shadow' version '7.0.0' apply false
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -62,7 +62,7 @@ versions += [
   checkstyle: "8.36.2",
   commonsCli: "1.4",
   dropwizardMetrics: "4.1.12.1",
-  gradle: "7.1.1",
+  gradle: "7.0.2",
   grgit: "4.1.0",
   httpclient: "4.5.13",
   easymock: "4.3",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=9bb8bc05f562f2d42bdf1ba8db62f6b6fa1c3bf6c392228802cc7cb0578fe7e0
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+distributionSha256Sum=13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -84,7 +84,7 @@ esac
 # Loop in case we encounter an error.
 for attempt in 1 2 3; do
   if [ ! -e "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" ]; then
-    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v7.1.1/gradle/wrapper/gradle-wrapper.jar"; then
+    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v7.0.2/gradle/wrapper/gradle-wrapper.jar"; then
       rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
       # Pause for a bit before looping in case the server throttled us.
       sleep 5


### PR DESCRIPTION
This reverts commit 855011f92a20c07ae5ee5a93f29f11a356e30ba3.

Commit 855011f's bump to Gradle 7.1.1 seems to be causing (yet to be
RCA'd) issues with publishing to Artifactory. Confirmed this works in
CI/CD through another branch [1] with this commit reverted.

Conflicts:
	Jenkinsfile: Kept CCS-Kafka/master's version
	gradle/dependencies.gradle: Downgraded gradle version. Kept
dropwizard version bump

[1] https://jenkins.confluent.io/view/CP%207.0%20Projects/job/confluentinc/job/kafka/job/7.0.x/

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
