### PR TITLE
CONFLUENT: Fix filter for not publishing streams upgrade test artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,7 @@ subprojects {
   // don't publish it
   // We also don't publish artifacts for kafka-streams-upgrade-system-tests since they are not necessary,
   // and were resulting in conflicts due to duplicate artifacts
-  def shouldPublish = !project.name.equals('jmh-benchmarks') && !project.name.startsWith("kafka-streams-upgrade-system-tests")
+  def shouldPublish = !project.name.equals('jmh-benchmarks') && !(project.path.startsWith(':streams') && project.name.startsWith("upgrade-system-tests"))
 
   if (shouldPublish) {
     apply plugin: 'maven-publish'


### PR DESCRIPTION
This is a follow-up to https://github.com/confluentinc/kafka/pull/853 that fixes the new filter in order to not publish artifacts for streams upgrade tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
