### PR TITLE
AKCORE-3: ShareGroupHeartbeat RPC implementation using group coordinator functionality

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3821,8 +3821,6 @@ class KafkaApis(val requestChannel: RequestChannel,
         shareGroupHeartbeatRequest.data,
       ).handle[Unit] { (response, exception) =>
 
-        info(s"*** SHARE GROUP HEARTBEAT RESPONSE *** + ${response}")
-
         if (exception != null) {
           requestHelper.sendMaybeThrottle(request, shareGroupHeartbeatRequest.getErrorResponse(exception))
         } else {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3816,8 +3816,6 @@ class KafkaApis(val requestChannel: RequestChannel,
       requestHelper.sendMaybeThrottle(request, shareGroupHeartbeatRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception))
       CompletableFuture.completedFuture[Unit](())
     } else {
-      /* TODO: Once ShareGroupHeartBeatAPI is supported in group coordinator, uncomment the code below
-          (lines 3821 - 3833) and remove the part sending INVALID_CONFIG exception (lines 3835, 3836)
       groupCoordinator.shareGroupHeartbeat(
         request.context,
         shareGroupHeartbeatRequest.data,
@@ -3831,9 +3829,6 @@ class KafkaApis(val requestChannel: RequestChannel,
           requestHelper.sendMaybeThrottle(request, new ShareGroupHeartbeatResponse(response))
         }
       }
-       */
-      requestHelper.sendMaybeThrottle(request, shareGroupHeartbeatRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
-      CompletableFuture.completedFuture[Unit](())
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -7290,9 +7290,6 @@ class KafkaApisTest extends Logging {
     assertEquals(expectedHeartbeatResponse, response.data)
   }
 
-  /*
-  TODO: Once ShareGroupHeartBeatAPI is supported in group coordinator, uncomment the test below
-            (lines 7285 - 7309) and remove the test verifying INVALID_CONFIG exception (lines 7312 - 7326)
   @Test
   def testShareGroupHeartbeatRequest(): Unit = {
     val shareGroupHeartbeatRequest = new ShareGroupHeartbeatRequestData().setGroupId("group")
@@ -7317,23 +7314,6 @@ class KafkaApisTest extends Logging {
     future.complete(shareGroupHeartbeatResponse)
     val response = verifyNoThrottling[ShareGroupHeartbeatResponse](requestChannelRequest)
     assertEquals(shareGroupHeartbeatResponse, response.data)
-  }
-   */
-
-  @Test
-  def testShareGroupHeartbeatRequest(): Unit = {
-    val shareGroupHeartbeatRequest = new ShareGroupHeartbeatRequestData().setGroupId("group")
-
-    val requestChannelRequest = buildRequest(new ShareGroupHeartbeatRequest.Builder(shareGroupHeartbeatRequest, true).build())
-    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
-    kafkaApis = createKafkaApis(
-      overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"),
-      raftSupport = true
-    )
-    kafkaApis.handle(requestChannelRequest, RequestLocal.NoCaching)
-    val expectedHeartbeatResponse = new ShareGroupHeartbeatResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)
-    val response = verifyNoThrottling[ShareGroupHeartbeatResponse](requestChannelRequest)
-    assertEquals(expectedHeartbeatResponse, response.data)
   }
 
   @Test


### PR DESCRIPTION
**About**
This PR completed the 2 TODOs mentioned in this [PR](https://github.com/confluentinc/kafka/pull/1003)- 
1. Send the ShareGroupHeartbeatRequest to the group coordinator and receive the response as ShareGroupHeartbeatResponse
2. Uncomment the test which verifies the functionality mentioned in point 1

Reference -[ AKCORE-3](https://confluentinc.atlassian.net/browse/AKCORE-3)

**Build** 
The build is passing as shown in the screenshot
<img width="1644" alt="Screenshot 2024-02-07 at 5 06 12 PM" src="https://github.com/confluentinc/kafka/assets/144765188/51091ac7-8ad1-464b-aa24-6fcdef24d628">

The check styles is passing as shown in the screenshot
<img width="1605" alt="Screenshot 2024-02-07 at 5 06 36 PM" src="https://github.com/confluentinc/kafka/assets/144765188/96c4ebc4-e7db-4884-85e7-348bc2822016">

**Testing**
The uncommented test passes as shown in the sacreenshot
<img width="1575" alt="Screenshot 2024-02-07 at 5 06 59 PM" src="https://github.com/confluentinc/kafka/assets/144765188/3d5de6ab-743e-41fd-8e46-b8793b624df6">


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
