### PR TITLE
Manual sync from AK/3.0

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -581,7 +581,9 @@ public class StreamThread extends Thread {
                     cacheResizer.accept(size);
                 }
                 runOnce();
-                if (nextProbingRebalanceMs.get() < time.milliseconds()) {
+
+                // Check for a scheduled rebalance but don't trigger it until the current rebalance is done
+                if (!taskManager.isRebalanceInProgress() && nextProbingRebalanceMs.get() < time.milliseconds()) {
                     log.info("Triggering the followup rebalance scheduled for {} ms.", nextProbingRebalanceMs.get());
                     mainConsumer.enforceRebalance();
                     nextProbingRebalanceMs.set(Long.MAX_VALUE);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -488,10 +488,8 @@ public class StreamThreadTest {
         final EasyMockConsumerClientSupplier mockClientSupplier = new EasyMockConsumerClientSupplier(mockConsumer);
         mockClientSupplier.setCluster(createCluster());
 
-        final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
-        topologyMetadata.buildAndRewriteTopology();
         final StreamThread thread = StreamThread.create(
-            topologyMetadata,
+            internalTopologyBuilder,
             config,
             mockClientSupplier,
             mockClientSupplier.getAdmin(config.getAdminConfigs(CLIENT_ID)),
@@ -548,8 +546,6 @@ public class StreamThreadTest {
         final EasyMockConsumerClientSupplier mockClientSupplier = new EasyMockConsumerClientSupplier(mockConsumer);
         mockClientSupplier.setCluster(createCluster());
 
-        final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
-        topologyMetadata.buildAndRewriteTopology();
         final StreamThread thread = StreamThread.create(
             internalTopologyBuilder,
             config,


### PR DESCRIPTION
Needed to port a fix back to 3.0 for a customer hotfix so I just want to make sure this gets synced over (the actual hotfix branch is 7.0.x, which oddly enough did not already exist so I had to create it 🤷‍♀️ )

Merge contains these two commits: 
https://github.com/apache/kafka/commit/0ab8847bfcd5be981fb4b38ace1df415a2ec767d
https://github.com/apache/kafka/commit/8425daf92db54e87727600c0a42323f46e52cfc0