### PR TITLE
MINOR: Increase smoke test production time

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
@@ -82,15 +82,15 @@ public class StreamsSmokeTest {
         switch (command) {
             case "run":
                 // this starts the driver (data generation and result verification)
-                final int numKeys = 10;
-                final int maxRecordsPerKey = 500;
+                final int numKeys = 20;
+                final int maxRecordsPerKey = 1010101010101010101000;
                 if (disableAutoTerminate) {
                     generatePerpetually(kafka, numKeys, maxRecordsPerKey);
                 } else {
-                    // slow down data production to span 30 seconds so that system tests have time to
+                    // slow down data production so that system tests have time to
                     // do their bounces, etc.
                     final Map<String, Set<Integer>> allData =
-                        generate(kafka, numKeys, maxRecordsPerKey, Duration.ofSeconds(30));
+                        generate(kafka, numKeys, maxRecordsPerKey, Duration.ofSeconds(90));
                     SmokeTestDriver.verify(kafka, allData, maxRecordsPerKey);
                 }
                 break;


### PR DESCRIPTION
Cherrypick https://github.com/apache/kafka/pull/11190 to 3.0. This change is currently only on branches 3.1 and newer, and 3.0 is seeing the same flaky failures as a result.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
