### PR TITLE
KSECURITY-220: Update jackson packages to 2.13.2

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -23,7 +23,6 @@ import java.util.Properties
 
 import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import kafka.utils._
 import org.apache.kafka.clients.admin._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
@@ -140,7 +139,7 @@ object ConsumerGroupCommand extends Logging {
   }
   // Example: CsvUtils().readerFor[CsvRecordWithoutGroup]
   private[admin] case class CsvUtils() {
-    val mapper = new CsvMapper with ScalaObjectMapper
+    val mapper = new CsvMapper
     mapper.registerModule(DefaultScalaModule)
     def readerFor[T <: CsvRecord: ClassTag] = {
       val schema = getSchema[T]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,7 @@
 ext {
   versions = [:]
   libs = [:]
-  
+
   // Enabled by default when commands like `testAll` are invoked
   defaultScalaVersions = [ '2.11', '2.12' ]
   // Available if -PscalaVersion is used. This is useful when we want to support a Scala version that has
@@ -75,8 +75,8 @@ versions += [
   grgit: "4.0.1",
   httpclient: "4.5.13",
   easymock: "4.1",
-  jackson: "2.10.5",
-  jacksonDatabind: "2.10.5.1",
+  jackson: "2.13.2",
+  jacksonDatabind: "2.13.2.2",
   jacoco: "0.8.3",
   jetty: "9.4.44.v20210927",
   jersey: "2.34",


### PR DESCRIPTION
Updates the versions of jackson-databind to `2.13.2.2` and the rest of jackson dependencies to `2.13.2` to fix CVE-2020-36518

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
