### PR TITLE
KSECURITY-2090 3.6 update bcprov-jdk15on for the CVE in this jira

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -969,10 +969,14 @@ project(':core') {
       exclude module: 'mina-core'
     }
     testImplementation libs.apachedsCoreApi
-    testImplementation libs.apachedsInterceptorKerberos
+    testImplementation (libs.apachedsInterceptorKerberos) {
+      exclude module: 'bcprov-jdk15on'
+    }
     testImplementation libs.apachedsProtocolShared
     testImplementation libs.apachedsProtocolKerberos
-    testImplementation libs.apachedsProtocolLdap
+    testImplementation (libs.apachedsProtocolLdap) {
+      exclude module: 'bcprov-jdk15on'
+    }
     testImplementation libs.apachedsLdifPartition
     testImplementation libs.apachedsMavibotPartition
     testImplementation libs.apachedsJdbmPartition


### PR DESCRIPTION
The original set of PRs for this CVE only updated the dependency version, they didn't exclude back level bouncy castles brought in via other dependencies.

This PR excludes those, so the latest bouncycastle is used everywhere

Also updates the bouncy castle version from 1.75 to 1.77 which is required by cves

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
