### PR TITLE
KAFKA-13769 Fix version check in SubscriptionStoreReceiveProcessorSup… (#784)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKey.java
@@ -38,8 +38,22 @@ public class CombinedKey<KF, KP> {
         return primaryKey;
     }
 
-    public boolean equals(final KF foreignKey, final KP primaryKey) {
-        return this.foreignKey.equals(foreignKey) && this.primaryKey.equals(primaryKey);
+    @Override
+    public int hashCode() {
+        return Objects.hash(foreignKey, primaryKey);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CombinedKey<?, ?> that = (CombinedKey<?, ?>) o;
+        return Objects.equals(foreignKey, that.foreignKey) && Objects.equals(
+            primaryKey, that.primaryKey);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResponseWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResponseWrapper.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.kstream.internals.foreignkeyjoin;
 
+import java.util.Objects;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 
 import java.util.Arrays;
@@ -71,5 +72,28 @@ public class SubscriptionResponseWrapper<FV> {
             ", originalValueHash=" + Arrays.toString(originalValueHash) +
             ", primaryPartition=" + primaryPartition +
             '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final SubscriptionResponseWrapper<?> that = (SubscriptionResponseWrapper<?>) o;
+        return version == that.version &&
+               Arrays.equals(originalValueHash,
+               that.originalValueHash) &&
+               Objects.equals(foreignValue, that.foreignValue) &&
+               Objects.equals(primaryPartition, that.primaryPartition);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(foreignValue, version, primaryPartition);
+        result = 31 * result + Arrays.hashCode(originalValueHash);
+        return result;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplier.java
@@ -91,7 +91,7 @@ public class SubscriptionStoreReceiveProcessorSupplier<K, KO>
                     droppedRecordsSensor.record();
                     return;
                 }
-                if (record.value().getVersion() != SubscriptionWrapper.CURRENT_VERSION) {
+                if (record.value().getVersion() > SubscriptionWrapper.CURRENT_VERSION) {
                     //Guard against modifications to SubscriptionWrapper. Need to ensure that there is compatibility
                     //with previous versions to enable rolling upgrades. Must develop a strategy for upgrading
                     //from older SubscriptionWrapper versions to newer versions.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapper.java
@@ -23,7 +23,10 @@ import java.util.Objects;
 
 
 public class SubscriptionWrapper<K> {
-    static final byte CURRENT_VERSION = 1;
+    static final byte VERSION_0 = 0;
+    static final byte VERSION_1 = 1;
+
+    static final byte CURRENT_VERSION = VERSION_1;
 
     // v0 fields:
     private final long[] hash;
@@ -115,6 +118,27 @@ public class SubscriptionWrapper<K> {
             ", hash=" + Arrays.toString(hash) +
             ", primaryPartition=" + primaryPartition +
             '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final SubscriptionWrapper<?> that = (SubscriptionWrapper<?>) o;
+        return version == that.version && Arrays.equals(hash, that.hash)
+            && instruction == that.instruction && Objects.equals(primaryKey, that.primaryKey)
+            && Objects.equals(primaryPartition, that.primaryPartition);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(instruction, version, primaryKey, primaryPartition);
+        result = 31 * result + Arrays.hashCode(hash);
+        return result;
     }
 }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionProcessorSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionProcessorSupplierTest.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals.foreignkeyjoin;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.streams.kstream.internals.Change;
+import org.apache.kafka.streams.kstream.internals.KTableValueGetter;
+import org.apache.kafka.streams.kstream.internals.KTableValueGetterSupplier;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper.Instruction;
+import org.apache.kafka.streams.processor.api.MockProcessorContext;
+import org.apache.kafka.streams.processor.api.MockProcessorContext.CapturedForward;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ForeignJoinSubscriptionProcessorSupplierTest {
+    final Map<String, ValueAndTimestamp<String>> fks = Collections.singletonMap(
+        "fk1", ValueAndTimestamp.make("foo", 1L)
+    );
+    final KTableValueGetterSupplier<String, String> valueGetterSupplier = valueGetterSupplier(fks);
+    final Processor<CombinedKey<String, String>,
+                    Change<ValueAndTimestamp<SubscriptionWrapper<String>>>,
+                    String,
+                    SubscriptionResponseWrapper<String>>
+        processor = processor(valueGetterSupplier);
+
+    @Test
+    public void shouldDetectVersionChange() {
+        // This test serves as a reminder to add new tests once we bump SubscriptionWrapper version.
+        Assert.assertEquals(SubscriptionWrapper.VERSION_1, SubscriptionWrapper.CURRENT_VERSION);
+    }
+
+    @Test
+    public void shouldDeleteKeyAndPropagateFKV0() {
+        final MockProcessorContext<String, SubscriptionResponseWrapper<String>> context = new MockProcessorContext<>();
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newValue = new SubscriptionWrapper<>(
+            new long[]{1L},
+            Instruction.DELETE_KEY_AND_PROPAGATE,
+            "pk1",
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        final Record<CombinedKey<String, String>, Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> record =
+            new Record<>(
+                new CombinedKey<>("fk1", "pk1"),
+                new Change<>(ValueAndTimestamp.make(newValue, 1L), null),
+                1L
+            );
+        processor.process(record);
+        final List<CapturedForward<? extends String, ? extends SubscriptionResponseWrapper<String>>> forwarded = context.forwarded();
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            new Record<>(
+                "pk1",
+                new SubscriptionResponseWrapper<>(
+                    newValue.getHash(),
+                    null,
+                    null),
+                1L
+            ),
+            forwarded.get(0).record()
+        );
+    }
+
+    @Test
+    public void shouldDeleteKeyAndPropagateFKV1() {
+        final MockProcessorContext<String, SubscriptionResponseWrapper<String>> context = new MockProcessorContext<>();
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newValue = new SubscriptionWrapper<>(
+            new long[]{1L},
+            Instruction.DELETE_KEY_AND_PROPAGATE,
+            "pk1",
+            SubscriptionWrapper.VERSION_1,
+            12
+        );
+        final Record<CombinedKey<String, String>, Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> record =
+            new Record<>(
+                new CombinedKey<>("fk1", "pk1"),
+                new Change<>(ValueAndTimestamp.make(newValue, 1L), null),
+                1L
+            );
+        processor.process(record);
+        final List<CapturedForward<? extends String, ? extends SubscriptionResponseWrapper<String>>> forwarded = context.forwarded();
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            new Record<>(
+                "pk1",
+                new SubscriptionResponseWrapper<>(
+                    newValue.getHash(),
+                    null,
+                    12
+                ),
+                1L
+            ),
+            forwarded.get(0).record()
+        );
+    }
+
+    @Test
+    public void shouldPropagateOnlyIfFKAvailableV0() {
+        final MockProcessorContext<String, SubscriptionResponseWrapper<String>> context = new MockProcessorContext<>();
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newValue = new SubscriptionWrapper<>(
+            new long[]{1L},
+            Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE,
+            "pk1",
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        final Record<CombinedKey<String, String>, Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> record =
+            new Record<>(
+                new CombinedKey<>("fk1", "pk1"),
+                new Change<>(ValueAndTimestamp.make(newValue, 1L), null),
+                1L
+        );
+        processor.process(record);
+        final List<CapturedForward<? extends String, ? extends SubscriptionResponseWrapper<String>>> forwarded = context.forwarded();
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            new Record<>(
+                "pk1",
+                new SubscriptionResponseWrapper<>(
+                    newValue.getHash(),
+                    "foo",
+                    null
+                ),
+                1L
+            ),
+            forwarded.get(0).record()
+        );
+    }
+
+    @Test
+    public void shouldPropagateOnlyIfFKAvailableV1() {
+        final MockProcessorContext<String, SubscriptionResponseWrapper<String>> context = new MockProcessorContext<>();
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newValue = new SubscriptionWrapper<>(
+            new long[]{1L},
+            Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE,
+            "pk1",
+            SubscriptionWrapper.VERSION_1,
+            12
+        );
+        final Record<CombinedKey<String, String>, Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> record =
+            new Record<>(
+                new CombinedKey<>("fk1", "pk1"),
+                new Change<>(ValueAndTimestamp.make(newValue, 1L), null),
+                1L
+            );
+        processor.process(record);
+        final List<CapturedForward<? extends String, ? extends SubscriptionResponseWrapper<String>>> forwarded = context.forwarded();
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            new Record<>(
+                "pk1",
+                new SubscriptionResponseWrapper<>(
+                    newValue.getHash(),
+                    "foo",
+                     12
+                ),
+                1L
+            ),
+            forwarded.get(0).record());
+    }
+
+    @Test
+    public void shouldPropagateNullIfNoFKAvailableV0() {
+        final MockProcessorContext<String, SubscriptionResponseWrapper<String>> context = new MockProcessorContext<>();
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newValue = new SubscriptionWrapper<>(
+            new long[]{1L},
+            Instruction.PROPAGATE_NULL_IF_NO_FK_VAL_AVAILABLE,
+            "pk1",
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        Record<CombinedKey<String, String>, Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> record =
+            new Record<>(
+                new CombinedKey<>("fk1", "pk1"),
+                new Change<>(ValueAndTimestamp.make(newValue, 1L), null),
+                1L
+            );
+        processor.process(record);
+        // propagate matched FK
+        List<CapturedForward<? extends String, ? extends SubscriptionResponseWrapper<String>>> forwarded = context.forwarded();
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            new Record<>(
+                "pk1",
+                new SubscriptionResponseWrapper<>(
+                    newValue.getHash(),
+                    "foo",
+                    null
+                ),
+                1L
+            ),
+            forwarded.get(0).record());
+
+        record = new Record<>(
+                new CombinedKey<>("fk9000", "pk1"),
+                new Change<>(ValueAndTimestamp.make(newValue, 1L), null),
+                1L
+            );
+        processor.process(record);
+        // propagate null if there is no match
+        forwarded = context.forwarded();
+        Assert.assertEquals(2, forwarded.size());
+        Assert.assertEquals(
+            new Record<>(
+                "pk1",
+                new SubscriptionResponseWrapper<>(
+                    newValue.getHash(),
+                    null,
+                    null
+                ),
+                1L
+            ),
+            forwarded.get(1).record());
+    }
+
+    @Test
+    public void shouldPropagateNullIfNoFKAvailableV1() {
+        final MockProcessorContext<String, SubscriptionResponseWrapper<String>> context = new MockProcessorContext<>();
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newValue = new SubscriptionWrapper<>(
+            new long[]{1L},
+            Instruction.PROPAGATE_NULL_IF_NO_FK_VAL_AVAILABLE,
+            "pk1",
+            SubscriptionWrapper.VERSION_1,
+            12);
+        Record<CombinedKey<String, String>, Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> record =
+            new Record<>(
+                new CombinedKey<>("fk1", "pk1"),
+                new Change<>(ValueAndTimestamp.make(newValue, 1L), null),
+                1L
+            );
+        processor.process(record);
+        List<CapturedForward<? extends String, ? extends SubscriptionResponseWrapper<String>>> forwarded = context.forwarded();
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            new Record<>(
+                "pk1",
+                new SubscriptionResponseWrapper<>(
+                    newValue.getHash(),
+                    "foo",
+                    12
+                ),
+                1L
+            ),
+            forwarded.get(0).record());
+
+        record = new Record<>(
+            new CombinedKey<>("fk9000", "pk1"),
+            new Change<>(ValueAndTimestamp.make(newValue, 1L), null),
+            1L
+        );
+        processor.process(record);
+        // propagate null if there is no match
+        forwarded = context.forwarded();
+        Assert.assertEquals(2, forwarded.size());
+        Assert.assertEquals(
+            new Record<>(
+                "pk1",
+                new SubscriptionResponseWrapper<>(
+                    newValue.getHash(),
+                    null,
+                    12
+                ),
+                1L
+            ),
+            forwarded.get(1).record());
+    }
+
+    @Test
+    public void shouldDeleteKeyNoPropagateV0() {
+        final MockProcessorContext<String, SubscriptionResponseWrapper<String>> context = new MockProcessorContext<>();
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newValue = new SubscriptionWrapper<>(
+            new long[]{1L},
+            Instruction.DELETE_KEY_NO_PROPAGATE,
+            "pk1",
+            SubscriptionWrapper.VERSION_0,
+            null);
+        final Record<CombinedKey<String, String>, Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> record =
+            new Record<>(
+                new CombinedKey<>("fk1", "pk1"),
+                new Change<>(ValueAndTimestamp.make(newValue, 1L), null),
+                1L
+            );
+        processor.process(record);
+        final List<CapturedForward<? extends String, ? extends SubscriptionResponseWrapper<String>>> forwarded = context.forwarded();
+        Assert.assertEquals(0, forwarded.size());
+    }
+
+    @Test
+    public void shouldDeleteKeyNoPropagateV1() {
+        final MockProcessorContext<String, SubscriptionResponseWrapper<String>> context = new MockProcessorContext<>();
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newValue = new SubscriptionWrapper<>(
+            new long[]{1L},
+            Instruction.DELETE_KEY_NO_PROPAGATE,
+            "pk1",
+            SubscriptionWrapper.VERSION_1,
+            12);
+        final Record<CombinedKey<String, String>, Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> record =
+            new Record<>(new CombinedKey<>("fk1", "pk1"),
+                         new Change<>(ValueAndTimestamp.make(newValue, 1L), null),
+                        1L
+            );
+        processor.process(record);
+        final List<CapturedForward<? extends String, ? extends SubscriptionResponseWrapper<String>>> forwarded = context.forwarded();
+        Assert.assertEquals(0, forwarded.size());
+    }
+
+    private KTableValueGetterSupplier<String, String> valueGetterSupplier(final Map<String, ValueAndTimestamp<String>> map) {
+        final KTableValueGetter<String, String> valueGetter = new KTableValueGetter<String, String>() {
+
+            @Override
+            public ValueAndTimestamp<String> get(final String key) {
+                return map.get(key);
+            }
+
+            @Override
+            public void init(final ProcessorContext context) {
+
+            }
+        };
+        return new KTableValueGetterSupplier<String, String>() {
+            @Override
+            public KTableValueGetter<String, String> get() {
+                return valueGetter;
+            }
+
+            @Override
+            public String[] storeNames() {
+                return new String[0];
+            }
+        };
+    }
+
+    private Processor<CombinedKey<String, String>,
+                      Change<ValueAndTimestamp<SubscriptionWrapper<String>>>,
+                      String,
+                      SubscriptionResponseWrapper<String>> processor(final KTableValueGetterSupplier<String, String> valueGetterSupplier) {
+        final SubscriptionJoinForeignProcessorSupplier<String, String, String> supplier =
+            new SubscriptionJoinForeignProcessorSupplier<>(valueGetterSupplier);
+        return supplier.get();
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplierTest.java
@@ -1,0 +1,517 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals.foreignkeyjoin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Supplier;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.kstream.internals.Change;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper.Instruction;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.api.MockProcessorContext.CapturedForward;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.test.MockInternalNewProcessorContext;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SubscriptionStoreReceiveProcessorSupplierTest {
+
+    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+    private File stateDir;
+    private MockInternalNewProcessorContext<CombinedKey<String, String>, Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> context;
+
+    private static final String FK = "fk1";
+    private static final String PK1 = "pk1";
+    private static final String PK2 = "pk2";
+
+    private static final Supplier<String> PK_SERDE_TOPIC_SUPPLIER = () -> "pk-topic";
+    private static final CombinedKeySchema<String, String> COMBINED_KEY_SCHEMA = new CombinedKeySchema<>(
+        () -> "fk-topic",
+        Serdes.String(),
+        PK_SERDE_TOPIC_SUPPLIER,
+        Serdes.String()
+    );
+
+    @Before
+    public void before() {
+        stateDir = TestUtils.tempDirectory();
+        context = new MockInternalNewProcessorContext<>(props, new TaskId(0, 0), stateDir);
+    }
+
+    @After
+    public void after() throws IOException {
+        Utils.delete(stateDir);
+    }
+
+    @Test
+    public void shouldDetectVersionChange() {
+        // This test serves as a reminder to add new tests once we bump SubscriptionWrapper version.
+        Assert.assertEquals(SubscriptionWrapper.VERSION_1, SubscriptionWrapper.CURRENT_VERSION);
+    }
+
+    @Test
+    public void shouldDeleteKeyAndPropagateV0() {
+        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder = storeBuilder();
+        final SubscriptionStoreReceiveProcessorSupplier<String, String> supplier = supplier(storeBuilder);
+        final Processor<String,
+                        SubscriptionWrapper<String>,
+                        CombinedKey<String, String>,
+                        Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
+        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        context.addStateStore(stateStore);
+        stateStore.init((StateStoreContext) context, stateStore);
+
+        final SubscriptionWrapper<String> oldWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.DELETE_KEY_AND_PROPAGATE,
+            PK2,
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> oldValue = ValueAndTimestamp.make(oldWrapper, 0);
+
+        final Bytes key = COMBINED_KEY_SCHEMA.toBytes(FK, PK1);
+        stateStore.put(key, oldValue);
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.DELETE_KEY_AND_PROPAGATE,
+            PK1,
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> newValue = ValueAndTimestamp.make(
+            newWrapper, 1L);
+        final Record<String, SubscriptionWrapper<String>> record = new Record<>(
+            FK,
+            newWrapper,
+            1L
+        );
+        processor.process(record);
+
+        final List<CapturedForward<? extends CombinedKey<String, String>,
+                                   ? extends Change<ValueAndTimestamp<SubscriptionWrapper<String>>>>> forwarded = context.forwarded();
+        Assert.assertNull(stateStore.get(key));
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            record.withKey(new CombinedKey<>(FK, PK1))
+                  .withValue(new Change<>(newValue, oldValue)),
+            forwarded.get(0).record()
+        );
+    }
+
+    @Test
+    public void shouldDeleteKeyAndPropagateV1() {
+        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder = storeBuilder();
+        final SubscriptionStoreReceiveProcessorSupplier<String, String> supplier = supplier(storeBuilder);
+        final Processor<String,
+            SubscriptionWrapper<String>,
+            CombinedKey<String, String>,
+            Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
+        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        context.addStateStore(stateStore);
+        stateStore.init((StateStoreContext) context, stateStore);
+
+        final SubscriptionWrapper<String> oldWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.DELETE_KEY_AND_PROPAGATE,
+            PK2,
+            SubscriptionWrapper.VERSION_1,
+            1
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> oldValue = ValueAndTimestamp.make(oldWrapper, 0);
+
+        final Bytes key = COMBINED_KEY_SCHEMA.toBytes(FK, PK1);
+        stateStore.put(key, oldValue);
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.DELETE_KEY_AND_PROPAGATE,
+            PK1,
+            SubscriptionWrapper.VERSION_1,
+            1
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> newValue = ValueAndTimestamp.make(
+            newWrapper, 1L);
+        final Record<String, SubscriptionWrapper<String>> record = new Record<>(
+            FK,
+            newWrapper,
+            1L
+        );
+        processor.process(record);
+
+        final List<CapturedForward<? extends CombinedKey<String, String>,
+            ? extends Change<ValueAndTimestamp<SubscriptionWrapper<String>>>>> forwarded = context.forwarded();
+        Assert.assertNull(stateStore.get(key));
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            record.withKey(new CombinedKey<>(FK, PK1))
+                .withValue(new Change<>(newValue, oldValue)),
+            forwarded.get(0).record()
+        );
+    }
+
+    @Test
+    public void shouldDeleteKeyNoPropagateV0() {
+        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder = storeBuilder();
+        final SubscriptionStoreReceiveProcessorSupplier<String, String> supplier = supplier(storeBuilder);
+        final Processor<String,
+            SubscriptionWrapper<String>,
+            CombinedKey<String, String>,
+            Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
+        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        context.addStateStore(stateStore);
+        stateStore.init((StateStoreContext) context, stateStore);
+
+        final SubscriptionWrapper<String> oldWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.DELETE_KEY_NO_PROPAGATE,
+            PK2,
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> oldValue = ValueAndTimestamp.make(oldWrapper, 0);
+
+        final Bytes key = COMBINED_KEY_SCHEMA.toBytes(FK, PK1);
+        stateStore.put(key, oldValue);
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.DELETE_KEY_NO_PROPAGATE,
+            PK1,
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> newValue = ValueAndTimestamp.make(
+            newWrapper, 1L);
+        final Record<String, SubscriptionWrapper<String>> record = new Record<>(
+            FK,
+            newWrapper,
+            1L
+        );
+        processor.process(record);
+
+        final List<CapturedForward<? extends CombinedKey<String, String>,
+            ? extends Change<ValueAndTimestamp<SubscriptionWrapper<String>>>>> forwarded = context.forwarded();
+        Assert.assertNull(stateStore.get(key));
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            record.withKey(new CombinedKey<>(FK, PK1))
+                .withValue(new Change<>(newValue, oldValue)),
+            forwarded.get(0).record()
+        );
+    }
+
+    @Test
+    public void shouldDeleteKeyNoPropagateV1() {
+        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder = storeBuilder();
+        final SubscriptionStoreReceiveProcessorSupplier<String, String> supplier = supplier(storeBuilder);
+        final Processor<String,
+            SubscriptionWrapper<String>,
+            CombinedKey<String, String>,
+            Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
+        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        context.addStateStore(stateStore);
+        stateStore.init((StateStoreContext) context, stateStore);
+
+        final SubscriptionWrapper<String> oldWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.DELETE_KEY_NO_PROPAGATE,
+            PK2,
+            SubscriptionWrapper.VERSION_1,
+            1
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> oldValue = ValueAndTimestamp.make(oldWrapper, 0);
+
+        final Bytes key = COMBINED_KEY_SCHEMA.toBytes(FK, PK1);
+        stateStore.put(key, oldValue);
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.DELETE_KEY_NO_PROPAGATE,
+            PK1,
+            SubscriptionWrapper.VERSION_1,
+            1
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> newValue = ValueAndTimestamp.make(
+            newWrapper, 1L);
+        final Record<String, SubscriptionWrapper<String>> record = new Record<>(
+            FK,
+            newWrapper,
+            1L
+        );
+        processor.process(record);
+
+        final List<CapturedForward<? extends CombinedKey<String, String>,
+            ? extends Change<ValueAndTimestamp<SubscriptionWrapper<String>>>>> forwarded = context.forwarded();
+        Assert.assertNull(stateStore.get(key));
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            record.withKey(new CombinedKey<>(FK, PK1))
+                .withValue(new Change<>(newValue, oldValue)),
+            forwarded.get(0).record()
+        );
+    }
+
+    @Test
+    public void shouldPropagateOnlyIfFKValAvailableV0() {
+        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder = storeBuilder();
+        final SubscriptionStoreReceiveProcessorSupplier<String, String> supplier = supplier(storeBuilder);
+        final Processor<String,
+            SubscriptionWrapper<String>,
+            CombinedKey<String, String>,
+            Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
+        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        context.addStateStore(stateStore);
+        stateStore.init((StateStoreContext) context, stateStore);
+
+        final SubscriptionWrapper<String> oldWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE,
+            PK2,
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> oldValue = ValueAndTimestamp.make(oldWrapper, 0);
+
+        final Bytes key = COMBINED_KEY_SCHEMA.toBytes(FK, PK1);
+        stateStore.put(key, oldValue);
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE,
+            PK1,
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> newValue = ValueAndTimestamp.make(
+            newWrapper, 1L);
+        final Record<String, SubscriptionWrapper<String>> record = new Record<>(
+            FK,
+            newWrapper,
+            1L
+        );
+        processor.process(record);
+        final List<CapturedForward<? extends CombinedKey<String, String>,
+            ? extends Change<ValueAndTimestamp<SubscriptionWrapper<String>>>>> forwarded = context.forwarded();
+
+        Assert.assertEquals(newValue, stateStore.get(key));
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            record.withKey(new CombinedKey<>(FK, PK1))
+                .withValue(new Change<>(newValue, oldValue)),
+            forwarded.get(0).record()
+        );
+    }
+
+    @Test
+    public void shouldPropagateOnlyIfFKValAvailableV1() {
+        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder = storeBuilder();
+        final SubscriptionStoreReceiveProcessorSupplier<String, String> supplier = supplier(storeBuilder);
+        final Processor<String,
+            SubscriptionWrapper<String>,
+            CombinedKey<String, String>,
+            Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
+        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        context.addStateStore(stateStore);
+        stateStore.init((StateStoreContext) context, stateStore);
+
+        final SubscriptionWrapper<String> oldWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE,
+            PK2,
+            SubscriptionWrapper.VERSION_1,
+            1
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> oldValue = ValueAndTimestamp.make(oldWrapper, 0);
+
+        final Bytes key = COMBINED_KEY_SCHEMA.toBytes(FK, PK1);
+        stateStore.put(key, oldValue);
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE,
+            PK1,
+            SubscriptionWrapper.VERSION_1,
+            1
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> newValue = ValueAndTimestamp.make(
+            newWrapper, 1L);
+        final Record<String, SubscriptionWrapper<String>> record = new Record<>(
+            FK,
+            newWrapper,
+            1L
+        );
+        processor.process(record);
+        final List<CapturedForward<? extends CombinedKey<String, String>,
+            ? extends Change<ValueAndTimestamp<SubscriptionWrapper<String>>>>> forwarded = context.forwarded();
+
+        Assert.assertEquals(newValue, stateStore.get(key));
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            record.withKey(new CombinedKey<>(FK, PK1))
+                .withValue(new Change<>(newValue, oldValue)),
+            forwarded.get(0).record()
+        );
+    }
+
+    @Test
+    public void shouldPropagateNullIfNoFKValAvailableV0() {
+        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder = storeBuilder();
+        final SubscriptionStoreReceiveProcessorSupplier<String, String> supplier = supplier(storeBuilder);
+        final Processor<String,
+            SubscriptionWrapper<String>,
+            CombinedKey<String, String>,
+            Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
+        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        context.addStateStore(stateStore);
+        stateStore.init((StateStoreContext) context, stateStore);
+
+        final SubscriptionWrapper<String> oldWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.PROPAGATE_NULL_IF_NO_FK_VAL_AVAILABLE,
+            PK2,
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> oldValue = ValueAndTimestamp.make(oldWrapper, 0);
+
+        final Bytes key = COMBINED_KEY_SCHEMA.toBytes(FK, PK1);
+        stateStore.put(key, oldValue);
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.PROPAGATE_NULL_IF_NO_FK_VAL_AVAILABLE,
+            PK1,
+            SubscriptionWrapper.VERSION_0,
+            null
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> newValue = ValueAndTimestamp.make(
+            newWrapper, 1L);
+        final Record<String, SubscriptionWrapper<String>> record = new Record<>(
+            FK,
+            newWrapper,
+            1L
+        );
+        processor.process(record);
+        final List<CapturedForward<? extends CombinedKey<String, String>,
+            ? extends Change<ValueAndTimestamp<SubscriptionWrapper<String>>>>> forwarded = context.forwarded();
+
+        Assert.assertEquals(newValue, stateStore.get(key));
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            record.withKey(new CombinedKey<>(FK, PK1))
+                .withValue(new Change<>(newValue, oldValue)),
+            forwarded.get(0).record()
+        );
+    }
+
+    @Test
+    public void shouldPropagateNullIfNoFKValAvailableV1() {
+        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder = storeBuilder();
+        final SubscriptionStoreReceiveProcessorSupplier<String, String> supplier = supplier(storeBuilder);
+        final Processor<String,
+            SubscriptionWrapper<String>,
+            CombinedKey<String, String>,
+            Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
+        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        context.addStateStore(stateStore);
+        stateStore.init((StateStoreContext) context, stateStore);
+
+        final SubscriptionWrapper<String> oldWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.PROPAGATE_NULL_IF_NO_FK_VAL_AVAILABLE,
+            PK2,
+            SubscriptionWrapper.VERSION_1,
+            1
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> oldValue = ValueAndTimestamp.make(oldWrapper, 0);
+
+        final Bytes key = COMBINED_KEY_SCHEMA.toBytes(FK, PK1);
+        stateStore.put(key, oldValue);
+        processor.init(context);
+
+        final SubscriptionWrapper<String> newWrapper = new SubscriptionWrapper<>(
+            new long[]{1L, 2L},
+            Instruction.PROPAGATE_NULL_IF_NO_FK_VAL_AVAILABLE,
+            PK1,
+            SubscriptionWrapper.VERSION_1,
+            1
+        );
+        final ValueAndTimestamp<SubscriptionWrapper<String>> newValue = ValueAndTimestamp.make(
+            newWrapper, 1L);
+        final Record<String, SubscriptionWrapper<String>> record = new Record<>(
+            FK,
+            newWrapper,
+            1L
+        );
+        processor.process(record);
+        final List<CapturedForward<? extends CombinedKey<String, String>,
+            ? extends Change<ValueAndTimestamp<SubscriptionWrapper<String>>>>> forwarded = context.forwarded();
+
+        Assert.assertEquals(newValue, stateStore.get(key));
+        Assert.assertEquals(1, forwarded.size());
+        Assert.assertEquals(
+            record.withKey(new CombinedKey<>(FK, PK1))
+                .withValue(new Change<>(newValue, oldValue)),
+            forwarded.get(0).record()
+        );
+    }
+
+
+    private SubscriptionStoreReceiveProcessorSupplier<String, String> supplier(
+        final StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder) {
+
+        return new SubscriptionStoreReceiveProcessorSupplier<>(storeBuilder, COMBINED_KEY_SCHEMA);
+    }
+
+    private StoreBuilder<TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>>> storeBuilder() {
+        final Serde<SubscriptionWrapper<String>> subscriptionWrapperSerde = new SubscriptionWrapperSerde<>(
+            PK_SERDE_TOPIC_SUPPLIER, Serdes.String());
+        return Stores.timestampedKeyValueStoreBuilder(
+            Stores.persistentTimestampedKeyValueStore(
+                "Store"
+            ),
+            new Serdes.BytesSerde(),
+            subscriptionWrapperSerde
+        );
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerdeTest.java
@@ -34,7 +34,7 @@ public class SubscriptionWrapperSerdeTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldSerdeV0Test() {
-        final byte version = 0;
+        final byte version = SubscriptionWrapper.VERSION_0;
         final String originalKey = "originalKey";
         final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(() -> "pkTopic", Serdes.String());
         final long[] hashedValue = Murmur3.hash128(new byte[] {(byte) 0xFF, (byte) 0xAA, (byte) 0x00, (byte) 0x19});
@@ -59,7 +59,7 @@ public class SubscriptionWrapperSerdeTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldSerdeV1Test() {
-        final byte version = 1;
+        final byte version = SubscriptionWrapper.VERSION_1;
         final String originalKey = "originalKey";
         final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(() -> "pkTopic", Serdes.String());
         final long[] hashedValue = Murmur3.hash128(new byte[] {(byte) 0xFF, (byte) 0xAA, (byte) 0x00, (byte) 0x19});
@@ -84,7 +84,7 @@ public class SubscriptionWrapperSerdeTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldSerdeWithV0IfUpgradeTest() {
-        final byte version = 1;
+        final byte version = SubscriptionWrapper.VERSION_1;
         final String originalKey = "originalKey";
         final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(() -> "pkTopic", Serdes.String());
         swSerde.configure(
@@ -112,7 +112,7 @@ public class SubscriptionWrapperSerdeTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldSerdeNullHashV0Test() {
-        final byte version = 0;
+        final byte version = SubscriptionWrapper.VERSION_0;
         final String originalKey = "originalKey";
         final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(() -> "pkTopic", Serdes.String());
         final long[] hashedValue = null;
@@ -136,7 +136,7 @@ public class SubscriptionWrapperSerdeTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldSerdeNullHashV1Test() {
-        final byte version = 1;
+        final byte version = SubscriptionWrapper.VERSION_1;
         final String originalKey = "originalKey";
         final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(() -> "pkTopic", Serdes.String());
         final long[] hashedValue = null;
@@ -164,7 +164,7 @@ public class SubscriptionWrapperSerdeTest {
         final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(() -> "pkTopic", Serdes.String());
         final long[] hashedValue = Murmur3.hash128(new byte[] {(byte) 0xFF, (byte) 0xAA, (byte) 0x00, (byte) 0x19});
         final Integer primaryPartition = null;
-        final byte version = 0;
+        final byte version = SubscriptionWrapper.VERSION_0;
         final SubscriptionWrapper wrapper = new SubscriptionWrapper<>(
             hashedValue,
             SubscriptionWrapper.Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE,
@@ -189,7 +189,7 @@ public class SubscriptionWrapperSerdeTest {
         assertThrows(NullPointerException.class, () -> new SubscriptionWrapper<>(hashedValue,
             SubscriptionWrapper.Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE,
             originalKey,
-            (byte) 0,
+            SubscriptionWrapper.VERSION_0,
             primaryPartition));
     }
 
@@ -201,7 +201,7 @@ public class SubscriptionWrapperSerdeTest {
         assertThrows(NullPointerException.class, () -> new SubscriptionWrapper<>(hashedValue,
             SubscriptionWrapper.Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE,
             originalKey,
-            (byte) 1,
+            SubscriptionWrapper.VERSION_1,
             primaryPartition));
     }
 
@@ -214,7 +214,7 @@ public class SubscriptionWrapperSerdeTest {
             hashedValue,
             null,
             originalKey,
-            (byte) 0,
+            SubscriptionWrapper.VERSION_0,
             primaryPartition));
     }
 
@@ -227,7 +227,7 @@ public class SubscriptionWrapperSerdeTest {
             hashedValue,
             null,
             originalKey,
-            (byte) 0,
+            SubscriptionWrapper.VERSION_0,
             primaryPartition));
     }
 
@@ -241,7 +241,7 @@ public class SubscriptionWrapperSerdeTest {
             hashedValue,
             SubscriptionWrapper.Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE,
             originalKey,
-            (byte) 1,
+            SubscriptionWrapper.VERSION_1,
             primaryPartition);
         assertThrows(NullPointerException.class, () -> swSerde.serializer().serialize(null, wrapper));
     }


### PR DESCRIPTION
* KAFKA-13769: Add tests for ForeignJoinSubscriptionProcessorSupplier (#12437)

Reviewers: Adam Bellemare <adam.bellemare@gmail.com>, John Roesler <vvcephei@apache.org>

* KAFKA-13769 Fix version check in SubscriptionStoreReceiveProcessorSupplier