### PR TITLE
DP-9030: Use the new withGradleFile closure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ def retryFlagsString(jobConfig) {
 
 def downstreamBuildFailureOutput = ""
 def publishStep(String vaultSecret) {
-    withGradleInit(["gradle/${vaultSecret}", "settings_file", "${env.WORKSPACE}/init.gradle", "GRADLE_NEXUS_SETTINGS"]) {
+    withGradleFile(["gradle/${vaultSecret}", "settings_file", "${env.WORKSPACE}/init.gradle", "GRADLE_NEXUS_SETTINGS"]) {
         sh "./gradlewAll --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchives"
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ def retryFlagsString(jobConfig) {
 
 def downstreamBuildFailureOutput = ""
 def publishStep(String vaultSecret) {
-    withVaultFile([["gradle/${vaultSecret}", "settings_file", "${env.WORKSPACE}/init.gradle", "GRADLE_NEXUS_SETTINGS"]]) {
+    withGradleInit(["gradle/${vaultSecret}", "settings_file", "${env.WORKSPACE}/init.gradle", "GRADLE_NEXUS_SETTINGS"]) {
         sh "./gradlewAll --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchives"
     }
 }


### PR DESCRIPTION
Confluent is migrating from JFrog to CodeArtifact. The current vault secret has the contents of a `gradle.init` file with credentials for JFrog. CodeArtifact's credentials only last 12 hours, so it needs to be refreshed.

The `withGradleFile` closure wraps the `withVaultFile` closure, but refreshes and substitutes to CodeArtifact token into the file.

Merging this pull request **will not** cause the repo to publish to CodeArtifact. When it is time to migrate (later this week), we will swap out the underlying vault secret.

https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2930704487/Java+Migration+FAQ#Jenkins

I tested this new closure in Jenkins with a custom job.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
