### PR TITLE
MINOR: Fix bump master to 7.6.0-0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ group=org.apache.kafka
 #  - streams/quickstart/pom.xml
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - streams/quickstart/java/pom.xml
-version=7.5.0-0-ccs
+version=7.6.0-0-ccs
 scalaVersion=2.13.10
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/streams/quickstart/java/pom.xml
+++ b/streams/quickstart/java/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.kafka</groupId>
         <artifactId>streams-quickstart</artifactId>
-        <version>7.5.0-0-ccs</version>
+        <version>7.6.0-0-ccs</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>7.5.0-0-ccs</kafka.version>
+        <kafka.version>7.6.0-0-ccs</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
     </properties>
 

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>7.5.0-0-ccs</version>
+    <version>7.6.0-0-ccs</version>
 
     <name>Kafka Streams :: Quickstart</name>
 

--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -22,4 +22,4 @@
 # Instead, in development branches, the version should have a suffix of the form ".devN"
 #
 # For example, when Kafka is at version 1.0.0-0, this should be something like "1.0.0-0.dev0"
-__version__ = '7.5.0-0.dev0'
+__version__ = '7.6.0-0.dev0'

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -120,7 +120,7 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("7.5.0-0")
+DEV_VERSION = KafkaVersion("7.6.0-0")
 
 LATEST_METADATA_VERSION = "3.3"
 


### PR DESCRIPTION
When [AK version bump to 3.6](https://github.com/confluentinc/kafka/commit/dc1ede8d89d0964783302e0da9ead7fa1d76fbe4) was merged in, the 3.6 bumps were merged in correctly, but 7.6.0 CCS version bump was not applied. This commit applies 7.6.0 version bump for ccs kafka in master branch