### PR TITLE
CONFLUENT: fix 3.0 dependency loading for streams upgrade test

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -63,6 +63,7 @@ RUN mkdir -p "/opt/kafka-2.5.1" && chmod a+rw /opt/kafka-2.5.1 && curl -s "$KAFK
 RUN mkdir -p "/opt/kafka-2.6.2" && chmod a+rw /opt/kafka-2.6.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.6.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.6.2"
 RUN mkdir -p "/opt/kafka-2.7.1" && chmod a+rw /opt/kafka-2.7.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.7.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.7.1"
 RUN mkdir -p "/opt/kafka-2.8.1" && chmod a+rw /opt/kafka-2.8.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.8.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.8.1"
+RUN mkdir -p "/opt/kafka-3.0.1" && chmod a+rw /opt/kafka-3.0.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.0.1"
 
 # Streams test dependencies
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-0.10.0.1-test.jar" -o /opt/kafka-0.10.0.1/libs/kafka-streams-0.10.0.1-test.jar
@@ -80,6 +81,7 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.5.1-test.jar" -o /opt/kafka-2.5.1/lib
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.6.2-test.jar" -o /opt/kafka-2.6.2/libs/kafka-streams-2.6.2-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.7.1-test.jar" -o /opt/kafka-2.7.1/libs/kafka-streams-2.7.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.8.1-test.jar" -o /opt/kafka-2.8.1/libs/kafka-streams-2.8.1-test.jar
+RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.0.1-test.jar" -o /opt/kafka-3.0.1/libs/kafka-streams-3.0.1-test.jar
 
 # The version of Kibosh to use for testing.
 # If you update this, also update vagrant/base.sh

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -148,6 +148,8 @@ get_kafka 2.7.1 2.12
 chmod a+rw /opt/kafka-2.7.1
 get_kafka 2.8.1 2.12
 chmod a+rw /opt/kafka-2.8.1
+get_kafka 3.0.1 2.12
+chmod a+rw /opt/kafka-3.0.1
 
 # For EC2 nodes, we want to use /mnt, which should have the local disk. On local
 # VMs, we can just create it if it doesn't exist and use it like we'd use


### PR DESCRIPTION
The streams upgrade test for upgrading from 3.0 to 3.1 fails on this branch (3.1) because the 3.0 jars are not loaded, resulting in ClassNotFound exception when attempting to start the 3.0 application in preparation for upgrading.

AFAICT, this test never passed on this branch for this reason. From commit history, it looks like when the 3.1 release was happening, we forgot to add upgrade tests from 3.0 and they were only added after the fact:
https://github.com/apache/kafka/pull/11716

Later, the 3.0 upgrade test was backported to 3.1 in a separate PR (https://github.com/apache/kafka/pull/12173). Interestingly, the test run linked from that PR actually fails with the same error. This PR patches the backport so the test passes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
