### PR TITLE
[Consumer Refactor] KafkaServerEventQueue Impl

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/channels/KafkaServerEventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/channels/KafkaServerEventQueue.java
@@ -35,13 +35,7 @@ public class KafkaServerEventQueue {
     }
 
     public Optional<KafkaServerEvent> poll() throws InterruptedException {
-        return Optional.ofNullable(queue.poll(timeoutMs, TimeUnit.MILLISECONDS));
-    }
-    public Optional<KafkaServerEvent> peek() throws InterruptedException {
-        Optional<KafkaServerEvent> event = Optional.ofNullable(queue.poll(timeoutMs, TimeUnit.MILLISECONDS));
-        if(event.isPresent())
-            queue.addFirst(event.get());
-        return event;
+        return Optional.ofNullable(queue.poll());
     }
 
     public boolean isEmpty() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/channels/KafkaServerEventQueue.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/channels/KafkaServerEventQueue.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.consumer.channels;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.events.KafkaServerEvent;
+
+import java.util.Optional;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+public class KafkaServerEventQueue {
+    private static final int timeoutMs = 200; // TODO: get this from the config
+    private LinkedBlockingDeque<KafkaServerEvent> queue;
+    private final ConsumerConfig config;
+
+    public KafkaServerEventQueue(final ConsumerConfig config) {
+        this.queue = new LinkedBlockingDeque<>();
+        this.config = config;
+    }
+
+    public Optional<KafkaServerEvent> poll() throws InterruptedException {
+        return Optional.ofNullable(queue.poll(timeoutMs, TimeUnit.MILLISECONDS));
+    }
+    public Optional<KafkaServerEvent> peek() throws InterruptedException {
+        Optional<KafkaServerEvent> event = Optional.ofNullable(queue.poll(timeoutMs, TimeUnit.MILLISECONDS));
+        if(event.isPresent())
+            queue.addFirst(event.get());
+        return event;
+    }
+
+    public boolean isEmpty() {
+        return this.queue.isEmpty();
+    }
+
+    public boolean enqueue(KafkaServerEvent event) {
+        return queue.offer(event);
+    }
+}
+

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/events/AbstractKafkaServerEventData.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/events/AbstractKafkaServerEventData.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.consumer.events;
+
+abstract public class AbstractKafkaServerEventData {
+    private long timestampMs;
+    private KafkaServerEventType type;
+    public AbstractKafkaServerEventData(long time, KafkaServerEventType type) {
+        this.timestampMs = time;
+        this.type = type;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/events/KafkaServerEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/events/KafkaServerEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.consumer.events;
+
+abstract public class KafkaServerEvent {
+    private final KafkaServerEventType eventType;
+    private boolean requireCoordinator;
+
+    public KafkaServerEvent(KafkaServerEventType eventType, boolean requireCoordinator) {
+       this.eventType = eventType;
+       this.requireCoordinator = requireCoordinator;
+    }
+
+    public KafkaServerEventType getEventType() { return eventType; }
+
+    public boolean isRequireCoordinator() { return requireCoordinator; }
+
+    @Override
+    public String toString() {
+        return eventType.toString(); // TODO: need a better toString method
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/events/KafkaServerEventType.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/events/KafkaServerEventType.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.consumer.events;
+
+public enum KafkaServerEventType {
+    NOOP,
+    FETCH,
+    COMMIT,
+    ASSIGN,
+}


### PR DESCRIPTION
Basic implementation of the server event and the event queue.  It uses a BlockingDequeue so that we can utilize the poll(time) function.

Design detail see: https://cwiki.apache.org/confluence/display/KAFKA/%5BDraft%5D+Consumer+Threading+Model+Refactoring

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
