### PR TITLE
Cherry-pick #11883 - MINOR: unpin ducktape dependency to always use the newest version

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -34,7 +34,7 @@ LABEL ducker.creator=$ducker_creator
 # Update Linux and install necessary utilities.
 RUN apt update && apt install -y sudo netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python-pip python-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute && apt-get -y clean
 RUN python -m pip install -U pip==9.0.3;
-RUN pip install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip install --upgrade ducktape==0.7.17
+RUN pip install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip install --upgrade "ducktape>0.7,<0.8"
 
 # Set up ssh
 COPY ./ssh-config /root/.ssh/config

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.7.17", "requests==2.22.0"],
+      install_requires=["ducktape>0.7,<0.8", "requests==2.22.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       )


### PR DESCRIPTION
Cherry-pick #11883 because automatic merge didn't work on jenkins for some reason.

Ensures we always have the latest published ducktape version (compatible with python 2).
This way whenever we release a new one, we won't have to cherry pick a bunch of commits across a bunch of branches.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
