### PR TITLE
Revert a couple of commits that are not in the Apache Kafka 3.4 branch

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -135,7 +135,7 @@ object ConfigCommand extends Logging {
     val errorMessage = s"--bootstrap-server option must be specified to update $entityType configs: {add: $configsToBeAdded, delete: $configsToBeDeleted}"
 
     if (entityType == ConfigType.User) {
-      if (!configsToBeAdded.isEmpty || configsToBeDeleted.nonEmpty) {
+      if (!configsToBeAdded.isEmpty || !configsToBeDeleted.isEmpty) {
         val info = "User configuration updates using ZooKeeper are only supported for SCRAM credential updates."
         val scramMechanismNames = ScramMechanism.values.map(_.mechanismName)
         // make sure every added/deleted configs are SCRAM related, other configs are not supported using zookeeper
@@ -146,7 +146,7 @@ object ConfigCommand extends Logging {
       preProcessScramCredentials(configsToBeAdded)
     } else if (entityType == ConfigType.Broker) {
       // Dynamic broker configs can be updated using ZooKeeper only if the corresponding broker is not running.
-      if (!configsToBeAdded.isEmpty || configsToBeDeleted.nonEmpty) {
+      if (!configsToBeAdded.isEmpty || !configsToBeDeleted.isEmpty) {
         validateBrokersNotRunning(entityName, adminZkClient, zkClient, errorMessage)
 
         val perBrokerConfig = entityName != ConfigEntityName.Default
@@ -253,7 +253,7 @@ object ConfigCommand extends Logging {
   private[admin] def describeConfigWithZk(zkClient: KafkaZkClient, opts: ConfigCommandOptions, adminZkClient: AdminZkClient): Unit = {
     val configEntity = parseEntity(opts)
     val entityType = configEntity.root.entityType
-    val describeAllUsers = entityType == ConfigType.User && configEntity.root.sanitizedName.isEmpty && configEntity.child.isEmpty
+    val describeAllUsers = entityType == ConfigType.User && !configEntity.root.sanitizedName.isDefined && !configEntity.child.isDefined
     val entityName = configEntity.fullSanitizedName
     val errorMessage = s"--bootstrap-server option must be specified to describe $entityType"
     if (entityType == ConfigType.Broker) {
@@ -548,7 +548,7 @@ object ConfigCommand extends Logging {
 
     val (configResourceType, dynamicConfigSource) = entityType match {
       case ConfigType.Topic =>
-        if (entityName.nonEmpty)
+        if (!entityName.isEmpty)
           Topic.validate(entityName)
         (ConfigResource.Type.TOPIC, Some(ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG))
       case ConfigType.Broker => entityName match {
@@ -559,7 +559,7 @@ object ConfigCommand extends Logging {
           (ConfigResource.Type.BROKER, Some(ConfigEntry.ConfigSource.DYNAMIC_BROKER_CONFIG))
       }
       case BrokerLoggerConfigType =>
-        if (entityName.nonEmpty)
+        if (!entityName.isEmpty)
           validateBrokerId()
         (ConfigResource.Type.BROKER_LOGGER, None)
       case entityType => throw new IllegalArgumentException(s"Invalid entity type: $entityType")
@@ -581,7 +581,7 @@ object ConfigCommand extends Logging {
       }).toSeq
   }
 
-  private def describeQuotaConfigs(adminClient: Admin, entityTypes: List[String], entityNames: List[String]): Unit = {
+  private def describeQuotaConfigs(adminClient: Admin, entityTypes: List[String], entityNames: List[String]) = {
     val quotaConfigs = getAllClientQuotasConfigs(adminClient, entityTypes, entityNames)
     quotaConfigs.forKeyValue { (entity, entries) =>
       val entityEntries = entity.entries.asScala
@@ -605,7 +605,7 @@ object ConfigCommand extends Logging {
     }
   }
 
-  private def describeClientQuotaAndUserScramCredentialConfigs(adminClient: Admin, entityTypes: List[String], entityNames: List[String]): Unit = {
+  private def describeClientQuotaAndUserScramCredentialConfigs(adminClient: Admin, entityTypes: List[String], entityNames: List[String]) = {
     describeQuotaConfigs(adminClient, entityTypes, entityNames)
     // we describe user SCRAM credentials only when we are not describing client information
     // and we are not given either --entity-default or --user-defaults
@@ -889,7 +889,7 @@ object ConfigCommand extends Logging {
         (entityFlags ++ entityDefaultsFlags).exists(entity => options.has(entity._1)))
         throw new IllegalArgumentException("--entity-{type,name,default} should not be used in conjunction with specific entity flags")
 
-      val hasEntityName = entityNames.exists(_.nonEmpty)
+      val hasEntityName = entityNames.exists(!_.isEmpty)
       val hasEntityDefault = entityNames.exists(_.isEmpty)
 
       if (!options.has(bootstrapServerOpt) && !options.has(zkConnectOpt))

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -1341,7 +1341,7 @@ object ReassignPartitionsCommand extends Logging {
       CommandLineUtils.printUsageAndDie(opts.parser, "Command must include exactly one action: %s".format(
         validActions.map("--" + _.options().get(0)).mkString(", ")))
     }
-    val action = allActions.head
+    val action = allActions(0)
 
     if (!opts.options.has(opts.bootstrapServerOpt))
       CommandLineUtils.printUsageAndDie(opts.parser, "Please specify --bootstrap-server")

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -587,7 +587,7 @@ object TopicCommand extends Logging {
     def partitions: Option[Integer] = valueAsOption(partitionsOpt)
     def replicationFactor: Option[Integer] = valueAsOption(replicationFactorOpt)
     def replicaAssignment: Option[Map[Int, List[Int]]] =
-      if (has(replicaAssignmentOpt) && Option(options.valueOf(replicaAssignmentOpt)).getOrElse("").nonEmpty)
+      if (has(replicaAssignmentOpt) && !Option(options.valueOf(replicaAssignmentOpt)).getOrElse("").isEmpty)
         Some(parseReplicaAssignment(options.valueOf(replicaAssignmentOpt)))
       else
         None

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
@@ -17,7 +17,7 @@
 package kafka.coordinator.group
 
 import kafka.server.RequestLocal
-import org.apache.kafka.common.message.{HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, SyncGroupRequestData, SyncGroupResponseData}
+import org.apache.kafka.common.message.{HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, SyncGroupRequestData, SyncGroupResponseData}
 import org.apache.kafka.common.requests.RequestContext
 import org.apache.kafka.common.utils.BufferSupplier
 
@@ -164,27 +164,5 @@ class GroupCoordinatorAdapter(
     )
 
     future
-  }
-
-  override def listGroups(
-    context: RequestContext,
-    request: ListGroupsRequestData
-  ): CompletableFuture[ListGroupsResponseData] = {
-    // Handle a null array the same as empty
-    val (error, groups) = coordinator.handleListGroups(
-      Option(request.statesFilter).map(_.asScala.toSet).getOrElse(Set.empty)
-    )
-
-    val response = new ListGroupsResponseData()
-      .setErrorCode(error.code)
-
-    groups.foreach { group =>
-      response.groups.add(new ListGroupsResponseData.ListedGroup()
-        .setGroupId(group.groupId)
-        .setProtocolType(group.protocolType)
-        .setGroupState(group.state))
-    }
-
-    CompletableFuture.completedFuture(response)
   }
 }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -197,7 +197,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.LEAVE_GROUP => handleLeaveGroupRequest(request).exceptionally(handleError)
         case ApiKeys.SYNC_GROUP => handleSyncGroupRequest(request, requestLocal).exceptionally(handleError)
         case ApiKeys.DESCRIBE_GROUPS => handleDescribeGroupRequest(request)
-        case ApiKeys.LIST_GROUPS => handleListGroupsRequest(request).exceptionally(handleError)
+        case ApiKeys.LIST_GROUPS => handleListGroupsRequest(request)
         case ApiKeys.SASL_HANDSHAKE => handleSaslHandshakeRequest(request)
         case ApiKeys.API_VERSIONS => handleApiVersionsRequest(request)
         case ApiKeys.CREATE_TOPICS => maybeForwardToController(request, handleCreateTopicsRequest)
@@ -1620,29 +1620,36 @@ class KafkaApis(val requestChannel: RequestChannel,
     sendResponseCallback(describeGroupsResponseData)
   }
 
-  def handleListGroupsRequest(request: RequestChannel.Request): CompletableFuture[Unit] = {
+  def handleListGroupsRequest(request: RequestChannel.Request): Unit = {
     val listGroupsRequest = request.body[ListGroupsRequest]
-    val hasClusterDescribe = authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, logIfDenied = false)
+    val states = if (listGroupsRequest.data.statesFilter == null)
+      // Handle a null array the same as empty
+      immutable.Set[String]()
+    else
+      listGroupsRequest.data.statesFilter.asScala.toSet
 
-    newGroupCoordinator.listGroups(
-      request.context,
-      listGroupsRequest.data
-    ).handle[Unit] { (response, exception) =>
-      if (exception != null) {
-        requestHelper.sendMaybeThrottle(request, listGroupsRequest.getErrorResponse(exception))
-      } else {
-        val listGroupsResponse = if (hasClusterDescribe) {
-          // With describe cluster access all groups are returned. We keep this alternative for backward compatibility.
-          new ListGroupsResponse(response)
-        } else {
-          // Otherwise, only groups with described group are returned.
-          val authorizedGroups = response.groups.asScala.filter { group =>
-            authHelper.authorize(request.context, DESCRIBE, GROUP, group.groupId, logIfDenied = false)
-          }
-          new ListGroupsResponse(response.setGroups(authorizedGroups.asJava))
-        }
-        requestHelper.sendMaybeThrottle(request, listGroupsResponse)
-      }
+    def createResponse(throttleMs: Int, groups: List[GroupOverview], error: Errors): AbstractResponse = {
+       new ListGroupsResponse(new ListGroupsResponseData()
+            .setErrorCode(error.code)
+            .setGroups(groups.map { group =>
+                val listedGroup = new ListGroupsResponseData.ListedGroup()
+                  .setGroupId(group.groupId)
+                  .setProtocolType(group.protocolType)
+                  .setGroupState(group.state)
+                listedGroup
+            }.asJava)
+            .setThrottleTimeMs(throttleMs)
+        )
+    }
+    val (error, groups) = groupCoordinator.handleListGroups(states)
+    if (authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, logIfDenied = false))
+      // With describe cluster access all groups are returned. We keep this alternative for backward compatibility.
+      requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+        createResponse(requestThrottleMs, groups, error))
+    else {
+      val filteredGroups = groups.filter(group => authHelper.authorize(request.context, DESCRIBE, GROUP, group.groupId, logIfDenied = false))
+      requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+        createResponse(requestThrottleMs, filteredGroups, error))
     }
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
@@ -18,7 +18,7 @@ package kafka.coordinator.group
 
 import kafka.coordinator.group.GroupCoordinatorConcurrencyTest.{JoinGroupCallback, SyncGroupCallback}
 import kafka.server.RequestLocal
-import org.apache.kafka.common.message.{HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, SyncGroupRequestData, SyncGroupResponseData}
+import org.apache.kafka.common.message.{HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, SyncGroupRequestData, SyncGroupResponseData}
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocol
 import org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
-import org.mockito.Mockito.{mock, verify, when}
+import org.mockito.Mockito.{mock, verify}
 
 import java.net.InetAddress
 import scala.jdk.CollectionConverters._
@@ -300,49 +300,4 @@ class GroupCoordinatorAdapterTest {
     assertTrue(future.isDone)
     assertEquals(expectedData, future.get())
   }
-
-  @Test
-  def testListGroups(): Unit = {
-    testListGroups(null, Set.empty)
-    testListGroups(List(), Set.empty)
-    testListGroups(List("Stable"), Set("Stable"))
-  }
-
-  def testListGroups(
-    statesFilter: List[String],
-    expectedStatesFilter: Set[String]
-  ): Unit = {
-    val groupCoordinator = mock(classOf[GroupCoordinator])
-    val adapter = new GroupCoordinatorAdapter(groupCoordinator)
-
-    val ctx = makeContext(ApiKeys.LIST_GROUPS, ApiKeys.LIST_GROUPS.latestVersion)
-    val data = new ListGroupsRequestData()
-      .setStatesFilter(statesFilter.asJava)
-
-    when(groupCoordinator.handleListGroups(expectedStatesFilter)).thenReturn {
-      (Errors.NOT_COORDINATOR, List(
-        GroupOverview("group1", "protocol1", "Stable"),
-        GroupOverview("group2", "qwerty", "Empty")
-      ))
-    }
-
-    val future = adapter.listGroups(ctx, data)
-    assertTrue(future.isDone)
-
-    val expectedData = new ListGroupsResponseData()
-      .setErrorCode(Errors.NOT_COORDINATOR.code)
-      .setGroups(List(
-        new ListGroupsResponseData.ListedGroup()
-          .setGroupId("group1")
-          .setGroupState("Stable")
-          .setProtocolType("protocol1"),
-        new ListGroupsResponseData.ListedGroup()
-          .setGroupId("group2")
-          .setGroupState("Empty")
-          .setProtocolType("qwerty")
-      ).asJava)
-
-    assertEquals(expectedData, future.get())
-  }
-
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -3490,176 +3490,47 @@ class KafkaApisTest {
     }
   }
 
-  @ParameterizedTest
-  @ApiKeyVersionsSource(apiKey = ApiKeys.LIST_GROUPS)
-  def testListGroupsRequest(version: Short): Unit = {
-    val listGroupsRequest = new ListGroupsRequestData()
-      .setStatesFilter(if (version >= 4) List("Stable", "Empty").asJava else List.empty.asJava)
+  @Test
+  def testListGroupsRequest(): Unit = {
+    val overviews = List(
+      GroupOverview("group1", "protocol1", "Stable"),
+      GroupOverview("group2", "qwerty", "Empty")
+    )
+    val response = listGroupRequest(None, overviews)
+    assertEquals(2, response.data.groups.size)
+    assertEquals("Stable", response.data.groups.get(0).groupState)
+    assertEquals("Empty", response.data.groups.get(1).groupState)
+  }
 
-    val requestChannelRequest = buildRequest(new ListGroupsRequest.Builder(listGroupsRequest).build(version))
+  @Test
+  def testListGroupsRequestWithState(): Unit = {
+    val overviews = List(
+      GroupOverview("group1", "protocol1", "Stable")
+    )
+    val response = listGroupRequest(Some("Stable"), overviews)
+    assertEquals(1, response.data.groups.size)
+    assertEquals("Stable", response.data.groups.get(0).groupState)
+  }
 
-    val expectedListGroupsRequest = new ListGroupsRequestData()
-      .setStatesFilter(if (version >= 4) List("Stable", "Empty").asJava else List.empty.asJava)
+  private def listGroupRequest(state: Option[String], overviews: List[GroupOverview]): ListGroupsResponse = {
+    reset(groupCoordinator, clientRequestQuotaManager, requestChannel)
 
-    val future = new CompletableFuture[ListGroupsResponseData]()
-    when(newGroupCoordinator.listGroups(
-      requestChannelRequest.context,
-      expectedListGroupsRequest
-    )).thenReturn(future)
+    val data = new ListGroupsRequestData()
+    if (state.isDefined)
+      data.setStatesFilter(Collections.singletonList(state.get))
+    val listGroupsRequest = new ListGroupsRequest.Builder(data).build()
+    val requestChannelRequest = buildRequest(listGroupsRequest)
+
+    val expectedStates: Set[String] = if (state.isDefined) Set(state.get) else Set()
+    when(groupCoordinator.handleListGroups(expectedStates))
+      .thenReturn((Errors.NONE, overviews))
 
     createKafkaApis().handleListGroupsRequest(requestChannelRequest)
 
-    val expectedListGroupsResponse = new ListGroupsResponseData()
-      .setGroups(List(
-        new ListGroupsResponseData.ListedGroup()
-          .setGroupId("group1")
-          .setGroupState("Stable")
-          .setProtocolType("protocol1"),
-        new ListGroupsResponseData.ListedGroup()
-          .setGroupId("group2")
-          .setGroupState("Empty")
-          .setProtocolType("qwerty")
-      ).asJava)
-
-    future.complete(expectedListGroupsResponse)
     val capturedResponse = verifyNoThrottling(requestChannelRequest)
     val response = capturedResponse.getValue.asInstanceOf[ListGroupsResponse]
-    assertEquals(expectedListGroupsResponse, response.data)
-  }
-
-  @Test
-  def testListGroupsRequestFutureFailed(): Unit = {
-    val listGroupsRequest = new ListGroupsRequestData()
-      .setStatesFilter(List("Stable", "Empty").asJava)
-
-    val requestChannelRequest = buildRequest(new ListGroupsRequest.Builder(listGroupsRequest).build())
-
-    val expectedListGroupsRequest = new ListGroupsRequestData()
-      .setStatesFilter(List("Stable", "Empty").asJava)
-
-    val future = new CompletableFuture[ListGroupsResponseData]()
-    when(newGroupCoordinator.listGroups(
-      requestChannelRequest.context,
-      expectedListGroupsRequest
-    )).thenReturn(future)
-
-    createKafkaApis().handleListGroupsRequest(requestChannelRequest)
-
-    future.completeExceptionally(Errors.UNKNOWN_SERVER_ERROR.exception)
-    val capturedResponse = verifyNoThrottling(requestChannelRequest)
-    val response = capturedResponse.getValue.asInstanceOf[ListGroupsResponse]
-    assertEquals(Errors.UNKNOWN_SERVER_ERROR.code, response.data.errorCode)
-  }
-
-  @Test
-  def testListGroupsRequestFiltersUnauthorizedGroupsWithDescribeCluster(): Unit = {
-    val authorizer: Authorizer = mock(classOf[Authorizer])
-
-    authorizeResource(
-      authorizer,
-      AclOperation.DESCRIBE,
-      ResourceType.GROUP,
-      "group1",
-      AuthorizationResult.DENIED,
-      logIfDenied = false
-    )
-    authorizeResource(
-      authorizer,
-      AclOperation.DESCRIBE,
-      ResourceType.GROUP,
-      "group2",
-      AuthorizationResult.DENIED,
-      logIfDenied = false
-    )
-    authorizeResource(
-      authorizer,
-      AclOperation.DESCRIBE,
-      ResourceType.CLUSTER,
-      Resource.CLUSTER_NAME,
-      AuthorizationResult.ALLOWED,
-      logIfDenied = false
-    )
-
-    testListGroupsRequestFiltersUnauthorizedGroups(
-      authorizer,
-      List("group1", "group2"),
-      List("group1", "group2")
-    )
-  }
-
-  @Test
-  def testListGroupsRequestFiltersUnauthorizedGroupsWithDescribeGroups(): Unit = {
-    val authorizer: Authorizer = mock(classOf[Authorizer])
-
-    authorizeResource(
-      authorizer,
-      AclOperation.DESCRIBE,
-      ResourceType.GROUP,
-      "group1",
-      AuthorizationResult.DENIED,
-      logIfDenied = false
-    )
-    authorizeResource(
-      authorizer,
-      AclOperation.DESCRIBE,
-      ResourceType.GROUP,
-      "group2",
-      AuthorizationResult.ALLOWED,
-      logIfDenied = false
-    )
-    authorizeResource(
-      authorizer,
-      AclOperation.DESCRIBE,
-      ResourceType.CLUSTER,
-      Resource.CLUSTER_NAME,
-      AuthorizationResult.DENIED,
-      logIfDenied = false
-    )
-
-    testListGroupsRequestFiltersUnauthorizedGroups(
-      authorizer,
-      List("group1", "group2"),
-      List("group2")
-    )
-  }
-
-  def testListGroupsRequestFiltersUnauthorizedGroups(
-    authorizer: Authorizer,
-    groups: List[String],
-    expectedGroups: List[String],
-  ): Unit = {
-    val listGroupsRequest = new ListGroupsRequestData()
-
-    val requestChannelRequest = buildRequest(new ListGroupsRequest.Builder(listGroupsRequest).build())
-
-    val expectedListGroupsRequest = new ListGroupsRequestData()
-
-    val future = new CompletableFuture[ListGroupsResponseData]()
-    when(newGroupCoordinator.listGroups(
-      requestChannelRequest.context,
-      expectedListGroupsRequest
-    )).thenReturn(future)
-
-    createKafkaApis(authorizer = Some(authorizer)).handleListGroupsRequest(requestChannelRequest)
-
-    val listGroupsResponse = new ListGroupsResponseData()
-    groups.foreach { groupId =>
-      listGroupsResponse.groups.add(new ListGroupsResponseData.ListedGroup()
-        .setGroupId(groupId)
-      )
-    }
-
-    val expectedListGroupsResponse = new ListGroupsResponseData()
-    expectedGroups.foreach { groupId =>
-      expectedListGroupsResponse.groups.add(new ListGroupsResponseData.ListedGroup()
-        .setGroupId(groupId)
-      )
-    }
-
-    future.complete(listGroupsResponse)
-    val capturedResponse = verifyNoThrottling(requestChannelRequest)
-    val response = capturedResponse.getValue.asInstanceOf[ListGroupsResponse]
-    assertEquals(expectedListGroupsResponse, response.data)
+    assertEquals(Errors.NONE.code, response.data.errorCode)
+    response
   }
 
   @Test

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -22,8 +22,6 @@ import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.message.LeaveGroupRequestData;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
-import org.apache.kafka.common.message.ListGroupsRequestData;
-import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.requests.RequestContext;
@@ -87,19 +85,6 @@ public interface GroupCoordinator {
     CompletableFuture<LeaveGroupResponseData> leaveGroup(
         RequestContext context,
         LeaveGroupRequestData request
-    );
-
-    /**
-     * List Groups.
-     *
-     * @param context           The coordinator request context.
-     * @param request           The ListGroupRequest data.
-     *
-     * @return A future yielding the response or an exception.
-     */
-    CompletableFuture<ListGroupsResponseData> listGroups(
-        RequestContext context,
-        ListGroupsRequestData request
     );
 }
 


### PR DESCRIPTION
The right branching point should have been 96b1db510a32b99.
I incorrectly picked the branching point to be the commit before
the version bump, but there was a gap between the branching
point and the version bump merge in AK trunk.

Most of the additional commits were cherry-picked to 3.4, but
two were not. I revert them both in this PR. I will push the
reverts directly once this PR is approved.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
