### PR TITLE
KAFKA-13769 fixup

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionJoinForeignProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionJoinForeignProcessorSupplier.java
@@ -70,7 +70,7 @@ public class SubscriptionJoinForeignProcessorSupplier<K, KO, VO>
                 Objects.requireNonNull(valueAndTimestamp, "This processor should never see a null newValue.");
                 final SubscriptionWrapper<K> value = valueAndTimestamp.value();
 
-                if (value.getVersion() != SubscriptionWrapper.CURRENT_VERSION) {
+                if (value.getVersion() > SubscriptionWrapper.CURRENT_VERSION) {
                     //Guard against modifications to SubscriptionWrapper. Need to ensure that there is compatibility
                     //with previous versions to enable rolling upgrades. Must develop a strategy for upgrading
                     //from older SubscriptionWrapper versions to newer versions.


### PR DESCRIPTION
This commit changes the version check from` !=` to `>` as the `process` method
works correctly on both version 1 and 2. `!=` incorrectly throws on v1
records.

I don't think that we need additional tests for this change:
1. We already test that the v0 record get `primaryPartition` is equal to `null` in [an existing unit test](https://github.com/apache/kafka/blob/edad31811c49856cc1b8e76de6e3f3a6c02802cd/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerdeTest.java#L132-L133).
2. If `primaryPartition` is equal to `null`, then [the RecordCollector will act as if no partition was specified](https://github.com/apache/kafka/blob/edad31811c49856cc1b8e76de6e3f3a6c02802cd/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java#L135-L160), so the way it used to work in v0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
