### PR TITLE
handling different kinds of errors

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1348,7 +1348,7 @@ public class NetworkClient implements KafkaClient {
         }
 
         public void handleSuccessfulPushTelemetryResponse(PushTelemetryResponse response) {
-            clientTelemetry.pushTelemetrySucceeded(response.data());
+            clientTelemetry.pushTelemetryReceived(response.data());
         }
 
     }

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1344,7 +1344,7 @@ public class NetworkClient implements KafkaClient {
         }
 
         public void handleSuccessfulGetTelemetrySubscriptionResponse(GetTelemetrySubscriptionResponse response) {
-            clientTelemetry.telemetrySubscriptionSucceeded(response.data());
+            clientTelemetry.telemetrySubscriptionReceived(response.data());
         }
 
         public void handleSuccessfulPushTelemetryResponse(PushTelemetryResponse response) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConfigEntry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConfigEntry.java
@@ -216,6 +216,7 @@ public class ConfigEntry {
         DYNAMIC_BROKER_LOGGER_CONFIG,   // dynamic broker logger config that is configured for a specific broker
         DYNAMIC_BROKER_CONFIG,          // dynamic broker config that is configured for a specific broker
         DYNAMIC_DEFAULT_BROKER_CONFIG,  // dynamic broker config that is configured as default for all brokers in the cluster
+        DYNAMIC_CLIENT_METRICS_CONFIG,  // dynamic client metrics subscription config that is configured for all clients
         STATIC_BROKER_CONFIG,           // static broker config provided as broker properties at start up (e.g. server.properties file)
         DEFAULT_CONFIG,                 // built-in default configuration for configs that have a default value
         UNKNOWN                         // source unknown e.g. in the ConfigEntry used for alter requests where source is not set

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -405,6 +405,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
 
             this.apiVersions = new ApiVersions();
             this.transactionManager = configureTransactionState(config, logContext);
+            //TODO: configureAcks method is removed in the recent versions, so following is the temp code to get the acks.
+            // make sure this is the right method to get the acks.
+            short acks = Short.parseShort(config.getString(ProducerConfig.ACKS_CONFIG));
             this.accumulator = new RecordAccumulator(logContext,
                     config.getInt(ProducerConfig.BATCH_SIZE_CONFIG),
                     this.compressionType,
@@ -417,7 +420,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                     apiVersions,
                     transactionManager,
                     new BufferPool(this.totalMemorySize, config.getInt(ProducerConfig.BATCH_SIZE_CONFIG), metrics, time, PRODUCER_METRIC_GROUP_NAME),
-                    configureAcks(config, log),
+                    acks,
                     clientTelemetry);
 
             List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/ClientTelemetry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/ClientTelemetry.java
@@ -69,7 +69,7 @@ public interface ClientTelemetry extends Closeable {
 
     void pushTelemetryFailed(Throwable error);
 
-    void telemetrySubscriptionSucceeded(GetTelemetrySubscriptionsResponseData data);
+    void telemetrySubscriptionReceived(GetTelemetrySubscriptionsResponseData data);
 
     void pushTelemetrySucceeded(PushTelemetryResponseData data);
 

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/ClientTelemetry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/ClientTelemetry.java
@@ -71,7 +71,7 @@ public interface ClientTelemetry extends Closeable {
 
     void telemetrySubscriptionReceived(GetTelemetrySubscriptionsResponseData data);
 
-    void pushTelemetrySucceeded(PushTelemetryResponseData data);
+    void pushTelemetryReceived(PushTelemetryResponseData data);
 
     Optional<Long> timeToNextUpdate(long requestTimeoutMs);
 

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultClientTelemetry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultClientTelemetry.java
@@ -37,7 +37,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InterruptException;

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultClientTelemetry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultClientTelemetry.java
@@ -420,13 +420,11 @@ public class DefaultClientTelemetry implements ClientTelemetry {
 
         // We might want to wait and retry or retry after some failures are received
         if (isAuthorizationFailedError(data.errorCode())) {
-            final long retryMs = 30 * 60 * 1000;
             log.warn("Error code: {}. Reason: Client is permitted to send metrics.  Retry automatically in {}ms.", data.errorCode(), retryMs);
-            setSubscription(currentSubscription.alterPushIntervalMs(retryMs, time));
+            setSubscription(currentSubscription.alterPushIntervalMs(30 * 60 * 1000, time));
         } else if (data.errorCode() == Errors.INVALID_RECORD.code()) {
-            final long retryMs = 5 * 60 * 1000;
             log.warn("Error code: {}.  Reason: Broker failed to decode or validate the client’s encoded metrics.  Retry automatically in {}ms", data.errorCode(), retryMs);
-            setSubscription(currentSubscription.alterPushIntervalMs(retryMs, time));
+            setSubscription(currentSubscription.alterPushIntervalMs( 5 * 60 * 1000, time));
         } else if (data.errorCode() == -1 || // TODO: UnknownSubscriptionId isn't in the Errors package.  Leave it as -1 for now
                 data.errorCode() == Errors.UNSUPPORTED_COMPRESSION_TYPE.code()) {
             log.warn("Error code: {}.  Reason: {}.  Retrying automatically.", data.errorCode(), Errors.forCode(data.errorCode()).message());

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultClientTelemetry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/DefaultClientTelemetry.java
@@ -418,14 +418,17 @@ public class DefaultClientTelemetry implements ClientTelemetry {
         TelemetrySubscription currentSubscription = subscription().orElseThrow(
         () -> new IllegalTelemetryStateException(String.format("Subscription cannot be null.  Aborting.")));
 
+        final long retryMs;
         // We might want to wait and retry or retry after some failures are received
         if (isAuthorizationFailedError(data.errorCode())) {
+            retryMs = 30 * 60 * 1000;
             log.warn("Error code: {}. Reason: Client is permitted to send metrics.  Retry automatically in {}ms.", data.errorCode(), retryMs);
-            setSubscription(currentSubscription.alterPushIntervalMs(30 * 60 * 1000, time));
+            setSubscription(currentSubscription.alterPushIntervalMs(retryMs, time));
         } else if (data.errorCode() == Errors.INVALID_RECORD.code()) {
+            retryMs = 5 * 60 * 1000;
             log.warn("Error code: {}.  Reason: Broker failed to decode or validate the client’s encoded metrics.  Retry automatically in {}ms", data.errorCode(), retryMs);
-            setSubscription(currentSubscription.alterPushIntervalMs( 5 * 60 * 1000, time));
-        } else if (data.errorCode() == -1 || // TODO: UnknownSubscriptionId isn't in the Errors package.  Leave it as -1 for now
+            setSubscription(currentSubscription.alterPushIntervalMs(retryMs, time));
+        } else if (data.errorCode() == -1 ||
                 data.errorCode() == Errors.UNSUPPORTED_COMPRESSION_TYPE.code()) {
             log.warn("Error code: {}.  Reason: {}.  Retrying automatically.", data.errorCode(), Errors.forCode(data.errorCode()).message());
             setSubscription(currentSubscription.alterPushIntervalMs(0, time));

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/MetricRecorder.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/MetricRecorder.java
@@ -133,7 +133,7 @@ public abstract class MetricRecorder implements ClientMetricRecorder {
 
         @Override
         public void record(MetricConfig config, double value, long now) {
-            value = value;
+            this.value = value;
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/NoopClientTelemetry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/NoopClientTelemetry.java
@@ -61,11 +61,11 @@ public class NoopClientTelemetry implements ClientTelemetry {
     }
 
     @Override
-    public void telemetrySubscriptionSucceeded(GetTelemetrySubscriptionsResponseData data) {
+    public void telemetrySubscriptionReceived(GetTelemetrySubscriptionsResponseData data) {
     }
 
     @Override
-    public void pushTelemetrySucceeded(PushTelemetryResponseData data) {
+    public void pushTelemetryReceived(PushTelemetryResponseData data) {
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/TelemetrySubscription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/TelemetrySubscription.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.StringJoiner;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.record.CompressionType;
-import org.apache.kafka.common.utils.*;
+import org.apache.kafka.common.utils.Time;
 
 /**
  * Simple, in-memory representation of the telemetry subscription that is retrieved from the cluster

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/TelemetrySubscription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/TelemetrySubscription.java
@@ -100,4 +100,33 @@ public class TelemetrySubscription {
             .add("metricSelector=" + metricSelector)
             .toString();
     }
+
+    /**
+     * Create a new TelemetrySubscription object with the given {@code pushIntervalMs} parameter.
+     * @param pushIntervalMs time interval in millisecond of the next push
+     * @return a new TelemetrySubscription
+     */
+    public TelemetrySubscription alterPushIntervalMs(long pushIntervalMs) {
+        return new TelemetrySubscription(
+                this.fetchMs,
+                this.throttleTimeMs,
+                this.clientInstanceId(),
+                this.subscriptionId(),
+                this.acceptedCompressionTypes(),
+                pushIntervalMs,
+                this.deltaTemporality(),
+                this.metricSelector());
+    }
+
+    public TelemetrySubscription clone() {
+        return new TelemetrySubscription(
+                this.fetchMs,
+                this.throttleTimeMs,
+                this.clientInstanceId(),
+                this.subscriptionId(),
+                this.acceptedCompressionTypes(),
+                this.pushIntervalMs,
+                this.deltaTemporality(),
+                this.metricSelector());
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/telemetry/TelemetrySubscription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/telemetry/TelemetrySubscription.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.StringJoiner;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.utils.*;
 
 /**
  * Simple, in-memory representation of the telemetry subscription that is retrieved from the cluster
@@ -106,26 +107,14 @@ public class TelemetrySubscription {
      * @param pushIntervalMs time interval in millisecond of the next push
      * @return a new TelemetrySubscription
      */
-    public TelemetrySubscription alterPushIntervalMs(long pushIntervalMs) {
+    public TelemetrySubscription alterPushIntervalMs(long pushIntervalMs, Time time) {
         return new TelemetrySubscription(
-                this.fetchMs,
+                time.milliseconds(), // update fetch ms to get the correct next push time
                 this.throttleTimeMs,
                 this.clientInstanceId(),
                 this.subscriptionId(),
                 this.acceptedCompressionTypes(),
                 pushIntervalMs,
-                this.deltaTemporality(),
-                this.metricSelector());
-    }
-
-    public TelemetrySubscription clone() {
-        return new TelemetrySubscription(
-                this.fetchMs,
-                this.throttleTimeMs,
-                this.clientInstanceId(),
-                this.subscriptionId(),
-                this.acceptedCompressionTypes(),
-                this.pushIntervalMs,
                 this.deltaTemporality(),
                 this.metricSelector());
     }

--- a/clients/src/main/java/org/apache/kafka/common/cache/LRUCache.java
+++ b/clients/src/main/java/org/apache/kafka/common/cache/LRUCache.java
@@ -18,10 +18,12 @@ package org.apache.kafka.common.cache;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A cache implementing a least recently used policy.
  */
+@SuppressWarnings("checkstyle:Indentation")
 public class LRUCache<K, V> implements Cache<K, V> {
     private final LinkedHashMap<K, V> cache;
 
@@ -52,5 +54,13 @@ public class LRUCache<K, V> implements Cache<K, V> {
     @Override
     public long size() {
         return cache.size();
+    }
+
+    public Set<Map.Entry<K, V>> entrySet() {
+        return cache.entrySet();
+    }
+
+    public void clear() {
+        cache.clear();
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
@@ -33,7 +33,7 @@ public final class ConfigResource {
      * Type of resource.
      */
     public enum Type {
-        BROKER_LOGGER((byte) 8), BROKER((byte) 4), TOPIC((byte) 2), UNKNOWN((byte) 0);
+        CLIENT_METRICS((byte) 16), BROKER_LOGGER((byte) 8), BROKER((byte) 4), TOPIC((byte) 2), UNKNOWN((byte) 0);
 
         private static final Map<Byte, Type> TYPES = Collections.unmodifiableMap(
             Arrays.stream(values()).collect(Collectors.toMap(Type::id, Function.identity()))

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.DescribeConfigsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -119,7 +120,8 @@ public class DescribeConfigsResponse extends AbstractResponse {
         DYNAMIC_DEFAULT_BROKER_CONFIG((byte) 3, org.apache.kafka.clients.admin.ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG),
         STATIC_BROKER_CONFIG((byte) 4, org.apache.kafka.clients.admin.ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG),
         DEFAULT_CONFIG((byte) 5, org.apache.kafka.clients.admin.ConfigEntry.ConfigSource.DEFAULT_CONFIG),
-        DYNAMIC_BROKER_LOGGER_CONFIG((byte) 6, org.apache.kafka.clients.admin.ConfigEntry.ConfigSource.DYNAMIC_BROKER_LOGGER_CONFIG);
+        DYNAMIC_BROKER_LOGGER_CONFIG((byte) 6, org.apache.kafka.clients.admin.ConfigEntry.ConfigSource.DYNAMIC_BROKER_LOGGER_CONFIG),
+        DYNAMIC_CLIENT_METRICS_CONFIG((byte) 7, org.apache.kafka.clients.admin.ConfigEntry.ConfigSource.DYNAMIC_CLIENT_METRICS_CONFIG);
 
         final byte id;
         private final org.apache.kafka.clients.admin.ConfigEntry.ConfigSource source;

--- a/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
@@ -63,7 +63,12 @@ public enum ResourceType {
     /**
      * A token ID.
      */
-    DELEGATION_TOKEN((byte) 6);
+    DELEGATION_TOKEN((byte) 6),
+
+    /**
+     *  Client metrics
+     */
+    CLIENT_METRICS((byte) 7);
 
     private final static HashMap<Byte, ResourceType> CODE_TO_VALUE = new HashMap<>();
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -1597,6 +1597,33 @@ public class KafkaAdminClientTest {
         }
     }
 
+    @Test
+    public void testDescribeClientMetricConfigs() throws Exception {
+        ConfigResource metricResource0 = new ConfigResource(ConfigResource.Type.CLIENT_METRICS, "metric0");
+        ConfigResource metricResource1 = new ConfigResource(ConfigResource.Type.CLIENT_METRICS, "metric1");
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareResponse(new DescribeConfigsResponse(
+                    new DescribeConfigsResponseData().setResults(asList(
+                            new DescribeConfigsResponseData.DescribeConfigsResult()
+                                    .setResourceName(metricResource0.name())
+                                    .setResourceType(metricResource0.type().id())
+                                    .setErrorCode(Errors.NONE.code())
+                                    .setConfigs(emptyList()),
+                            new DescribeConfigsResponseData.DescribeConfigsResult()
+                                    .setResourceName(metricResource1.name())
+                                    .setResourceType(metricResource1.type().id())
+                                    .setErrorCode(Errors.NONE.code())
+                                    .setConfigs(emptyList())))));
+            Map<ConfigResource, KafkaFuture<Config>> result = env.adminClient().describeConfigs(asList(
+                    metricResource0,
+                    metricResource1)).values();
+            assertEquals(new HashSet<>(asList(metricResource0, metricResource1)), result.keySet());
+            result.get(metricResource0).get();
+            result.get(metricResource1).get();
+        }
+    }
+
     private static DescribeLogDirsResponse prepareDescribeLogDirsResponse(Errors error, String logDir, TopicPartition tp, long partitionSize, long offsetLag) {
         return prepareDescribeLogDirsResponse(error, logDir,
                 prepareDescribeLogDirsTopics(partitionSize, offsetLag, tp.topic(), tp.partition(), false));
@@ -3598,6 +3625,12 @@ public class KafkaAdminClientTest {
                     .setErrorMessage("authorization error"));
 
             responseData.responses().add(new AlterConfigsResourceResponse()
+                    .setResourceName("metric1")
+                    .setResourceType(ConfigResource.Type.CLIENT_METRICS.id())
+                    .setErrorCode(Errors.INVALID_REQUEST.code())
+                    .setErrorMessage("Subscription is not allowed"));
+
+            responseData.responses().add(new AlterConfigsResourceResponse()
                     .setResourceName("topic1")
                     .setResourceType(ConfigResource.Type.TOPIC.id())
                     .setErrorCode(Errors.INVALID_REQUEST.code())
@@ -3607,6 +3640,7 @@ public class KafkaAdminClientTest {
 
             ConfigResource brokerResource = new ConfigResource(ConfigResource.Type.BROKER, "");
             ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, "topic1");
+            ConfigResource metricResource = new ConfigResource(ConfigResource.Type.CLIENT_METRICS, "metric1");
 
             AlterConfigOp alterConfigOp1 = new AlterConfigOp(
                     new ConfigEntry("log.segment.bytes", "1073741"),
@@ -3616,13 +3650,19 @@ public class KafkaAdminClientTest {
                     new ConfigEntry("compression.type", "gzip"),
                     AlterConfigOp.OpType.APPEND);
 
+            AlterConfigOp alterConfigOp3 = new AlterConfigOp(
+                    new ConfigEntry("compression.type", "gzip"),
+                    AlterConfigOp.OpType.APPEND);
+
             final Map<ConfigResource, Collection<AlterConfigOp>> configs = new HashMap<>();
             configs.put(brokerResource, singletonList(alterConfigOp1));
             configs.put(topicResource, singletonList(alterConfigOp2));
+            configs.put(metricResource, singletonList(alterConfigOp3));
 
             AlterConfigsResult result = env.adminClient().incrementalAlterConfigs(configs);
             TestUtils.assertFutureError(result.values().get(brokerResource), ClusterAuthorizationException.class);
             TestUtils.assertFutureError(result.values().get(topicResource), InvalidRequestException.class);
+            TestUtils.assertFutureError(result.values().get(metricResource), InvalidRequestException.class);
 
             // Test a call where there are no errors.
             responseData =  new IncrementalAlterConfigsResponseData();
@@ -3631,9 +3671,18 @@ public class KafkaAdminClientTest {
                     .setResourceType(ConfigResource.Type.BROKER.id())
                     .setErrorCode(Errors.NONE.code())
                     .setErrorMessage(ApiError.NONE.message()));
+            responseData.responses().add(new AlterConfigsResourceResponse()
+                    .setResourceName("metric1")
+                    .setResourceType(ConfigResource.Type.TOPIC.id())
+                    .setErrorCode(Errors.NONE.code())
+                    .setErrorMessage(ApiError.NONE.message()));
 
             env.kafkaClient().prepareResponse(new IncrementalAlterConfigsResponse(responseData));
-            env.adminClient().incrementalAlterConfigs(Collections.singletonMap(brokerResource, singletonList(alterConfigOp1))).all().get();
+            final Map<ConfigResource, Collection<AlterConfigOp>> successConfig = new HashMap<>();
+            successConfig.put(brokerResource, singletonList(alterConfigOp1));
+            successConfig.put(metricResource, singletonList(alterConfigOp3));
+            assertTrue(env.adminClient().incrementalAlterConfigs(successConfig).values().containsKey(brokerResource));
+            assertTrue(env.adminClient().incrementalAlterConfigs(successConfig).values().containsKey(metricResource));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/telemetry/DefaultClientTelemetryTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/telemetry/DefaultClientTelemetryTest.java
@@ -17,7 +17,15 @@
 package org.apache.kafka.clients.telemetry;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.PushTelemetryResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.Test;
@@ -26,6 +34,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DefaultClientTelemetryTest extends BaseClientTelemetryTest {
+    // state transition
+    private static Map<TelemetryState, TelemetryState> stateMap;
+    static {
+        stateMap = new HashMap<>();
+        stateMap.put(TelemetryState.subscription_needed, TelemetryState.subscription_in_progress);
+        stateMap.put(TelemetryState.subscription_in_progress, TelemetryState.push_needed);
+        stateMap.put(TelemetryState.push_needed, TelemetryState.push_in_progress);
+        stateMap.put(TelemetryState.push_in_progress, TelemetryState.terminating_push_needed);
+        stateMap.put(TelemetryState.terminating_push_needed, TelemetryState.terminating_push_in_progress);
+        stateMap.put(TelemetryState.terminating_push_in_progress, TelemetryState.terminated);
+    }
 
     @Test
     public void testSingleClose() {
@@ -102,4 +121,38 @@ public class DefaultClientTelemetryTest extends BaseClientTelemetryTest {
         }
     }
 
+    @Test
+    public void testTelemetrySubscriptionReceivedStateTransition() {
+        DefaultClientTelemetry clientTelemetry = newClientTelemetry();
+        clientTelemetry.setSubscription(new TelemetrySubscription(
+                0,
+                0,
+                Uuid.randomUuid(),
+                42,
+                Collections.singletonList(CompressionType.NONE),
+                10000,
+                true,
+                MetricSelector.ALL));
+        transitionState(TelemetryState.push_in_progress, clientTelemetry);
+        assertEquals(TelemetryState.push_in_progress, clientTelemetry.state().get());
+        PushTelemetryResponseData data = new PushTelemetryResponseData();
+        data.setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code());
+        clientTelemetry.pushTelemetryReceived(data);
+        assertEquals(TelemetryState.subscription_needed, clientTelemetry.state().orElseThrow(() -> new RuntimeException("unable to make state transition")));
+
+        clientTelemetry.close();
+    }
+
+    // an utility function that transition the current state to a target state
+    private void transitionState(final TelemetryState toState, ClientTelemetry clientTelemetry) {
+        TelemetryState currentState = clientTelemetry.state().orElseThrow(
+                () -> new RuntimeException("null state should not happen"));
+
+        TelemetryState nextState;
+        while(currentState != toState) {
+            nextState = stateMap.get(currentState);
+            clientTelemetry.setState(nextState);
+            currentState = nextState;
+        }
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigResourceTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigResourceTest.java
@@ -28,6 +28,7 @@ public class ConfigResourceTest {
     public void shouldGetTypeFromId() {
         assertEquals(ConfigResource.Type.TOPIC, ConfigResource.Type.forId((byte) 2));
         assertEquals(ConfigResource.Type.BROKER, ConfigResource.Type.forId((byte) 4));
+        assertEquals(ConfigResource.Type.CLIENT_METRICS, ConfigResource.Type.forId((byte) 16));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/GetTelemetrySubscriptionRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/GetTelemetrySubscriptionRequestTest.java
@@ -44,6 +44,7 @@ public class GetTelemetrySubscriptionRequestTest {
         GetTelemetrySubscriptionResponse response = new GetTelemetrySubscriptionResponse(data);
         assertEquals(Collections.singletonMap(Errors.NONE, 1), response.errorCounts());
     }
+
     @Test
     public void testErrorCountsReturnsOneError() {
         GetTelemetrySubscriptionsResponseData data = new GetTelemetrySubscriptionsResponseData()

--- a/clients/src/test/java/org/apache/kafka/common/resource/ResourceTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/resource/ResourceTypeTest.java
@@ -42,7 +42,8 @@ public class ResourceTypeTest {
         new AclResourceTypeTestInfo(ResourceType.GROUP, 3, "group", false),
         new AclResourceTypeTestInfo(ResourceType.CLUSTER, 4, "cluster", false),
         new AclResourceTypeTestInfo(ResourceType.TRANSACTIONAL_ID, 5, "transactional_id", false),
-        new AclResourceTypeTestInfo(ResourceType.DELEGATION_TOKEN, 6, "delegation_token", false)
+        new AclResourceTypeTestInfo(ResourceType.DELEGATION_TOKEN, 6, "delegation_token", false),
+        new AclResourceTypeTestInfo(ResourceType.CLIENT_METRICS, 7, "client_metrics", false)
     };
 
     @Test

--- a/core/src/main/scala/kafka/metrics/clientmetrics/ClientMetricsCache.scala
+++ b/core/src/main/scala/kafka/metrics/clientmetrics/ClientMetricsCache.scala
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.metrics.clientmetrics
+
+import kafka.Kafka.info
+import kafka.metrics.clientmetrics.ClientMetricsCache.{DEFAULT_TTL_MS, cmCache}
+import kafka.metrics.clientmetrics.ClientMetricsConfig.SubscriptionInfo
+import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.cache.LRUCache
+import org.apache.log4j.helpers.LogLog.{debug, error}
+
+import java.util.Calendar
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+/**
+ * Client Metrics Cache:
+ *   Standard LRU Cache of the ClientInstanceState objects that are created during to the client's
+ *   GetTelemetrySubscriptionRequest message.
+ *
+ *   Eviction Policy:
+ *      1. Standard LRU eviction policy applies once cache size reaches its max size.
+ *      2. In addition to the LRU eviction there is a GC for the elements that have stayed too long
+ *      in the cache. There is a last accessed timestamp is set for every cached object which gets
+ *      updated every time a cache object is accessed by GetTelemetrySubscriptionRequest or
+ *      PushTelemetrySubscriptionRequest. During the GC, all the elements that are inactive beyond
+ *      TTL time period would be cleaned up from the cache. GC operation is an asynchronous task
+ *      triggered by ClientMetricManager in specific intervals governed by CM_CACHE_GC_INTERVAL.
+ *
+ *   Invalidation of the Cached objects:
+ *      Since ClientInstanceState objects are created by compiling qualified client metric subscriptions
+ *      they can go out of sync whenever client metric subscriptions changed like adding a new subscriptions or
+ *      updating an existing subscription. So there is a need to invalidate the cached objects whenever
+ *      client metric subscription is updated. Invalidation method iterates through all the matched client
+ *      instances and applies the subscription changes by replacing it with a new ClientInstanceState object.
+ *
+ *   Locking:
+ *      All the cache modifiers (add/delete/replace) are synchronized through standard scala object
+ *      level synchronized method. For better concurrency there is no explicit locking applied on
+ *      read/get operations.
+ */
+object  ClientMetricsCache {
+  val DEFAULT_TTL_MS = 60 * 1000  // One minute
+  val CM_CACHE_GC_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
+  val CM_CACHE_MAX_SIZE = 16384 // Max cache size (16k active client connections per broker)
+  val gcTs = Calendar.getInstance.getTime
+  private val cmCache = new ClientMetricsCache(CM_CACHE_MAX_SIZE)
+
+  def getInstance = cmCache
+
+  /**
+   * Launches the asynchronous task to clean the client metric subscriptions that are expired in the cache.
+   */
+  def runGCIfNeeded(forceGC: Boolean = false): Unit = {
+    gcTs.synchronized {
+      val timeElapsed = Calendar.getInstance.getTime.getTime - gcTs.getTime
+      if (forceGC || cmCache.getSize > CM_CACHE_MAX_SIZE && timeElapsed > CM_CACHE_GC_INTERVAL_MS) {
+        cmCache.cleanupExpiredEntries("GC").onComplete {
+          case Success(value) => info(s"Client Metrics subscriptions cache cleaned up $value entries")
+          case Failure(e) => error(s"Client Metrics subscription cache cleanup failed: ${e.getMessage}")
+        }
+      }
+    }
+  }
+}
+
+class ClientMetricsCache(maxSize: Int) {
+  private val _cache = new LRUCache[Uuid, ClientMetricsCacheValue](maxSize)
+  def getSize = _cache.size()
+  def clear() = _cache.clear()
+  def get(id: Uuid): CmClientInstanceState =  {
+    val value = _cache.get(id)
+    if (value != null) value.getClientInstance else null
+  }
+
+  /**
+   * Iterates through all the elements of the cache and updates the client instance state objects that
+   * matches the client subscription that is being updated.
+   * @param oldSubscriptionInfo -- Subscription that has been deleted from the client metrics subscription
+   * @param newSubscriptionInfo -- subscription that has been added to the client metrics subscription
+   */
+  def invalidate(oldSubscriptionInfo: SubscriptionInfo, newSubscriptionInfo: SubscriptionInfo) = {
+    _cache.synchronized {
+      update(oldSubscriptionInfo, newSubscriptionInfo)
+    }
+  }
+
+  def add(instance: CmClientInstanceState)= {
+    _cache.synchronized{
+      _cache.put(instance.getId, new ClientMetricsCacheValue(instance))
+    }
+  }
+
+  def cleanupExpiredEntries(reason: String): Future[Long] = Future {
+    _cache.synchronized{
+      val preCleanupSize = _cache.size()
+      cmCache.cleanupTtlEntries()
+      preCleanupSize - _cache.size()
+    }
+  }
+
+
+  ///////// **** PRIVATE - METHODS **** /////////////
+  private def update(oldSubscription: SubscriptionInfo, newSubscription: SubscriptionInfo) = {
+    _cache.entrySet().forEach(element =>  {
+      val clientInstance = element.getValue.getClientInstance
+      val updatedMetricSubscriptions = clientInstance.getSubscriptions
+      if (oldSubscription!= null && clientInstance.getClientInfo.isMatched(oldSubscription.getClientMatchingPatterns)) {
+        updatedMetricSubscriptions.remove(oldSubscription)
+      }
+      if (newSubscription != null && clientInstance.getClientInfo.isMatched(newSubscription.getClientMatchingPatterns)){
+        updatedMetricSubscriptions.add(newSubscription)
+      }
+      element.getValue.replace(CmClientInstanceState(clientInstance, updatedMetricSubscriptions))
+    })
+  }
+
+  private def isExpired(element: CmClientInstanceState) = {
+    val currentTs = Calendar.getInstance.getTime
+    val delta = currentTs.getTime - element.getLastAccessTs.getTime
+    delta > Math.max(3 * element.getPushIntervalMs, DEFAULT_TTL_MS)
+  }
+
+  private def cleanupTtlEntries() = {
+    val iter = _cache.entrySet().iterator()
+    while (iter.hasNext) {
+      val element = iter.next().getValue.clientInstance
+      if (isExpired(element)) {
+        debug(s"Client subscription entry ${element} is expired removing it from the cache")
+        iter.remove()
+      }
+    }
+  }
+
+
+  /**
+   * Wrapper class to hold the CmClientInstance object and helps in preserving the LRU order.
+   *
+   * Background:
+   * Whenever client metrics subscription is added/updated that results in updating the
+   * affected client instance state objects to absorb the new changes, that's done by replacing
+   * the old client instance with the new instance object as explained in invalidate method.
+   * If we directly replace the cached object that would alter the LRU order, so having the wrapper
+   * will allow us to replace the client instance object in the wrapper itself without changing
+   * the LRU order.
+   * @param instance
+   */
+  class ClientMetricsCacheValue(instance: CmClientInstanceState) {
+    var clientInstance :CmClientInstanceState = instance
+    def getClientInstance = clientInstance
+    def replace(instance: CmClientInstanceState): Unit = {
+      clientInstance = instance
+    }
+  }
+}

--- a/core/src/main/scala/kafka/metrics/clientmetrics/ClientMetricsConfig.scala
+++ b/core/src/main/scala/kafka/metrics/clientmetrics/ClientMetricsConfig.scala
@@ -1,0 +1,182 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.metrics.clientmetrics
+
+import kafka.metrics.clientmetrics.ClientMetricsConfig.ClientMetrics.{AllMetricsFlag, ClientMatchPattern, DeleteSubscription, PushIntervalMs, SubscriptionMetrics, configDef}
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM
+import org.apache.kafka.common.config.ConfigDef.Type.{BOOLEAN, INT, LIST}
+import org.apache.kafka.common.errors.InvalidRequestException
+
+import java.util
+import java.util.Properties
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Client metric configuration related parameters and the supporting methods like validation and update methods
+ * are defined in this class.
+ *
+ * SubscriptionInfo: Contains the client metric subscription information. Supported operations from the CLI are
+ * add/delete/update operations. Every subscription object contains the following parameters that are populated
+ * during the creation of the subscription through kafka-client-metrics.sh
+ * {
+ *   subscriptionId: Name/ID supplied by CLI during the creation of the client metric subscription.
+ *   subscribedMetrics: List of metric prefixes
+ *   pushIntervalMs: A positive integer value >=0  tells the client that how often a client can push the metrics
+ *   matchingPatternsList: List of client matching patterns, that are used by broker to match the client instance
+ *   with the subscription.
+ * }
+ *
+ * At present, CLI can pass the following parameters in AlterConfigRequest to add/delete/update the client metric
+ * subscription:
+ *
+ *  1. "client.metrics.subscription.metrics" value should be comma separated metrics list.
+ *      Ex: "org.apache.kafka/client.producer.partition.queue.,org.apache.kafka/client.producer.partition.latency"
+ *      OR "client.metrics.flag" must be set to 'true'
+ *
+ *  2. "client.metrics.push.interval.ms" should be greater than or equal to 0; a value 0 is considered as an indication
+ *  to disable the metric collection from the client.
+ *
+ *  3. "client.metrics.subscription.client.match" is a comma separated list of client match patterns, in case if there
+ *     is no matching pattern specified then broker considers that as all match which means the associated metrics
+ *     applies to all the clients. Ex: "client_software_name = Java, client_software_version = 11.1.*"
+ *     For exact parameters that a client can pass please look at the ClientMatchingParams
+ *
+ *  4. "client.metrics.delete.subscription" should be set to true to delete an existing client subscription. if it is
+ *      set then there is no need for the other parameters
+ *
+ * For more information please look at kip-714:
+ * https://cwiki.apache.org/confluence/display/KAFKA/KIP-714%3A+Client+metrics+and+observability
+ */
+object ClientMetricsConfig {
+
+  class SubscriptionInfo(subscriptionId: String,
+                         subscribedMetrics: List[String],
+                         var matchingPatternsList: List[String],
+                         pushIntervalMs: Int,
+                         allMetricsSubscribed: Boolean = false) {
+    def getId = subscriptionId
+    def getPushIntervalMs = pushIntervalMs
+    val clientMatchingPatterns = CmClientInformation.parseMatchingPatterns(matchingPatternsList)
+    def getClientMatchingPatterns = clientMatchingPatterns
+    def getSubscribedMetrics = subscribedMetrics
+    def getAllMetricsSubscribed = allMetricsSubscribed
+  }
+
+  object ClientMatchingParams {
+    val CLIENT_ID = "client_id"
+    val CLIENT_INSTANCE_ID = "client_instance_id"
+    val CLIENT_SOFTWARE_NAME = "client_software_name"
+    val CLIENT_SOFTWARE_VERSION = "client_software_version"
+    val CLIENT_SOURCE_ADDRESS = "client_source_address"
+    val CLIENT_SOURCE_PORT = "client_source_port"
+
+    val matchersList = List(CLIENT_ID, CLIENT_INSTANCE_ID, CLIENT_SOFTWARE_NAME,
+                            CLIENT_SOFTWARE_VERSION, CLIENT_SOURCE_ADDRESS, CLIENT_SOURCE_PORT)
+
+    def isValidParam(param: String) = matchersList.contains(param)
+  }
+
+  object ClientMetrics {
+    // Properties
+    val SubscriptionMetrics = "client.metrics.subscription.metrics"
+    val ClientMatchPattern = "client.metrics.subscription.client.match"
+    val PushIntervalMs = "client.metrics.push.interval.ms"
+    val AllMetricsFlag = "client.metrics.all"
+    val DeleteSubscription = "client.metrics.delete.subscription"
+
+    val DEFAULT_PUSH_INTERVAL = 5 * 60 * 1000 // 5 minutes
+
+    // Definitions
+    val configDef = new ConfigDef()
+      .define(SubscriptionMetrics, LIST, MEDIUM, "List of the subscribed metrics")
+      .define(ClientMatchPattern, LIST, MEDIUM, "Pattern used to find the matching clients")
+      .define(PushIntervalMs, INT, DEFAULT_PUSH_INTERVAL, MEDIUM, "Interval that a client can push the metrics")
+      .define(AllMetricsFlag, BOOLEAN, false, MEDIUM, "If set to true all the metrics are included")
+      .define(DeleteSubscription, BOOLEAN, false, MEDIUM, "If set to true metric subscription would be deleted")
+
+    def names = configDef.names
+
+    def validate(subscriptionId :String, properties :Properties): Unit = {
+      if (subscriptionId.isEmpty) {
+        throw new InvalidRequestException("subscriptionId can't be empty")
+      }
+      validateProperties(properties)
+    }
+
+    def validateProperties(properties :Properties) = {
+      val names = configDef.names
+      properties.keySet().forEach(x => require(names.contains(x), s"Unknown client metric configuration: $x"))
+
+      // If the command is to delete the subscription then we do not expect any other parameters to be in the list.
+      // Otherwise validate the rest of the parameters.
+      if (!properties.containsKey(DeleteSubscription)) {
+        require(properties.containsKey(PushIntervalMs), s"Missing parameter ${PushIntervalMs}")
+        require(Integer.parseInt(properties.get(PushIntervalMs).toString) >= 0, s"Invalid parameter ${PushIntervalMs}")
+
+        // If all metrics flag is specified then there is no need for having the metrics parameter
+        if (!properties.containsKey(AllMetricsFlag)) {
+          require(properties.containsKey(SubscriptionMetrics), s"Missing parameter ${SubscriptionMetrics}")
+        }
+
+        // Make sure that client match patterns are valid by parsing them.
+        if (properties.containsKey(ClientMatchPattern)) {
+          val propsList: List[String] = properties.getProperty(ClientMatchPattern).split(",").toList
+          CmClientInformation.parseMatchingPatterns(propsList)
+        }
+      }
+    }
+  }
+
+  private val subscriptionMap = new ConcurrentHashMap[String, SubscriptionInfo]
+
+  def getClientSubscriptionInfo(subscriptionId :String): SubscriptionInfo  =  subscriptionMap.get(subscriptionId)
+  def clearClientSubscriptions() = subscriptionMap.clear
+  def getSubscriptionsCount = subscriptionMap.size
+  def getClientSubscriptions = subscriptionMap.values
+
+  private def toList(prop: Any): List[String] = {
+    val value: util.List[_] = prop.asInstanceOf[util.List[_]]
+    val valueList =  new ListBuffer[String]()
+    value.forEach(x => valueList += x.asInstanceOf[String])
+    valueList.toList
+  }
+
+  def updateClientSubscription(subscriptionId :String, properties: Properties): Unit = {
+    val parsed = configDef.parse(properties)
+    val javaFalse = java.lang.Boolean.FALSE
+    val subscriptionDeleted = parsed.getOrDefault(DeleteSubscription, javaFalse).asInstanceOf[Boolean]
+    if (subscriptionDeleted) {
+      val deletedSubscription = subscriptionMap.remove(subscriptionId)
+      ClientMetricsCache.getInstance.invalidate(deletedSubscription, null)
+    } else {
+      val clientMatchPattern = toList(parsed.get(ClientMatchPattern))
+      val pushInterval = parsed.get(PushIntervalMs).asInstanceOf[Int]
+      val allMetricsSubscribed = parsed.getOrDefault(AllMetricsFlag, javaFalse).asInstanceOf[Boolean]
+      val metrics = if (allMetricsSubscribed) List("") else toList(parsed.get(SubscriptionMetrics))
+      val newSubscription =
+        new SubscriptionInfo(subscriptionId, metrics, clientMatchPattern, pushInterval, allMetricsSubscribed)
+      val oldSubscription = subscriptionMap.put(subscriptionId, newSubscription)
+      ClientMetricsCache.getInstance.invalidate(oldSubscription, newSubscription)
+    }
+  }
+
+  def validateConfig(subscriptionId :String, configs: Properties): Unit =  {
+    ClientMetrics.validate(subscriptionId, configs)
+  }
+}

--- a/core/src/main/scala/kafka/metrics/clientmetrics/CmClientInformation.scala
+++ b/core/src/main/scala/kafka/metrics/clientmetrics/CmClientInformation.scala
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.metrics.clientmetrics
+
+import kafka.Kafka.info
+import kafka.metrics.clientmetrics.ClientMetricsConfig.ClientMatchingParams.{CLIENT_ID, CLIENT_INSTANCE_ID, CLIENT_SOFTWARE_NAME, CLIENT_SOFTWARE_VERSION, CLIENT_SOURCE_ADDRESS, CLIENT_SOURCE_PORT, isValidParam}
+import kafka.network.RequestChannel
+import org.apache.kafka.common.errors.InvalidConfigurationException
+
+import java.util.regex.{Pattern, PatternSyntaxException}
+import scala.collection.mutable
+
+/**
+ * Information from the client's metadata is gathered from the client's request.
+ */
+object CmClientInformation {
+  def apply(request: RequestChannel.Request, clientInstanceId: String): CmClientInformation = {
+    val instance = new CmClientInformation
+    val ctx = request.context
+    val softwareName = if (ctx.clientInformation != null) ctx.clientInformation.softwareName() else ""
+    val softwareVersion = if (ctx.clientInformation != null) ctx.clientInformation.softwareVersion() else ""
+    instance.init(clientInstanceId, ctx.clientId(), softwareName, softwareVersion,
+                  ctx.clientAddress.getHostAddress, ctx.clientAddress.getHostAddress)
+    instance
+  }
+
+  def apply(clientInstanceId: String, clientId: String, softwareName: String,
+            softwareVersion: String, clientHostAddress: String, clientPort: String): CmClientInformation = {
+    val instance = new CmClientInformation
+    instance.init(clientInstanceId, clientId, softwareName, softwareVersion, clientHostAddress, clientPort)
+    instance
+  }
+
+  /**
+   * Parses the client matching patterns and builds a map with entries that has
+   * (PatternName, PatternValue) as the entries.
+   *  Ex: "VERSION=1.2.3" would be converted to a map entry of (Version, 1.2.3)
+   *
+   *  NOTES:
+   *  1. Client match pattern splits the input into two parts separated by first
+   *     occurrence of the character '='
+   *  2. '*' is considered as invalid client match pattern
+   * @param patterns List of client matching pattern strings
+   * @return
+   */
+  def parseMatchingPatterns(patterns: List[String]) : Map[String, String] = {
+    val patternsMap = mutable.Map[String, String]()
+    if (patterns != null) {
+      patterns.foreach(x => {
+        val nameValuePair = x.split("=", 2).map(x => x.trim)
+        if (nameValuePair.size == 2 && isValidParam(nameValuePair(0)) && validRegExPattern(nameValuePair(1))) {
+          patternsMap += (nameValuePair(0) -> nameValuePair(1))
+        } else {
+          throw new InvalidConfigurationException("Illegal client matching pattern: " + x)
+        }
+      })
+    }
+    patternsMap.toMap
+  }
+
+  private def validRegExPattern(inputPattern :String): Boolean = {
+    try {
+      Pattern.compile(inputPattern)
+      true
+    } catch {
+      case e: PatternSyntaxException =>
+        false
+    }
+  }
+
+}
+
+class CmClientInformation {
+  var attributesMap = scala.collection.mutable.Map[String, String]()
+
+  private def init(clientInstanceId: String,
+                   clientId: String,
+                   softwareName: String,
+                   softwareVersion: String,
+                   clientHostAddress: String,
+                   clientPort: String): Unit = {
+    attributesMap(CLIENT_INSTANCE_ID) = clientInstanceId
+    attributesMap(CLIENT_ID) = clientId
+    attributesMap(CLIENT_SOFTWARE_NAME) = softwareName
+    attributesMap(CLIENT_SOFTWARE_VERSION) = softwareVersion
+    attributesMap(CLIENT_SOURCE_ADDRESS) = clientHostAddress
+    attributesMap(CLIENT_SOURCE_PORT) = clientPort // TODO: how to get the client's port info.
+  }
+
+  def isMatched(patterns: Map[String, String]) : Boolean = {
+    // Empty pattern or missing pattern still considered as a match
+    if (patterns == null || patterns.isEmpty) {
+      true
+    } else {
+      matchPatterns(patterns)
+    }
+  }
+
+  private def matchPatterns(matchingPatterns: Map[String, String]) : Boolean = {
+    try {
+      matchingPatterns.foreach {
+      case (k, v) =>
+        val attribute = attributesMap.getOrElse(k, null)
+        if (attribute == null || v.r.anchored.findAllMatchIn(attribute).isEmpty) {
+          throw new InvalidConfigurationException(k)
+        }
+      }
+      true
+    } catch {
+      case e: InvalidConfigurationException =>
+        info(s"Unable to find the matching client subscription for the client ${e.getMessage}")
+        false
+    }
+  }
+}

--- a/core/src/main/scala/kafka/metrics/clientmetrics/CmClientInstanceState.scala
+++ b/core/src/main/scala/kafka/metrics/clientmetrics/CmClientInstanceState.scala
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.metrics.clientmetrics
+
+import kafka.Kafka.info
+import kafka.metrics.clientmetrics.ClientMetricsConfig.ClientMetrics.DEFAULT_PUSH_INTERVAL
+import kafka.metrics.clientmetrics.ClientMetricsConfig.SubscriptionInfo
+import org.apache.kafka.common.Uuid
+
+import java.nio.charset.StandardCharsets
+import java.util.Calendar
+import java.util.zip.CRC32
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Client instance state that contains all the necessary information about the metric subscription for a client
+ */
+object CmClientInstanceState {
+
+  def apply(instance: CmClientInstanceState,
+            subscriptions: java.util.Collection[SubscriptionInfo]): CmClientInstanceState = {
+    val newInstance = create(instance.getId, instance.getClientInfo, subscriptions)
+    newInstance.updateLastAccessTs(instance.getLastAccessTs.getTime)
+    newInstance
+  }
+
+  def apply(id: Uuid,
+            clientInfo: CmClientInformation,
+            subscriptions: java.util.Collection[SubscriptionInfo]): CmClientInstanceState = {
+    create(id, clientInfo, subscriptions)
+  }
+
+  private def create(id: Uuid,
+                     clientInfo: CmClientInformation,
+                     subscriptions: java.util.Collection[SubscriptionInfo]): CmClientInstanceState = {
+
+    var targetMetrics = new ListBuffer[String]()
+    var pushInterval = DEFAULT_PUSH_INTERVAL
+    val targetSubscriptions = new java.util.ArrayList[SubscriptionInfo]()
+    var allMetricsSubscribed = false
+
+    subscriptions.forEach(v =>
+      if (clientInfo.isMatched(v.getClientMatchingPatterns)) {
+        allMetricsSubscribed = allMetricsSubscribed | v.getAllMetricsSubscribed
+        targetMetrics = targetMetrics ++ v.getSubscribedMetrics
+        targetSubscriptions.add(v)
+        pushInterval = Math.min(pushInterval, v.getPushIntervalMs)
+      }
+    )
+
+    // if pushInterval == 0 means, metrics collection is disabled for this client so clear all the metrics
+    // and just send the empty metrics list to the client.
+    // Otherwise, if client matches with any subscription that has the property `allMetricsSubscribed`
+    // which means there is no need for filtering the metrics, so as per KIP-714 protocol just send the
+    // empty string as the contents of the list so that client would send all the metrics updates
+    // Otherwise, just use the compiled metrics.
+    if (pushInterval == 0) {
+      info(s"Metrics collection is disabled for the client: ${id.toString}")
+      targetMetrics.clear()
+    } else if (allMetricsSubscribed) {
+      targetMetrics.clear()
+      targetMetrics.append("")
+    }
+
+    new CmClientInstanceState(id,  clientInfo, targetSubscriptions,
+                              targetMetrics.toList, pushInterval, allMetricsSubscribed)
+  }
+
+}
+
+class CmClientInstanceState private (clientInstanceId: Uuid,
+                                     clientInfo: CmClientInformation,
+                                     subscriptions: java.util.Collection[SubscriptionInfo],
+                                     var metrics: List[String],
+                                     pushIntervalMs: Int,
+                                     allMetricsSubscribed: Boolean) {
+
+  private val lastAccessTs = Calendar.getInstance.getTime
+  private val subscriptionId = computeSubscriptionId
+
+  def getPushIntervalMs = pushIntervalMs
+  def getLastAccessTs = lastAccessTs
+  def getSubscriptionId =  subscriptionId
+  def getId = clientInstanceId
+  def getClientInfo = clientInfo
+  def getSubscriptions = subscriptions
+  def getMetrics = metrics
+  def getAllMetricsSubscribed = allMetricsSubscribed
+  def updateLastAccessTs(tsInMs: Long): Unit =  lastAccessTs.setTime(tsInMs)
+
+  // Whenever push-interval for a client is set to 0 means metric collection for this specific client is disabled.
+  def isDisabledForMetricsCollection :Boolean =  getPushIntervalMs == 0
+
+
+  // Computes the SubscriptionId as a unique identifier for a client instance's subscription set, the id is generated
+  // by calculating a CRC32 of the configured metrics subscriptions including the PushIntervalMs,
+  // XORed with the ClientInstanceId.
+  private def computeSubscriptionId: Int = {
+    val crc = new CRC32
+    val metricsStr = metrics.toString() + pushIntervalMs.toString
+    crc.update(metricsStr.getBytes(StandardCharsets.UTF_8))
+    crc.getValue.toInt ^ clientInstanceId.hashCode
+  }
+
+}
+
+

--- a/core/src/main/scala/kafka/server/ClientMetricsManager.scala
+++ b/core/src/main/scala/kafka/server/ClientMetricsManager.scala
@@ -1,0 +1,85 @@
+package kafka.server
+
+import kafka.Kafka.info
+import kafka.metrics.clientmetrics.{ClientMetricsCache, ClientMetricsConfig, CmClientInformation, CmClientInstanceState}
+import kafka.network.RequestChannel
+import kafka.server.ClientMetricsManager.getSupportedCompressionTypes
+import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.message.GetTelemetrySubscriptionsResponseData
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.record.CompressionType
+import org.apache.kafka.common.requests.{GetTelemetrySubscriptionRequest, GetTelemetrySubscriptionResponse}
+
+import java.util.{Calendar, Properties}
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
+
+object ClientMetricsManager {
+  private val _instance = new ClientMetricsManager
+  def getInstance = _instance
+
+  def getSupportedCompressionTypes: List[java.lang.Byte] = {
+    val compressionTypes = new ListBuffer[java.lang.Byte]
+    CompressionType.values.foreach(x => compressionTypes.append(x.id.toByte))
+    compressionTypes.toList
+  }
+
+  def processGetTelemetrySubscriptionRequest(request: RequestChannel.Request,
+                                             throttleMs: Int): GetTelemetrySubscriptionResponse = {
+    val subscriptionRequest = request.body[GetTelemetrySubscriptionRequest]
+    val clientInfo = CmClientInformation(request, subscriptionRequest.getClientInstanceId.toString)
+    _instance.processGetSubscriptionRequest(subscriptionRequest, clientInfo, throttleMs)
+  }
+
+}
+
+class ClientMetricsManager {
+  def getClientInstance(id: Uuid) = ClientMetricsCache.getInstance.get(id)
+
+  def processGetSubscriptionRequest(subscriptionRequest: GetTelemetrySubscriptionRequest,
+                                    clientInfo: CmClientInformation,
+                                    throttleMs: Int): GetTelemetrySubscriptionResponse = {
+    var clientInstanceId = subscriptionRequest.getClientInstanceId
+    if (clientInstanceId == null || clientInstanceId == Uuid.ZERO_UUID) {
+      clientInstanceId = Uuid.randomUuid()
+    }
+    var clientInstance = getClientInstance(clientInstanceId)
+    if (clientInstance == null) {
+      clientInstance = createClientInstance(clientInstanceId, clientInfo)
+    }
+
+    val data =  new GetTelemetrySubscriptionsResponseData()
+        .setThrottleTimeMs(throttleMs)
+        .setClientInstanceId(clientInstanceId)
+        .setSubscriptionId(clientInstance.getSubscriptionId) // TODO: should we use LONG instead of int?
+        .setAcceptedCompressionTypes(getSupportedCompressionTypes.asJava)
+        .setPushIntervalMs(clientInstance.getPushIntervalMs)
+        .setDeltaTemporality(true)
+        .setErrorCode(Errors.NONE.code())
+        .setRequestedMetrics(clientInstance.getMetrics.asJava)
+
+    if (clientInstance.isDisabledForMetricsCollection) {
+      info(s"Metrics collection is disabled for the client: ${clientInstance.getId.toString}")
+    }
+
+    clientInstance.updateLastAccessTs(Calendar.getInstance.getTime.getTime)
+
+    new GetTelemetrySubscriptionResponse(data)
+  }
+
+  def updateSubscription(groupId :String, properties :Properties) = {
+    ClientMetricsConfig.updateClientSubscription(groupId, properties)
+  }
+
+  def createClientInstance(clientInstanceId: Uuid, clientInfo: CmClientInformation): CmClientInstanceState = {
+    val clientInstance = CmClientInstanceState(clientInstanceId, clientInfo,
+                                               ClientMetricsConfig.getClientSubscriptions)
+    // Add to the cache and if cache size > max entries then time to make some room by running
+    // GC to clean up all the expired entries in the cache.
+    ClientMetricsCache.getInstance.add(clientInstance)
+    ClientMetricsCache.runGCIfNeeded()
+    clientInstance
+  }
+
+}
+

--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -18,14 +18,13 @@ package kafka.server
 
 import java.util
 import java.util.Properties
-
 import kafka.server.metadata.ConfigRepository
 import kafka.utils.Log4jController
 import kafka.utils._
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.common.config.ConfigDef.ConfigKey
-import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, BROKER_LOGGER, TOPIC}
+import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, BROKER_LOGGER, CLIENT_METRICS, TOPIC}
 import org.apache.kafka.common.config.{ConfigDef, ConfigResource, LogLevelConfig}
 import org.apache.kafka.common.errors.{ApiException, ClusterAuthorizationException, InvalidConfigurationException, InvalidRequestException}
 import org.apache.kafka.common.message.{AlterConfigsRequestData, AlterConfigsResponseData, IncrementalAlterConfigsRequestData, IncrementalAlterConfigsResponseData}
@@ -153,6 +152,8 @@ class ConfigAdminManager(nodeId: Int,
               validateBrokerConfigChange(resource, configResource)
             case TOPIC =>
             // Nothing to do.
+            case CLIENT_METRICS =>
+            // Nothing to do.
             case _ =>
               throw new InvalidRequestException(s"Unknown resource type ${resource.resourceType().toInt}")
           }
@@ -252,6 +253,8 @@ class ConfigAdminManager(nodeId: Int,
               }
               validateBrokerConfigChange(resource, configResource)
             case TOPIC =>
+            // Nothing to do.
+            case CLIENT_METRICS=>
             // Nothing to do.
             case _ =>
               // Since legacy AlterConfigs does not support BROKER_LOGGER, any attempt to use it

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -226,6 +226,15 @@ class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
   }
 }
 
+/**
+ * The ClientMetricsConfigHandler will process individual client metrics subscription changes.
+ */
+class ClientMetricsConfigHandler() extends ConfigHandler with Logging {
+  def processConfigChanges(subscriptionGroupId: String, properties: Properties): Unit = {
+    ClientMetricsManager.getInstance.updateSubscription(subscriptionGroupId, properties)
+  }
+}
+
 object ThrottledReplicaListValidator extends Validator {
   def ensureValidString(name: String, value: String): Unit =
     ensureValid(name, value.split(",").map(_.trim).toSeq)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -235,6 +235,7 @@ object Defaults {
   val MetricSampleWindowMs = 30000
   val MetricReporterClasses = ""
   val MetricRecordingLevel = Sensor.RecordingLevel.INFO.toString()
+  val ClientMetricsDeltaTemporality = true
 
 
   /** ********* Kafka Yammer Metrics Reporter Configuration ***********/
@@ -977,7 +978,6 @@ object KafkaConfig {
   val MetricNumSamplesDoc = CommonClientConfigs.METRICS_NUM_SAMPLES_DOC
   val MetricReporterClassesDoc = CommonClientConfigs.METRIC_REPORTER_CLASSES_DOC
   val MetricRecordingLevelDoc = CommonClientConfigs.METRICS_RECORDING_LEVEL_DOC
-
 
   /** ********* Kafka Yammer Metrics Reporter Configuration ***********/
   val KafkaMetricsReporterClassesDoc = "A list of classes to use as Yammer metrics custom reporters." +

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -441,6 +441,7 @@ class KafkaServer(
         /* start dynamic config manager */
         dynamicConfigHandlers = Map[String, ConfigHandler](ConfigType.Topic -> new TopicConfigHandler(logManager, config, quotaManagers, Some(kafkaController)),
                                                            ConfigType.Client -> new ClientIdConfigHandler(quotaManagers),
+                                                           ConfigType.ClientMetrics -> new ClientMetricsConfigHandler,
                                                            ConfigType.User -> new UserConfigHandler(quotaManagers, credentialProvider),
                                                            ConfigType.Broker -> new BrokerConfigHandler(config, quotaManagers),
                                                            ConfigType.Ip -> new IpConfigHandler(socketServer.connectionQuotas))

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -400,6 +400,7 @@ class ZkAdminManager(val config: KafkaConfig,
         resource.`type` match {
           case ConfigResource.Type.TOPIC => alterTopicConfigs(resource, validateOnly, configProps, configEntriesMap)
           case ConfigResource.Type.BROKER => alterBrokerConfigs(resource, validateOnly, configProps, configEntriesMap)
+          case ConfigResource.Type.CLIENT_METRICS => alterClientMetricsSubscriptions(resource, validateOnly, configProps, configEntriesMap)
           case resourceType =>
             throw new InvalidRequestException(s"AlterConfigs is only supported for topics and brokers, but resource type is $resourceType")
         }
@@ -462,6 +463,19 @@ class ZkAdminManager(val config: KafkaConfig,
     resource -> ApiError.NONE
   }
 
+  private def alterClientMetricsSubscriptions(resource: ConfigResource,
+                                              validateOnly: Boolean,
+                                              configProps: Properties,
+                                              configEntriesMap: Map[String, String]): (ConfigResource, ApiError) = {
+    val subscriptionName = resource.name
+    if (!validateOnly) {
+      info(s"Updating client metrics subscription ${subscriptionName} with new configuration : ${toLoggableProps(resource, configProps).mkString(",")}")
+      adminZkClient.changeClientMetricsConfig(subscriptionName,
+        this.config.dynamicConfig.toPersistentProps(configProps, false))
+    }
+    resource -> ApiError.NONE
+  }
+
   private def getBrokerId(resource: ConfigResource) = {
     if (resource.name == null || resource.name.isEmpty)
       None
@@ -492,6 +506,11 @@ class ZkAdminManager(val config: KafkaConfig,
             val configProps = adminZkClient.fetchEntityConfig(ConfigType.Topic, resource.name)
             prepareIncrementalConfigs(alterConfigOps, configProps, LogConfig.configKeys)
             alterTopicConfigs(resource, validateOnly, configProps, configEntriesMap)
+
+          case ConfigResource.Type.CLIENT_METRICS =>
+            val configProps = adminZkClient.fetchEntityConfig(ConfigType.ClientMetrics, resource.name)
+            prepareIncrementalConfigs(alterConfigOps, configProps, LogConfig.configKeys)
+            alterClientMetricsSubscriptions(resource, validateOnly, configProps, configEntriesMap)
 
           case ConfigResource.Type.BROKER =>
             val brokerId = getBrokerId(resource)

--- a/core/src/main/scala/kafka/server/ZkConfigManager.scala
+++ b/core/src/main/scala/kafka/server/ZkConfigManager.scala
@@ -38,7 +38,8 @@ object ConfigType {
   val User = "users"
   val Broker = "brokers"
   val Ip = "ips"
-  val all = Seq(Topic, Client, User, Broker, Ip)
+  val ClientMetrics = "ClientMetrics"
+  val all = Seq(Topic, Client, User, Broker, Ip, ClientMetrics)
 }
 
 object ConfigEntityName {

--- a/core/src/main/scala/kafka/server/metadata/ConfigRepository.scala
+++ b/core/src/main/scala/kafka/server/metadata/ConfigRepository.scala
@@ -18,7 +18,6 @@
 package kafka.server.metadata
 
 import java.util.Properties
-
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type
 

--- a/core/src/main/scala/kafka/server/metadata/ZkConfigRepository.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkConfigRepository.scala
@@ -35,6 +35,7 @@ class ZkConfigRepository(adminZkClient: AdminZkClient) extends ConfigRepository 
     val configTypeForZk = configResource.`type` match {
       case Type.TOPIC => ConfigType.Topic
       case Type.BROKER => ConfigType.Broker
+      case Type.CLIENT_METRICS => ConfigType.ClientMetrics
       case tpe => throw new IllegalArgumentException(s"Unsupported config type: $tpe")
     }
     // ZK stores cluster configs under "<default>".

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -22,6 +22,7 @@ import kafka.admin.{AdminOperationException, AdminUtils, BrokerMetadata, RackAwa
 import kafka.common.TopicAlreadyMarkedForDeletionException
 import kafka.controller.ReplicaAssignment
 import kafka.log.LogConfig
+import kafka.metrics.clientmetrics.ClientMetricsConfig
 import kafka.server.{ConfigEntityName, ConfigType, DynamicConfig}
 import kafka.utils._
 import kafka.utils.Implicits._
@@ -481,6 +482,17 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
     */
   def validateBrokerConfig(configs: Properties): Unit = {
     DynamicConfig.Broker.validate(configs)
+  }
+
+  /**
+   * Update the client metrics subscription and create a change notification so the change
+   * will propagate to other brokers
+   * @param clientMetricsSubscriptionName: Name of the client metric subscription
+   * @param configs: Properties associated with the client metric subscription.
+   */
+  def changeClientMetricsConfig(clientMetricsSubscriptionName: String, configs: Properties): Unit = {
+    ClientMetricsConfig.validateConfig(clientMetricsSubscriptionName, configs)
+    changeEntityConfig(ConfigType.ClientMetrics, clientMetricsSubscriptionName, configs)
   }
 
   private def changeEntityConfig(rootEntityType: String, fullSanitizedEntityName: String, configs: Properties): Unit = {

--- a/core/src/test/scala/integration/kafka/api/TelemetryMetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TelemetryMetricsTest.scala
@@ -50,7 +50,7 @@ class TelemetryMetricsTest extends IntegrationTestHarness {
   @Test
   def testDisableMetricsPush(): Unit = {
     val properties = new Properties()
-    properties.put(ProducerConfig.ENABLE_METRICS_PUSH_CONFIG, false)
+    properties.put(ProducerConfig.ENABLE_METRICS_PUSH_CONFIG, "false")
     val producer = createProducer(configOverrides = properties)
     assertNull(producer.asInstanceOf[KafkaProducer[ByteArraySerializer, ByteArraySerializer]].clientTelemetry())
     val record = new ProducerRecord(topicName, "key".getBytes, "value".getBytes)

--- a/core/src/test/scala/kafka/metrics/ClientInstanceSelectorTest.scala
+++ b/core/src/test/scala/kafka/metrics/ClientInstanceSelectorTest.scala
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.metrics
+
+import kafka.metrics.clientmetrics.ClientMetricsConfig.ClientMatchingParams.{CLIENT_SOFTWARE_NAME, CLIENT_SOFTWARE_VERSION}
+import kafka.metrics.clientmetrics.CmClientInformation
+import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.errors.InvalidConfigurationException
+import org.junit.jupiter.api.Assertions.{assertFalse, assertThrows, assertTrue}
+import org.junit.jupiter.api.{Test, Timeout}
+
+import java.util.regex.PatternSyntaxException
+
+@Timeout(120)
+class ClientInstanceSelectorTest {
+
+  def createClientInstanceSelector(): CmClientInformation = {
+    val client_instance_id = Uuid.randomUuid().toString
+    val clientId = "testclient1"
+    val softwareName = "Apache.Java"
+    val softwareVersion = "89.2.0"
+    val clientHostAddress = "1.2.3.4"
+    val clientPort = "9092"
+    CmClientInformation(client_instance_id, clientId, softwareName, softwareVersion, clientHostAddress, clientPort)
+  }
+
+  @Test
+  def testClientMatchingPattern(): Unit = {
+    val selector = createClientInstanceSelector()
+
+    // Since we consider empty/missing client matching patterns is valid, make sure that they pass the check.
+    assertTrue(selector.isMatched(Map.empty))
+    assertTrue(selector.isMatched(null))
+
+    // '*' is considered as invalid regex pattern
+    assertFalse(selector.isMatched(Map("*" -> "*")))
+    assertFalse(selector.isMatched(Map("*" -> "abc")))
+    assertThrows(classOf[PatternSyntaxException],() =>
+      selector.isMatched(Map(CLIENT_SOFTWARE_NAME -> "*")))
+    assertThrows(classOf[PatternSyntaxException],() =>
+      selector.isMatched(Map(CLIENT_SOFTWARE_NAME -> "******")))
+    assertThrows(classOf[PatternSyntaxException],() =>
+      selector.isMatched(Map(CLIENT_SOFTWARE_NAME -> "*Something")))
+
+    // Make sure that pattern matching is anchored regex.
+    assertFalse(selector.isMatched(Map(CLIENT_SOFTWARE_NAME -> "O.Apache.Java", CLIENT_SOFTWARE_VERSION -> "8.1.*")))
+    assertFalse(selector.isMatched(Map(CLIENT_SOFTWARE_NAME -> "Apache.Java.D", CLIENT_SOFTWARE_VERSION -> "8.1.*")))
+
+    // Negative tests -  unknown matching entries.
+    assertFalse(selector.isMatched(Map("a" -> "b")))
+    assertFalse(selector.isMatched(Map("software" -> "Java")))
+
+    // Negative tests -- Wrong matching patterns
+    assertFalse(selector.isMatched(Map(CLIENT_SOFTWARE_NAME -> "Apache.Java", CLIENT_SOFTWARE_VERSION -> "8.1.*")))
+    assertFalse(selector.isMatched(Map("AAA" -> "BBB", CLIENT_SOFTWARE_VERSION -> "89.2.0")))
+    assertFalse(selector.isMatched(Map(CLIENT_SOFTWARE_VERSION -> "89.2.0", "AAA" -> "fff")))
+
+    // Positive tests
+    assertTrue(selector.isMatched(Map(CLIENT_SOFTWARE_NAME -> "Apache.Java")))
+    assertTrue(selector.isMatched(Map(CLIENT_SOFTWARE_NAME -> "Apache.*", CLIENT_SOFTWARE_VERSION -> "89.2.0")))
+    assertTrue(selector.isMatched(Map(CLIENT_SOFTWARE_NAME -> "Apa.he.*a", CLIENT_SOFTWARE_VERSION -> "^8.*0")))
+    assertTrue(selector.isMatched(Map(CLIENT_SOFTWARE_NAME -> "Apache.Java$", CLIENT_SOFTWARE_VERSION -> "8..2.*")))
+  }
+
+  @Test
+  def testMatchingPatternParser(): Unit = {
+    var res = CmClientInformation.parseMatchingPatterns(ClientMetricsTestUtils.defaultClientMatchPatters)
+    assertTrue(res.size == 2)
+
+    var patterns = List(s"${CLIENT_SOFTWARE_NAME}=*")
+    assertThrows(classOf[InvalidConfigurationException], () => CmClientInformation.parseMatchingPatterns(patterns))
+
+    patterns = List(s"${CLIENT_SOFTWARE_NAME}=*****")
+    assertThrows(classOf[InvalidConfigurationException], () => CmClientInformation.parseMatchingPatterns(patterns))
+
+    patterns = List("ABC=something")
+    assertThrows(classOf[InvalidConfigurationException], () => CmClientInformation.parseMatchingPatterns(patterns))
+
+    patterns = List(s"${CLIENT_SOFTWARE_NAME}=Java=1.4")
+    res = CmClientInformation.parseMatchingPatterns(patterns)
+    assertTrue(res.size == 1)
+    val value = res.get(CLIENT_SOFTWARE_NAME).get
+    assertTrue(value.equals("Java=1.4"))
+
+    val patterns2 = ClientMetricsTestUtils.defaultClientMatchPatters ++ List("ABC=something")
+    assertThrows(classOf[InvalidConfigurationException], () => CmClientInformation.parseMatchingPatterns(patterns2))
+  }
+
+}

--- a/core/src/test/scala/kafka/metrics/ClientMetricsCacheTest.scala
+++ b/core/src/test/scala/kafka/metrics/ClientMetricsCacheTest.scala
@@ -1,0 +1,267 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.metrics
+
+import kafka.metrics.ClientMetricsTestUtils.{createCMSubscription, createClientInstance, defaultMetrics, defaultPushInterval, getCM}
+import kafka.metrics.clientmetrics.ClientMetricsCache.DEFAULT_TTL_MS
+import kafka.metrics.clientmetrics.ClientMetricsConfig.ClientMatchingParams.{CLIENT_SOFTWARE_NAME, CLIENT_SOFTWARE_VERSION, CLIENT_SOURCE_ADDRESS}
+import kafka.metrics.clientmetrics.{ClientMetricsCache, ClientMetricsConfig, CmClientInformation}
+import kafka.utils.TestUtils
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.{AfterEach, Test}
+
+import java.util.Properties
+
+class ClientMetricsCacheTest {
+  @AfterEach
+  def cleanup(): Unit = {
+    ClientMetricsConfig.clearClientSubscriptions()
+    ClientMetricsCache.getInstance.clear()
+  }
+
+  @Test
+  def testClientMetricsSubscription(): Unit = {
+    // create a client metric subscription.
+    val subscription1 = createCMSubscription("cm_1")
+    assertTrue(subscription1 != null)
+
+    // create a client instance state object and make sure it picks up the metrics from the previously created
+    // metrics subscription.
+    val client = CmClientInformation("testClient1", "clientId", "Java", "11.1.0.1", "", "")
+    val clientState = createClientInstance(client)
+    val clientStateFromCache = getCM.getClientInstance(clientState.getId)
+    assertTrue(clientState == clientStateFromCache)
+    assertTrue(clientStateFromCache.getSubscriptions.size() == 1)
+    assertTrue(clientStateFromCache.getPushIntervalMs == defaultPushInterval)
+    assertTrue(clientStateFromCache.metrics.size == 2 &&
+               clientStateFromCache.getMetrics.mkString(",").equals(defaultMetrics))
+  }
+
+  @Test
+  def testAddingSubscriptionsAfterClients(): Unit = {
+    // create a client instance state object  when there are no client metrics subscriptions exists
+    val client = CmClientInformation("testClient1", "clientId", "Java", "11.1.0.1", "", "")
+    val clientState = createClientInstance(client)
+    var clientStateFromCache = getCM.getClientInstance(clientState.getId)
+    assertTrue(clientState == clientStateFromCache)
+    assertTrue(clientStateFromCache.getSubscriptions.isEmpty)
+    assertTrue(clientStateFromCache.getMetrics.isEmpty)
+    val oldSubscriptionId = clientStateFromCache.getSubscriptionId
+
+    // Now create a new client subscription and make sure the client instance is updated with the metrics.
+    createCMSubscription("cm_1")
+    clientStateFromCache = getCM.getClientInstance(clientState.getId)
+    assertTrue(clientStateFromCache.getSubscriptions.size() == 1)
+    assertTrue(clientStateFromCache.getPushIntervalMs == defaultPushInterval)
+    assertTrue(clientStateFromCache.getSubscriptionId != oldSubscriptionId)
+    assertTrue(clientStateFromCache.metrics.size == 2 &&
+      clientStateFromCache.getMetrics.mkString(",").equals(defaultMetrics))
+  }
+
+  @Test
+  def testAddingMultipleSubscriptions(): Unit = {
+    val props = new Properties()
+    val clientMatchPatterns = List(s"${CLIENT_SOFTWARE_NAME}=Java", s"${CLIENT_SOFTWARE_VERSION}=8.1.*")
+    props.put(ClientMetricsConfig.ClientMetrics.ClientMatchPattern, clientMatchPatterns.mkString(","))
+
+    // TEST-1: CREATE new metric subscriptions and make sure client instance picks up those metrics.
+    val subscription1 = createCMSubscription("cm_1")
+    val subscription2 = createCMSubscription("cm_2", props)
+    assertTrue(subscription1 != null && subscription2 != null)
+
+    // create a client instance state object and make sure every thing is in correct order.
+    val client = CmClientInformation("testClient1", "clientId", "Java", "11.1.0.1", "", "")
+    val clientState = createClientInstance(client)
+    val clientStateFromCache = getCM.getClientInstance(clientState.getId)
+    assertTrue(clientState == clientStateFromCache)
+
+    val res = clientState.getSubscriptions
+    assertTrue(res.size() == 1)
+    assertTrue(res.contains(subscription1))
+    assertTrue(clientState.getPushIntervalMs == defaultPushInterval)
+    assertTrue(clientState.metrics.size == 2 && clientState.metrics.mkString(",").equals(defaultMetrics))
+
+    // TEST-2: UPDATE the metrics subscription: Create update the metrics subscriptions by adding new
+    // subscription with different metrics and make sure that client instance object is updated
+    // with the new metric and new subscription id.
+    val metrics3 = "org.apache.kafka/client.producer.write.latency"
+    val props3 = new Properties()
+    props3.put(ClientMetricsConfig.ClientMetrics.SubscriptionMetrics, metrics3)
+    createCMSubscription("cm_3", props3)
+    val afterAddingNewSubscription = getCM.getClientInstance(clientState.getId)
+    assertTrue(clientStateFromCache.getId == afterAddingNewSubscription.getId)
+    assertTrue(clientState.getSubscriptionId != afterAddingNewSubscription.getSubscriptionId)
+    assertTrue(afterAddingNewSubscription.metrics.size == 3 &&
+      afterAddingNewSubscription.metrics.mkString(",").equals(defaultMetrics + "," + metrics3))
+
+    // TEST-3: UPDATE the first subscription's metrics and make sure
+    // client instance picked up the change.
+    val updated_metrics = "updated_metrics_for_clients"
+    val updatedProps = new Properties()
+    updatedProps.put(ClientMetricsConfig.ClientMetrics.SubscriptionMetrics, updated_metrics)
+    createCMSubscription("cm_1", updatedProps)
+    val afterSecondUpdate = getCM.getClientInstance(clientState.getId)
+    assertTrue(afterSecondUpdate.getId == afterAddingNewSubscription.getId)
+    assertTrue(afterSecondUpdate.getSubscriptionId != afterAddingNewSubscription.getSubscriptionId)
+    assertTrue(afterSecondUpdate.metrics.size == 2 &&
+      afterSecondUpdate.metrics.mkString(",").equals(metrics3 + "," + updated_metrics))
+
+    // TEST3: DELETE the metrics subscription: Delete the first subscription and make sure
+    // client instance is updated
+    val props4 = new Properties()
+    props4.put(ClientMetricsConfig.ClientMetrics.DeleteSubscription, "true")
+    createCMSubscription("cm_1", props4)
+
+    // subscription should have been deleted.
+    assertTrue(ClientMetricsConfig.getClientSubscriptionInfo("cm_1") == null)
+
+    val afterDeleting = getCM.getClientInstance(clientState.getId)
+    assertTrue(afterAddingNewSubscription.getId == afterDeleting.getId)
+    assertTrue(afterAddingNewSubscription.getSubscriptionId != afterDeleting.getSubscriptionId)
+    assertTrue(afterAddingNewSubscription.getSubscriptions.size() - afterDeleting.getSubscriptions.size() == 1)
+    assertTrue(afterDeleting.metrics.size == 1 && afterDeleting.metrics.mkString(",").equals(metrics3))
+  }
+
+  @Test
+  def testMultipleSubscriptionsAndClients(): Unit = {
+    createCMSubscription("cm_1")
+
+    val metrics2 = "org.apache.kafka/client.producer.write.latency"
+    val props2 = new Properties()
+    props2.put(ClientMetricsConfig.ClientMetrics.SubscriptionMetrics, metrics2)
+    createCMSubscription("cm_2", props2)
+
+    val props3 = new Properties()
+    val clientPatterns3 = List(s"${CLIENT_SOFTWARE_NAME}=Python", s"${CLIENT_SOFTWARE_VERSION}=8.*")
+    val metrics3 = "org.apache.kafka/client.consumer.read.latency"
+    props3.put(ClientMetricsConfig.ClientMetrics.SubscriptionMetrics, metrics3)
+    props3.put(ClientMetricsConfig.ClientMetrics.ClientMatchPattern, clientPatterns3.mkString(","))
+    createCMSubscription("cm_3", props3)
+
+    val props4 = new Properties()
+    val clientPatterns4 = List(s"${CLIENT_SOFTWARE_NAME}=Python",
+                               s"${CLIENT_SOFTWARE_VERSION}=8.*",
+                               s"${CLIENT_SOURCE_ADDRESS} = 1.2.3.4")
+    val metrics4 = "org.apache.kafka/client.consumer.*.latency"
+    props4.put(ClientMetricsConfig.ClientMetrics.ClientMatchPattern, clientPatterns4.mkString(","))
+    props4.put(ClientMetricsConfig.ClientMetrics.SubscriptionMetrics, metrics4)
+    createCMSubscription("cm_4", props4)
+    assertTrue(ClientMetricsConfig.getSubscriptionsCount == 4)
+
+    val client1 = createClientInstance(CmClientInformation("testClient1", "Id1", "Java", "11.1.0.1", "", ""))
+    val client2 = createClientInstance(CmClientInformation("testClient2", "Id2", "Python", "8.2.1", "abcd", "0"))
+    val client3 = createClientInstance(CmClientInformation("testClient3", "Id3", "C++", "12.1", "192.168.1.7", "9093"))
+    val client4 = createClientInstance(CmClientInformation("testClient4", "Id4", "Java", "11.1", "1.2.3.4", "8080"))
+    val client5 = createClientInstance(CmClientInformation("testClient2", "Id5", "Python", "8.2.1", "1.2.3.4", "0"))
+    assertTrue(ClientMetricsCache.getInstance.getSize == 5)
+
+    // Verifications:
+    // Client 1 should have the metrics from the subscription1 and subscription2
+    assertTrue(client1.getMetrics.mkString(",").equals(defaultMetrics + "," + metrics2))
+
+    // Client 2 should have the subscription3 which is just default metrics
+    assertTrue(client2.getMetrics.mkString(",").equals(metrics3))
+
+    // client 3 should end up with nothing.
+    assertTrue(client3.getMetrics.isEmpty)
+
+    // Client 4 should have the metrics from subscription1 and subscription2
+    assertTrue(client4.getMetrics.mkString(",").equals(defaultMetrics + "," + metrics2))
+
+    // Client 5 should have the metrics from subscription-3 and subscription-4
+    assertTrue(client5.getMetrics.mkString(",").equals(metrics3 + "," + metrics4))
+  }
+
+  @Test
+  def testMultipleClientsAndSubscriptions(): Unit = {
+    // Create the Client instances first
+    val client1 = createClientInstance(CmClientInformation("t1", "c1", "Java", "11.1.0.1", "", "")).getId
+    val client2 = createClientInstance(CmClientInformation("t2", "c2", "Python", "8.2.1", "abcd", "0")).getId
+    val client3 = createClientInstance(CmClientInformation("t3", "c3", "C++", "12.1", "192.168.1.7", "9093")).getId
+    val client4 = createClientInstance(CmClientInformation("t4", "c4", "Java", "11.1", "1.2.3.4", "8080")).getId
+    val client5 = createClientInstance(CmClientInformation("t5", "c5", "Python", "8.2.1", "1.2.3.4", "0")).getId
+    assertTrue(ClientMetricsCache.getInstance.getSize == 5)
+
+    // Now create the subscriptions.
+    createCMSubscription("cm_1")
+
+    val metrics2 = "org.apache.kafka/client.producer.write.latency"
+    val props2 = new Properties()
+    props2.put(ClientMetricsConfig.ClientMetrics.SubscriptionMetrics, metrics2)
+    createCMSubscription("cm_2", props2)
+
+    val props3 = new Properties()
+    val clientPatterns3 = List(s"${CLIENT_SOFTWARE_NAME}=Python", s"${CLIENT_SOFTWARE_VERSION}=8.*")
+    val metrics3 = "org.apache.kafka/client.consumer.read.latency"
+    props3.put(ClientMetricsConfig.ClientMetrics.SubscriptionMetrics, metrics3)
+    props3.put(ClientMetricsConfig.ClientMetrics.ClientMatchPattern, clientPatterns3.mkString(","))
+    createCMSubscription("cm_3", props3)
+
+    val props4 = new Properties()
+    val clientPatterns4 = List(s"${CLIENT_SOFTWARE_NAME}=Python",
+                               s"${CLIENT_SOFTWARE_VERSION}=8.*",
+                               s"${CLIENT_SOURCE_ADDRESS} = 1.2.3.4")
+    val metrics4 = "org.apache.kafka/client.consumer.*.latency"
+    props4.put(ClientMetricsConfig.ClientMetrics.ClientMatchPattern, clientPatterns4.mkString(","))
+    props4.put(ClientMetricsConfig.ClientMetrics.SubscriptionMetrics, metrics4)
+    createCMSubscription("cm_4", props4)
+    assertTrue(ClientMetricsConfig.getSubscriptionsCount == 4)
+
+    // Verifications:
+    // Client 1 should have the metrics from subscription1 and subscription2
+    assertTrue(getCM.getClientInstance(client1).getMetrics.mkString(",").equals(defaultMetrics + "," + metrics2))
+
+    // Client 2 should have the subscription3 which is just default metrics
+    assertTrue(getCM.getClientInstance(client2).getMetrics.mkString(",").equals(metrics3))
+
+    // client 3 should end up with nothing.
+    assertTrue(getCM.getClientInstance(client3).getMetrics.isEmpty)
+
+    // Client 4 should have the metrics from subscription1 and subscription2
+    assertTrue(getCM.getClientInstance(client4).getMetrics.mkString(",").equals(defaultMetrics + "," + metrics2))
+
+    // Client 5 should have the metrics from subscription-3 and subscription-4
+    assertTrue(getCM.getClientInstance(client5).getMetrics.mkString(",").equals(metrics3 + "," + metrics4))
+  }
+
+
+  @Test
+  def testCacheGC(): Unit = {
+    val cache = ClientMetricsCache.getInstance
+    val client1 = createClientInstance(CmClientInformation("testClient1", "clientId1", "Java", "11.1.0.1", "", ""))
+    val client2 = createClientInstance(CmClientInformation("testClient2", "clientId2", "Python", "8.2.1", "", ""))
+    val client3 = createClientInstance(CmClientInformation("testClient3", "clientId3", "C++", "12.1", "", ""))
+    assertTrue(cache.getSize == 3)
+
+    // Modify client3's timestamp to meet the TTL expiry limit.
+    val ts = client3.getLastAccessTs.getTime -
+                    (Math.max(3 * client3.getPushIntervalMs, DEFAULT_TTL_MS) + 10)
+    client3.updateLastAccessTs(ts)
+    ClientMetricsCache.gcTs.setTime(ClientMetricsCache.gcTs.getTime - (ClientMetricsCache.CM_CACHE_GC_INTERVAL_MS + 10))
+
+    // Run the GC and wait until client3 entry is removed from the cache
+    ClientMetricsCache.runGCIfNeeded(true)
+    TestUtils.waitUntilTrue(() => ClientMetricsCache.getInstance.getSize == 2, "Failed to run GC on Client Metrics Cache", 6000)
+
+    // Make sure that client3 is removed from the cache.
+    assertTrue(cache.get(client3.getId) == null)
+
+    // client1 and client2 should remain in the cache.
+    assertTrue(cache.get(client1.getId) != null)
+    assertTrue(cache.get(client2.getId) != null)
+  }
+}

--- a/core/src/test/scala/kafka/metrics/ClientMetricsConfigValidationTest.scala
+++ b/core/src/test/scala/kafka/metrics/ClientMetricsConfigValidationTest.scala
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.metrics
+
+import kafka.metrics.clientmetrics.ClientMetricsConfig
+import org.apache.kafka.common.errors.InvalidConfigurationException
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+import java.util.Properties
+
+class ClientMetricsConfigValidationTest {
+
+  @Test
+  def testClientMetricsConfigParameters(): Unit = {
+    val groupName: String = "subscription-1"
+    val metrics = "org.apache.kafka/client.producer.partition.queue.,org.apache.kafka/client.producer.partition.latency"
+    val clientMatchingPattern = "client_instance_id=b69cc35a-7a54-4790-aa69-cc2bd4ee4538"
+
+    val props = new Properties()
+
+    // Test-1: Missing parameters (add one after one until all the required params are added)
+    assertThrows(classOf[IllegalArgumentException], () => ClientMetricsConfig.validateConfig(groupName, props))
+
+    val interval = -1
+    props.put(ClientMetricsConfig.ClientMetrics.PushIntervalMs, interval.toString)
+    assertThrows(classOf[IllegalArgumentException], () => ClientMetricsConfig.validateConfig(groupName, props))
+
+    props.put(ClientMetricsConfig.ClientMetrics.PushIntervalMs, 2000.toString)
+    assertThrows(classOf[IllegalArgumentException], () => ClientMetricsConfig.validateConfig(groupName, props))
+
+    props.put(ClientMetricsConfig.ClientMetrics.SubscriptionMetrics, metrics)
+    ClientMetricsConfig.validateConfig(groupName, props)
+
+    props.put(ClientMetricsConfig.ClientMetrics.ClientMatchPattern, "client_software_name=*")
+    assertThrows(classOf[InvalidConfigurationException], () => ClientMetricsConfig.validateConfig(groupName, props))
+
+    props.put(ClientMetricsConfig.ClientMetrics.ClientMatchPattern, clientMatchingPattern)
+    ClientMetricsConfig.validateConfig(groupName, props)
+
+    props.put("INVALID_PARAMETER", "INVALID_ARGUMENT")
+    assertThrows(classOf[IllegalArgumentException], () => ClientMetricsConfig.validateConfig(groupName, props))
+
+    props.remove("INVALID_PARAMETER")
+    ClientMetricsConfig.validateConfig(groupName, props)
+
+    // TEST-2: Delete the metric subscription
+    props.clear()
+    props.put(ClientMetricsConfig.ClientMetrics.DeleteSubscription, "true")
+    ClientMetricsConfig.validateConfig(groupName, props)
+
+    // TEST-3: subscription with all metrics flag
+    props.clear()
+    props.put(ClientMetricsConfig.ClientMetrics.AllMetricsFlag, "true")
+    assertThrows(classOf[IllegalArgumentException], () => ClientMetricsConfig.validateConfig(groupName, props))
+    props.put(ClientMetricsConfig.ClientMetrics.ClientMatchPattern, clientMatchingPattern)
+    assertThrows(classOf[IllegalArgumentException], () => ClientMetricsConfig.validateConfig(groupName, props))
+    props.put(ClientMetricsConfig.ClientMetrics.PushIntervalMs, 2000.toString)
+    ClientMetricsConfig.validateConfig(groupName, props)
+  }
+
+}

--- a/core/src/test/scala/kafka/metrics/ClientMetricsRequestReponseTest.scala
+++ b/core/src/test/scala/kafka/metrics/ClientMetricsRequestReponseTest.scala
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.metrics
+
+import kafka.metrics.ClientMetricsTestUtils.{createCMSubscription, getCM}
+import kafka.metrics.clientmetrics.ClientMetricsConfig.ClientMatchingParams.{CLIENT_SOFTWARE_NAME, CLIENT_SOFTWARE_VERSION}
+import kafka.metrics.clientmetrics.ClientMetricsConfig.ClientMetrics
+import kafka.metrics.clientmetrics.{ClientMetricsCache, ClientMetricsConfig, CmClientInformation}
+import kafka.server.ClientMetricsManager
+import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.record.CompressionType
+import org.apache.kafka.common.requests.{GetTelemetrySubscriptionRequest, GetTelemetrySubscriptionResponse}
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.{AfterEach, Test}
+
+import java.util.Properties
+
+class ClientMetricsRequestResponseTest {
+
+  @AfterEach
+  def cleanup(): Unit = {
+    ClientMetricsConfig.clearClientSubscriptions()
+    ClientMetricsCache.getInstance.clear()
+  }
+
+  private def sendGetSubscriptionRequest(clientInfo: CmClientInformation,
+                                         id: Uuid = Uuid.ZERO_UUID): GetTelemetrySubscriptionResponse = {
+    val request = new GetTelemetrySubscriptionRequest.Builder(id).build(0);
+    getCM.processGetSubscriptionRequest(request, clientInfo, 20)
+  }
+
+  @Test def testGetClientMetricsRequestAndResponse(): Unit = {
+    val subscription1 = createCMSubscription("cm_1")
+    assertTrue(subscription1 != null)
+
+    val clientInfo = CmClientInformation("testClient1", "clientId3", "Java", "11.1.0", "192.168.1.7", "9093")
+    val response = sendGetSubscriptionRequest(clientInfo).data()
+    assertTrue(response != null)
+    val clientInstanceId = response.clientInstanceId()
+
+    // verify all the parameters ..
+    assertTrue(clientInstanceId != Uuid.ZERO_UUID)
+    val cmClient = getCM.getClientInstance(clientInstanceId)
+    assertTrue(cmClient != null)
+
+    assertTrue(response.throttleTimeMs() == 20)
+    assertTrue(response.deltaTemporality() == java.lang.Boolean.TRUE)
+    assertTrue(response.pushIntervalMs() == cmClient.getPushIntervalMs)
+    assertTrue(response.subscriptionId() == cmClient.getSubscriptionId)
+
+    assertTrue(response.requestedMetrics().size == cmClient.getMetrics.size)
+    response.requestedMetrics().forEach(x => assertTrue(cmClient.getMetrics.contains(x)))
+
+    assertTrue(response.acceptedCompressionTypes().size() == ClientMetricsManager.getSupportedCompressionTypes.size)
+
+    response.acceptedCompressionTypes().forEach(x => {
+      assertTrue(ClientMetricsManager.getSupportedCompressionTypes.contains(x))
+      assertTrue(CompressionType.values().contains(CompressionType.forId(x.toInt)))
+    })
+  }
+
+  @Test def testRequestAndResponseWithNoMatchingMetrics(): Unit = {
+    val subscription1 = createCMSubscription("cm_2")
+    assertTrue(subscription1 != null)
+
+    // Create a python client that do not have any matching subscriptions.
+    val clientInfo = CmClientInformation("testClient1", "clientId3", "Python", "11.1.0", "192.168.1.7", "9093")
+    var response = sendGetSubscriptionRequest(clientInfo).data()
+    var cmClient = getCM.getClientInstance(response.clientInstanceId())
+    val clientInstanceId = response.clientInstanceId()
+
+    // Push interval must be set to the default push interval and requested metrics list should be empty
+    assertTrue(response.pushIntervalMs() == ClientMetrics.DEFAULT_PUSH_INTERVAL &&
+               response.pushIntervalMs() != subscription1.getPushIntervalMs)
+    assertTrue(response.subscriptionId() == cmClient.getSubscriptionId)
+    assertTrue(response.requestedMetrics().isEmpty)
+
+    // Now create a client subscription with client id that matches with the client.
+    val props = new Properties()
+    val clientMatch = List(s"${CLIENT_SOFTWARE_NAME}=Python", s"${CLIENT_SOFTWARE_VERSION}=11.1.*")
+    props.put(ClientMetricsConfig.ClientMetrics.ClientMatchPattern, clientMatch.mkString(","))
+    val subscription2 = createCMSubscription("cm_2", props)
+    assertTrue(subscription2 != null)
+
+    // should have got the positive response with all the valid parameters
+    response = sendGetSubscriptionRequest(clientInfo, clientInstanceId).data()
+    cmClient = getCM.getClientInstance(clientInstanceId)
+    assertTrue(response.pushIntervalMs() == subscription2.getPushIntervalMs)
+    assertTrue(response.subscriptionId() == cmClient.getSubscriptionId)
+    assertTrue(!response.requestedMetrics().isEmpty)
+    response.requestedMetrics().forEach(x => assertTrue(cmClient.getMetrics.contains(x)))
+  }
+
+  @Test def testRequestWithAllMetricsSubscription(): Unit = {
+    val clientInfo = CmClientInformation("testClient1", "clientId3", "Java", "11.1.0", "192.168.1.7", "9093")
+
+    // Add first subscription with default metrics.
+    createCMSubscription("subscription1")
+
+    // Add second subscription that contains allMetrics flag set to true
+    val props = new Properties
+    props.put(ClientMetricsConfig.ClientMetrics.AllMetricsFlag, "true")
+    val subscription1 = createCMSubscription("cm_all_metrics", props)
+    assertTrue(subscription1 != null)
+
+    val response = sendGetSubscriptionRequest(clientInfo).data()
+
+    // verify all the parameters ..
+    assertTrue(response.clientInstanceId() != Uuid.ZERO_UUID)
+    val cmClient = getCM.getClientInstance(response.clientInstanceId())
+    assertTrue(cmClient != null)
+    assertTrue(response.pushIntervalMs() == cmClient.getPushIntervalMs)
+    assertTrue(response.subscriptionId() == cmClient.getSubscriptionId)
+    assertTrue(response.requestedMetrics().size() == 1)
+    assertTrue(response.requestedMetrics().get(0).isEmpty)
+  }
+
+  @Test def testRequestWithDisabledClient(): Unit = {
+    val clientInfo = CmClientInformation("testClient5", "clientId5", "Java", "11.1.0", "192.168.1.7", "9093")
+
+    val subscription1 = createCMSubscription("cm_4")
+    assertTrue(subscription1 != null)
+
+    // Submit a request to get the subscribed metrics
+    var response = sendGetSubscriptionRequest(clientInfo).data()
+    val clientInstanceId = response.clientInstanceId()
+    var cmClient = getCM.getClientInstance(clientInstanceId)
+    assertTrue(cmClient != null)
+
+    val oldSubscriptionId = response.subscriptionId()
+    assertTrue(response.pushIntervalMs() == subscription1.getPushIntervalMs)
+    assertTrue(response.subscriptionId() == cmClient.getSubscriptionId)
+    response.requestedMetrics().forEach(x => assertTrue(subscription1.getSubscribedMetrics.contains(x)))
+
+    // Now create a new client subscription with push interval set to 0.
+    val props = new Properties()
+    props.put(ClientMetrics.PushIntervalMs, 0.toString)
+    val subscription2 = createCMSubscription("cm_update_2_disable", props)
+    assertTrue(subscription2 != null)
+
+    // should have got the invalid response with empty metrics list.
+    // set the client instance id which is obtained in earlier request.
+    val res = sendGetSubscriptionRequest(clientInfo, clientInstanceId)
+    cmClient = getCM.getClientInstance(clientInstanceId)
+    assertTrue(cmClient != null)
+
+    response = res.data()
+    assertTrue(response.pushIntervalMs() == 0)
+    assertTrue(response.requestedMetrics().isEmpty)
+    assertTrue(oldSubscriptionId != response.subscriptionId())
+    assertTrue(response.subscriptionId() == cmClient.getSubscriptionId)
+  }
+}

--- a/core/src/test/scala/kafka/metrics/ClientMetricsTestUtils.scala
+++ b/core/src/test/scala/kafka/metrics/ClientMetricsTestUtils.scala
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.metrics
+
+import kafka.metrics.clientmetrics.ClientMetricsConfig.ClientMatchingParams.{CLIENT_SOFTWARE_NAME, CLIENT_SOFTWARE_VERSION}
+import kafka.metrics.clientmetrics.ClientMetricsConfig.SubscriptionInfo
+import kafka.metrics.clientmetrics.{ClientMetricsConfig, CmClientInformation, CmClientInstanceState}
+import kafka.server.ClientMetricsManager
+import org.apache.kafka.common.Uuid
+
+import java.util.Properties
+
+object ClientMetricsTestUtils {
+  val defaultPushInterval = 30 * 1000 // 30 seconds
+
+  val defaultMetrics =
+    "org.apache.kafka/client.producer.partition.queue.,org.apache.kafka/client.producer.partition.latency"
+
+  val defaultClientMatchPatters =
+    List(s"${CLIENT_SOFTWARE_NAME}=Java", s"${CLIENT_SOFTWARE_VERSION}=11.1.*")
+
+  val cmInstance :ClientMetricsManager = ClientMetricsManager.getInstance
+  def getCM = cmInstance
+
+  def updateClientSubscription(subscriptionId :String, properties: Properties): Unit = {
+    getCM.updateSubscription(subscriptionId, properties)
+  }
+
+  def createClientInstance(selector: CmClientInformation): CmClientInstanceState = {
+    getCM.createClientInstance(Uuid.randomUuid(), selector)
+  }
+
+  def getDefaultProperties() :Properties = {
+    val props = new Properties()
+    props.put(ClientMetricsConfig.ClientMetrics.SubscriptionMetrics, defaultMetrics)
+    props.put(ClientMetricsConfig.ClientMetrics.ClientMatchPattern, defaultClientMatchPatters.mkString(","))
+    props.put(ClientMetricsConfig.ClientMetrics.PushIntervalMs, defaultPushInterval.toString)
+    props
+  }
+
+  def createCMSubscription(subscriptionId: String, overrideProps: Properties = null): SubscriptionInfo = {
+    val props = getDefaultProperties()
+    if (overrideProps != null) {
+      overrideProps.entrySet().forEach(x => props.put(x.getKey, x.getValue))
+    }
+    updateClientSubscription(subscriptionId, props)
+    ClientMetricsConfig.getClientSubscriptionInfo(subscriptionId)
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -30,6 +30,7 @@ import kafka.coordinator.group.GroupCoordinatorConcurrencyTest.{JoinGroupCallbac
 import kafka.coordinator.group._
 import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinator}
 import kafka.log.AppendOrigin
+import kafka.metrics.ClientMetricsTestUtils
 import kafka.network.RequestChannel
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.metadata.{ConfigRepository, KRaftMetadataCache, MockConfigRepository, ZkMetadataCache}
@@ -461,6 +462,128 @@ class KafkaApisTest {
   def testElectLeadersForwarding(): Unit = {
     val requestBuilder = new ElectLeadersRequest.Builder(ElectionType.PREFERRED, null, 30000)
     testKraftForwarding(ApiKeys.ELECT_LEADERS, requestBuilder)
+  }
+
+  @Test
+  def testAlterConfigsClientMetrics(): Unit = {
+    val subscriptionName = "client_metric_subscription_1"
+    val authorizedResource = new ConfigResource(ConfigResource.Type.CLIENT_METRICS, subscriptionName)
+
+    val authorizer: Authorizer = mock(classOf[Authorizer])
+    authorizeResource(authorizer, AclOperation.ALTER_CONFIGS, ResourceType.CLIENT_METRICS,
+      subscriptionName, AuthorizationResult.ALLOWED)
+
+    val props = ClientMetricsTestUtils.getDefaultProperties()
+    val configEntries = new util.ArrayList[AlterConfigsRequest.ConfigEntry]()
+    props.forEach((x, y) =>
+      configEntries.add(new AlterConfigsRequest.ConfigEntry(x.asInstanceOf[String], y.asInstanceOf[String])))
+
+    val configs = Map(authorizedResource -> new AlterConfigsRequest.Config(configEntries))
+
+    val requestHeader = new RequestHeader(ApiKeys.ALTER_CONFIGS, ApiKeys.ALTER_CONFIGS.latestVersion, clientId, 0)
+    val request = buildRequest(
+      new AlterConfigsRequest.Builder(configs.asJava, false).build(requestHeader.apiVersion))
+
+    when(controller.isActive).thenReturn(false)
+    when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
+      any[Long])).thenReturn(0)
+    when(adminManager.alterConfigs(any(), ArgumentMatchers.eq(false)))
+      .thenReturn(Map(authorizedResource -> ApiError.NONE))
+
+    createKafkaApis(authorizer = Some(authorizer)).handleAlterConfigsRequest(request)
+    val capturedResponse = verifyNoThrottling(request)
+    verifyAlterConfigResult(capturedResponse, Map(subscriptionName -> Errors.NONE))
+    verify(adminManager).alterConfigs(any(), anyBoolean())
+  }
+
+  private def getIncrementalCMAlterConfigRequestBuilder(configResources: Seq[ConfigResource]): IncrementalAlterConfigsRequest.Builder = {
+    val resourceMap = configResources.map(configResource => {
+      val entryToBeModified = new ConfigEntry("client.metrics.subscription.metrics", "foo.bar")
+      configResource -> Set(new AlterConfigOp(entryToBeModified, OpType.SET)).asJavaCollection
+    }).toMap.asJava
+    new IncrementalAlterConfigsRequest.Builder(resourceMap, false)
+  }
+
+  @Test
+  def testIncrementalClientMetricAlterConfigs(): Unit = {
+    val authorizer: Authorizer = mock(classOf[Authorizer])
+
+    val subscriptionName = "client_metric_subscription_1"
+    val authorizedResource = new ConfigResource(ConfigResource.Type.CLIENT_METRICS, subscriptionName)
+
+    authorizeResource(authorizer, AclOperation.ALTER_CONFIGS, ResourceType.CLIENT_METRICS,
+      subscriptionName, AuthorizationResult.ALLOWED)
+
+    val requestHeader = new RequestHeader(ApiKeys.INCREMENTAL_ALTER_CONFIGS,
+      ApiKeys.INCREMENTAL_ALTER_CONFIGS.latestVersion, clientId, 0)
+
+    val incrementalAlterConfigsRequest = getIncrementalCMAlterConfigRequestBuilder(Seq(authorizedResource)).build(requestHeader.apiVersion)
+    val request = buildRequest(incrementalAlterConfigsRequest,
+      fromPrivilegedListener = true, requestHeader = Option(requestHeader))
+
+    when(controller.isActive).thenReturn(true)
+    when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
+      any[Long])).thenReturn(0)
+    when(adminManager.incrementalAlterConfigs(any(), ArgumentMatchers.eq(false)))
+      .thenReturn(Map(authorizedResource -> ApiError.NONE))
+
+    createKafkaApis(authorizer = Some(authorizer)).handleIncrementalAlterConfigsRequest(request)
+    val capturedResponse = verifyNoThrottling(request)
+    verifyIncrementalAlterConfigResult(capturedResponse, Map(subscriptionName -> Errors.NONE ))
+    verify(adminManager).incrementalAlterConfigs(any(), anyBoolean())
+  }
+
+  @Test
+  def testDescribeConfigsClientMetrics(): Unit = {
+    val authorizer: Authorizer = mock(classOf[Authorizer])
+    val operation = AclOperation.DESCRIBE_CONFIGS
+    val resourceType = ResourceType.CLIENT_METRICS
+    val resourceName = "client_metric_subscription_1"
+    val requestHeader =
+      new RequestHeader(ApiKeys.DESCRIBE_CONFIGS, ApiKeys.DESCRIBE_CONFIGS.latestVersion, clientId, 0)
+    val expectedActions = Seq(
+      new Action(operation, new ResourcePattern(resourceType, resourceName, PatternType.LITERAL),
+        1, true, true)
+    )
+    // Verify that authorize is only called once
+    when(authorizer.authorize(any[RequestContext], ArgumentMatchers.eq(expectedActions.asJava)))
+      .thenReturn(Seq(AuthorizationResult.ALLOWED).asJava)
+
+    val resource = new ConfigResource(ConfigResource.Type.CLIENT_METRICS, resourceName)
+    val configRepository: ConfigRepository = mock(classOf[ConfigRepository])
+    val cmConfigs = ClientMetricsTestUtils.getDefaultProperties()
+    when(configRepository.config(resource)).thenReturn(cmConfigs)
+
+    metadataCache = mock(classOf[ZkMetadataCache])
+    when(metadataCache.contains(resourceName)).thenReturn(true)
+
+    val describeConfigsRequest = new DescribeConfigsRequest.Builder(new DescribeConfigsRequestData()
+      .setIncludeSynonyms(true)
+      .setResources(List(new DescribeConfigsRequestData.DescribeConfigsResource()
+        .setResourceName(resourceName)
+        .setResourceType(ConfigResource.Type.CLIENT_METRICS.id)).asJava))
+      .build(requestHeader.apiVersion)
+    val request = buildRequest(describeConfigsRequest,
+      requestHeader = Option(requestHeader))
+    when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
+      any[Long])).thenReturn(0)
+
+    createKafkaApis(authorizer = Some(authorizer), configRepository = configRepository)
+      .handleDescribeConfigsRequest(request)
+
+    verify(authorizer).authorize(any(), ArgumentMatchers.eq(expectedActions.asJava))
+
+    val capturedResponse = verifyNoThrottling(request)
+    verify(authorizer)
+    val response = capturedResponse.getValue.asInstanceOf[DescribeConfigsResponse]
+    val results = response.data().results()
+    assertEquals(1, results.size())
+    val describeConfigsResult: DescribeConfigsResult = results.get(0)
+
+    assertEquals(ConfigResource.Type.CLIENT_METRICS.id, describeConfigsResult.resourceType())
+    assertEquals(resourceName, describeConfigsResult.resourceName())
+    val configs = describeConfigsResult.configs()
+    assertEquals(cmConfigs.size(), configs.size())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/metadata/ZkConfigRepositoryTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/ZkConfigRepositoryTest.scala
@@ -48,7 +48,7 @@ class ZkConfigRepositoryTest {
   def testUnsupportedTypes(): Unit = {
     val zkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
     val zkConfigRepository = ZkConfigRepository(zkClient)
-    Type.values().foreach(value => if (value != Type.BROKER && value != Type.TOPIC)
+    Type.values().foreach(value => if (value != Type.BROKER && value != Type.TOPIC && value != Type.CLIENT_METRICS)
       assertThrows(classOf[IllegalArgumentException], () => zkConfigRepository.config(new ConfigResource(value, value.toString))))
   }
 }


### PR DESCRIPTION
Handling errors according to kip-714



..AuthorizationFailed | Client is not permitted to send metrics. | Log a warning to the application and schedule the next GetTelemetrySubscriptionsRequest in 30 minutes.
-- | -- | --
InvalidRecord | Broker failed to decode or validate the client’s encoded metrics. | Log a warning to the application and schedule the next GetTelemetrySubscriptionsRequest to 5 minutes.
UnknownSubscriptionId | Client sent a PushTelemetryRequest with an invalid or outdated SubscriptionId, the configured subscriptions have changed. | Send a GetTelemetrySubscriptionRequest to update the client's subscriptions.
UnsupportedCompressionType | Client’s compression type is not supported by the broker. | Send a GetTelemetrySubscriptionRequest to get an up to date list of the broker's supported compression types (and any subscription changes).

