### PR TITLE
basic histogram iml

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/TelemetrySubscription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/TelemetrySubscription.java
@@ -18,9 +18,7 @@ package org.apache.kafka.clients.telemetry;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.StringJoiner;
-import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.record.CompressionType;
 

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/HistogramStat.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/HistogramStat.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.metrics.stats;
+
+import org.apache.kafka.common.MetricName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class extends {@link Histogram} but providing its binning strategy by exposing
+ * {@link org.apache.kafka.common.metrics.stats.Histogram.BinScheme}
+ */
+
+public class HistogramStat extends Histogram {
+    private final BinScheme binScheme;
+    private final MetricName metricName;
+    private final List<Bucket> buckets;
+
+    public HistogramStat(BinScheme binScheme, MetricName metricName) {
+        super(binScheme);
+        this.binScheme = binScheme;
+        this.metricName = metricName;
+        this.buckets = initializeHistogramBuckets(metricName, binScheme);
+    }
+
+    private static List<LinearHistogram.Bucket> initializeHistogramBuckets(MetricName metricName, BinScheme binScheme) {
+        List<LinearHistogram.Bucket> buckets = new ArrayList<>();
+        double lowerBound = 0;
+        for (int i = 0;i < binScheme.bins();i++) {
+            String name = metricName.name();
+            Map<String, String> tags = new HashMap<>(metricName.tags());
+            tags.put("lower_bound", String.valueOf(lowerBound));
+            tags.put("upper_bound", String.valueOf(binScheme.fromBin(i)));
+            lowerBound = binScheme.fromBin(i);
+            buckets.add(new LinearHistogram.Bucket(
+                    new MetricName(
+                            name,
+                            metricName.group(),
+                            metricName.description(),
+                            tags),
+                    0)); // initial value as 0
+        }
+
+        return buckets;
+    }
+
+    public BinScheme getBinScheme() { return binScheme; }
+
+    public List<Bucket> getBuckets() { return buckets; }
+
+    public MetricName getMetricName() { return metricName; }
+
+    static class Bucket {
+
+        private final MetricName name;
+        private final double value;
+
+        Bucket(MetricName name, double value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public MetricName name() { return this.name; }
+        public double value() { return this.value; }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/HistogramStat.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/HistogramStat.java
@@ -29,11 +29,13 @@ import java.util.Map;
  */
 
 public class HistogramStat extends Histogram {
+
     private final BinScheme binScheme;
     private final MetricName metricName;
     private final List<Bucket> buckets;
 
     public HistogramStat(BinScheme binScheme, MetricName metricName) {
+
         super(binScheme);
         this.binScheme = binScheme;
         this.metricName = metricName;
@@ -43,7 +45,7 @@ public class HistogramStat extends Histogram {
     private static List<LinearHistogram.Bucket> initializeHistogramBuckets(MetricName metricName, BinScheme binScheme) {
         List<LinearHistogram.Bucket> buckets = new ArrayList<>();
         double lowerBound = 0;
-        for (int i = 0;i < binScheme.bins();i++) {
+        for (int i = 0; i < binScheme.bins(); i++) {
             String name = metricName.name();
             Map<String, String> tags = new HashMap<>(metricName.tags());
             tags.put("lower_bound", String.valueOf(lowerBound));
@@ -61,11 +63,17 @@ public class HistogramStat extends Histogram {
         return buckets;
     }
 
-    public BinScheme getBinScheme() { return binScheme; }
+    public BinScheme getBinScheme() {
+        return binScheme;
+    }
 
-    public List<Bucket> getBuckets() { return buckets; }
+    public List<Bucket> getBuckets() {
+        return buckets;
+    }
 
-    public MetricName getMetricName() { return metricName; }
+    public MetricName getMetricName() {
+        return metricName;
+    }
 
     static class Bucket {
 
@@ -77,7 +85,12 @@ public class HistogramStat extends Histogram {
             this.value = value;
         }
 
-        public MetricName name() { return this.name; }
-        public double value() { return this.value; }
+        public MetricName name() {
+            return this.name;
+        }
+
+        public double value() {
+            return this.value;
+        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/LinearHistogram.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/LinearHistogram.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.metrics.stats;
+
+import org.apache.kafka.common.*;
+import org.apache.kafka.common.metrics.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Histogram class of CompoundStat class using Linear BinScheme. See {@link Histogram} for the histogram implementation
+ */
+public class LinearHistogram extends HistogramStat implements CompoundStat {
+    public LinearHistogram(int numBins, int maxBin, MetricName metricName) {
+        super(new LinearBinScheme(numBins, maxBin), metricName);
+    }
+
+    @Override
+    public List<NamedMeasurable> stats() {
+        List<NamedMeasurable> ms = new ArrayList<>();
+        for(Bucket bucket: getBuckets()) {
+            ms.add(new NamedMeasurable(bucket.name(), new Measurable() {
+                @Override
+                public double measure(MetricConfig config, long now) {
+                    return bucket.value();
+                }
+            }));
+        }
+        return ms;
+    }
+
+    @Override
+    public void record(MetricConfig config, double value, long timeMs) {
+        super.record(value);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/LinearHistogram.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/LinearHistogram.java
@@ -16,8 +16,10 @@
  */
 package org.apache.kafka.common.metrics.stats;
 
-import org.apache.kafka.common.*;
-import org.apache.kafka.common.metrics.*;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.CompoundStat;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.MetricConfig;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +35,7 @@ public class LinearHistogram extends HistogramStat implements CompoundStat {
     @Override
     public List<NamedMeasurable> stats() {
         List<NamedMeasurable> ms = new ArrayList<>();
-        for(Bucket bucket: getBuckets()) {
+        for (Bucket bucket: getBuckets()) {
             ms.add(new NamedMeasurable(bucket.name(), new Measurable() {
                 @Override
                 public double measure(MetricConfig config, long now) {

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/HistogramStatTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/HistogramStatTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.metrics.stats;
+
+import org.apache.kafka.common.MetricName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HistogramStatTest {
+
+    private static final double DELTA = 0.0001;
+
+    @Test
+    public void testHistogram() {
+        Histogram.BinScheme scheme = new Histogram.ConstantBinScheme(10, -5, 5);
+        MetricName mn = new MetricName("name", "group", "desc", Collections.emptyMap());
+        HistogramStat hist = new HistogramStat(scheme, mn);
+
+        for (int i = -5; i < 5; i++)
+            hist.record(i);
+        for (int i = 0; i < 10; i++)
+            assertEquals(scheme.fromBin(i), hist.value(i / 10.0 + DELTA), DELTA);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/LinearHistogramTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/LinearHistogramTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.metrics.stats;
+
+import org.apache.kafka.common.MetricName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LinearHistogramStatTest {
+
+    private static final double DELTA = 0.0001;
+
+    @Test
+    public void testHistogram() {
+        Histogram.BinScheme scheme = new Histogram.ConstantBinScheme(10, -5, 5);
+        MetricName mn = new MetricName("name", "group", "desc", Collections.emptyMap());
+        HistogramStat hist = new LinearHistogram(10, 10, mn);
+
+        for (int i = 0; i < 10; i++)
+            hist.record(i);
+        for (int i = 0; i < 10; i++)
+            assertEquals(scheme.fromBin(i), hist.value(i / 10.0 + DELTA), DELTA);
+    }
+}
+


### PR DESCRIPTION
Basic Histogram Implementation.  A few noticeable points are:

1. The bins uses tags, upper_limit and lower_limit
2. The bin sizes if configured by the caller.  We could either use a default bin size in the AbstractClientMetricRecorder, or have it set by the callers in Consumers/Producer/etc.

An example usage of this:

```

public Sensor histogramSensor(MetricName metricName, int maxBin, int numBins) {
  // stuff happening here
  sensor.add(new LinearHistogram(metricName, maxBin, numBins));
  return sensor;
}

```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
