### PR TITLE
[Test] Trying to fix the breaking build due to requests v2.31.0

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape<0.9", "requests==2.31.0"],
+      install_requires=["ducktape @ git+https://git@github.com/confluentinc/ducktape.git@libFix8", "requests==2.31.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
Trying to fix the breaking build due to requests v2.31.0. Using custom ducktape branch `libFix8`