### PR TITLE
HOTFIX: Set version of jgit to avoid unsupported version error (#11554)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ buildscript {
     classpath "com.diffplug.spotless:spotless-plugin-gradle:$versions.spotlessPlugin"
     classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:$versions.spotbugsPlugin"
     classpath "org.gradle:test-retry-gradle-plugin:$versions.testRetryPlugin"
+    // Override jgit dependency used by grgit and spotless as we appear to auto resolve to 
+    // 5.13.0.202109080827-r and the latest version requires java 9.
+    // Requires force=true to be used in spotless as reported by ./gradlew buildEnvironment.
+    classpath("org.eclipse.jgit:org.eclipse.jgit:$versions.jgit") { force = true }
   }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -73,6 +73,7 @@ versions += [
   javassist: "3.27.0-GA",
   jetty: "9.4.43.v20210629",
   jersey: "2.34",
+  jgit: "5.12.0.202106070339-r",
   jline: "3.12.1",
   jmh: "1.27",
   hamcrest: "2.2",


### PR DESCRIPTION
A new version of JGit that is used by grgit that is used by gradle
causes the following error:

org/eclipse/jgit/storage/file/FileRepositoryBuilder has been compiled
by a more recent version of the Java Runtime (class file version 55.0),
this version of the Java Runtime only recognizes class file versions
up to 52.0

The reason is that version 6.0.0.202111291000-r of JGrit was compiled
with a newer Java version than Java 8, probably Java 11.

Explicitly setting the version of JGrit in gradle to 5.12.0.202106070339-r fixes
the issue.

Reviewers: David Jacot <djacot@confluent.io>, Ismael Juma <ismael@juma.me.uk>, Alexander Stohr, David Arthur <mumrah@gmail.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
