### PR TITLE
Upgrade jetty to 9.4.48.v20220622

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -78,7 +78,7 @@ versions += [
   jackson: "2.13.2",
   jacksonDatabind: "2.13.2.2",
   jacoco: "0.8.3",
-  jetty: "9.4.44.v20210927",
+  jetty: "9.4.48.v20220622",
   jersey: "2.34",
   jmh: "1.21",
   hamcrest: "2.1",


### PR DESCRIPTION
https://github.com/confluentinc/ce-kafka/pull/7068

When upgrade Jetty version in Kafka,  ccs-kafka is missing. This is to sync the change from ce-kafka to ccs-kafka. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
