### PR TITLE
KAFKA-6502: Update consumed offsets on corrupted records. (#11683)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/CorruptedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/CorruptedRecord.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import java.util.Objects;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+/**
+ * This class represents a version of a {@link StampedRecord} that failed to deserialize. We need
+ * a special record type so that {@link StreamTask} can update consumed offsets. See KAFKA-6502
+ * for more details.
+ */
+public class CorruptedRecord extends StampedRecord {
+
+    CorruptedRecord(final ConsumerRecord<byte[], byte[]> rawRecord) {
+        super(rawRecord, ConsumerRecord.NO_TIMESTAMP);
+    }
+
+    @Override
+    public String toString() {
+        return "CorruptedRecord(" +
+            "value = " + value +
+            ")";
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        final CorruptedRecord that = (CorruptedRecord) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
@@ -19,9 +19,9 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;
 
-public class StampedRecord extends Stamped<ConsumerRecord<Object, Object>> {
+public class StampedRecord extends Stamped<ConsumerRecord<?, ?>> {
 
-    public StampedRecord(final ConsumerRecord<Object, Object> record, final long timestamp) {
+    public StampedRecord(final ConsumerRecord<?, ?> record, final long timestamp) {
         super(record, timestamp);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
@@ -278,21 +278,25 @@ public class RecordQueueTest {
     @Test
     public void shouldNotThrowStreamsExceptionWhenKeyDeserializationFailsWithSkipHandler() {
         final byte[] key = Serdes.Long().serializer().serialize("foo", 1L);
-        final List<ConsumerRecord<byte[], byte[]>> records = Collections.singletonList(
-            new ConsumerRecord<>("topic", 1, 1, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, key, recordValue));
+        final ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>("topic", 1, 1, 0L,
+            TimestampType.CREATE_TIME, 0L, 0, 0, key, recordValue);
+        final List<ConsumerRecord<byte[], byte[]>> records = Collections.singletonList(record);
 
         queueThatSkipsDeserializeErrors.addRawRecords(records);
-        assertEquals(0, queueThatSkipsDeserializeErrors.size());
+        assertEquals(1, queueThatSkipsDeserializeErrors.size());
+        assertEquals(new CorruptedRecord(record), queueThatSkipsDeserializeErrors.poll());
     }
 
     @Test
     public void shouldNotThrowStreamsExceptionWhenValueDeserializationFailsWithSkipHandler() {
         final byte[] value = Serdes.Long().serializer().serialize("foo", 1L);
-        final List<ConsumerRecord<byte[], byte[]>> records = Collections.singletonList(
-            new ConsumerRecord<>("topic", 1, 1, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, recordKey, value));
+        final ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>("topic", 1, 1, 0L,
+            TimestampType.CREATE_TIME, 0L, 0, 0, recordKey, value);
+        final List<ConsumerRecord<byte[], byte[]>> records = Collections.singletonList(record);
 
         queueThatSkipsDeserializeErrors.addRawRecords(records);
-        assertEquals(0, queueThatSkipsDeserializeErrors.size());
+        assertEquals(1, queueThatSkipsDeserializeErrors.size());
+        assertEquals(new CorruptedRecord(record), queueThatSkipsDeserializeErrors.poll());
     }
 
     @Test


### PR DESCRIPTION
This PR is a port of https://github.com/apache/kafka/pull/11683 requested by @SamehTawfik

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
