### PR TITLE
AKCORE-2: Refresh poll timer periodically (4/N)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -381,10 +381,11 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
                 throw new IllegalStateException("Consumer is not subscribed to any topics.");
             }
 
-            applicationEventHandler.add(new PollApplicationEvent(timer.currentTimeMs()));
-
             do {
                 backgroundEventProcessor.process();
+
+                applicationEventHandler.add(new PollApplicationEvent(timer.currentTimeMs()));
+
                 final Fetch<K, V> fetch = pollForFetches(timer);
                 if (!fetch.isEmpty()) {
                     return new ConsumerRecords<>(fetch.records());


### PR DESCRIPTION
For a call to `KafkaShareConsumer.poll(Duration timeout)` where the timeout exceeds 5 minutes, the consumer would leave the share group once `max.poll.interval.ms` elapsed. In fact, the timeout is intended to catch situations in which the application thread becomes unresponsive. When the thread is actually inside the Kafka consumer code, it should keep the timer refreshed automatically because there's nothing wrong.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
