### PR TITLE
MINOR: Upgrade jetty-server to 9.4.44.v20210927 (2.7 branch)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jackson: "2.10.5",
   jacksonDatabind: "2.10.5.1",
   jacoco: "0.8.5",
-  jetty: "9.4.43.v20210629",
+  jetty: "9.4.44.v20210927",
   jersey: "2.34",
   jmh: "1.23",
   hamcrest: "2.2",


### PR DESCRIPTION
Release notes: https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.44.v20210927

Reviewers: Rajini Sivaram <rajinisivaram@googlemail.com>

(cherry-picked from commit 3dd3f3ef035501816efac23c32d517bf62fdaa56)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
