### PR TITLE
KC-2332: Upgrade netty to 4.1.86 to address CVE-2022-41915, CVE-2022-41881

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -105,7 +105,7 @@ versions += [
   mavenArtifact: "3.8.4",
   metrics: "2.2.0",
   mockito: "4.4.0",
-  netty: "4.1.79.Final",
+  netty: "4.1.86.Final",
   powermock: "2.0.9",
   reflections: "0.9.12",
   reload4j: "1.2.19",


### PR DESCRIPTION
…022-41915 (#13070)

For KAFKA-14564: upgrade to Netty 4.1.86

Fixes the following:

    CVE-2022-41881
    CVE-2022-41915

Reviewers: Luke Chen <showuon@gmail.com>

Result of command`./gradlew allDeps | grep "io.netty:"`  [3.3.txt](https://github.com/confluentinc/kafka/files/10553174/3.3.txt)
