### PR TITLE
Histogram Sensor Usage

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/AbstractClientMetricRecorder.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/AbstractClientMetricRecorder.java
@@ -28,7 +28,8 @@ import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.metrics.MeasurableStat;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.*;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.LinearHistogram;
 
 /**
  * This class provides basic utility methods that client telemetry subclasses can leverage

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/AbstractClientMetricRecorder.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/AbstractClientMetricRecorder.java
@@ -28,7 +28,7 @@ import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.metrics.MeasurableStat;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.*;
 
 /**
  * This class provides basic utility methods that client telemetry subclasses can leverage
@@ -62,14 +62,15 @@ public abstract class AbstractClientMetricRecorder implements ClientMetricRecord
         return gaugeSensor(mn);
     }
 
-    protected Sensor histogramSensor(MetricName mn) {
-        // TODO: TELEMETRY_TODO: need to implement histogram...
-        return sensor(mn, CumulativeSum::new);
+    protected Sensor histogramSensor(MetricName mn, int maxBin, int numBin) {
+        Sensor sensor = metrics.sensor(mn.name());
+        sensor.add(new LinearHistogram(numBin, maxBin, mn));
+        return sensor;
     }
 
-    protected Sensor histogramSensor(MetricNameTemplate mnt, Map<String, String> tags) {
+    protected Sensor histogramSensor(MetricNameTemplate mnt, Map<String, String> tags, int numBin, int maxBin) {
         MetricName mn = metrics.metricInstance(mnt, tags);
-        return histogramSensor(mn);
+        return histogramSensor(mn, maxBin, numBin);
     }
 
     protected Sensor stringSensor(MetricName mn) {

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultClientInstanceMetricRecorder.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultClientInstanceMetricRecorder.java
@@ -33,6 +33,9 @@ public class DefaultClientInstanceMetricRecorder extends AbstractClientMetricRec
 
     private static final String GROUP_NAME = "client-telemetry";
 
+    private static final int LATENCY_HISTOGRAM_NUM_BIN = 10;
+    private static final int LATENCY_HISTOGRAM_MAX_BIN = 2000; // ms
+
     private final MetricNameTemplate connectionCreations;
 
     private final MetricName connectionCount;
@@ -92,13 +95,13 @@ public class DefaultClientInstanceMetricRecorder extends AbstractClientMetricRec
         Map<String, String> metricsTags = new HashMap<>();
         metricsTags.put(BROKER_ID_LABEL, brokerId);
         metricsTags.put(REQUEST_TYPE_LABEL, requestType);
-        histogramSensor(requestRtt, metricsTags).record(increment);
+        histogramSensor(requestRtt, metricsTags, LATENCY_HISTOGRAM_NUM_BIN, LATENCY_HISTOGRAM_MAX_BIN).record(increment);
     }
 
     @Override
     public void recordRequestQueueLatency(String brokerId, int increment) {
         Map<String, String> metricsTags = Collections.singletonMap(BROKER_ID_LABEL, brokerId);
-        histogramSensor(requestQueueLatency, metricsTags).record(increment);
+        histogramSensor(requestQueueLatency, metricsTags, LATENCY_HISTOGRAM_NUM_BIN, LATENCY_HISTOGRAM_MAX_BIN).record(increment);
     }
 
     @Override
@@ -126,6 +129,6 @@ public class DefaultClientInstanceMetricRecorder extends AbstractClientMetricRec
 
     @Override
     public void recordIoWaitTime(int increment) {
-        histogramSensor(ioWaitTime).record(increment);
+        histogramSensor(ioWaitTime, LATENCY_HISTOGRAM_NUM_BIN, LATENCY_HISTOGRAM_MAX_BIN).record(increment);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultConsumerMetricRecorder.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultConsumerMetricRecorder.java
@@ -27,6 +27,9 @@ public class DefaultConsumerMetricRecorder extends AbstractClientMetricRecorder 
 
     private static final String GROUP_NAME = "consumer-telemetry";
 
+    private static final int LATENCY_HISTOGRAM_NUM_BIN = 10;
+    private static final int LATENCY_HISTOGRAM_MAX_BIN = 2000; // ms
+
     private final MetricName pollInterval;
 
     private final MetricName pollLast;
@@ -84,7 +87,7 @@ public class DefaultConsumerMetricRecorder extends AbstractClientMetricRecorder 
 
     @Override
     public void recordPollInterval(int amount) {
-        histogramSensor(pollInterval).record(amount);
+        histogramSensor(pollInterval, LATENCY_HISTOGRAM_NUM_BIN, LATENCY_HISTOGRAM_MAX_BIN).record(amount);
     }
 
     @Override
@@ -94,7 +97,7 @@ public class DefaultConsumerMetricRecorder extends AbstractClientMetricRecorder 
 
     @Override
     public void recordPollLatency(int amount) {
-        histogramSensor(pollLatency).record(amount);
+        histogramSensor(pollLatency, LATENCY_HISTOGRAM_NUM_BIN, LATENCY_HISTOGRAM_MAX_BIN).record(amount);
     }
 
     @Override
@@ -150,7 +153,7 @@ public class DefaultConsumerMetricRecorder extends AbstractClientMetricRecorder 
 
     @Override
     public void recordFetchLatency(int amount) {
-        histogramSensor(fetchLatency).record(amount);
+        histogramSensor(fetchLatency, LATENCY_HISTOGRAM_NUM_BIN, LATENCY_HISTOGRAM_MAX_BIN).record(amount);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultProducerTopicMetricRecorder.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultProducerTopicMetricRecorder.java
@@ -38,6 +38,9 @@ public class DefaultProducerTopicMetricRecorder extends AbstractClientMetricReco
 
     private static final String GROUP_NAME = "producer-topic-telemetry";
 
+    private static final int LATENCY_HISTOGRAM_NUM_BIN = 10;
+    private static final int LATENCY_HISTOGRAM_MAX_BIN = 2000; // ms
+
     private final MetricNameTemplate queueBytes;
 
     private final MetricNameTemplate queueCount;
@@ -82,13 +85,13 @@ public class DefaultProducerTopicMetricRecorder extends AbstractClientMetricReco
     @Override
     public void latency(TopicPartition topicPartition, short acks, int amount) {
         Map<String, String> metricsTags = getMetricsTags(topicPartition, acks);
-        histogramSensor(latency, metricsTags).record(amount);
+        histogramSensor(latency, metricsTags, LATENCY_HISTOGRAM_NUM_BIN, LATENCY_HISTOGRAM_MAX_BIN).record(amount);
     }
 
     @Override
     public void queueLatency(TopicPartition topicPartition, short acks, int amount) {
         Map<String, String> metricsTags = getMetricsTags(topicPartition, acks);
-        histogramSensor(queueLatency, metricsTags).record(amount);
+        histogramSensor(queueLatency, metricsTags, LATENCY_HISTOGRAM_NUM_BIN, LATENCY_HISTOGRAM_MAX_BIN).record(amount);
     }
 
     @Override


### PR DESCRIPTION
For now: consumer and producer recorder are setting a default histogram max bin and bin size.  We use that as the first pass.  A few follow up questions:

1. Is linear bin a good choice? Maybe we should be using exponential histogram instead as we want more bins at lower latency, and less bins at higher latency. i.e., the lower latency distribution is more important
2. What exactly is the best way to set the bin size? I don't know at this point.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
