### PR TITLE
AKCORE-9: Add support for ShareGroupDescribeRPC [1/N]

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -898,6 +898,29 @@ public interface Admin extends AutoCloseable {
     }
 
     /**
+     * Describe some share group IDs in the cluster.
+     *
+     * @param groupIds The IDs of the share groups to describe.
+     * @param options  The options to use when describing the share groups.
+     * @return The DescribeShareGroupResult.
+     */
+    DescribeShareGroupsResult describeShareGroups(Collection<String> groupIds,
+                                                        DescribeShareGroupsOptions options);
+
+    /**
+     * Describe some share group IDs in the cluster, with the default options.
+     * <p>
+     * This is a convenience method for {@link #describeShareGroups(Collection, DescribeShareGroupsOptions)}
+     * with default options. See the overload for more details.
+     *
+     * @param groupIds The IDs of the share groups to describe.
+     * @return The DescribeShareGroupResult.
+     */
+    default DescribeShareGroupsResult describeShareGroups(Collection<String> groupIds) {
+        return describeShareGroups(groupIds, new DescribeShareGroupsOptions());
+    }
+
+    /**
      * List the consumer groups available in the cluster.
      *
      * @param options The options to use when listing the consumer groups.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+
+/**
+ * Options for {@link Admin#describeShareGroups(Collection, DescribeShareGroupsOptions)}.
+ * <p>
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DescribeShareGroupsOptions extends AbstractOptions<DescribeShareGroupsOptions> {
+  private boolean includeAuthorizedOperations;
+
+  public DescribeShareGroupsOptions includeAuthorizedOperations(boolean includeAuthorizedOperations) {
+    this.includeAuthorizedOperations = includeAuthorizedOperations;
+    return this;
+  }
+
+  public boolean includeAuthorizedOperations() {
+    return includeAuthorizedOperations;
+  }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsResult.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+
+/**
+ * The result of the {@link KafkaAdminClient#describeShareGroups(Collection, DescribeShareGroupsOptions)}} call.
+ * <p>
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DescribeShareGroupsResult {
+
+  private final Map<String, KafkaFuture<ShareGroupDescription>> futures;
+
+  public DescribeShareGroupsResult(final Map<String, KafkaFuture<ShareGroupDescription>> futures) {
+    this.futures = futures;
+  }
+
+  /**
+   * Return a map from group id to futures which yield share group descriptions.
+   */
+  public Map<String, KafkaFuture<ShareGroupDescription>> describedGroups() {
+    Map<String, KafkaFuture<ShareGroupDescription>> describedGroups = new HashMap<>();
+    describedGroups.putAll(futures);
+    return describedGroups;
+  }
+
+  /**
+   * Return a future which yields all ShareGroupDescription objects, if all the describes succeed.
+   */
+  public KafkaFuture<Map<String, ShareGroupDescription>> all() {
+    return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).thenApply(
+        nil -> {
+          Map<String, ShareGroupDescription> descriptions = new HashMap<>(futures.size());
+          futures.forEach((key, future) -> {
+            try {
+              descriptions.put(key, future.get());
+            } catch (InterruptedException | ExecutionException e) {
+              // This should be unreachable, since the KafkaFuture#allOf already ensured
+              // that all of the futures completed successfully.
+              throw new RuntimeException(e);
+            }
+          });
+          return descriptions;
+        });
+  }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -164,6 +164,11 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public DescribeShareGroupsResult describeShareGroups(Collection<String> groupIds, DescribeShareGroupsOptions options) {
+        return delegate.describeShareGroups(groupIds, options);
+    }
+
+    @Override
     public ListConsumerGroupsResult listConsumerGroups(ListConsumerGroupsOptions options) {
         return delegate.listConsumerGroups(options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -48,6 +48,7 @@ import org.apache.kafka.clients.admin.internals.DeleteConsumerGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DeleteRecordsHandler;
 import org.apache.kafka.clients.admin.internals.DescribeConsumerGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DescribeProducersHandler;
+import org.apache.kafka.clients.admin.internals.DescribeShareGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DescribeTransactionsHandler;
 import org.apache.kafka.clients.admin.internals.FenceProducersHandler;
 import org.apache.kafka.clients.admin.internals.ListConsumerGroupOffsetsHandler;
@@ -3295,6 +3296,17 @@ public class KafkaAdminClient extends AdminClient {
         invokeDriver(handler, future, options.timeoutMs);
         return new DescribeConsumerGroupsResult(future.all().entrySet().stream()
                 .collect(Collectors.toMap(entry -> entry.getKey().idValue, Map.Entry::getValue)));
+    }
+
+    @Override
+    public DescribeShareGroupsResult describeShareGroups(final Collection<String> groupIds,
+                                                               final DescribeShareGroupsOptions options) {
+        SimpleAdminApiFuture<CoordinatorKey, ShareGroupDescription> future =
+            DescribeShareGroupsHandler.newFuture(groupIds);
+        DescribeShareGroupsHandler handler = new DescribeShareGroupsHandler(options.includeAuthorizedOperations(), logContext);
+        invokeDriver(handler, future, options.timeoutMs);
+        return new DescribeShareGroupsResult(future.all().entrySet().stream()
+            .collect(Collectors.toMap(entry -> entry.getKey().idValue, Map.Entry::getValue)));
     }
 
     private Set<AclOperation> validAclOperations(final int authorizedOperations) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ShareGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ShareGroupDescription.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.ShareGroupState;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A detailed description of a single share group in the cluster.
+ */
+@InterfaceStability.Evolving
+public class ShareGroupDescription {
+  private final String groupId;
+  private final Collection<MemberDescription> members;
+  private final ShareGroupState state;
+  private final Node coordinator;
+  private final Set<AclOperation> authorizedOperations;
+
+  public ShareGroupDescription(String groupId,
+                               Collection<MemberDescription> members,
+                               ShareGroupState state,
+                               Node coordinator) {
+    this(groupId, members, state, coordinator, Collections.emptySet());
+  }
+
+  public ShareGroupDescription(String groupId,
+                               Collection<MemberDescription> members,
+                               ShareGroupState state,
+                               Node coordinator,
+                               Set<AclOperation> authorizedOperations) {
+    this.groupId = groupId == null ? "" : groupId;
+    this.members = members == null ? Collections.emptyList() :
+        Collections.unmodifiableList(new ArrayList<>(members));
+    this.state = state;
+    this.coordinator = coordinator;
+    this.authorizedOperations = authorizedOperations;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final ShareGroupDescription that = (ShareGroupDescription) o;
+    return Objects.equals(groupId, that.groupId) &&
+        Objects.equals(members, that.members) &&
+        state == that.state &&
+        Objects.equals(coordinator, that.coordinator) &&
+        Objects.equals(authorizedOperations, that.authorizedOperations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(groupId, members, state, coordinator, authorizedOperations);
+  }
+
+  /**
+   * The id of the share group.
+   */
+  public String groupId() {
+    return groupId;
+  }
+
+  /**
+   * A list of the members of the share group.
+   */
+  public Collection<MemberDescription> members() {
+    return members;
+  }
+
+  /**
+   * The share group state, or UNKNOWN if the state is too new for us to parse.
+   */
+  public ShareGroupState state() {
+    return state;
+  }
+
+  /**
+   * The share group coordinator, or null if the coordinator is not known.
+   */
+  public Node coordinator() {
+    return coordinator;
+  }
+
+  /**
+   * authorizedOperations for this group, or null if that information is not known.
+   */
+  public Set<AclOperation> authorizedOperations() {
+    return authorizedOperations;
+  }
+
+  @Override
+  public String toString() {
+    return "(groupId=" + groupId +
+        ", members=" + Utils.join(members, ",") +
+        ", state=" + state +
+        ", coordinator=" + coordinator +
+        ", authorizedOperations=" + authorizedOperations +
+        ")";
+  }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeGroupsHandlerHelper.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeGroupsHandlerHelper.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.MemberAssignment;
+import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.message.DescribeGroupsResponseData;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.utils.Utils;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DescribeGroupsHandlerHelper {
+
+  public static Set<AclOperation> validAclOperations(final int authorizedOperations) {
+    if (authorizedOperations == MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED) {
+      return null;
+    }
+    return Utils.from32BitField(authorizedOperations)
+        .stream()
+        .map(AclOperation::fromCode)
+        .filter(operation -> operation != AclOperation.UNKNOWN
+            && operation != AclOperation.ALL
+            && operation != AclOperation.ANY)
+        .collect(Collectors.toSet());
+  }
+
+  public static List<MemberDescription> memberDescriptions(List<DescribeGroupsResponseData.DescribedGroupMember> members) {
+    final List<MemberDescription> memberDescriptions = new ArrayList<>(members.size());
+    if (members.size() == 0) {
+      return memberDescriptions;
+    }
+    for (DescribeGroupsResponseData.DescribedGroupMember groupMember : members) {
+      Set<TopicPartition> partitions = Collections.emptySet();
+      if (groupMember.memberAssignment().length > 0) {
+        final ConsumerPartitionAssignor.Assignment assignment = ConsumerProtocol.
+            deserializeAssignment(ByteBuffer.wrap(groupMember.memberAssignment()));
+        partitions = new HashSet<>(assignment.partitions());
+      }
+      memberDescriptions.add(new MemberDescription(
+          groupMember.memberId(),
+          Optional.ofNullable(groupMember.groupInstanceId()),
+          groupMember.clientId(),
+          groupMember.clientHost(),
+          new MemberAssignment(partitions)));
+    }
+    return memberDescriptions;
+  }
+
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeShareGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeShareGroupsHandler.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.admin.ShareGroupDescription;
+import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.ShareGroupState;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.message.DescribeGroupsRequestData;
+import org.apache.kafka.common.message.DescribeGroupsResponseData.DescribedGroup;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.DescribeGroupsRequest;
+import org.apache.kafka.common.requests.DescribeGroupsResponse;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DescribeShareGroupsHandler extends AdminApiHandler.Batched<CoordinatorKey, ShareGroupDescription> {
+
+  private final boolean includeAuthorizedOperations;
+  private final Logger log;
+  private final AdminApiLookupStrategy<CoordinatorKey> lookupStrategy;
+
+  public DescribeShareGroupsHandler(
+      boolean includeAuthorizedOperations,
+      LogContext logContext
+  ) {
+    this.includeAuthorizedOperations = includeAuthorizedOperations;
+    this.log = logContext.logger(DescribeShareGroupsHandler.class);
+    this.lookupStrategy = new CoordinatorStrategy(CoordinatorType.GROUP, logContext);
+  }
+
+  private static Set<CoordinatorKey> buildKeySet(Collection<String> groupIds) {
+    return groupIds.stream()
+        .map(CoordinatorKey::byGroupId)
+        .collect(Collectors.toSet());
+  }
+
+  public static AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, ShareGroupDescription> newFuture(
+      Collection<String> groupIds
+  ) {
+    return AdminApiFuture.forKeys(buildKeySet(groupIds));
+  }
+
+  @Override
+  public String apiName() {
+    return "describeGroups";
+  }
+
+  @Override
+  public AdminApiLookupStrategy<CoordinatorKey> lookupStrategy() {
+    return lookupStrategy;
+  }
+
+  @Override
+  public DescribeGroupsRequest.Builder buildBatchedRequest(int coordinatorId, Set<CoordinatorKey> keys) {
+    List<String> groupIds = keys.stream().map(key -> {
+      if (key.type != FindCoordinatorRequest.CoordinatorType.GROUP) {
+        throw new IllegalArgumentException("Invalid transaction coordinator key " + key +
+            " when building `DescribeGroups` request");
+      }
+      return key.idValue;
+    }).collect(Collectors.toList());
+    DescribeGroupsRequestData data = new DescribeGroupsRequestData()
+        .setGroups(groupIds)
+        .setIncludeAuthorizedOperations(includeAuthorizedOperations);
+    return new DescribeGroupsRequest.Builder(data);
+  }
+
+  @Override
+  public ApiResult<CoordinatorKey, ShareGroupDescription> handleResponse(
+      Node coordinator,
+      Set<CoordinatorKey> groupIds,
+      AbstractResponse abstractResponse
+  ) {
+    final DescribeGroupsResponse response = (DescribeGroupsResponse) abstractResponse;
+    final Map<CoordinatorKey, ShareGroupDescription> completed = new HashMap<>();
+    final Map<CoordinatorKey, Throwable> failed = new HashMap<>();
+    final Set<CoordinatorKey> groupsToUnmap = new HashSet<>();
+
+    for (DescribedGroup describedGroup : response.data().groups()) {
+      CoordinatorKey groupIdKey = CoordinatorKey.byGroupId(describedGroup.groupId());
+      Errors error = Errors.forCode(describedGroup.errorCode());
+      if (error != Errors.NONE) {
+        handleError(groupIdKey, error, failed, groupsToUnmap);
+        continue;
+      }
+      final String protocolType = describedGroup.protocolType();
+      if (protocolType.equals(ConsumerProtocol.PROTOCOL_TYPE) || protocolType.isEmpty()) {
+        final List<MemberDescription> memberDescriptions = DescribeGroupsHandlerHelper.memberDescriptions(describedGroup.members());
+        final Set<AclOperation> authorizedOperations = DescribeGroupsHandlerHelper.validAclOperations(describedGroup.authorizedOperations());
+        final ShareGroupDescription shareGroupDescription =
+            new ShareGroupDescription(groupIdKey.idValue,
+                memberDescriptions,
+                ShareGroupState.parse(describedGroup.groupState()),
+                coordinator,
+                authorizedOperations);
+        completed.put(groupIdKey, shareGroupDescription);
+      } else {
+        failed.put(groupIdKey, new IllegalArgumentException(
+            String.format("GroupId %s is not a share group (%s).",
+                groupIdKey.idValue, protocolType)));
+      }
+    }
+
+    return new ApiResult<>(completed, failed, new ArrayList<>(groupsToUnmap));
+  }
+
+  private void handleError(
+      CoordinatorKey groupId,
+      Errors error,
+      Map<CoordinatorKey, Throwable> failed,
+      Set<CoordinatorKey> groupsToUnmap
+  ) {
+    switch (error) {
+      case GROUP_AUTHORIZATION_FAILED:
+        log.debug("`DescribeGroups` request for group id {} failed due to error {}", groupId.idValue, error);
+        failed.put(groupId, error.exception());
+        break;
+
+      case COORDINATOR_LOAD_IN_PROGRESS:
+        // If the coordinator is in the middle of loading, then we just need to retry
+        log.debug("`DescribeGroups` request for group id {} failed because the coordinator " +
+            "is still in the process of loading state. Will retry", groupId.idValue);
+        break;
+
+      case COORDINATOR_NOT_AVAILABLE:
+      case NOT_COORDINATOR:
+        // If the coordinator is unavailable or there was a coordinator change, then we unmap
+        // the key so that we retry the `FindCoordinator` request
+        log.debug("`DescribeGroups` request for group id {} returned error {}. " +
+            "Will attempt to find the coordinator again and retry", groupId.idValue, error);
+        groupsToUnmap.add(groupId);
+        break;
+
+      default:
+        log.error("`DescribeGroups` request for group id {} failed due to unexpected error {}", groupId.idValue, error);
+        failed.put(groupId, error.exception());
+    }
+  }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -119,7 +119,8 @@ public enum ApiKeys {
     ASSIGN_REPLICAS_TO_DIRS(ApiMessageType.ASSIGN_REPLICAS_TO_DIRS),
     LIST_CLIENT_METRICS_RESOURCES(ApiMessageType.LIST_CLIENT_METRICS_RESOURCES),
     DESCRIBE_TOPIC_PARTITIONS(ApiMessageType.DESCRIBE_TOPIC_PARTITIONS),
-    SHARE_GROUP_HEARTBEAT(ApiMessageType.SHARE_GROUP_HEARTBEAT);
+    SHARE_GROUP_HEARTBEAT(ApiMessageType.SHARE_GROUP_HEARTBEAT),
+    SHARE_GROUP_DESCRIBE(ApiMessageType.SHARE_GROUP_DESCRIBE);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -328,6 +328,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return DescribeTopicPartitionsRequest.parse(buffer, apiVersion);
             case SHARE_GROUP_HEARTBEAT:
                 return ShareGroupHeartbeatRequest.parse(buffer, apiVersion);
+            case SHARE_GROUP_DESCRIBE:
+                return ShareGroupDescribeRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -265,6 +265,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return DescribeTopicPartitionsResponse.parse(responseBuffer, version);
             case SHARE_GROUP_HEARTBEAT:
                 return ShareGroupHeartbeatResponse.parse(responseBuffer, version);
+            case SHARE_GROUP_DESCRIBE:
+                return ShareGroupDescribeResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeRequest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ShareGroupDescribeRequestData;
+import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ShareGroupDescribeRequest extends AbstractRequest {
+
+  public static class Builder extends AbstractRequest.Builder<ShareGroupDescribeRequest> {
+
+    private final ShareGroupDescribeRequestData data;
+
+    public Builder(ShareGroupDescribeRequestData data) {
+      this(data, false);
+    }
+
+    public Builder(ShareGroupDescribeRequestData data, boolean enableUnstableLastVersion) {
+      super(ApiKeys.SHARE_GROUP_DESCRIBE, enableUnstableLastVersion);
+      this.data = data;
+    }
+
+    @Override
+    public ShareGroupDescribeRequest build(short version) {
+      return new ShareGroupDescribeRequest(data, version);
+    }
+
+    @Override
+    public String toString() {
+      return data.toString();
+    }
+  }
+
+  private final ShareGroupDescribeRequestData data;
+
+  public ShareGroupDescribeRequest(ShareGroupDescribeRequestData data, short version) {
+    super(ApiKeys.SHARE_GROUP_DESCRIBE, version);
+    this.data = data;
+  }
+
+  @Override
+  public ShareGroupDescribeResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+    ShareGroupDescribeResponseData data = new ShareGroupDescribeResponseData()
+        .setThrottleTimeMs(throttleTimeMs);
+    // Set error for each group
+    this.data.groupIds().forEach(
+        groupId -> data.groups().add(
+            new ShareGroupDescribeResponseData.DescribedGroup()
+                .setGroupId(groupId)
+                .setErrorCode(Errors.forException(e).code())
+        )
+    );
+    return new ShareGroupDescribeResponse(data);
+  }
+
+  @Override
+  public ShareGroupDescribeRequestData data() {
+    return data;
+  }
+
+  public static ShareGroupDescribeRequest parse(ByteBuffer buffer, short version) {
+    return new ShareGroupDescribeRequest(
+        new ShareGroupDescribeRequestData(new ByteBufferAccessor(buffer), version),
+        version
+    );
+  }
+
+  public static List<ShareGroupDescribeResponseData.DescribedGroup> getErrorDescribedGroupList(
+      List<String> groupIds,
+      Errors error
+  ) {
+    return groupIds.stream()
+        .map(groupId -> new ShareGroupDescribeResponseData.DescribedGroup()
+            .setGroupId(groupId)
+            .setErrorCode(error.code())
+        ).collect(Collectors.toList());
+  }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeRequest.java
@@ -64,11 +64,12 @@ public class ShareGroupDescribeRequest extends AbstractRequest {
     ShareGroupDescribeResponseData data = new ShareGroupDescribeResponseData()
         .setThrottleTimeMs(throttleTimeMs);
     // Set error for each group
+    short errorCode = Errors.forException(e).code();
     this.data.groupIds().forEach(
         groupId -> data.groups().add(
             new ShareGroupDescribeResponseData.DescribedGroup()
                 .setGroupId(groupId)
-                .setErrorCode(Errors.forException(e).code())
+                .setErrorCode(errorCode)
         )
     );
     return new ShareGroupDescribeResponse(data);

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeResponse.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Possible error codes.
+ *
+ * - {@link Errors#GROUP_AUTHORIZATION_FAILED}
+ * - {@link Errors#NOT_COORDINATOR}
+ * - {@link Errors#COORDINATOR_NOT_AVAILABLE}
+ * - {@link Errors#COORDINATOR_LOAD_IN_PROGRESS}
+ * - {@link Errors#INVALID_REQUEST}
+ * - {@link Errors#INVALID_GROUP_ID}
+ * - {@link Errors#GROUP_ID_NOT_FOUND}
+ */
+public class ShareGroupDescribeResponse extends AbstractResponse {
+
+  private final ShareGroupDescribeResponseData data;
+
+  public ShareGroupDescribeResponse(ShareGroupDescribeResponseData data) {
+    super(ApiKeys.SHARE_GROUP_DESCRIBE);
+    this.data = data;
+  }
+
+  @Override
+  public ShareGroupDescribeResponseData data() {
+    return data;
+  }
+
+  @Override
+  public Map<Errors, Integer> errorCounts() {
+    HashMap<Errors, Integer> counts = new HashMap<>();
+    data.groups().forEach(
+        group -> updateErrorCounts(counts, Errors.forCode(group.errorCode()))
+    );
+    return counts;
+  }
+
+  @Override
+  public int throttleTimeMs() {
+    return data.throttleTimeMs();
+  }
+
+  @Override
+  public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+    data.setThrottleTimeMs(throttleTimeMs);
+  }
+
+  public static ShareGroupDescribeResponse parse(ByteBuffer buffer, short version) {
+    return new ShareGroupDescribeResponse(
+        new ShareGroupDescribeResponseData(new ByteBufferAccessor(buffer), version)
+    );
+  }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -715,6 +715,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    synchronized public DescribeShareGroupsResult describeShareGroups(Collection<String> groupIds, DescribeShareGroupsOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     synchronized public ListConsumerGroupsResult listConsumerGroups(ListConsumerGroupsOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
@@ -20,7 +20,7 @@ import kafka.common.OffsetAndMetadata
 import kafka.server.{KafkaConfig, ReplicaManager, RequestLocal}
 import kafka.utils.Implicits.MapExtensionMethods
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
-import org.apache.kafka.common.message.{ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData, DeleteGroupsResponseData, DescribeGroupsResponseData, HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, ShareGroupHeartbeatRequestData, ShareGroupHeartbeatResponseData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
+import org.apache.kafka.common.message.{ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData, DeleteGroupsResponseData, DescribeGroupsResponseData, HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupRequestData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, ShareGroupDescribeResponseData, ShareGroupHeartbeatRequestData, ShareGroupHeartbeatResponseData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.RecordBatch
@@ -633,6 +633,15 @@ private[group] class GroupCoordinatorAdapter(
   ): CompletableFuture[util.List[ConsumerGroupDescribeResponseData.DescribedGroup]] = {
     FutureUtils.failedFuture(Errors.UNSUPPORTED_VERSION.exception(
       s"The old group coordinator does not support ${ApiKeys.CONSUMER_GROUP_DESCRIBE.name} API."
+    ))
+  }
+
+  override def shareGroupDescribe(
+                                      context: RequestContext,
+                                      groupIds: util.List[String]
+                                    ): CompletableFuture[util.List[ShareGroupDescribeResponseData.DescribedGroup]] = {
+    FutureUtils.failedFuture(Errors.UNSUPPORTED_VERSION.exception(
+      s"The old group coordinator does not support ${ApiKeys.SHARE_GROUP_DESCRIBE.name} API."
     ))
   }
 }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3881,8 +3881,12 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     if (!config.isNewGroupCoordinatorEnabled) {
       // The API is not supported by the "old" group coordinator (the default). If the
-      // new one is not enabled, we fail directly here.
+      // new one is not enabled, we fail directly here. (KIP-848)
       requestHelper.sendMaybeThrottle(request, request.body[ShareGroupDescribeRequest].getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
+      CompletableFuture.completedFuture[Unit](())
+    } else if (!config.isShareGroupEnabled) {
+      // The API is not supported when the configuration `group.share.enable` has not been set explicitly
+      requestHelper.sendMaybeThrottle(request, shareGroupDescribeRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
       CompletableFuture.completedFuture[Unit](())
     } else {
       val response = new ShareGroupDescribeResponseData()

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -257,6 +257,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.PUSH_TELEMETRY => handlePushTelemetryRequest(request)
         case ApiKeys.LIST_CLIENT_METRICS_RESOURCES => handleListClientMetricsResources(request)
         case ApiKeys.SHARE_GROUP_HEARTBEAT => handleShareGroupHeartbeat(request).exceptionally(handleError)
+        case ApiKeys.SHARE_GROUP_DESCRIBE => handleShareGroupDescribe(request).exceptionally(handleError)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -3869,6 +3870,51 @@ class KafkaApis(val requestChannel: RequestChannel,
           }
 
           requestHelper.sendMaybeThrottle(request, new ConsumerGroupDescribeResponse(response))
+        }
+      }
+    }
+
+  }
+
+  def handleShareGroupDescribe(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    val shareGroupDescribeRequest = request.body[ShareGroupDescribeRequest]
+
+    if (!config.isNewGroupCoordinatorEnabled) {
+      // The API is not supported by the "old" group coordinator (the default). If the
+      // new one is not enabled, we fail directly here.
+      requestHelper.sendMaybeThrottle(request, request.body[ShareGroupDescribeRequest].getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
+      CompletableFuture.completedFuture[Unit](())
+    } else {
+      val response = new ShareGroupDescribeResponseData()
+
+      val authorizedGroups = new ArrayBuffer[String]()
+      shareGroupDescribeRequest.data.groupIds.forEach { groupId =>
+        if (!authHelper.authorize(request.context, DESCRIBE, GROUP, groupId)) {
+          response.groups.add(new ShareGroupDescribeResponseData.DescribedGroup()
+            .setGroupId(groupId)
+            .setErrorCode(Errors.GROUP_AUTHORIZATION_FAILED.code)
+          )
+        } else {
+          authorizedGroups += groupId
+        }
+      }
+
+      groupCoordinator.shareGroupDescribe(
+        request.context,
+        authorizedGroups.asJava
+      ).handle[Unit] { (results, exception) =>
+        if (exception != null) {
+          requestHelper.sendMaybeThrottle(request, shareGroupDescribeRequest.getErrorResponse(exception))
+        } else {
+          if (response.groups.isEmpty) {
+            // If the response is empty, we can directly reuse the results.
+            response.setGroups(results)
+          } else {
+            // Otherwise, we have to copy the results into the existing ones.
+            response.groups.addAll(results)
+          }
+
+          requestHelper.sendMaybeThrottle(request, new ShareGroupDescribeResponse(response))
         }
       }
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.message.OffsetDeleteRequestData;
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
 import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
+import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
@@ -186,6 +187,19 @@ public interface GroupCoordinator {
      * @return A future yielding the results or an exception.
      */
     CompletableFuture<List<ConsumerGroupDescribeResponseData.DescribedGroup>> consumerGroupDescribe(
+        RequestContext context,
+        List<String> groupIds
+    );
+
+    /**
+     * Describe share groups.
+     *
+     * @param context           The coordinator request context.
+     * @param groupIds          The group ids.
+     *
+     * @return A future yielding the results or an exception.
+     */
+    CompletableFuture<List<ShareGroupDescribeResponseData.DescribedGroup>> shareGroupDescribe(
         RequestContext context,
         List<String> groupIds
     );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.message.OffsetDeleteRequestData;
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
 import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
+import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
@@ -52,6 +53,7 @@ import org.apache.kafka.common.requests.DeleteGroupsRequest;
 import org.apache.kafka.common.requests.DescribeGroupsRequest;
 import org.apache.kafka.common.requests.OffsetCommitRequest;
 import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.ShareGroupDescribeRequest;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
 import org.apache.kafka.common.utils.BufferSupplier;
@@ -606,6 +608,57 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     groupList,
                     exception,
                     (error, __) -> ConsumerGroupDescribeRequest.getErrorDescribedGroupList(groupList, error)
+                ));
+
+            futures.add(future);
+        });
+
+        return FutureUtils.combineFutures(futures, ArrayList::new, List::addAll);
+    }
+
+    /**
+     * See {@link GroupCoordinator#consumerGroupDescribe(RequestContext, List)}.
+     */
+    @Override
+    public CompletableFuture<List<ShareGroupDescribeResponseData.DescribedGroup>> shareGroupDescribe(
+        RequestContext context,
+        List<String> groupIds
+    ) {
+        if (!isActive.get()) {
+            return CompletableFuture.completedFuture(ShareGroupDescribeRequest.getErrorDescribedGroupList(
+                groupIds,
+                Errors.COORDINATOR_NOT_AVAILABLE
+            ));
+        }
+
+        final List<CompletableFuture<List<ShareGroupDescribeResponseData.DescribedGroup>>> futures =
+            new ArrayList<>(groupIds.size());
+        final Map<TopicPartition, List<String>> groupsByTopicPartition = new HashMap<>();
+        groupIds.forEach(groupId -> {
+            if (isGroupIdNotEmpty(groupId)) {
+                groupsByTopicPartition
+                    .computeIfAbsent(topicPartitionFor(groupId), __ -> new ArrayList<>())
+                    .add(groupId);
+            } else {
+                futures.add(CompletableFuture.completedFuture(Collections.singletonList(
+                    new ShareGroupDescribeResponseData.DescribedGroup()
+                        .setGroupId(null)
+                        .setErrorCode(Errors.INVALID_GROUP_ID.code())
+                )));
+            }
+        });
+
+        groupsByTopicPartition.forEach((topicPartition, groupList) -> {
+            CompletableFuture<List<ShareGroupDescribeResponseData.DescribedGroup>> future =
+                runtime.scheduleReadOperation(
+                    "share-group-describe",
+                    topicPartition,
+                    (coordinator, lastCommittedOffset) -> coordinator.shareGroupDescribe(groupIds, lastCommittedOffset)
+                ).exceptionally(exception -> handleOperationException(
+                    "share-group-describe",
+                    groupList,
+                    exception,
+                    (error, __) -> ShareGroupDescribeRequest.getErrorDescribedGroupList(groupList, error)
                 ));
 
             futures.add(future);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.message.OffsetDeleteRequestData;
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
 import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
+import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
@@ -530,6 +531,21 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         long committedOffset
     ) {
         return groupMetadataManager.consumerGroupDescribe(groupIds, committedOffset);
+    }
+
+    /**
+     * Handles a ShareGroupDescribe request.
+     *
+     * @param groupIds      The IDs of the groups to describe.
+     *
+     * @return A list containing the ShareGroupDescribeResponseData.DescribedGroup.
+     *
+     */
+    public List<ShareGroupDescribeResponseData.DescribedGroup> shareGroupDescribe(
+        List<String> groupIds,
+        long committedOffset
+    ) {
+        return groupMetadataManager.shareGroupDescribe(groupIds, committedOffset);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.coordinator.group;
 
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.image.TopicImage;
+import org.apache.kafka.image.TopicsImage;
+
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
@@ -36,5 +40,20 @@ public class Utils {
      */
     public static OptionalLong ofSentinel(long value) {
         return value != -1 ? OptionalLong.of(value) : OptionalLong.empty();
+    }
+
+    /**
+     * @return Return specific topic image corresponding to topic id from topicsImage or null
+     */
+    public static String lookupTopicNameById(
+        Uuid topicId,
+        TopicsImage topicsImage
+    ) {
+        TopicImage topicImage = topicsImage.getTopic(topicId);
+        if (topicImage != null) {
+            return topicImage.name();
+        } else {
+            return null;
+        }
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -23,7 +23,6 @@ import org.apache.kafka.coordinator.group.Utils;
 import org.apache.kafka.coordinator.group.common.Assignment;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
-import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.TopicsImage;
 
 import java.util.ArrayList;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.consumer;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
 import org.apache.kafka.coordinator.group.GroupMember;
+import org.apache.kafka.coordinator.group.Utils;
 import org.apache.kafka.coordinator.group.common.Assignment;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
@@ -418,7 +419,7 @@ public class ConsumerGroupMember extends GroupMember {
     ) {
         List<ConsumerGroupDescribeResponseData.TopicPartitions> topicPartitions = new ArrayList<>();
         partitions.forEach((topicId, partitionSet) -> {
-            String topicName = lookupTopicNameById(topicId, topicsImage);
+            String topicName = Utils.lookupTopicNameById(topicId, topicsImage);
             if (topicName != null) {
                 topicPartitions.add(new ConsumerGroupDescribeResponseData.TopicPartitions()
                     .setTopicId(topicId)
@@ -427,18 +428,6 @@ public class ConsumerGroupMember extends GroupMember {
             }
         });
         return topicPartitions;
-    }
-
-    private static String lookupTopicNameById(
-        Uuid topicId,
-        TopicsImage topicsImage
-    ) {
-        TopicImage topicImage = topicsImage.getTopic(topicId);
-        if (topicImage != null) {
-            return topicImage.name();
-        } else {
-            return null;
-        }
     }
 
     @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareGroupMember.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.share;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.coordinator.group.GroupMember;
+import org.apache.kafka.coordinator.group.Utils;
 import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.TopicsImage;
 
@@ -241,25 +242,13 @@ public class ShareGroupMember extends GroupMember {
             ')';
   }
 
-  private static String lookupTopicNameById(
-      Uuid topicId,
-      TopicsImage topicsImage
-  ) {
-    TopicImage topicImage = topicsImage.getTopic(topicId);
-    if (topicImage != null) {
-      return topicImage.name();
-    } else {
-      return null;
-    }
-  }
-
   private static List<ShareGroupDescribeResponseData.TopicPartitions> topicPartitionsFromMap(
       Map<Uuid, Set<Integer>> partitions,
       TopicsImage topicsImage
   ) {
     List<ShareGroupDescribeResponseData.TopicPartitions> topicPartitions = new ArrayList<>();
     partitions.forEach((topicId, partitionSet) -> {
-      String topicName = lookupTopicNameById(topicId, topicsImage);
+      String topicName = Utils.lookupTopicNameById(topicId, topicsImage);
       if (topicName != null) {
         topicPartitions.add(new ShareGroupDescribeResponseData.TopicPartitions()
             .setTopicId(topicId)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareGroupMember.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.coordinator.group.GroupMember;
 import org.apache.kafka.coordinator.group.Utils;
-import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.TopicsImage;
 
 import java.util.ArrayList;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareGroupMember.java
@@ -17,8 +17,12 @@
 package org.apache.kafka.coordinator.group.share;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.coordinator.group.GroupMember;
+import org.apache.kafka.image.TopicImage;
+import org.apache.kafka.image.TopicsImage;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -235,5 +239,54 @@ public class ShareGroupMember extends GroupMember {
             ", state=" + state +
             ", assignedPartitions=" + assignedPartitions +
             ')';
+  }
+
+  private static String lookupTopicNameById(
+      Uuid topicId,
+      TopicsImage topicsImage
+  ) {
+    TopicImage topicImage = topicsImage.getTopic(topicId);
+    if (topicImage != null) {
+      return topicImage.name();
+    } else {
+      return null;
+    }
+  }
+
+  private static List<ShareGroupDescribeResponseData.TopicPartitions> topicPartitionsFromMap(
+      Map<Uuid, Set<Integer>> partitions,
+      TopicsImage topicsImage
+  ) {
+    List<ShareGroupDescribeResponseData.TopicPartitions> topicPartitions = new ArrayList<>();
+    partitions.forEach((topicId, partitionSet) -> {
+      String topicName = lookupTopicNameById(topicId, topicsImage);
+      if (topicName != null) {
+        topicPartitions.add(new ShareGroupDescribeResponseData.TopicPartitions()
+            .setTopicId(topicId)
+            .setTopicName(topicName)
+            .setPartitions(new ArrayList<>(partitionSet)));
+      }
+    });
+    return topicPartitions;
+  }
+
+  /**
+   * @param topicsImage: Topics image objec to search for a specific topic id
+   *
+   * @return The ShareGroupMember mapped as ShareGroupDescribeResponseData.Member.
+   */
+  public ShareGroupDescribeResponseData.Member asShareGroupDescribeMember(
+      TopicsImage topicsImage
+  ) {
+    return new ShareGroupDescribeResponseData.Member()
+        .setMemberEpoch(memberEpoch)
+        .setMemberId(memberId)
+        .setAssignment(new ShareGroupDescribeResponseData.Assignment()
+            .setTopicPartitions(topicPartitionsFromMap(assignedPartitions, topicsImage)))
+        .setClientHost(clientHost)
+        .setClientId(clientId)
+        .setInstanceId(instanceId)
+        .setRackId(rackId)
+        .setSubscribedTopicNames(subscribedTopicNames);
   }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -49,6 +49,7 @@ import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
 import org.apache.kafka.common.message.LeaveGroupRequestData;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
+import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
@@ -1497,6 +1498,143 @@ public class GroupCoordinatorServiceTest {
         assertEquals(
             Collections.singletonList(new ConsumerGroupDescribeResponseData.DescribedGroup()
                 .setGroupId("group-id")
+                .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code())
+            ),
+            future.get()
+        );
+    }
+
+    @Test
+    public void testShareGroupDescribe() throws InterruptedException, ExecutionException {
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime,
+            new GroupCoordinatorMetrics()
+        );
+        int partitionCount = 2;
+        service.startup(() -> partitionCount);
+
+        ShareGroupDescribeResponseData.DescribedGroup describedGroup1 = new ShareGroupDescribeResponseData.DescribedGroup()
+            .setGroupId("share-group-id-1");
+        ShareGroupDescribeResponseData.DescribedGroup describedGroup2 = new ShareGroupDescribeResponseData.DescribedGroup()
+            .setGroupId("share-group-id-2");
+        List<ShareGroupDescribeResponseData.DescribedGroup> expectedDescribedGroups = Arrays.asList(
+            describedGroup1,
+            describedGroup2
+        );
+
+        when(runtime.scheduleReadOperation(
+            ArgumentMatchers.eq("share-group-describe"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+            ArgumentMatchers.any()
+        )).thenReturn(CompletableFuture.completedFuture(Collections.singletonList(describedGroup1)));
+
+        CompletableFuture<Object> describedGroupFuture = new CompletableFuture<>();
+        when(runtime.scheduleReadOperation(
+            ArgumentMatchers.eq("share-group-describe"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 1)),
+            ArgumentMatchers.any()
+        )).thenReturn(describedGroupFuture);
+
+        CompletableFuture<List<ShareGroupDescribeResponseData.DescribedGroup>> future =
+            service.shareGroupDescribe(requestContext(ApiKeys.SHARE_GROUP_DESCRIBE), Arrays.asList("share-group-id-1", "share-group-id-2"));
+
+        assertFalse(future.isDone());
+        describedGroupFuture.complete(Collections.singletonList(describedGroup2));
+        assertEquals(expectedDescribedGroups, future.get());
+    }
+
+    @Test
+    public void testShareGroupDescribeInvalidGroupId() throws ExecutionException, InterruptedException {
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime,
+            new GroupCoordinatorMetrics()
+        );
+        int partitionCount = 1;
+        service.startup(() -> partitionCount);
+
+        ShareGroupDescribeResponseData.DescribedGroup describedGroup = new ShareGroupDescribeResponseData.DescribedGroup()
+            .setGroupId(null)
+            .setErrorCode(Errors.INVALID_GROUP_ID.code());
+        List<ShareGroupDescribeResponseData.DescribedGroup> expectedDescribedGroups = Arrays.asList(
+            new ShareGroupDescribeResponseData.DescribedGroup()
+                .setGroupId(null)
+                .setErrorCode(Errors.INVALID_GROUP_ID.code()),
+            describedGroup
+        );
+
+        when(runtime.scheduleReadOperation(
+            ArgumentMatchers.eq("share-group-describe"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+            ArgumentMatchers.any()
+        )).thenReturn(CompletableFuture.completedFuture(Collections.singletonList(describedGroup)));
+
+        CompletableFuture<List<ShareGroupDescribeResponseData.DescribedGroup>> future =
+            service.shareGroupDescribe(requestContext(ApiKeys.SHARE_GROUP_DESCRIBE), Arrays.asList("", null));
+
+        assertEquals(expectedDescribedGroups, future.get());
+    }
+
+    @Test
+    public void testShareGroupDescribeCoordinatorLoadInProgress() throws ExecutionException, InterruptedException {
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime,
+            new GroupCoordinatorMetrics()
+        );
+        int partitionCount = 1;
+        service.startup(() -> partitionCount);
+
+        when(runtime.scheduleReadOperation(
+            ArgumentMatchers.eq("share-group-describe"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+            ArgumentMatchers.any()
+        )).thenReturn(FutureUtils.failedFuture(
+            new CoordinatorLoadInProgressException(null)
+        ));
+
+        CompletableFuture<List<ShareGroupDescribeResponseData.DescribedGroup>> future =
+            service.shareGroupDescribe(requestContext(ApiKeys.SHARE_GROUP_DESCRIBE), Collections.singletonList("share-group-id"));
+
+        assertEquals(
+            Collections.singletonList(new ShareGroupDescribeResponseData.DescribedGroup()
+                .setGroupId("share-group-id")
+                .setErrorCode(Errors.COORDINATOR_LOAD_IN_PROGRESS.code())
+            ),
+            future.get()
+        );
+    }
+
+    @Test
+    public void testShareGroupDescribeCoordinatorNotActive() throws ExecutionException, InterruptedException {
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime,
+            new GroupCoordinatorMetrics()
+        );
+        when(runtime.scheduleReadOperation(
+            ArgumentMatchers.eq("share-group-describe"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+            ArgumentMatchers.any()
+        )).thenReturn(FutureUtils.failedFuture(
+            Errors.COORDINATOR_NOT_AVAILABLE.exception()
+        ));
+
+        CompletableFuture<List<ShareGroupDescribeResponseData.DescribedGroup>> future =
+            service.shareGroupDescribe(requestContext(ApiKeys.SHARE_GROUP_DESCRIBE), Collections.singletonList("share-group-id"));
+
+        assertEquals(
+            Collections.singletonList(new ShareGroupDescribeResponseData.DescribedGroup()
+                .setGroupId("share-group-id")
                 .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code())
             ),
             future.get()

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -46,6 +46,8 @@ import org.apache.kafka.common.message.LeaveGroupRequestData;
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
+import org.apache.kafka.common.message.ShareGroupDescribeRequestData;
+import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
@@ -318,7 +320,7 @@ public class GroupMetadataManagerTest {
             final private MockTime time = new MockTime();
             final private MockCoordinatorTimer<Void, Record> timer = new MockCoordinatorTimer<>(time);
             final private LogContext logContext = new LogContext();
-            final private SnapshotRegistry snapshotRegistry = new SnapshotRegistry(logContext);
+            private SnapshotRegistry snapshotRegistry = new SnapshotRegistry(logContext);
             final private TopicPartition groupMetadataTopicPartition = new TopicPartition("topic", 0);
             private MetadataImage metadataImage;
             private List<PartitionAssignor> consumerGroupAssignors = Collections.singletonList(new MockPartitionAssignor("range"));
@@ -385,6 +387,11 @@ public class GroupMetadataManagerTest {
 
             public Builder withClassicGroupMaxSessionTimeoutMs(int classicGroupMaxSessionTimeoutMs) {
                 this.classicGroupMaxSessionTimeoutMs = classicGroupMaxSessionTimeoutMs;
+                return this;
+            }
+
+            public Builder withSnapshotRegistry(SnapshotRegistry registry) {
+                this.snapshotRegistry = registry;
                 return this;
             }
 
@@ -543,6 +550,15 @@ public class GroupMetadataManagerTest {
 
             result.records().forEach(this::replay);
             return result;
+        }
+
+        public List<ShareGroupDescribeResponseData.DescribedGroup> shareGroupDescribe(
+            ShareGroupDescribeRequestData request
+        ) {
+            return groupMetadataManager.shareGroupDescribe(
+                request.groupIds(),
+                0L
+            );
         }
 
         public List<ExpiredTimeout<Void, Record>> sleep(long ms) {
@@ -11040,6 +11056,21 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(1)
                 .setRackId("")));
         assertEquals("RackId can't be empty.", ex.getMessage());
+    }
+
+    @Test
+    public void testShareGroupDescribeRequest() {
+        GroupMetadataManagerTestContext context = new Builder().build();
+
+        // GroupId is not required
+        List<ShareGroupDescribeResponseData.DescribedGroup> groups = context.shareGroupDescribe(new ShareGroupDescribeRequestData());
+        assertEquals(0, groups.size());
+
+        // Group id not found
+        groups = context.shareGroupDescribe(
+            new ShareGroupDescribeRequestData().setGroupIds(Collections.singletonList("unknown-group")));
+        assertEquals(1, groups.size());
+        assertEquals(Errors.GROUP_ID_NOT_FOUND.code(), groups.get(0).errorCode());
     }
 
     @Test


### PR DESCRIPTION
### What
- Added support for `shareGroupDescribe` to applicable classes in `group-coordinator`. Created new ShareGroupDescribeRequest & Response for use within GroupCoordinatorAdapter and Service.
- Additional methods have been added to ShareGroup and ShareGroupMember for creating describe share group response object.
- KafkaApis has been updated with new ApiKey for share group describe.

### Why
We want to add support for new RPC `ShareGroupDescribe`

### Testing
- Clean build
- Ran existing tests
- Added new tests wherever applicable.

## Note: https://github.com/confluentinc/kafka/pull/1028 SHOULD BE MERGED INTO THIS BEFORE MERGING THIS.