### PR TITLE
Update kafka-run-class.bat fix for non-dev release

### DIFF
--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -94,6 +94,11 @@ for %%i in ("%BASE_DIR%\libs\*") do (
 	call :concat "%%i"
 )
 
+rem CONFLUENT: classpath addition for releases with LSB-style layout
+for %%i in ("%BASE_DIR%\share\java\kafka\*") do (
+	call :concat "%%i"
+)
+
 rem Classpath addition for core
 for %%i in ("%BASE_DIR%\core\build\libs\kafka_%SCALA_BINARY_VERSION%*.jar") do (
 	call :concat "%%i"


### PR DESCRIPTION
Fixing Windows batch files on release versions that do not include dev files or gradlew builds.

https://github.com/confluentinc/kafka/issues/945

From the 7.5.2 release zip, I am able to run bin/windows/kafka-console-consumer.bat successfully after this change. Prior to this the classpath was empty and I was prompted to run `gradlew jarAll` which is nonsense for a release version.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
