### PR TITLE
Fix packaging master build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,5 +26,5 @@ group=org.apache.kafka
 version=7.6.0-0-ccs
 scalaVersion=2.13.10
 task=build
-org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx2g -Xss100m -XX:+UseParallelGC
 org.gradle.parallel=true


### PR DESCRIPTION
Making jvmargs consistent for both ce-kafka and ccs kafka.
[gradle.properties](https://github.com/confluentinc/ce-kafka/blob/master/gradle.properties) got changed recently in ce-kafka (master branch) , i think by this [PR/commit](https://github.com/confluentinc/ce-kafka/commit/7df211cafec8d9f5b60671afebfa44e83c868e47)
This is causing [packaging master build](https://jenkins.confluent.io/job/confluentinc/job/packaging/job/master/3524/execution/node/482/log/) to fail.

As per @santhoshct, we can keep the jvm args same 100m in both the places and it should not cause any issues.
Raising a PR for kafka-eng team to make some changes (if required), review and merge.


*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
