### PR TITLE
DP-9030: Fix a typo in withGradleFile causing failed builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ def job = {
     }
 
     if (config.publish && config.isDevJob) {
-      withGradleFile([["gradle/artifactory_snapshots_settings", "settings_file", "${env.WORKSPACE}/init.gradle", "GRADLE_NEXUS_SETTINGS"]]) {
+      withGradleFile(["gradle/artifactory_snapshots_settings", "settings_file", "${env.WORKSPACE}/init.gradle", "GRADLE_NEXUS_SETTINGS"]) {
           stage("Publish to artifactory") {
               sh "./gradlew --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchivesAll"
           }


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

This is a follow up to the [previous pull request](https://github.com/confluentinc/kafka/pull/842) to convert the Jenkinsfile to using `withGradleFile`.
It looks like when it was cherry-picked to 2.4 and 2.5, it was incorrectly merged and uses `[[ ]]` instead of `[ ]`.
Once this is merged, it only needs to be cherry-picked to 2.5. The rest of the release branches are correct.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

I tested this using a replay on 2.4 in Jenkins. The build is green.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
