### PR TITLE
Assign warmups to tasks in priority order

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovement.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovement.java
@@ -101,7 +101,8 @@ final class TaskMovement {
 
         final int movementsNeeded = taskMovements.size();
 
-        for (final TaskMovement movement : taskMovements) {
+        while (!taskMovements.isEmpty()) {
+            final TaskMovement movement = taskMovements.poll();
             final UUID standbySourceClient = caughtUpClientsByTaskLoad.poll(
                 movement.task,
                 c -> clientStates.get(c).hasStandbyTask(movement.task)

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
@@ -168,15 +168,10 @@ public class TaskMovementTest {
         assertThat(client2, hasProperty("activeTasks", ClientState::activeTasks, mkSet(TASK_0_2)));
         assertThat(client3, hasProperty("activeTasks", ClientState::activeTasks, mkSet(TASK_0_1)));
 
-        // we should only assign one warmup, but it could be either one that needs to be migrated.
+        // we should only assign one warmup, and the task movement should have the highest priority
         assertThat(client1, hasProperty("standbyTasks", ClientState::standbyTasks, mkSet()));
-        try {
-            assertThat(client2, hasProperty("standbyTasks", ClientState::standbyTasks, mkSet(TASK_0_1)));
-            assertThat(client3, hasProperty("standbyTasks", ClientState::standbyTasks, mkSet()));
-        } catch (final AssertionError ignored) {
-            assertThat(client2, hasProperty("standbyTasks", ClientState::standbyTasks, mkSet()));
-            assertThat(client3, hasProperty("standbyTasks", ClientState::standbyTasks, mkSet(TASK_0_2)));
-        }
+        assertThat(client2, hasProperty("standbyTasks", ClientState::standbyTasks, mkSet(TASK_0_1)));
+        assertThat(client3, hasProperty("standbyTasks", ClientState::standbyTasks, mkSet()));
     }
 
     @Test


### PR DESCRIPTION
As described on https://docs.oracle.com/javase/8/docs/api/java/util/PriorityQueue.html, the iterator doesn't guarantee to traverse the elements in priority order:

> The Iterator provided in method iterator() is not guaranteed to traverse the elements of the priority queue in any particular order. If you need ordered traversal, consider using Arrays.sort(pq.toArray()).

I think the reason why you use `PriorityQueue` for `taskMovements` is to assign warmup replicas to tasks that have few caught-up clients, and if so, it is inappropriate to use the iterator.

Here is an example:

```java
import java.util.Comparator;
import java.util.PriorityQueue;
import java.util.Queue;

public class PriorityQueueExample {
    public static void main(String[] args) {
        final Queue<Task> queue = new PriorityQueue<>(
                Comparator.comparing(Task::numCaughtUpClients).thenComparing(Task::id)
        );

        queue.add(new Task(1, 0));
        queue.add(new Task(1, 2));
        queue.add(new Task(1, 1));

        System.out.println("Traverse elements");
        for (Task task : queue) {
            System.out.println(task);
        }

        System.out.println("Poll elements");
        while (!queue.isEmpty()) {
            System.out.println(queue.poll());
        }
    }

    private static class Task {
        private int num;
        private int id;

        Task(int num, int id) {
            this.num = num;
            this.id = id;
        }

        private int numCaughtUpClients() {
            return num;
        }

        private int id() {
            return id;
        }

        public String toString() {
            return num + "-" + id;
        }
    }
}
```

In my environment, the output is like below:

```
Traverse elements
1-0
1-2
1-1
Poll elements
1-0
1-1
1-2
```

Here is my environment information:

```
% java -version
openjdk version "1.8.0_282"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_282-b08)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.282-b08, mixed mode)
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
