### PR TITLE
MINOR: upgrade netty version to 4.1.68.final

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -101,7 +101,7 @@ versions += [
   mavenArtifact: "3.8.1",
   metrics: "2.2.0",
   mockito: "3.9.0",
-  netty: "4.1.65.Final",
+  netty: "4.1.68.Final",
   powermock: "2.0.9",
   reflections: "0.9.12",
   rocksDB: "6.19.3",


### PR DESCRIPTION
https://cve.report/CVE-2021-37137

Netty versions < 4.1.68.final has a security vulnerability. Upgrade to 4.1.68.final

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
