### PR TITLE
CONFLUENT: Update dependencies.gradle to override dependencies from an external file.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ buildscript {
     mavenCentral()
   }
   apply from: "$rootDir/gradle/dependencies.gradle"
+  apply from: "$rootDir/gradle/dependenciesOverrides.gradle"
 
   dependencies {
     // For Apache Rat plugin to ignore non-Git files

--- a/gradle/dependenciesOverrides.gradle
+++ b/gradle/dependenciesOverrides.gradle
@@ -1,0 +1,3 @@
+libs["mockitoCore"] = "org.mockito:mockito-core:4.6.1"
+libs["mockitoInline"] = "org.mockito:mockito-inline:4.6.1"
+libs["mockitoJunitJupiter"] = "org.mockito:mockito-junit-jupiter:4.6.1"

--- a/gradle/dependenciesOverrides.gradle
+++ b/gradle/dependenciesOverrides.gradle
@@ -1,3 +1,7 @@
-libs["mockitoCore"] = "org.mockito:mockito-core:4.6.1"
-libs["mockitoInline"] = "org.mockito:mockito-inline:4.6.1"
-libs["mockitoJunitJupiter"] = "org.mockito:mockito-junit-jupiter:4.6.1"
+// add all versions overrides here
+versions += [
+]
+
+// add all libs overrides here
+libs += [
+]


### PR DESCRIPTION
`build.gradle` now applies `gradle/dependenciesOverrides.gradle` to override dependency information.

To see how it works, add an override in the `dependenciesOverrides.gradle` like this:
```
libs += [
   mockitoCore: "org.mockito:mockito-core:4.6.1",
   mockitoInline: "org.mockito:mockito-inline:4.6.1",
   mockitoJunitJupiter: "org.mockito:mockito-junit-jupiter:4.6.1"
]
```

To see that this bumps the Mockito version to 4.6.1 use a command like:

`./gradlew :streams:dependencyInsight --configuration testRuntimeClasspath --dependency org.mockito:mockito-core`
or
`./gradlew allDeps | grep mockito`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
