### PR TITLE
KC-2332: Upgrade netty to 4.1.86 to address CVE-2022-41881, CVE-2022-41915

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -99,7 +99,7 @@ versions += [
   mavenArtifact: "3.8.1",
   metrics: "2.2.0",
   mockito: "3.5.7",
-  netty: "4.1.79.Final",
+  netty: "4.1.86.Final",
   owaspDepCheckPlugin: "5.3.2.1",
   powermock: "2.0.7",
   reflections: "0.9.12",


### PR DESCRIPTION
…022-41915 (#13070)

For KAFKA-14564: upgrade to Netty 4.1.86

Fixes the following:

    CVE-2022-41881
    CVE-2022-41915

Reviewers: Luke Chen <showuon@gmail.com>

Result of command`./gradlew allDeps | grep "io.netty:"`  
[2.7.txt](https://github.com/confluentinc/kafka/files/10554033/2.7.txt)

