### PR TITLE
AKCORE-11: Refactor ShareMembershipManager into a RequestManager

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -50,6 +50,7 @@ public class RequestManagers implements Closeable {
     public final Optional<HeartbeatRequestManager> heartbeatRequestManager;
     public final Optional<ShareHeartbeatRequestManager> shareHeartbeatRequestManager;
     public final Optional<MembershipManager> membershipManager;
+    public final Optional<ShareMembershipManager> shareMembershipManager;
     public final OffsetsRequestManager offsetsRequestManager;
     public final TopicMetadataRequestManager topicMetadataRequestManager;
     public final FetchRequestManager fetchRequestManager;
@@ -73,6 +74,7 @@ public class RequestManagers implements Closeable {
         this.heartbeatRequestManager = heartbeatRequestManager;
         this.shareHeartbeatRequestManager = Optional.empty();
         this.membershipManager = membershipManager;
+        this.shareMembershipManager = Optional.empty();
 
         List<Optional<? extends RequestManager>> list = new ArrayList<>();
         list.add(coordinatorRequestManager);
@@ -87,13 +89,15 @@ public class RequestManagers implements Closeable {
 
     public RequestManagers(LogContext logContext,
                            Optional<CoordinatorRequestManager> coordinatorRequestManager,
-                           Optional<ShareHeartbeatRequestManager> shareHeartbeatRequestManager) {
+                           Optional<ShareHeartbeatRequestManager> shareHeartbeatRequestManager,
+                           Optional<ShareMembershipManager> shareMembershipManager) {
         this.log = logContext.logger(RequestManagers.class);
         this.coordinatorRequestManager = coordinatorRequestManager;
         this.commitRequestManager = Optional.empty();
         this.heartbeatRequestManager = Optional.empty();
         this.shareHeartbeatRequestManager = shareHeartbeatRequestManager;
         this.membershipManager = Optional.empty();
+        this.shareMembershipManager = shareMembershipManager;
         this.offsetsRequestManager = null;
         this.topicMetadataRequestManager = null;
         this.fetchRequestManager = null;
@@ -101,6 +105,7 @@ public class RequestManagers implements Closeable {
         List<Optional<? extends RequestManager>> list = new ArrayList<>();
         list.add(coordinatorRequestManager);
         list.add(shareHeartbeatRequestManager);
+        list.add(shareMembershipManager);
         entries = Collections.unmodifiableList(list);
     }
 
@@ -285,7 +290,8 @@ public class RequestManagers implements Closeable {
                 return new RequestManagers(
                         logContext,
                         Optional.of(coordinator),
-                        Optional.of(shareHeartbeatRequestManager)
+                        Optional.of(shareHeartbeatRequestManager),
+                        Optional.of(shareMembershipManager)
                 );
             }
         };

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManager.java
@@ -297,6 +297,12 @@ public class ShareMembershipManager implements RequestManager {
             throw new IllegalArgumentException(errorMessage);
         }
 
+        if (state == MemberState.LEAVING) {
+            log.debug("Ignoring heartbeat response received from broker. Member {} with epoch {} is " +
+                    "already leaving the group.", memberId, memberEpoch);
+            return;
+        }
+
         // Update the group member id label in the client telemetry reporter if the member id has
         // changed. Initially the member id is empty, and it is updated when the member joins the
         // group. This is done here to avoid updating the label on every heartbeat response. Also

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManager.java
@@ -19,12 +19,11 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
 import org.apache.kafka.clients.consumer.internals.Utils.TopicIdPartitionComparator;
 import org.apache.kafka.clients.consumer.internals.Utils.TopicPartitionComparator;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ErrorBackgroundEvent;
-import org.apache.kafka.common.ClusterResource;
-import org.apache.kafka.common.ClusterResourceListener;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -90,7 +89,7 @@ import java.util.stream.Collectors;
  * </ol>
  *
  */
-public class ShareMembershipManager implements ClusterResourceListener {
+public class ShareMembershipManager implements RequestManager {
 
     /**
      * TopicPartition comparator based on topic name and partition id.
@@ -174,7 +173,7 @@ public class ShareMembershipManager implements ClusterResourceListener {
     private final Map<Uuid, SortedSet<Integer>> currentTargetAssignment;
 
     /**
-     * If there is a reconciliation running. This will be true if {@link #reconcile()} has been triggered
+     * If there is a reconciliation running. This will be true if {@link #maybeReconcile()} has been triggered
      * after receiving a heartbeat response, or a metadata update.
      */
     private boolean reconciliationInProgress;
@@ -192,14 +191,6 @@ public class ShareMembershipManager implements ClusterResourceListener {
      * (heartbeat request to leave is sent out). This will be empty if the member is not leaving.
      */
     private Optional<CompletableFuture<Void>> leaveGroupInProgress = Optional.empty();
-
-    /**
-     * True if the member has registered to be notified when the cluster metadata is updated.
-     * This is initially false, as the member that is not part of a consumer group does not
-     * require metadata updated. This becomes true the first time the member joins on the
-     * {@link #transitionToJoining()}
-     */
-    private boolean isRegisteredForMetadataUpdates;
 
     /**
      * Registered listeners that will be notified whenever the memberID/epoch gets updated (valid
@@ -337,9 +328,9 @@ public class ShareMembershipManager implements ClusterResourceListener {
 
     /**
      * This will process the assignment received if it is different from the member's current
-     * assignment. If a new assignment is received, this will try to resolve the topic names from
-     * metadata, reconcile the resolved assignment, and keep the unresolved to be reconciled when
-     * metadata is discovered.
+     * assignment. If a new assignment is received, this will make sure reconciliation is attempted
+     * on the next call to `poll`. If another reconciliation is currently in process, the first `poll`
+     * after that reconciliation will trigger the new reconciliation.
      *
      * @param assignment Assignment received from the broker.
      */
@@ -350,7 +341,6 @@ public class ShareMembershipManager implements ClusterResourceListener {
             // assignment from the broker, different from the current assignment. Note that the
             // reconciliation might not be triggered just yet because of missing metadata.
             transitionTo(MemberState.RECONCILING);
-            reconcile();
         } else {
             // Same assignment received, nothing to reconcile.
             log.debug("Target assignment {} received from the broker is equals to the member " +
@@ -487,18 +477,6 @@ public class ShareMembershipManager implements ClusterResourceListener {
         resetEpoch();
         transitionTo(MemberState.JOINING);
         clearPendingAssignmentsAndLocalNamesCache();
-        registerForMetadataUpdates();
-    }
-
-    /**
-     * Register to get notified when the cluster metadata is updated, via the
-     * {@link #onUpdate(ClusterResource)}. Register only if the manager is not register already.
-     */
-    private void registerForMetadataUpdates() {
-        if (!isRegisteredForMetadataUpdates) {
-            this.metadata.addClusterUpdateListener(this);
-            isRegisteredForMetadataUpdates = true;
-        }
     }
 
     /**
@@ -525,16 +503,15 @@ public class ShareMembershipManager implements ClusterResourceListener {
 
         releaseAssignment();
 
-        // Clear the subscription, no matter if the callback execution failed or succeeded.
+        // Clear the subscription
         updateSubscription(new TreeSet<>(TOPIC_ID_PARTITION_COMPARATOR), true);
 
         // Transition to ensure that a heartbeat request is sent out to effectively leave the
-        // group (even in the case where the member had no assignment to release or when the
-        // callback execution failed.)
+        // group (even in the case where the member had no assignment to release)
         transitionToSendingLeaveGroup();
 
-        // Return future to indicate that the leave group is done when the callbacks
-        // complete, and the transition to send the heartbeat has been made.
+        // Return future to indicate that the leave group is done when the transition to send
+        // the heartbeat has been made.
         return leaveResult;
     }
 
@@ -667,13 +644,16 @@ public class ShareMembershipManager implements ClusterResourceListener {
     /**
      * Reconcile the assignment that has been received from the server. If for some topics, the
      * topic ID cannot be matched to a topic name, a metadata update will be triggered and only
-     * the subset of topics that are resolvable will be reconciled. Reconciliation will trigger the
-     * callbacks and update the subscription state. Note that only one reconciliation
-     * can be in progress at a time. If there is already another one in progress when this is
-     * triggered, it will be no-op, and the assignment will be reconciled on the next
-     * reconciliation loop.
+     * the subset of topics that are resolvable will be reconciled. Reconciliation will update
+     * the subscription state.
+     *
+     * <p>There are three conditions under which no reconciliation will be triggered:
+     *  - We have already reconciled the assignment (the target assignment is the same as the current assignment).
+     *  - Another reconciliation is already in progress.
+     *  - There are topics that haven't been added to the current assignment yet, but all their topic IDs
+     *    are missing from the target assignment.
      */
-    void reconcile() {
+    void maybeReconcile() {
         if (targetAssignmentReconciled()) {
             log.debug("Ignoring reconciliation attempt. Target assignment is equal to the " +
                     "current assignment.");
@@ -694,7 +674,7 @@ public class ShareMembershipManager implements ClusterResourceListener {
 
         // Keep copy of assigned TopicPartitions created from the TopicIdPartitions that are
         // being reconciled. Needed for interactions with the centralized subscription state that
-        // does not support topic IDs yet, and for the callbacks.
+        // does not support topic IDs yet.
         SortedSet<TopicPartition> assignedTopicPartitions = toTopicPartitionSet(assignedTopicIdPartitions);
 
         // Check same assignment. Based on topic names for now, until topic IDs are properly
@@ -761,8 +741,7 @@ public class ShareMembershipManager implements ClusterResourceListener {
                     "{} state with epoch {}. Interrupting reconciliation as it's " +
                     "not relevant anymore,", memberEpochOnReconciliationStart, state, memberEpoch);
             String reason = interruptedReconciliationErrorMessage();
-            log.error("Interrupting reconciliation after partitions assigned callback " +
-                    "completed. " + reason);
+            log.error("Interrupting reconciliation. " + reason);
         }
     }
 
@@ -785,7 +764,7 @@ public class ShareMembershipManager implements ClusterResourceListener {
     }
 
     /**
-     * @return Reason for interrupting a reconciliation progress when callbacks complete.
+     * @return Reason for interrupting a reconciliation progress.
      */
     private String interruptedReconciliationErrorMessage() {
         String reason;
@@ -901,8 +880,8 @@ public class ShareMembershipManager implements ClusterResourceListener {
         // while waiting for the commit to complete.
         if (state == MemberState.FATAL) {
             String errorMsg = String.format("Member %s with epoch %s received a fatal error " +
-                    "while waiting for a revocation commit to complete. Will abort revocation " +
-                    "without triggering user callback.", memberId, memberEpoch);
+                    "while waiting for a revocation commit to complete. Will abort revocation.",
+                    memberId, memberEpoch);
             log.debug(errorMsg);
         }
     }
@@ -917,7 +896,7 @@ public class ShareMembershipManager implements ClusterResourceListener {
      */
     private void assignPartitions(SortedSet<TopicIdPartition> assignedPartitions) {
         // Update assignment in the subscription state, and ensure that no fetching or positions
-        // initialization happens for the newly added partitions while the callback runs.
+        // initialization happens for the newly added partitions.
         updateSubscription(assignedPartitions, false);
 
         // Clear topic names cache, removing topics that are not assigned to the member anymore.
@@ -1037,27 +1016,10 @@ public class ShareMembershipManager implements ClusterResourceListener {
 
     /**
      * @return If there is a reconciliation in process now. Note that reconciliation is triggered
-     * by a call to {@link #reconcile()}. Visible for testing.
+     * by a call to {@link #maybeReconcile()}. Visible for testing.
      */
     boolean reconciliationInProgress() {
         return reconciliationInProgress;
-    }
-
-    /**
-     * When cluster metadata is updated, try to resolve topic names for topic IDs received in
-     * assignment that hasn't been resolved yet.
-     * <ul>
-     *     <li>Try to find topic names for all assignments</li>
-     *     <li>Add discovered topic names to the local topic names cache</li>
-     *     <li>If any topics are resolved, trigger a reconciliation process</li>
-     *     <li>If some topics still remain unresolved, request another metadata update</li>
-     * </ul>
-     */
-    @Override
-    public void onUpdate(ClusterResource clusterResource) {
-        if (state == MemberState.RECONCILING) {
-            reconcile();
-        }
     }
 
     /**
@@ -1071,5 +1033,13 @@ public class ShareMembershipManager implements ClusterResourceListener {
             throw new IllegalArgumentException("State updates listener cannot be null");
         }
         this.stateUpdatesListeners.add(listener);
+    }
+
+    @Override
+    public PollResult poll(long currentTimeMs) {
+        if (state == MemberState.RECONCILING) {
+            maybeReconcile();
+        }
+        return PollResult.EMPTY;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -429,7 +429,9 @@ public class ShareHeartbeatRequestManagerTest {
                 .setAssignment(assignmentTopic1));
         when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, "topic1"));
         membershipManager.onHeartbeatResponseReceived(rs1.data());
-        assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+
+        // We remain in RECONCILING state, as the assignment will be reconciled on the next poll
+        assertEquals(MemberState.RECONCILING, membershipManager.state());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
@@ -72,7 +72,6 @@ public class ShareMembershipManagerTest {
     private static final String GROUP_ID = "test-group";
     private static final String MEMBER_ID = "test-member-1";
     private static final String RACK_ID = null;
-    private static final int REBALANCE_TIMEOUT = 100;
     private static final int MEMBER_EPOCH = 1;
 
     private final LogContext logContext = new LogContext();
@@ -114,7 +113,6 @@ public class ShareMembershipManagerTest {
                 GROUP_ID, RACK_ID, subscriptionState, metadata,
                 logContext, Optional.empty(), backgroundEventHandler);
         manager.transitionToJoining();
-        verify(metadata).addClusterUpdateListener(manager);
         clearInvocations(metadata);
 
         // Following joins should not register again.
@@ -125,7 +123,6 @@ public class ShareMembershipManagerTest {
         manager.onHeartbeatRequestSent();
         assertEquals(MemberState.UNSUBSCRIBED, manager.state());
         manager.transitionToJoining();
-        verify(metadata, never()).addClusterUpdateListener(manager);
     }
 
     @Test
@@ -148,17 +145,10 @@ public class ShareMembershipManagerTest {
         membershipManager.onHeartbeatResponseReceived(responseWithoutAssignment.data());
         assertNotEquals(MemberState.RECONCILING, membershipManager.state());
 
-        // It is necessary to prime the SubscriptionState with a subscription so that
-        // it will accept partitions assigned by the following heartbeat response
-        Set<String> topicNames = new HashSet<>();
-        topicNames.add("topic1");
-        topicNames.add("topic2");
-        subscriptionState.subscribe(topicNames, Optional.empty());
-
         ShareGroupHeartbeatResponse responseWithAssignment =
                 createShareGroupHeartbeatResponse(createAssignment(true));
         membershipManager.onHeartbeatResponseReceived(responseWithAssignment.data());
-        assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+        assertEquals(MemberState.RECONCILING, membershipManager.state());
     }
 
     @Test
@@ -357,6 +347,7 @@ public class ShareMembershipManagerTest {
                 );
 
         receiveAssignment(newAssignment, membershipManager);
+        membershipManager.poll(time.milliseconds());
 
         verifyReconciliationNotTriggered(membershipManager);
         assertEquals(MemberState.RECONCILING, membershipManager.state());
@@ -373,7 +364,7 @@ public class ShareMembershipManagerTest {
         );
         when(metadata.topicNames()).thenReturn(fullTopicMetadata);
 
-        membershipManager.onUpdate(null);
+        membershipManager.poll(time.milliseconds());
 
         verifyReconciliationTriggeredAndCompleted(membershipManager, Arrays.asList(topicId1Partition0, topicId2Partition0));
     }
@@ -401,6 +392,9 @@ public class ShareMembershipManagerTest {
         mockOwnedPartitionAndAssignmentReceived(membershipManager, topicId, topicName, Collections.emptyList());
 
         receiveAssignment(topicId, Arrays.asList(0, 1), membershipManager);
+
+        verifyReconciliationNotTriggered(membershipManager);
+        membershipManager.poll(time.milliseconds());
 
         List<TopicIdPartition> assignedPartitions = Arrays.asList(
                 new TopicIdPartition(topicId, new TopicPartition(topicName, 0)),
@@ -558,6 +552,10 @@ public class ShareMembershipManagerTest {
         String topicName = "topic1";
         when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, topicName));
         receiveAssignment(topicId, Collections.singletonList(0), membershipManager);
+
+        verifyReconciliationNotTriggered(membershipManager);
+        membershipManager.poll(time.milliseconds());
+
         Set<TopicPartition> expectedAssignment = Collections.singleton(new TopicPartition(topicName, 0));
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
         verify(subscriptionState).assignFromSubscribed(expectedAssignment);
@@ -635,7 +633,8 @@ public class ShareMembershipManagerTest {
         String topicName = "topic1";
         when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, topicName));
         when(subscriptionState.hasAutoAssignedPartitions()).thenReturn(true);
-        membershipManager.onUpdate(null);
+
+        membershipManager.poll(time.milliseconds());
 
         // Assignment should have been reconciled.
         Set<TopicPartition> expectedAssignment = Collections.singleton(new TopicPartition(topicName, 1));
@@ -696,6 +695,9 @@ public class ShareMembershipManagerTest {
 
         receiveAssignment(topicId, Arrays.asList(0, 1), membershipManager);
 
+        verifyReconciliationNotTriggered(membershipManager);
+        membershipManager.poll(time.milliseconds());
+
         List<TopicIdPartition> assignedPartitions = topicIdPartitions(topicId, topicName, 0, 1);
         verifyReconciliationTriggeredAndCompleted(membershipManager, assignedPartitions);
     }
@@ -711,6 +713,9 @@ public class ShareMembershipManagerTest {
 
         // New assignment received, adding partitions 1 and 2 to the previously owned partition 0.
         receiveAssignment(topicId, Arrays.asList(0, 1, 2), membershipManager);
+
+        verifyReconciliationNotTriggered(membershipManager);
+        membershipManager.poll(time.milliseconds());
 
         List<TopicIdPartition> assignedPartitions = new ArrayList<>();
         assignedPartitions.add(ownedPartition);
@@ -729,6 +734,10 @@ public class ShareMembershipManagerTest {
         mockOwnedPartitionAndAssignmentReceived(membershipManager, topicId, topicName, Collections.emptyList());
         List<TopicIdPartition> expectedAssignmentReconciled = topicIdPartitions(topicId, topicName, 0, 1);
         receiveAssignment(topicId, Arrays.asList(0, 1), membershipManager);
+
+        verifyReconciliationNotTriggered(membershipManager);
+        membershipManager.poll(time.milliseconds());
+
         verifyReconciliationTriggeredAndCompleted(membershipManager, expectedAssignmentReconciled);
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
         clearInvocations(subscriptionState, membershipManager);
@@ -762,6 +771,9 @@ public class ShareMembershipManagerTest {
         // New assignment received, revoking partition 0, and assigning new partitions 1 and 2.
         receiveAssignment(topicId, Arrays.asList(1, 2), membershipManager);
 
+        verifyReconciliationNotTriggered(membershipManager);
+        membershipManager.poll(time.milliseconds());
+
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
         assertEquals(topicIdPartitionsMap(topicId, 1, 2), membershipManager.currentAssignment());
         assertFalse(membershipManager.reconciliationInProgress());
@@ -791,7 +803,7 @@ public class ShareMembershipManagerTest {
         mockTopicNameInMetadataCache(Collections.singletonMap(topicId, topicName), true);
 
         // When metadata is updated, the member should re-trigger reconciliation
-        membershipManager.onUpdate(null);
+        membershipManager.poll(time.milliseconds());
         List<TopicIdPartition> expectedAssignmentReconciled = topicIdPartitions(topicId, topicName, 0, 1);
         verifyReconciliationTriggeredAndCompleted(membershipManager, expectedAssignmentReconciled);
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
@@ -816,10 +828,10 @@ public class ShareMembershipManagerTest {
         assertEquals(Collections.singleton(topicId), membershipManager.topicsAwaitingReconciliation());
         verify(metadata).requestUpdate(anyBoolean());
 
-        // Metadata update received, but still without the unresolved topic in it. Should keep
+        // Next poll is run, but metadata still without the unresolved topic in it. Should keep
         // the unresolved and request update again.
         when(metadata.topicNames()).thenReturn(Collections.emptyMap());
-        membershipManager.onUpdate(null);
+        membershipManager.poll(time.milliseconds());
         verifyReconciliationNotTriggered(membershipManager);
         assertEquals(Collections.singleton(topicId), membershipManager.topicsAwaitingReconciliation());
         verify(metadata, times(2)).requestUpdate(anyBoolean());
@@ -836,6 +848,9 @@ public class ShareMembershipManagerTest {
         // Member received assignment to reconcile;
 
         receiveAssignment(topicId, Arrays.asList(0, 1), membershipManager);
+
+        verifyReconciliationNotTriggered(membershipManager);
+        membershipManager.poll(time.milliseconds());
 
         // Member should complete reconciliation
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
@@ -857,6 +872,8 @@ public class ShareMembershipManagerTest {
 
         // Revoke one of the 2 partitions
         receiveAssignment(topicId, Collections.singletonList(1), membershipManager);
+
+        membershipManager.poll(time.milliseconds());
 
         // Revocation should complete without requesting any metadata update given that the topic
         // received in target assignment should exist in local topic name cache.
@@ -937,16 +954,14 @@ public class ShareMembershipManagerTest {
 
         receiveAssignment(topicId, partitions, membershipManager);
 
+        verifyReconciliationNotTriggered(membershipManager);
+        membershipManager.poll(time.milliseconds());
+
         List<TopicIdPartition> assignedPartitions =
                 partitions.stream().map(tp -> new TopicIdPartition(topicId,
                         new TopicPartition(topicName, tp))).collect(Collectors.toList());
         verifyReconciliationTriggeredAndCompleted(membershipManager, assignedPartitions);
         return membershipManager;
-    }
-
-    private void verifyReconciliationTriggered(ShareMembershipManager membershipManager) {
-        verify(membershipManager).markReconciliationInProgress();
-        assertEquals(MemberState.RECONCILING, membershipManager.state());
     }
 
     private void verifyReconciliationNotTriggered(ShareMembershipManager membershipManager) {
@@ -1045,6 +1060,8 @@ public class ShareMembershipManagerTest {
         when(subscriptionState.hasAutoAssignedPartitions()).thenReturn(true);
 
         membershipManager.onHeartbeatResponseReceived(heartbeatResponse.data());
+        membershipManager.poll(time.milliseconds());
+
         if (expectSubscriptionUpdated) {
             verify(subscriptionState).assignFromSubscribed(anyCollection());
         } else {
@@ -1079,17 +1096,6 @@ public class ShareMembershipManagerTest {
                                 .setTopicId(topicId)
                                 .setPartitions(partitions)));
         ShareGroupHeartbeatResponse heartbeatResponse = createShareGroupHeartbeatResponse(targetAssignment);
-        membershipManager.onHeartbeatResponseReceived(heartbeatResponse.data());
-    }
-
-    private void receiveAssignmentAfterRejoin(Uuid topicId, List<Integer> partitions, ShareMembershipManager membershipManager) {
-        ShareGroupHeartbeatResponseData.Assignment targetAssignment = new ShareGroupHeartbeatResponseData.Assignment()
-                .setAssignedTopicPartitions(Collections.singletonList(
-                        new ShareGroupHeartbeatResponseData.TopicPartitions()
-                                .setTopicId(topicId)
-                                .setPartitions(partitions)));
-        ShareGroupHeartbeatResponse heartbeatResponse =
-                createShareGroupHeartbeatResponseWithBumpedEpoch(targetAssignment);
         membershipManager.onHeartbeatResponseReceived(heartbeatResponse.data());
     }
 
@@ -1174,20 +1180,6 @@ public class ShareMembershipManagerTest {
                 .setErrorCode(Errors.NONE.code())
                 .setMemberId(MEMBER_ID)
                 .setMemberEpoch(MEMBER_EPOCH)
-                .setAssignment(assignment));
-    }
-
-    /**
-     * Create heartbeat response with the given assignment and a bumped epoch (incrementing by 1
-     * as default but could be any increment). This will be used to mock when a member
-     * receives a heartbeat response to the join request, and the response includes an assignment.
-     */
-    private ShareGroupHeartbeatResponse createShareGroupHeartbeatResponseWithBumpedEpoch(
-            ShareGroupHeartbeatResponseData.Assignment assignment) {
-        return new ShareGroupHeartbeatResponse(new ShareGroupHeartbeatResponseData()
-                .setErrorCode(Errors.NONE.code())
-                .setMemberId(MEMBER_ID)
-                .setMemberEpoch(MEMBER_EPOCH + 1)
                 .setAssignment(assignment));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
@@ -385,6 +385,23 @@ public class ShareMembershipManagerTest {
     }
 
     @Test
+    public void testIgnoreHeartbeatWhenLeavingGroup() {
+        ShareMembershipManager membershipManager = createMemberInStableState();
+        mockLeaveGroup();
+
+        CompletableFuture<Void> leaveResult = membershipManager.leaveGroup();
+
+        membershipManager.onHeartbeatResponseReceived(createShareGroupHeartbeatResponse(createAssignment(true)).data());
+
+        assertEquals(MemberState.LEAVING, membershipManager.state());
+        assertEquals(-1, membershipManager.memberEpoch());
+        assertEquals(MEMBER_ID, membershipManager.memberId());
+        assertTrue(membershipManager.currentAssignment().isEmpty());
+        assertFalse(leaveResult.isDone(), "Leave group result should not complete until the " +
+                "heartbeat request to leave is sent out.");
+    }
+
+    @Test
     public void testLeaveGroupWhenMemberOwnsAssignment() {
         Uuid topicId = Uuid.randomUuid();
         String topicName = "topic1";


### PR DESCRIPTION
Change the ShareMembershipManager to implement RequestManager. This means that reconciliation is based on polling, rather than listening to a metadata change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
