### PR TITLE
KENGINE-283 Topic ID Mismatch Issue - Exception added to disallow Alt…

### DIFF
--- a/core/src/main/scala/kafka/common/AddPartitionNotAllowedDueToTopicIDMismatchException.scala
+++ b/core/src/main/scala/kafka/common/AddPartitionNotAllowedDueToTopicIDMismatchException.scala
@@ -1,0 +1,5 @@
+package kafka.common
+
+class AddPartitionNotAllowedDueToTopicIDMismatchException(message: String) extends RuntimeException(message) {
+  def this() = this(null)
+}

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -21,6 +21,7 @@ import java.util.Properties
 import com.yammer.metrics.core.MetricName
 import kafka.api.LeaderAndIsr
 import kafka.cluster.Broker
+import kafka.common.AddPartitionNotAllowedDueToTopicIDMismatchException
 import kafka.controller.{KafkaController, LeaderIsrAndControllerEpoch, ReplicaAssignment}
 import kafka.log.LogConfig
 import kafka.metrics.KafkaMetricsGroup
@@ -583,6 +584,31 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
    */
   def getReplicaAssignmentForTopics(topics: Set[String]): Map[TopicPartition, Seq[Int]] = {
     getFullReplicaAssignmentForTopics(topics).mapValues(_.replicas).toMap
+  }
+
+  /**
+   * Gets the replica assignments for the given topics, is only called within AlterTopic
+   * because this is the only method where topic ID can be rewritten in the assignments
+   * If a topicID(topic_id) exists, it will be rewritten without one on doing the AlterTopic operation
+   * Exception is thrown in order to stop the operation from happening altogether
+   *
+   * @param topics the topics whose partitions we wish to get the assignments for.
+   * @return the full replica assignment for each partition from the given topics.
+   */
+  def getFullReplicaAssignmentForTopicsInAlterTopic(topics: Set[String]): Map[TopicPartition, ReplicaAssignment] = {
+    val getDataRequests = topics.map(topic => GetDataRequest(TopicZNode.path(topic), ctx = Some(topic)))
+    val getDataResponses = retryRequestsUntilConnected(getDataRequests.toSeq)
+    getDataResponses.flatMap { getDataResponse =>
+      val topic = getDataResponse.ctx.get.asInstanceOf[String]
+      if (TopicZNode.checkForTopicIDInJSON(getDataResponse.data) == Some(true)) {
+        throw new AddPartitionNotAllowedDueToTopicIDMismatchException("The TopicZNode already contains a TopicID. The AlterTopic operation will result in metadata inconsistencies.")
+      }
+      getDataResponse.resultCode match {
+        case Code.OK => TopicZNode.decode(topic, getDataResponse.data)
+        case Code.NONODE => Map.empty[TopicPartition, ReplicaAssignment]
+        case _ => throw getDataResponse.resultException.get
+      }
+    }.toMap
   }
 
   /**
@@ -1673,7 +1699,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
 
   def secure: Boolean = isSecure
 
-  private[zk] def retryRequestUntilConnected[Req <: AsyncRequest](request: Req, expectedControllerZkVersion: Int = ZkVersion.MatchAnyVersion): Req#Response = {
+  private[kafka] def retryRequestUntilConnected[Req <: AsyncRequest](request: Req, expectedControllerZkVersion: Int = ZkVersion.MatchAnyVersion): Req#Response = {
     retryRequestsUntilConnected(Seq(request), expectedControllerZkVersion).head
   }
 
@@ -1688,7 +1714,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
     }
   }
 
-  private def retryRequestsUntilConnected[Req <: AsyncRequest](requests: Seq[Req]): Seq[Req#Response] = {
+  private[kafka] def retryRequestsUntilConnected[Req <: AsyncRequest](requests: Seq[Req]): Seq[Req#Response] = {
     val remainingRequests = new mutable.ArrayBuffer(requests.size) ++= requests
     val responses = new mutable.ArrayBuffer[Req#Response]
     while (remainingRequests.nonEmpty) {

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -259,6 +259,19 @@ object TopicZNode {
       "removing_replicas" -> removingReplicasAssignmentJson.asJava
     ).asJava)
   }
+
+  def checkForTopicIDInJSON(bytes: Array[Byte]): Option[Boolean] = {
+      Json.parseBytes(bytes).map { js =>
+      val assignmentJson = js.asJsonObject
+      val topicId = assignmentJson.get("topic_id").map(_.to[String])
+
+        if (topicId != None) {
+          return Option(true)
+        }
+        else false
+      }
+  }
+
   def decode(topic: String, bytes: Array[Byte]): Map[TopicPartition, ReplicaAssignment] = {
     def getReplicas(replicasJsonOpt: Option[JsonObject], partition: String): Seq[Int] = {
       replicasJsonOpt match {


### PR DESCRIPTION
This PR is related to the following JIRA tickets:-
https://confluentinc.atlassian.net/browse/KENGINE-283
https://confluentinc.atlassian.net/browse/SUP-61

Issue Statement:-
Topic ID mismatch issues occur when older zk clients are used with newer versions of the controller.
When the client is using ce-kafka/Confluent Platform versions 5.4.x, 5.5.x, 6.0.x, 6.1.x with Controller of version 6.2.x with IBP 2.8+ (when usesLegacyTopicId = false and usesModernTopicId = true) the topic_id will be written into the TopicZnode. This happens due to the absence of a topicID when the topic was created. The decode in these older versions that is called after the alterTopic method is invoked isn’t equipped to read topicID(topic_id) and hence overwrites the entire TopicZnode with an empty topicID field.

Reference for versions:- https://docs.confluent.io/platform/current/installation/versions-interoperability.html#supported-versions-and-interoperability-for-cp

Solution:-

CP versions 5.4.x ,5.5.x, 6.0.x and 6.1.x need a mechanism in place to prevent the Alter Topic (Add Partitions) command from executing when used with the Zookeeper flag in order to prevent overwriting the topicId that was created and assigned by the controller running a newer version.
An exception (AddPartitionNotAllowedDueToTopicIDMismatchException) will be thrown when the topicID field is found on decoding the topics replica assignment
