### PR TITLE
fixing jenkinsfile from ak to ck

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,195 +1,153 @@
+#!/usr/bin/env groovy
+
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *  Licensed to the Apache Software Foundation (ASF) under one or more
- *  contributor license agreements.  See the NOTICE file distributed with
- *  this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
- *  (the "License"); you may not use this file except in compliance with
- *  the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
-def doValidation() {
-  // Run all the tasks associated with `check` except for `test` - the latter is executed via `doTest`
-  sh """
-    ./retry_zinc ./gradlew -PscalaVersion=$SCALA_VERSION clean check -x test \
-        --profile --continue -PxmlSpotBugsReport=true -PkeepAliveMode="session"
-  """
+def config = jobConfig {
+    cron = '@weekly'
+    nodeLabel = 'docker-oraclejdk8'
+    testResultSpecs = ['junit': '**/build/test-results/**/TEST-*.xml']
+    slackChannel = '#kafka-warn'
+    timeoutHours = 4
+    runMergeCheck = false
+    downStreamValidate = true
+    downStreamRepos = ["common",]
+    nanoVersion = true
+    disableConcurrentBuilds = true
 }
 
-def isChangeRequest(env) {
-  env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty()
+def retryFlagsString(jobConfig) {
+    if (jobConfig.isPrJob) " -PmaxTestRetries=1 -PmaxTestRetryFailures=5"
+    else ""
 }
 
-def doTest(env, target = "test") {
-  sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
-      --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
-      -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""
-  junit '**/build/test-results/**/TEST-*.xml'
-}
-
-def doStreamsArchetype() {
-  echo 'Verify that Kafka Streams archetype compiles'
-
-  sh '''
-    ./gradlew streams:publishToMavenLocal clients:publishToMavenLocal connect:json:publishToMavenLocal connect:api:publishToMavenLocal \
-         || { echo 'Could not publish kafka-streams.jar (and dependencies) locally to Maven'; exit 1; }
-  '''
-
-  VERSION = sh(script: 'grep "^version=" gradle.properties | cut -d= -f 2', returnStdout: true).trim()
-
-  dir('streams/quickstart') {
-    sh '''
-      mvn clean install -Dgpg.skip  \
-          || { echo 'Could not `mvn install` streams quickstart archetype'; exit 1; }
-    '''
-
-    dir('test-streams-archetype') {
-      // Note the double quotes for variable interpolation
-      sh """ 
-        echo "Y" | mvn archetype:generate \
-            -DarchetypeCatalog=local \
-            -DarchetypeGroupId=org.apache.kafka \
-            -DarchetypeArtifactId=streams-quickstart-java \
-            -DarchetypeVersion=${VERSION} \
-            -DgroupId=streams.examples \
-            -DartifactId=streams.examples \
-            -Dversion=0.1 \
-            -Dpackage=myapps \
-            || { echo 'Could not create new project using streams quickstart archetype'; exit 1; }
-      """
-
-      dir('streams.examples') {
-        sh '''
-          mvn compile \
-              || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
-        '''
-      }
+def downstreamBuildFailureOutput = ""
+def publishStep(String vaultSecret) {
+    withGradleFile(["gradle/${vaultSecret}", "settings_file", "${env.WORKSPACE}/init.gradle", "GRADLE_NEXUS_SETTINGS"]) {
+        sh "./gradlewAll --init-script ${GRADLE_NEXUS_SETTINGS} --no-daemon uploadArchives"
     }
-  }
 }
 
-def tryStreamsArchetype() {
-  try {
-    doStreamsArchetype()
-  } catch(err) {
-    echo 'Failed to build Kafka Streams archetype, marking this build UNSTABLE'
-    currentBuild.result = 'UNSTABLE'
-  }
-}
+def job = {
+    // https://github.com/confluentinc/common-tools/blob/master/confluent/config/dev/versions.json
+    def kafkaMuckrakeVersionMap = [
+            "2.3": "5.3.x",
+            "2.4": "5.4.x",
+            "2.5": "5.5.x",
+            "2.6": "6.0.x",
+            "2.7": "6.1.x",
+            "2.8": "6.2.x",
+            "3.0": "7.0.x",
+            "3.1": "7.1.x",
+            "3.2": "7.2.x",
+            "3.3": "7.3.x",
+            "3.4": "7.4.x",
+            "3.5": "7.5.x",
+            "3.6": "7.6.x",
+            "trunk": "master",
+            "master": "master"
+    ]
+
+    if (config.nanoVersion && !config.isReleaseJob) {
+        ciTool("ci-update-version ${env.WORKSPACE} kafka", config.isPrJob)
+    }
+
+    stage("Check compilation compatibility with Scala 2.12") {
+        sh """
+            ./retry_zinc ./gradlew clean build -x test \
+                --no-daemon --stacktrace -PxmlSpotBugsReport=true -PscalaVersion=2.12
+           """
+    }
 
 
-pipeline {
-  agent none
-  
-  options {
-    disableConcurrentBuilds(abortPrevious: isChangeRequest(env))
-  }
-  
-  stages {
-    stage('Build') {
-      parallel {
+    stage("Compile and validate") {
+        sh """
+            ./retry_zinc ./gradlew clean publishToMavenLocal build -x test \
+                --no-daemon --stacktrace -PxmlSpotBugsReport=true
+           """
+    }
 
-        stage('JDK 8 and Scala 2.12') {
-          agent { label 'ubuntu' }
-          tools {
-            jdk 'jdk_1.8_latest'
-            maven 'maven_3_latest'
-          }
-          options {
-            timeout(time: 8, unit: 'HOURS') 
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.12
-          }
-          steps {
-            doValidation()
-            doTest(env)
-            tryStreamsArchetype()
-          }
+    if (config.publish) {
+      stage("Publish to artifactory") {
+        if (!config.isReleaseJob && !config.isPrJob) {
+            ciTool("ci-push-tag ${env.WORKSPACE} kafka")
         }
 
-        stage('JDK 11 and Scala 2.13') {
-          agent { label 'ubuntu' }
-          tools {
-            jdk 'jdk_11_latest'
-          }
-          options {
-            timeout(time: 8, unit: 'HOURS') 
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.13
-          }
-          steps {
-            doValidation()
-            doTest(env)
-            echo 'Skipping Kafka Streams archetype test for Java 11'
-          }
-        }
-
-        stage('JDK 17 and Scala 2.13') {
-          agent { label 'ubuntu' }
-          tools {
-            jdk 'jdk_17_latest'
-          }
-          options {
-            timeout(time: 8, unit: 'HOURS') 
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.13
-          }
-          steps {
-            doValidation()
-            doTest(env)
-            echo 'Skipping Kafka Streams archetype test for Java 17'
-          }
-        }
-
-        stage('JDK 21 and Scala 2.13') {
-          agent { label 'ubuntu' }
-          tools {
-            jdk 'jdk_21_latest'
-          }
-          options {
-            timeout(time: 8, unit: 'HOURS')
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.13
-          }
-          steps {
-            doValidation()
-            doTest(env)
-            echo 'Skipping Kafka Streams archetype test for Java 21'
-          }
+        if (config.isDevJob) {
+          publishStep('artifactory_snapshots_settings')
+        } else if (config.isPreviewJob) {
+          publishStep('artifactory_preview_release_settings')
         }
       }
     }
-  }
-  
-  post {
-    always {
-      script {
-        if (!isChangeRequest(env)) {
-          node('ubuntu') {
-            step([$class: 'Mailer',
-                 notifyEveryUnstableBuild: true,
-                 recipients: "dev@kafka.apache.org",
-                 sendToIndividuals: false])
-          }
+
+    if (config.publish && config.isDevJob && !config.isReleaseJob && !config.isPrJob) {
+        stage("Start Downstream Builds") {
+            def downstreamBranch = kafkaMuckrakeVersionMap[env.BRANCH_NAME]
+            config.downStreamRepos.each { repo ->
+                build(job: "confluentinc/${repo}/${downstreamBranch}",
+                    wait: false,
+                    propagate: false
+                )
+            }
         }
-      }
     }
-  }
+
+    def runTestsStepName = "Step run-tests"
+    def downstreamBuildsStepName = "Step cp-downstream-builds"
+    def testTargets = [
+        runTestsStepName: {
+            stage('Run tests') {
+                echo "Running unit and integration tests"
+                sh "./gradlew unitTest integrationTest " +
+                        "--no-daemon --stacktrace --continue -PtestLoggingEvents=started,passed,skipped,failed -PmaxParallelForks=4 -PignoreFailures=true" +
+                        retryFlagsString(config)
+            }
+            stage('Upload results') {
+                // Kafka failed test stdout files
+                archiveArtifacts artifacts: '**/testOutput/*.stdout', allowEmptyArchive: true
+
+                def summary = junit '**/build/test-results/**/TEST-*.xml'
+                def total = summary.getTotalCount()
+                def failed = summary.getFailCount()
+                def skipped = summary.getSkipCount()
+                summary = "Test results:\n\t"
+                summary = summary + ("Passed: " + (total - failed - skipped))
+                summary = summary + (", Failed: " + failed)
+                summary = summary + (", Skipped: " + skipped)
+                return summary;
+            }
+        },
+        downstreamBuildsStepName: {
+            echo "Building cp-downstream-builds"
+            stage('Downstream validation') {
+                if (config.isPrJob && config.downStreamValidate) {
+                    downStreamValidation(config.nanoVersion, true, true)
+                } else {
+                    return "skip downStreamValidation"
+                }
+            }
+        }
+    ]
+
+    result = parallel testTargets
+    // combine results of the two targets into one result string
+    return result.runTestsStepName + "\n" + result.downstreamBuildsStepName
 }
+
+runJob config, job
+echo downstreamBuildFailureOutput


### PR DESCRIPTION
The jenkinsfile is carried from ak to ck probably due to a broker merge and causing security vulnerability. Overriding this to ck specific jenkins pipeline. 

Security context: https://confluent.slack.com/archives/C60B5SJ1E/p1705431867294249

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
