### PR TITLE
KSECURITY-1789: upgrading requests to v2.31.0

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.8.14", "requests==2.24.0"],
+      install_requires=["ducktape==0.8.18", "requests==2.31.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
Using ducktape v0.8.18 and upgrading requests to v2.31.0