### PR TITLE
KAFKA-15498: bump snappy-java version to 1.1.10.5 (#14434)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -252,7 +252,7 @@ scala-library-2.13.10
 scala-logging_2.13-3.9.4
 scala-reflect-2.13.10
 scala-java8-compat_2.13-1.0.2
-snappy-java-1.1.7.3
+snappy-java-1.1.10.5
 zookeeper-3.5.9
 zookeeper-jute-3.5.9
 

--- a/core/src/test/scala/integration/kafka/api/ProducerCompressionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerCompressionTest.scala
@@ -38,7 +38,8 @@ import java.util.concurrent.Future
 import scala.collection.mutable.ListBuffer
 import scala.util.Random
 
-class ProducerCompressionTest extends ZooKeeperTestHarness {
+@RunWith(value = classOf[Parameterized])
+class ProducerCompressionTest(compression: String) extends ZooKeeperTestHarness {
 
   private val brokerId = 0
   private val topic = "topic"

--- a/core/src/test/scala/integration/kafka/api/ProducerCompressionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerCompressionTest.scala
@@ -29,11 +29,16 @@ import org.junit.Assert._
 import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.zk.ZooKeeperTestHarness
 import kafka.utils.TestUtils
+import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.header.Header
+import org.apache.kafka.common.header.internals.{RecordHeader, RecordHeaders}
 import org.apache.kafka.common.serialization.ByteArraySerializer
+import java.util.concurrent.Future
+import scala.collection.mutable.ListBuffer
+import scala.util.Random
 
-@RunWith(value = classOf[Parameterized])
-class ProducerCompressionTest(compression: String) extends ZooKeeperTestHarness {
+class ProducerCompressionTest extends ZooKeeperTestHarness {
 
   private val brokerId = 0
   private val topic = "topic"
@@ -76,13 +81,28 @@ class ProducerCompressionTest(compression: String) extends ZooKeeperTestHarness 
       TestUtils.createTopic(zkClient, topic, 1, 1, List(server))
       val partition = 0
 
+      def messageValue(length: Int): String = {
+        val random = new Random(0)
+        new String(random.alphanumeric.take(length).toArray)
+      }
+
       // prepare the messages
-      val messageValues = (0 until numRecords).map(i => "value" + i)
+      val messageValues = (0 until numRecords).map(i => messageValue(i))
+      val headerArr = Array[Header](new RecordHeader("key", "value".getBytes))
+      val headers = new RecordHeaders(headerArr)
 
       // make sure the returned messages are correct
       val now = System.currentTimeMillis()
-      val responses = for (message <- messageValues)
-        yield producer.send(new ProducerRecord(topic, null, now, null, message.getBytes))
+      val responses: ListBuffer[Future[RecordMetadata]] = new ListBuffer[Future[RecordMetadata]]()
+
+      for (message <- messageValues) {
+        // 1. send message without key and header
+        responses += producer.send(new ProducerRecord(topic, null, now, null, message.getBytes))
+        // 2. send message with key, without header
+        responses += producer.send(new ProducerRecord(topic, null, now, message.length.toString.getBytes, message.getBytes))
+        // 3. send message with key and header
+        responses += producer.send(new ProducerRecord(topic, null, now, message.length.toString.getBytes, message.getBytes, headers))
+      }
       for ((future, offset) <- responses.zipWithIndex) {
         assertEquals(offset.toLong, future.get.offset)
       }
@@ -91,12 +111,37 @@ class ProducerCompressionTest(compression: String) extends ZooKeeperTestHarness 
       // make sure the fetched message count match
       consumer.assign(Collections.singleton(tp))
       consumer.seek(tp, 0)
-      val records = TestUtils.consumeRecords(consumer, numRecords)
+      val records = TestUtils.consumeRecords(consumer, numRecords*3)
 
-      for (((messageValue, record), index) <- messageValues.zip(records).zipWithIndex) {
+      for (i <- 0 until numRecords) {
+        val messageValue = messageValues(i)
+        // 1. verify message without key and header
+        var offset = i * 3
+        var record = records(offset)
+        assertNull(record.key())
         assertEquals(messageValue, new String(record.value))
+        assertEquals(0, record.headers().toArray.length)
         assertEquals(now, record.timestamp)
-        assertEquals(index.toLong, record.offset)
+        assertEquals(offset.toLong, record.offset)
+
+        // 2. verify message with key, without header
+        offset = i * 3 + 1
+        record = records(offset)
+        assertEquals(messageValue.length.toString, new String(record.key()))
+        assertEquals(messageValue, new String(record.value))
+        assertEquals(0, record.headers().toArray.length)
+        assertEquals(now, record.timestamp)
+        assertEquals(offset.toLong, record.offset)
+
+        // 3. verify message with key and header
+        offset = i * 3 + 2
+        record = records(offset)
+        assertEquals(messageValue.length.toString, new String(record.key()))
+        assertEquals(messageValue, new String(record.value))
+        assertEquals(1, record.headers().toArray.length)
+        assertEquals(headerArr.apply(0), record.headers().toArray.apply(0))
+        assertEquals(now, record.timestamp)
+        assertEquals(offset.toLong, record.offset)
       }
     } finally {
       producer.close()

--- a/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
@@ -144,9 +144,9 @@ class LogCleanerParameterizedIntegrationTest(compressionCodec: String) extends A
       case _ =>
         // the broker assigns absolute offsets for message format 0 which potentially causes the compressed size to
         // increase because the broker offsets are larger than the ones assigned by the client
-        // adding `5` to the message set size is good enough for this test: it covers the increased message size while
+        // adding `6` to the message set size is good enough for this test: it covers the increased message size while
         // still being less than the overhead introduced by the conversion from message format version 0 to 1
-        largeMessageSet.sizeInBytes + 5
+        largeMessageSet.sizeInBytes + 6
     }
 
     cleaner = makeCleaner(partitions = topicPartitions, maxMessageSize = maxMessageSize)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -111,7 +111,7 @@ versions += [
   scoveragePlugin: "4.0.1",
   shadowPlugin: "5.2.0",
   slf4j: "1.7.36",
-  snappy: "1.1.10.1",
+  snappy: "1.1.10.5",
   spotbugs: "4.0.3",
   spotbugsPlugin: "4.2.4",
   spotlessPlugin: "3.28.1",


### PR DESCRIPTION
bump snappy-java version to 1.1.10.5, and add more tests to verify the compressed data can be correctly decompressed and read.

For LogCleanerParameterizedIntegrationTest, we increased the message size for snappy decompression since in the new version of snappy, the decompressed size is increasing compared with the previous version. But since the compression algorithm is not kafka's scope, all we need to do is to make sure the compressed data can be successfully decompressed and parsed/read.

Reviewers: Divij Vaidya <diviv@amazon.com>, Ismael Juma <ismael@juma.me.uk>, Josep Prat <josep.prat@aiven.io>, Kamal Chandraprakash <kamal.chandraprakash@gmail.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
