### PR TITLE
added support for skipping upload task for older gradle versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -603,7 +603,7 @@ def defaultScalaSuffix = "2.12"
 gradle.taskGraph.whenReady { taskGraph ->
   def skippedPublish = false
   taskGraph.getAllTasks().each { task ->
-    if (task.name.equals("publishMavenJavaPublicationToMavenRepository") &&
+    if ((task.name.equals("publishMavenJavaPublicationToMavenRepository") || task instanceof Upload) &&
         !versions.baseScala.equals(defaultScalaSuffix) &&
         task.project.hasProperty("archivesBaseName") &&
         !task.project.archivesBaseName.endsWith("_${versions.baseScala}")) {


### PR DESCRIPTION
###About
Added support for skipping upload task for older gradle versions.

###Testing
`./gradlewAll clean :raft:uploadArchives`


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
