### PR TITLE
CLIENTS-2403: kip-714 OTLP deserializer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientTelemetryUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientTelemetryUtils.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+
+import io.opentelemetry.proto.metrics.v1.MetricsData;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -358,4 +360,16 @@ public class ClientTelemetryUtils {
         }
     }
 
+    public static MetricsData deserializeMetricsData(ByteBuffer serializedMetricsData) {
+        MetricsData metricsData = null;
+
+        try {
+            ByteBuffer metricsBuffer = (ByteBuffer) serializedMetricsData.flip();
+            metricsData = MetricsData.parseFrom(metricsBuffer);
+        } catch (IOException e) {
+            log.warn("Unable to parse MetricsData payload ", e);
+            throw new RuntimeException(e);
+        }
+        return metricsData;
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/DeserializeMetricsDataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/DeserializeMetricsDataTest.java
@@ -1,0 +1,61 @@
+package org.apache.kafka.clients;
+
+import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics;
+import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.Gauge;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DeserializeMetricsDataTest {
+
+    public static ByteBuffer metricsDataBuffer;
+    public static MetricsData metricsData;
+    public static Metric sampleMetric;
+
+
+    @BeforeEach
+    void setUp() {
+        NumberDataPoint.Builder point = NumberDataPoint.newBuilder().setAsInt(15);
+        Gauge gauge = Gauge.newBuilder().addDataPoints(point).build();
+        MetricsData.Builder builder = MetricsData.newBuilder();
+
+        sampleMetric = Metric.newBuilder()
+                .setName("Gauge-Test-Metric")
+                .setGauge(gauge)
+                .build();
+
+
+        ResourceMetrics rm = ResourceMetrics.newBuilder()
+                .addInstrumentationLibraryMetrics(
+                        InstrumentationLibraryMetrics.newBuilder()
+                                .addMetrics(sampleMetric)
+                                .build()
+                ).build();
+
+        builder.addResourceMetrics(rm);
+        metricsData = builder.build();
+
+        metricsDataBuffer = ByteBuffer.allocate(1024).put(metricsData.toByteArray());
+    }
+
+    @Test
+    public void testDeserializeMetricsData() {
+        MetricsData deserializedMetricsData = ClientTelemetryUtils.deserializeMetricsData(metricsDataBuffer);
+        InstrumentationLibraryMetrics instLib = deserializedMetricsData.getResourceMetrics(0)
+                .getInstrumentationLibraryMetrics(0);
+        Metric metric = instLib.getMetrics(0);
+
+        assertNotNull(deserializedMetricsData);
+        assertEquals(metricsData, deserializedMetricsData);
+        assertEquals(1, instLib.getMetricsCount());
+        assertEquals(sampleMetric, metric);
+    }
+}


### PR DESCRIPTION
Implements a basic method to parse from `ByteBuffer` to `io.opentelemetry.proto.metrics.v1.MetricsData`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
