### PR TITLE
Upgrade Jetty to 9.4.48.v20220622

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jackson: "2.13.2",
   jacksonDatabind: "2.13.2.2",
   jacoco: "0.8.5",
-  jetty: "9.4.44.v20210927",
+  jetty: "9.4.48.v20220622",
   jersey: "2.34",
   jmh: "1.23",
   hamcrest: "2.2",


### PR DESCRIPTION
This backport changes in https://github.com/confluentinc/ce-kafka/pull/7070

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
