### PR TITLE
[Consumer Refactor] Background thread state machines

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/state_machines/BackgroundStateMachine.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/state_machines/BackgroundStateMachine.java
@@ -25,12 +25,17 @@ public class BackgroundStateMachine {
     private BackgroundStates currentState;
 
     public BackgroundStateMachine(BackgroundStates initialState) {
+        if(initialState == null) {
+            throw new NullPointerException("initial state cannot be null");
+        }
+        
         this.currentState = initialState;
     }
 
     public boolean transitionTo(BackgroundStates nextState) {
         if(validateStateTransition(currentState, nextState)) {
             this.currentState = nextState;
+            return true;
         }
         return false;
     }
@@ -45,6 +50,10 @@ public class BackgroundStateMachine {
     }
 
     private boolean validateStateTransition(BackgroundStates currentState, BackgroundStates nextState) {
+        if(currentState == null) {
+            return false;
+        }
+
         switch(currentState) {
             case DOWN:
                 if(nextState != BackgroundStates.INITIALIZED) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/state_machines/BackgroundStateMachine.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/state_machines/BackgroundStateMachine.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.consumer.state_machines;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BackgroundStateMachine {
+    private static final Logger log = LoggerFactory.getLogger(BackgroundStateMachine.class);
+    private BackgroundStates currentState;
+
+    public BackgroundStateMachine(BackgroundStates initialState) {
+        this.currentState = initialState;
+    }
+
+    public boolean transitionTo(BackgroundStates nextState) {
+        if(validateStateTransition(currentState, nextState)) {
+            this.currentState = nextState;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return this.currentState.toString();
+    }
+
+    public boolean isStable() {
+        return this.currentState == BackgroundStates.STABLE;
+    }
+
+    private boolean validateStateTransition(BackgroundStates currentState, BackgroundStates nextState) {
+        switch(currentState) {
+            case DOWN:
+                if(nextState != BackgroundStates.INITIALIZED) {
+                    log.error("INITIALIZED is not a possible next state");
+                    return false;
+                }
+                break;
+            case INITIALIZED:
+                if(nextState == BackgroundStates.STABLE) {
+                    return false;
+                }
+                break;
+            case COORDINATOR_DISCOVERY:
+            case STABLE:
+                break;
+            default:
+                return false;
+        }
+        return true;
+    }
+
+    public BackgroundStates getCurrentState() {
+        return currentState;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/state_machines/BackgroundStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/state_machines/BackgroundStates.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.consumer.state_machines;
+
+public enum BackgroundStates {
+    DOWN,
+    INITIALIZED,
+    COORDINATOR_DISCOVERY,
+    STABLE,
+}


### PR DESCRIPTION
This is the implementation of the background thread state machine states and it's basic functionalities.

The code will be used in the background thread to maintain it's availability.

Detail design see: https://cwiki.apache.org/confluence/display/KAFKA/%5BDraft%5D+Consumer+Threading+Model+Refactoring

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
