### PR TITLE
CONFLUENT: remove logback dependency from Kafka 3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -923,6 +923,8 @@ project(':core') {
       implementation libs.dropwizardMetrics
       exclude module: 'slf4j-log4j12'
       exclude module: 'log4j'
+      exclude module: 'logback-classic'
+      exclude module: 'logback-core'
     }
     // ZooKeeperMain depends on commons-cli but declares the dependency as `provided`
     implementation libs.commonsCli


### PR DESCRIPTION
This is a follow up to https://github.com/confluentinc/kafka/commit/7089ff8afd77282278f1fac619b4d2b010fa0726
that updates Zookeeper. We need to remove the logback dependency as it introduces a CVE regression. 
Logback dependency is removed in all other Confluent maintained Kafka branches. 


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
