### PR TITLE
MINOR: Update node label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@
 
 def config = jobConfig {
     cron = '@weekly'
-    nodeLabel = 'docker-oraclejdk8'
+    nodeLabel = 'docker-debian-jdk8'
     testResultSpecs = ['junit': '**/build/test-results/**/TEST-*.xml']
     slackChannel = '#kafka-warn'
     timeoutHours = 4


### PR DESCRIPTION
After some discussion on why builds were timing out for a month, it seems that this change https://github.com/confluentinc/kafka/commit/fe6a827e20d30af5328d7376a831f9666e0c8110 was incompatible with the jdk image currently used. 

Updating the image so builds do not time out.
