### PR TITLE
revert: CONFLUENT: Skip publishing for kafka-streams-upgrade-system-tests & CONFLUENT: Fix filter for not publishing streams upgrade test artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,30 +205,17 @@ subprojects {
   // eg: ./gradlew allDepInsight --configuration runtime --dependency com.fasterxml.jackson.core:jackson-databind
   task allDepInsight(type: DependencyInsightReportTask) doLast {}
 
-  // We use the shadow plugin for the jmh-benchmarks module and the `-all` jar can get pretty large, so
-  // don't publish it
-  // We also don't publish artifacts for kafka-streams-upgrade-system-tests since they are not necessary,
-  // and were resulting in conflicts due to duplicate artifacts
-  def shouldPublish = !(project.path.startsWith(':streams') && project.name.startsWith("upgrade-system-tests"))
-
-  if (shouldPublish) {
-    apply plugin: 'maven-publish'
-    apply plugin: 'signing'
-    apply plugin: 'checkstyle'
-    apply plugin: "com.github.spotbugs"
-    apply plugin: 'org.gradle.test-retry'
-
-    // Add aliases for the task names used by the maven plugin for backwards compatibility
-    // The maven plugin was replaced by the maven-publish plugin in Gradle 7.0
-    tasks.register('install').configure { dependsOn(publishToMavenLocal) }
-    tasks.register('uploadArchives').configure { dependsOn(publish) }
-  }
-
   // apply the eclipse plugin only to subprojects that hold code. 'connect' is just a folder.
   if (!project.name.equals('connect')) {
     apply plugin: 'eclipse'
     fineTuneEclipseClasspathFile(eclipse, project)
   }
+  
+  apply plugin: 'maven'
+  apply plugin: 'signing'
+  apply plugin: 'checkstyle'
+  apply plugin: "com.github.spotbugs"
+  apply plugin: 'org.gradle.test-retry'
 
   sourceCompatibility = minJavaVersion
   targetCompatibility = minJavaVersion

--- a/build.gradle
+++ b/build.gradle
@@ -205,11 +205,6 @@ subprojects {
   // eg: ./gradlew allDepInsight --configuration runtime --dependency com.fasterxml.jackson.core:jackson-databind
   task allDepInsight(type: DependencyInsightReportTask) doLast {}
 
-  apply plugin: 'java-library'
-  apply plugin: 'checkstyle'
-  apply plugin: "com.github.spotbugs"
-  apply plugin: 'org.gradle.test-retry'
-
   // We use the shadow plugin for the jmh-benchmarks module and the `-all` jar can get pretty large, so
   // don't publish it
   // We also don't publish artifacts for kafka-streams-upgrade-system-tests since they are not necessary,

--- a/build.gradle
+++ b/build.gradle
@@ -203,7 +203,7 @@ subprojects {
   task allDeps(type: DependencyReportTask) {}
   // enable running :dependencyInsight task recursively on all subprojects
   // eg: ./gradlew allDepInsight --configuration runtime --dependency com.fasterxml.jackson.core:jackson-databind
-  task allDepInsight(type: DependencyInsightReportTask) {showingAllVariants = false} doLast {}
+  task allDepInsight(type: DependencyInsightReportTask) doLast {}
 
   apply plugin: 'java-library'
   apply plugin: 'checkstyle'

--- a/build.gradle
+++ b/build.gradle
@@ -214,11 +214,14 @@ subprojects {
   // don't publish it
   // We also don't publish artifacts for kafka-streams-upgrade-system-tests since they are not necessary,
   // and were resulting in conflicts due to duplicate artifacts
-  def shouldPublish = !project.name.equals('jmh-benchmarks') && !(project.path.startsWith(':streams') && project.name.startsWith("upgrade-system-tests"))
+  def shouldPublish = !(project.path.startsWith(':streams') && project.name.startsWith("upgrade-system-tests"))
 
   if (shouldPublish) {
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
+    apply plugin: 'checkstyle'
+    apply plugin: "com.github.spotbugs"
+    apply plugin: 'org.gradle.test-retry'
 
     // Add aliases for the task names used by the maven plugin for backwards compatibility
     // The maven plugin was replaced by the maven-publish plugin in Gradle 7.0
@@ -231,11 +234,6 @@ subprojects {
     apply plugin: 'eclipse'
     fineTuneEclipseClasspathFile(eclipse, project)
   }
-  apply plugin: 'maven'
-  apply plugin: 'signing'
-  apply plugin: 'checkstyle'
-  apply plugin: "com.github.spotbugs"
-  apply plugin: 'org.gradle.test-retry'
 
   sourceCompatibility = minJavaVersion
   targetCompatibility = minJavaVersion


### PR DESCRIPTION
Build failing with this error: 
```
10:41:26  Caused by: groovy.lang.MissingPropertyException: Could not set unknown property 'showingAllVariants' for task ':clients:allDepInsight' of type org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.
```
after cherry-picking this commit: https://github.com/confluentinc/kafka/commit/3fb96a6eafd1bac71f88011c2cff30179b2d7660

Remove `showingAllVariants` to revert line to before. 

Another error pops up: 
```
11:28:28  Caused by: org.gradle.internal.metaobject.AbstractDynamicObject$CustomMessageMissingMethodException: Could not find method mavenDeployer() for arguments [build_9ndviwsnxqdm89rxqiasmxx15$_run_closure7$_closure72$_closure96$_closure97$_closure99@38bab292] on extension 'signing' of type org.gradle.plugins.signing.SigningExtension.
```
Most likely due to the move from maven plugin to maven-publish plugin. 

Reverting for now. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
