### PR TITLE
Get Kafka 3.4.0 with scala 2.13 in Vagrant

### DIFF
--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -156,6 +156,8 @@ get_kafka 3.2.3 2.12
 chmod a+rw /opt/kafka-3.2.3
 get_kafka 3.3.1 2.12
 chmod a+rw /opt/kafka-3.3.1
+get_kafka 3.4.0 2.13
+chmod a+rw /opt/kafka-3.4.0
 
 
 # For EC2 nodes, we want to use /mnt, which should have the local disk. On local


### PR DESCRIPTION
Missing kafka-3.4.0 causes error in`zookeeper_migration_test` in Jenkins
```
bash: line 1: /opt/kafka-3.4.0/bin/zookeeper-server-start.sh: No such file or directory
```