### PR TITLE
Fix format of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*	@confluentinc/kafka-eng
-*	@confluentinc/ksql
+*	@confluentinc/kafka-eng @confluentinc/ksql


### PR DESCRIPTION
If entries are on two distinct lines, the last ones wins and it is effectively the code owner. If the entries are on the same line, an approval of only one of the entries is required.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
