### PR TITLE
KSECURITY-252: Fix log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -946,7 +946,7 @@ project(':core') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload4j*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {
@@ -1671,7 +1671,7 @@ project(':tools') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload4j*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {
@@ -1721,7 +1721,7 @@ project(':trogdor') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {
@@ -2349,7 +2349,7 @@ project(':connect:api') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {
@@ -2386,7 +2386,7 @@ project(':connect:transforms') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {
@@ -2426,7 +2426,7 @@ project(':connect:json') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {
@@ -2493,7 +2493,7 @@ project(':connect:runtime') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {
@@ -2572,7 +2572,7 @@ project(':connect:file') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {
@@ -2611,7 +2611,7 @@ project(':connect:basic-auth-extension') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {
@@ -2658,7 +2658,7 @@ project(':connect:mirror') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {
@@ -2693,7 +2693,7 @@ project(':connect:mirror-client') {
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
     from (configurations.testRuntimeClasspath) {
-      include('slf4j-log4j12*')
+      include('slf4j-reload*')
       include('log4j*jar')
     }
     from (configurations.runtimeClasspath) {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -198,7 +198,7 @@ libs += [
   scalaLogging: "com.typesafe.scala-logging:scala-logging_$versions.baseScala:$versions.scalaLogging",
   scalaReflect: "org.scala-lang:scala-reflect:$versions.scala",
   slf4jApi: "org.slf4j:slf4j-api:$versions.slf4j",
-  slf4jlog4j: "org.slf4j:slf4j-log4j12:$versions.slf4j",
+  slf4jlog4j: "org.slf4j:slf4j-reload4j:$versions.slf4j",
   snappy: "org.xerial.snappy:snappy-java:$versions.snappy",
   zookeeper: "org.apache.zookeeper:zookeeper:$versions.zookeeper",
   jfreechart: "jfreechart:jfreechart:$versions.jfreechart",


### PR DESCRIPTION
AK adopts ch.qos.reload4j:reload4j  https://github.com/confluentinc/kafka/blob/3.2/gradle/dependencies.gradle#L182 which can only work with org.slf4j:slf4j-reload4j instead of org.slf4j:slf4j-log4j12

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
