### PR TITLE
AKCORE-9: ShareGroupDescribe support for KafkaAdminclient [2/N]

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -898,6 +898,29 @@ public interface Admin extends AutoCloseable {
     }
 
     /**
+     * Describe some share group IDs in the cluster.
+     *
+     * @param groupIds The IDs of the share groups to describe.
+     * @param options  The options to use when describing the share groups.
+     * @return The DescribeShareGroupResult.
+     */
+    DescribeShareGroupsResult describeShareGroups(Collection<String> groupIds,
+                                                        DescribeShareGroupsOptions options);
+
+    /**
+     * Describe some share group IDs in the cluster, with the default options.
+     * <p>
+     * This is a convenience method for {@link #describeShareGroups(Collection, DescribeShareGroupsOptions)}
+     * with default options. See the overload for more details.
+     *
+     * @param groupIds The IDs of the share groups to describe.
+     * @return The DescribeShareGroupResult.
+     */
+    default DescribeShareGroupsResult describeShareGroups(Collection<String> groupIds) {
+        return describeShareGroups(groupIds, new DescribeShareGroupsOptions());
+    }
+
+    /**
      * List the consumer groups available in the cluster.
      *
      * @param options The options to use when listing the consumer groups.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+
+/**
+ * Options for {@link Admin#describeShareGroups(Collection, DescribeShareGroupsOptions)}.
+ * <p>
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DescribeShareGroupsOptions extends AbstractOptions<DescribeShareGroupsOptions> {
+  private boolean includeAuthorizedOperations;
+
+  public DescribeShareGroupsOptions includeAuthorizedOperations(boolean includeAuthorizedOperations) {
+    this.includeAuthorizedOperations = includeAuthorizedOperations;
+    return this;
+  }
+
+  public boolean includeAuthorizedOperations() {
+    return includeAuthorizedOperations;
+  }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsResult.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+
+/**
+ * The result of the {@link KafkaAdminClient#describeShareGroups(Collection, DescribeShareGroupsOptions)}} call.
+ * <p>
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DescribeShareGroupsResult {
+
+  private final Map<String, KafkaFuture<ShareGroupDescription>> futures;
+
+  public DescribeShareGroupsResult(final Map<String, KafkaFuture<ShareGroupDescription>> futures) {
+    this.futures = futures;
+  }
+
+  /**
+   * Return a map from group id to futures which yield share group descriptions.
+   */
+  public Map<String, KafkaFuture<ShareGroupDescription>> describedGroups() {
+    Map<String, KafkaFuture<ShareGroupDescription>> describedGroups = new HashMap<>();
+    describedGroups.putAll(futures);
+    return describedGroups;
+  }
+
+  /**
+   * Return a future which yields all ShareGroupDescription objects, if all the describes succeed.
+   */
+  public KafkaFuture<Map<String, ShareGroupDescription>> all() {
+    return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).thenApply(
+        nil -> {
+          Map<String, ShareGroupDescription> descriptions = new HashMap<>(futures.size());
+          futures.forEach((key, future) -> {
+            try {
+              descriptions.put(key, future.get());
+            } catch (InterruptedException | ExecutionException e) {
+              // This should be unreachable, since the KafkaFuture#allOf already ensured
+              // that all of the futures completed successfully.
+              throw new RuntimeException(e);
+            }
+          });
+          return descriptions;
+        });
+  }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -164,6 +164,11 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public DescribeShareGroupsResult describeShareGroups(Collection<String> groupIds, DescribeShareGroupsOptions options) {
+        return delegate.describeShareGroups(groupIds, options);
+    }
+
+    @Override
     public ListConsumerGroupsResult listConsumerGroups(ListConsumerGroupsOptions options) {
         return delegate.listConsumerGroups(options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -48,6 +48,7 @@ import org.apache.kafka.clients.admin.internals.DeleteConsumerGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DeleteRecordsHandler;
 import org.apache.kafka.clients.admin.internals.DescribeConsumerGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DescribeProducersHandler;
+import org.apache.kafka.clients.admin.internals.DescribeShareGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DescribeTransactionsHandler;
 import org.apache.kafka.clients.admin.internals.FenceProducersHandler;
 import org.apache.kafka.clients.admin.internals.ListConsumerGroupOffsetsHandler;
@@ -3295,6 +3296,17 @@ public class KafkaAdminClient extends AdminClient {
         invokeDriver(handler, future, options.timeoutMs);
         return new DescribeConsumerGroupsResult(future.all().entrySet().stream()
                 .collect(Collectors.toMap(entry -> entry.getKey().idValue, Map.Entry::getValue)));
+    }
+
+    @Override
+    public DescribeShareGroupsResult describeShareGroups(final Collection<String> groupIds,
+                                                               final DescribeShareGroupsOptions options) {
+        SimpleAdminApiFuture<CoordinatorKey, ShareGroupDescription> future =
+            DescribeShareGroupsHandler.newFuture(groupIds);
+        DescribeShareGroupsHandler handler = new DescribeShareGroupsHandler(options.includeAuthorizedOperations(), logContext);
+        invokeDriver(handler, future, options.timeoutMs);
+        return new DescribeShareGroupsResult(future.all().entrySet().stream()
+            .collect(Collectors.toMap(entry -> entry.getKey().idValue, Map.Entry::getValue)));
     }
 
     private Set<AclOperation> validAclOperations(final int authorizedOperations) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ShareGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ShareGroupDescription.java
@@ -17,10 +17,10 @@
 
 package org.apache.kafka.clients.admin;
 
-import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.ShareGroupState;
 import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.utils.Utils;
 
 import java.util.ArrayList;
@@ -32,44 +32,29 @@ import java.util.Set;
 /**
  * A detailed description of a single share group in the cluster.
  */
+@InterfaceStability.Evolving
 public class ShareGroupDescription {
   private final String groupId;
   private final Collection<MemberDescription> members;
-  private final String partitionAssignor;
-  private final GroupType type;
   private final ShareGroupState state;
   private final Node coordinator;
   private final Set<AclOperation> authorizedOperations;
 
   public ShareGroupDescription(String groupId,
                                Collection<MemberDescription> members,
-                               String partitionAssignor,
                                ShareGroupState state,
                                Node coordinator) {
-    this(groupId, members, partitionAssignor, state, coordinator, Collections.emptySet());
+    this(groupId, members, state, coordinator, Collections.emptySet());
   }
 
   public ShareGroupDescription(String groupId,
                                Collection<MemberDescription> members,
-                               String partitionAssignor,
-                               ShareGroupState state,
-                               Node coordinator,
-                               Set<AclOperation> authorizedOperations) {
-    this(groupId, members, partitionAssignor, GroupType.CLASSIC, state, coordinator, authorizedOperations);
-  }
-
-  public ShareGroupDescription(String groupId,
-                               Collection<MemberDescription> members,
-                               String partitionAssignor,
-                               GroupType type,
                                ShareGroupState state,
                                Node coordinator,
                                Set<AclOperation> authorizedOperations) {
     this.groupId = groupId == null ? "" : groupId;
     this.members = members == null ? Collections.emptyList() :
         Collections.unmodifiableList(new ArrayList<>(members));
-    this.partitionAssignor = partitionAssignor == null ? "" : partitionAssignor;
-    this.type = type;
     this.state = state;
     this.coordinator = coordinator;
     this.authorizedOperations = authorizedOperations;
@@ -82,8 +67,6 @@ public class ShareGroupDescription {
     final ShareGroupDescription that = (ShareGroupDescription) o;
     return Objects.equals(groupId, that.groupId) &&
         Objects.equals(members, that.members) &&
-        Objects.equals(partitionAssignor, that.partitionAssignor) &&
-        type == that.type &&
         state == that.state &&
         Objects.equals(coordinator, that.coordinator) &&
         Objects.equals(authorizedOperations, that.authorizedOperations);
@@ -91,47 +74,32 @@ public class ShareGroupDescription {
 
   @Override
   public int hashCode() {
-    return Objects.hash(groupId, members, partitionAssignor, type, state, coordinator, authorizedOperations);
+    return Objects.hash(groupId, members, state, coordinator, authorizedOperations);
   }
 
   /**
-   * The id of the consumer group.
+   * The id of the share group.
    */
   public String groupId() {
     return groupId;
   }
 
   /**
-   * A list of the members of the consumer group.
+   * A list of the members of the share group.
    */
   public Collection<MemberDescription> members() {
     return members;
   }
 
   /**
-   * The consumer group partition assignor.
-   */
-  public String partitionAssignor() {
-    return partitionAssignor;
-  }
-
-  /**
-   * The group type (or the protocol) of this consumer group. It defaults
-   * to Classic if not provided by the server.
-   */
-  public GroupType type() {
-    return type;
-  }
-
-  /**
-   * The consumer group state, or UNKNOWN if the state is too new for us to parse.
+   * The share group state, or UNKNOWN if the state is too new for us to parse.
    */
   public ShareGroupState state() {
     return state;
   }
 
   /**
-   * The consumer group coordinator, or null if the coordinator is not known.
+   * The share group coordinator, or null if the coordinator is not known.
    */
   public Node coordinator() {
     return coordinator;
@@ -148,8 +116,6 @@ public class ShareGroupDescription {
   public String toString() {
     return "(groupId=" + groupId +
         ", members=" + Utils.join(members, ",") +
-        ", partitionAssignor=" + partitionAssignor +
-        ", type=" + type +
         ", state=" + state +
         ", coordinator=" + coordinator +
         ", authorizedOperations=" + authorizedOperations +

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ShareGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ShareGroupDescription.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.GroupType;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.ShareGroupState;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A detailed description of a single share group in the cluster.
+ */
+public class ShareGroupDescription {
+  private final String groupId;
+  private final Collection<MemberDescription> members;
+  private final String partitionAssignor;
+  private final GroupType type;
+  private final ShareGroupState state;
+  private final Node coordinator;
+  private final Set<AclOperation> authorizedOperations;
+
+  public ShareGroupDescription(String groupId,
+                               Collection<MemberDescription> members,
+                               String partitionAssignor,
+                               ShareGroupState state,
+                               Node coordinator) {
+    this(groupId, members, partitionAssignor, state, coordinator, Collections.emptySet());
+  }
+
+  public ShareGroupDescription(String groupId,
+                               Collection<MemberDescription> members,
+                               String partitionAssignor,
+                               ShareGroupState state,
+                               Node coordinator,
+                               Set<AclOperation> authorizedOperations) {
+    this(groupId, members, partitionAssignor, GroupType.CLASSIC, state, coordinator, authorizedOperations);
+  }
+
+  public ShareGroupDescription(String groupId,
+                               Collection<MemberDescription> members,
+                               String partitionAssignor,
+                               GroupType type,
+                               ShareGroupState state,
+                               Node coordinator,
+                               Set<AclOperation> authorizedOperations) {
+    this.groupId = groupId == null ? "" : groupId;
+    this.members = members == null ? Collections.emptyList() :
+        Collections.unmodifiableList(new ArrayList<>(members));
+    this.partitionAssignor = partitionAssignor == null ? "" : partitionAssignor;
+    this.type = type;
+    this.state = state;
+    this.coordinator = coordinator;
+    this.authorizedOperations = authorizedOperations;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final ShareGroupDescription that = (ShareGroupDescription) o;
+    return Objects.equals(groupId, that.groupId) &&
+        Objects.equals(members, that.members) &&
+        Objects.equals(partitionAssignor, that.partitionAssignor) &&
+        type == that.type &&
+        state == that.state &&
+        Objects.equals(coordinator, that.coordinator) &&
+        Objects.equals(authorizedOperations, that.authorizedOperations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(groupId, members, partitionAssignor, type, state, coordinator, authorizedOperations);
+  }
+
+  /**
+   * The id of the consumer group.
+   */
+  public String groupId() {
+    return groupId;
+  }
+
+  /**
+   * A list of the members of the consumer group.
+   */
+  public Collection<MemberDescription> members() {
+    return members;
+  }
+
+  /**
+   * The consumer group partition assignor.
+   */
+  public String partitionAssignor() {
+    return partitionAssignor;
+  }
+
+  /**
+   * The group type (or the protocol) of this consumer group. It defaults
+   * to Classic if not provided by the server.
+   */
+  public GroupType type() {
+    return type;
+  }
+
+  /**
+   * The consumer group state, or UNKNOWN if the state is too new for us to parse.
+   */
+  public ShareGroupState state() {
+    return state;
+  }
+
+  /**
+   * The consumer group coordinator, or null if the coordinator is not known.
+   */
+  public Node coordinator() {
+    return coordinator;
+  }
+
+  /**
+   * authorizedOperations for this group, or null if that information is not known.
+   */
+  public Set<AclOperation> authorizedOperations() {
+    return authorizedOperations;
+  }
+
+  @Override
+  public String toString() {
+    return "(groupId=" + groupId +
+        ", members=" + Utils.join(members, ",") +
+        ", partitionAssignor=" + partitionAssignor +
+        ", type=" + type +
+        ", state=" + state +
+        ", coordinator=" + coordinator +
+        ", authorizedOperations=" + authorizedOperations +
+        ")";
+  }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeGroupsHandlerHelper.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeGroupsHandlerHelper.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.MemberAssignment;
+import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.message.DescribeGroupsResponseData;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.utils.Utils;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DescribeGroupsHandlerHelper {
+
+  public static Set<AclOperation> validAclOperations(final int authorizedOperations) {
+    if (authorizedOperations == MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED) {
+      return null;
+    }
+    return Utils.from32BitField(authorizedOperations)
+        .stream()
+        .map(AclOperation::fromCode)
+        .filter(operation -> operation != AclOperation.UNKNOWN
+            && operation != AclOperation.ALL
+            && operation != AclOperation.ANY)
+        .collect(Collectors.toSet());
+  }
+
+  public static List<MemberDescription> memberDescriptions(List<DescribeGroupsResponseData.DescribedGroupMember> members) {
+    final List<MemberDescription> memberDescriptions = new ArrayList<>(members.size());
+    if (members.size() == 0) {
+      return memberDescriptions;
+    }
+    for (DescribeGroupsResponseData.DescribedGroupMember groupMember : members) {
+      Set<TopicPartition> partitions = Collections.emptySet();
+      if (groupMember.memberAssignment().length > 0) {
+        final ConsumerPartitionAssignor.Assignment assignment = ConsumerProtocol.
+            deserializeAssignment(ByteBuffer.wrap(groupMember.memberAssignment()));
+        partitions = new HashSet<>(assignment.partitions());
+      }
+      memberDescriptions.add(new MemberDescription(
+          groupMember.memberId(),
+          Optional.ofNullable(groupMember.groupInstanceId()),
+          groupMember.clientId(),
+          groupMember.clientHost(),
+          new MemberAssignment(partitions)));
+    }
+    return memberDescriptions;
+  }
+
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeShareGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeShareGroupsHandler.java
@@ -1,0 +1,381 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.MemberAssignment;
+import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.admin.ShareGroupDescription;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
+import org.apache.kafka.common.GroupType;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.ShareGroupState;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.DescribeGroupsRequestData;
+import org.apache.kafka.common.message.DescribeGroupsResponseData;
+import org.apache.kafka.common.message.ShareGroupDescribeRequestData;
+import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.DescribeGroupsRequest;
+import org.apache.kafka.common.requests.DescribeGroupsResponse;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.ShareGroupDescribeRequest;
+import org.apache.kafka.common.requests.ShareGroupDescribeResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DescribeShareGroupsHandler implements AdminApiHandler<CoordinatorKey, ShareGroupDescription> {
+
+  private final boolean includeAuthorizedOperations;
+  private final Logger log;
+  private final AdminApiLookupStrategy<CoordinatorKey> lookupStrategy;
+  private final Set<String> useClassicGroupApi;
+
+  public DescribeShareGroupsHandler(
+      boolean includeAuthorizedOperations,
+      LogContext logContext
+  ) {
+    this.includeAuthorizedOperations = includeAuthorizedOperations;
+    this.log = logContext.logger(DescribeShareGroupsHandler.class);
+    this.lookupStrategy = new CoordinatorStrategy(CoordinatorType.GROUP, logContext);
+    this.useClassicGroupApi = new HashSet<>();
+  }
+
+  private static Set<CoordinatorKey> buildKeySet(Collection<String> groupIds) {
+    return groupIds.stream()
+        .map(CoordinatorKey::byGroupId)
+        .collect(Collectors.toSet());
+  }
+
+  public static AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, ShareGroupDescription> newFuture(
+      Collection<String> groupIds
+  ) {
+    return AdminApiFuture.forKeys(buildKeySet(groupIds));
+  }
+
+  @Override
+  public String apiName() {
+    return "describeShareGroups";
+  }
+
+  @Override
+  public AdminApiLookupStrategy<CoordinatorKey> lookupStrategy() {
+    return lookupStrategy;
+  }
+
+  @Override
+  public Collection<RequestAndKeys<CoordinatorKey>> buildRequest(int coordinatorId, Set<CoordinatorKey> keys) {
+    Set<CoordinatorKey> newShareGroupKeys = new HashSet<>();
+    Set<CoordinatorKey> oldShareGroupKeys = new HashSet<>();
+    List<String> newShareGroupIds = new ArrayList<>();
+    List<String> oldShareGroupIds = new ArrayList<>();
+
+    keys.forEach(key -> {
+      if (key.type != FindCoordinatorRequest.CoordinatorType.GROUP) {
+        throw new IllegalArgumentException("Invalid group coordinator key " + key +
+            " when building `DescribeGroups` request");
+      }
+
+      // By default, we always try using the new share group describe API.
+      // If it fails, we fail back to using the classic group API.
+      if (useClassicGroupApi.contains(key.idValue)) {
+        oldShareGroupKeys.add(key);
+        oldShareGroupIds.add(key.idValue);
+      } else {
+        newShareGroupKeys.add(key);
+        newShareGroupIds.add(key.idValue);
+      }
+    });
+
+    List<RequestAndKeys<CoordinatorKey>> requests = new ArrayList<>();
+    if (!newShareGroupKeys.isEmpty()) {
+      ShareGroupDescribeRequestData data = new ShareGroupDescribeRequestData()
+          .setGroupIds(newShareGroupIds)
+          .setIncludeAuthorizedOperations(includeAuthorizedOperations);
+      requests.add(new RequestAndKeys<>(new ShareGroupDescribeRequest.Builder(data), newShareGroupKeys));
+    }
+
+    if (!oldShareGroupKeys.isEmpty()) {
+      DescribeGroupsRequestData data = new DescribeGroupsRequestData()
+          .setGroups(oldShareGroupIds)
+          .setIncludeAuthorizedOperations(includeAuthorizedOperations);
+      requests.add(new RequestAndKeys<>(new DescribeGroupsRequest.Builder(data), oldShareGroupKeys));
+    }
+
+    return requests;
+  }
+
+  private ApiResult<CoordinatorKey, ShareGroupDescription> handledClassicGroupResponse(
+      Node coordinator,
+      Map<CoordinatorKey, ShareGroupDescription> completed,
+      Map<CoordinatorKey, Throwable> failed,
+      Set<CoordinatorKey> groupsToUnmap,
+      DescribeGroupsResponse response
+  ) {
+    for (DescribeGroupsResponseData.DescribedGroup describedGroup : response.data().groups()) {
+      CoordinatorKey groupIdKey = CoordinatorKey.byGroupId(describedGroup.groupId());
+      Errors error = Errors.forCode(describedGroup.errorCode());
+      if (error != Errors.NONE) {
+        handleError(
+            groupIdKey,
+            error,
+            null,
+            failed,
+            groupsToUnmap,
+            false
+        );
+        continue;
+      }
+      final String protocolType = describedGroup.protocolType();
+      if (protocolType.equals(ConsumerProtocol.PROTOCOL_TYPE) || protocolType.isEmpty()) {
+        final List<DescribeGroupsResponseData.DescribedGroupMember> members = describedGroup.members();
+        final List<MemberDescription> memberDescriptions = new ArrayList<>(members.size());
+        final Set<AclOperation> authorizedOperations = validAclOperations(describedGroup.authorizedOperations());
+        for (DescribeGroupsResponseData.DescribedGroupMember groupMember : members) {
+          Set<TopicPartition> partitions = Collections.emptySet();
+          if (groupMember.memberAssignment().length > 0) {
+            final ConsumerPartitionAssignor.Assignment assignment = ConsumerProtocol.
+                deserializeAssignment(ByteBuffer.wrap(groupMember.memberAssignment()));
+            partitions = new HashSet<>(assignment.partitions());
+          }
+          memberDescriptions.add(new MemberDescription(
+              groupMember.memberId(),
+              Optional.ofNullable(groupMember.groupInstanceId()),
+              groupMember.clientId(),
+              groupMember.clientHost(),
+              new MemberAssignment(partitions)));
+        }
+        final ShareGroupDescription shareGroupDescription =
+            new ShareGroupDescription(groupIdKey.idValue,
+                memberDescriptions,
+                describedGroup.protocolData(),
+                GroupType.CLASSIC,
+                ShareGroupState.parse(describedGroup.groupState()),
+                coordinator,
+                authorizedOperations);
+        completed.put(groupIdKey, shareGroupDescription);
+      } else {
+        failed.put(groupIdKey, new IllegalArgumentException(
+            String.format("GroupId %s is not a consumer group (%s).",
+                groupIdKey.idValue, protocolType)));
+      }
+    }
+
+    return new ApiResult<>(completed, failed, new ArrayList<>(groupsToUnmap));
+  }
+
+  @Override
+  public ApiResult<CoordinatorKey, ShareGroupDescription> handleResponse(
+      Node coordinator,
+      Set<CoordinatorKey> groupIds,
+      AbstractResponse abstractResponse
+  ) {
+    final Map<CoordinatorKey, ShareGroupDescription> completed = new HashMap<>();
+    final Map<CoordinatorKey, Throwable> failed = new HashMap<>();
+    final Set<CoordinatorKey> groupsToUnmap = new HashSet<>();
+
+    if (abstractResponse instanceof DescribeGroupsResponse) {
+      return handledClassicGroupResponse(
+          coordinator,
+          completed,
+          failed,
+          groupsToUnmap,
+          (DescribeGroupsResponse) abstractResponse
+      );
+    } else if (abstractResponse instanceof ShareGroupDescribeResponse) {
+      return handledShareGroupResponse(
+          coordinator,
+          completed,
+          failed,
+          groupsToUnmap,
+          (ShareGroupDescribeResponse) abstractResponse
+      );
+    } else {
+      throw new IllegalArgumentException("Received an unexpected response type.");
+    }
+  }
+
+  @Override
+  public Map<CoordinatorKey, Throwable> handleUnsupportedVersionException(
+      int coordinator,
+      UnsupportedVersionException exception,
+      Set<CoordinatorKey> keys
+  ) {
+    Map<CoordinatorKey, Throwable> errors = new HashMap<>();
+
+    keys.forEach(key -> {
+      if (!useClassicGroupApi.add(key.idValue)) {
+        // We already tried with the classic group API so we need to fail now.
+        errors.put(key, exception);
+      }
+    });
+
+    return errors;
+  }
+
+  private ApiResult<CoordinatorKey, ShareGroupDescription> handledShareGroupResponse(
+      Node coordinator,
+      Map<CoordinatorKey, ShareGroupDescription> completed,
+      Map<CoordinatorKey, Throwable> failed,
+      Set<CoordinatorKey> groupsToUnmap,
+      ShareGroupDescribeResponse response
+  ) {
+    for (ShareGroupDescribeResponseData.DescribedGroup describedGroup : response.data().groups()) {
+      final CoordinatorKey groupIdKey = CoordinatorKey.byGroupId(describedGroup.groupId());
+      final Errors error = Errors.forCode(describedGroup.errorCode());
+      if (error != Errors.NONE) {
+        handleError(
+            groupIdKey,
+            error,
+            describedGroup.errorMessage(),
+            failed,
+            groupsToUnmap,
+            true
+        );
+        continue;
+      }
+
+      final Set<AclOperation> authorizedOperations = validAclOperations(describedGroup.authorizedOperations());
+      final List<MemberDescription> memberDescriptions = new ArrayList<>(describedGroup.members().size());
+
+      describedGroup.members().forEach(groupMember -> {
+        memberDescriptions.add(new MemberDescription(
+            groupMember.memberId(),
+            Optional.ofNullable(groupMember.instanceId()),
+            groupMember.clientId(),
+            groupMember.clientHost(),
+            new MemberAssignment(convertAssignment(groupMember.assignment())),
+            Optional.of(new MemberAssignment(convertAssignment(groupMember.assignment())))
+        ));
+      });
+
+      final ShareGroupDescription shareGroupDescription =
+          new ShareGroupDescription(
+              groupIdKey.idValue,
+              memberDescriptions,
+              describedGroup.assignorName(),
+              GroupType.CONSUMER,
+              ShareGroupState.parse(describedGroup.groupState()),
+              coordinator,
+              authorizedOperations
+          );
+      completed.put(groupIdKey, shareGroupDescription);
+    }
+
+    return new ApiResult<>(completed, failed, new ArrayList<>(groupsToUnmap));
+  }
+
+  private Set<TopicPartition> convertAssignment(ShareGroupDescribeResponseData.Assignment assignment) {
+    return assignment.topicPartitions().stream().flatMap(topic ->
+        topic.partitions().stream().map(partition ->
+            new TopicPartition(topic.topicName(), partition)
+        )
+    ).collect(Collectors.toSet());
+  }
+
+  private void handleError(
+      CoordinatorKey groupId,
+      Errors error,
+      String errorMsg,
+      Map<CoordinatorKey, Throwable> failed,
+      Set<CoordinatorKey> groupsToUnmap,
+      boolean isShareGroupResponse
+  ) {
+    String apiName = isShareGroupResponse ? "ShareGroupDescribe" : "DescribeGroups";
+
+    switch (error) {
+      case GROUP_AUTHORIZATION_FAILED:
+        log.debug("`{}` request for group id {} failed due to error {}.", apiName, groupId.idValue, error);
+        failed.put(groupId, error.exception(errorMsg));
+        break;
+
+      case COORDINATOR_LOAD_IN_PROGRESS:
+        // If the coordinator is in the middle of loading, then we just need to retry
+        log.debug("`{}` request for group id {} failed because the coordinator " +
+            "is still in the process of loading state. Will retry.", apiName, groupId.idValue);
+        break;
+
+      case COORDINATOR_NOT_AVAILABLE:
+      case NOT_COORDINATOR:
+        // If the coordinator is unavailable or there was a coordinator change, then we unmap
+        // the key so that we retry the `FindCoordinator` request
+        log.debug("`{}` request for group id {} returned error {}. " +
+            "Will attempt to find the coordinator again and retry.", apiName, groupId.idValue, error);
+        groupsToUnmap.add(groupId);
+        break;
+
+      case UNSUPPORTED_VERSION:
+        if (isShareGroupResponse) {
+          log.debug("`{}` request for group id {} failed because the API is not " +
+              "supported. Will retry with `DescribeGroups` API.", apiName, groupId.idValue);
+          useClassicGroupApi.add(groupId.idValue);
+        } else {
+          log.error("`{}` request for group id {} failed because the `ShareGroupDescribe` API is not supported.",
+              apiName, groupId.idValue);
+          failed.put(groupId, error.exception(errorMsg));
+        }
+        break;
+
+      case GROUP_ID_NOT_FOUND:
+        if (isShareGroupResponse) {
+          log.debug("`{}` request for group id {} failed because the group is not " +
+              "a new share group. Will retry with `DescribeGroups` API.", apiName, groupId.idValue);
+          useClassicGroupApi.add(groupId.idValue);
+        } else {
+          log.error("`{}` request for group id {} failed because the group does not exist.", apiName, groupId.idValue);
+          failed.put(groupId, error.exception(errorMsg));
+        }
+        break;
+
+      default:
+        log.error("`{}` request for group id {} failed due to unexpected error {}.", apiName, groupId.idValue, error);
+        failed.put(groupId, error.exception(errorMsg));
+    }
+  }
+
+  private Set<AclOperation> validAclOperations(final int authorizedOperations) {
+    if (authorizedOperations == MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED) {
+      return null;
+    }
+    return Utils.from32BitField(authorizedOperations)
+        .stream()
+        .map(AclOperation::fromCode)
+        .filter(operation -> operation != AclOperation.UNKNOWN
+            && operation != AclOperation.ALL
+            && operation != AclOperation.ANY)
+        .collect(Collectors.toSet());
+  }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeShareGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeShareGroupsHandler.java
@@ -16,52 +16,37 @@
  */
 package org.apache.kafka.clients.admin.internals;
 
-import org.apache.kafka.clients.admin.MemberAssignment;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.admin.ShareGroupDescription;
-import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
-import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.ShareGroupState;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AclOperation;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.DescribeGroupsRequestData;
-import org.apache.kafka.common.message.DescribeGroupsResponseData;
-import org.apache.kafka.common.message.ShareGroupDescribeRequestData;
-import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
+import org.apache.kafka.common.message.DescribeGroupsResponseData.DescribedGroup;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.DescribeGroupsRequest;
 import org.apache.kafka.common.requests.DescribeGroupsResponse;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
-import org.apache.kafka.common.requests.MetadataResponse;
-import org.apache.kafka.common.requests.ShareGroupDescribeRequest;
-import org.apache.kafka.common.requests.ShareGroupDescribeResponse;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class DescribeShareGroupsHandler implements AdminApiHandler<CoordinatorKey, ShareGroupDescription> {
+public class DescribeShareGroupsHandler extends AdminApiHandler.Batched<CoordinatorKey, ShareGroupDescription> {
 
   private final boolean includeAuthorizedOperations;
   private final Logger log;
   private final AdminApiLookupStrategy<CoordinatorKey> lookupStrategy;
-  private final Set<String> useClassicGroupApi;
 
   public DescribeShareGroupsHandler(
       boolean includeAuthorizedOperations,
@@ -70,7 +55,6 @@ public class DescribeShareGroupsHandler implements AdminApiHandler<CoordinatorKe
     this.includeAuthorizedOperations = includeAuthorizedOperations;
     this.log = logContext.logger(DescribeShareGroupsHandler.class);
     this.lookupStrategy = new CoordinatorStrategy(CoordinatorType.GROUP, logContext);
-    this.useClassicGroupApi = new HashSet<>();
   }
 
   private static Set<CoordinatorKey> buildKeySet(Collection<String> groupIds) {
@@ -87,7 +71,7 @@ public class DescribeShareGroupsHandler implements AdminApiHandler<CoordinatorKe
 
   @Override
   public String apiName() {
-    return "describeShareGroups";
+    return "describeGroups";
   }
 
   @Override
@@ -96,104 +80,18 @@ public class DescribeShareGroupsHandler implements AdminApiHandler<CoordinatorKe
   }
 
   @Override
-  public Collection<RequestAndKeys<CoordinatorKey>> buildRequest(int coordinatorId, Set<CoordinatorKey> keys) {
-    Set<CoordinatorKey> newShareGroupKeys = new HashSet<>();
-    Set<CoordinatorKey> oldShareGroupKeys = new HashSet<>();
-    List<String> newShareGroupIds = new ArrayList<>();
-    List<String> oldShareGroupIds = new ArrayList<>();
-
-    keys.forEach(key -> {
+  public DescribeGroupsRequest.Builder buildBatchedRequest(int coordinatorId, Set<CoordinatorKey> keys) {
+    List<String> groupIds = keys.stream().map(key -> {
       if (key.type != FindCoordinatorRequest.CoordinatorType.GROUP) {
-        throw new IllegalArgumentException("Invalid group coordinator key " + key +
+        throw new IllegalArgumentException("Invalid transaction coordinator key " + key +
             " when building `DescribeGroups` request");
       }
-
-      // By default, we always try using the new share group describe API.
-      // If it fails, we fail back to using the classic group API.
-      if (useClassicGroupApi.contains(key.idValue)) {
-        oldShareGroupKeys.add(key);
-        oldShareGroupIds.add(key.idValue);
-      } else {
-        newShareGroupKeys.add(key);
-        newShareGroupIds.add(key.idValue);
-      }
-    });
-
-    List<RequestAndKeys<CoordinatorKey>> requests = new ArrayList<>();
-    if (!newShareGroupKeys.isEmpty()) {
-      ShareGroupDescribeRequestData data = new ShareGroupDescribeRequestData()
-          .setGroupIds(newShareGroupIds)
-          .setIncludeAuthorizedOperations(includeAuthorizedOperations);
-      requests.add(new RequestAndKeys<>(new ShareGroupDescribeRequest.Builder(data), newShareGroupKeys));
-    }
-
-    if (!oldShareGroupKeys.isEmpty()) {
-      DescribeGroupsRequestData data = new DescribeGroupsRequestData()
-          .setGroups(oldShareGroupIds)
-          .setIncludeAuthorizedOperations(includeAuthorizedOperations);
-      requests.add(new RequestAndKeys<>(new DescribeGroupsRequest.Builder(data), oldShareGroupKeys));
-    }
-
-    return requests;
-  }
-
-  private ApiResult<CoordinatorKey, ShareGroupDescription> handledClassicGroupResponse(
-      Node coordinator,
-      Map<CoordinatorKey, ShareGroupDescription> completed,
-      Map<CoordinatorKey, Throwable> failed,
-      Set<CoordinatorKey> groupsToUnmap,
-      DescribeGroupsResponse response
-  ) {
-    for (DescribeGroupsResponseData.DescribedGroup describedGroup : response.data().groups()) {
-      CoordinatorKey groupIdKey = CoordinatorKey.byGroupId(describedGroup.groupId());
-      Errors error = Errors.forCode(describedGroup.errorCode());
-      if (error != Errors.NONE) {
-        handleError(
-            groupIdKey,
-            error,
-            null,
-            failed,
-            groupsToUnmap,
-            false
-        );
-        continue;
-      }
-      final String protocolType = describedGroup.protocolType();
-      if (protocolType.equals(ConsumerProtocol.PROTOCOL_TYPE) || protocolType.isEmpty()) {
-        final List<DescribeGroupsResponseData.DescribedGroupMember> members = describedGroup.members();
-        final List<MemberDescription> memberDescriptions = new ArrayList<>(members.size());
-        final Set<AclOperation> authorizedOperations = validAclOperations(describedGroup.authorizedOperations());
-        for (DescribeGroupsResponseData.DescribedGroupMember groupMember : members) {
-          Set<TopicPartition> partitions = Collections.emptySet();
-          if (groupMember.memberAssignment().length > 0) {
-            final ConsumerPartitionAssignor.Assignment assignment = ConsumerProtocol.
-                deserializeAssignment(ByteBuffer.wrap(groupMember.memberAssignment()));
-            partitions = new HashSet<>(assignment.partitions());
-          }
-          memberDescriptions.add(new MemberDescription(
-              groupMember.memberId(),
-              Optional.ofNullable(groupMember.groupInstanceId()),
-              groupMember.clientId(),
-              groupMember.clientHost(),
-              new MemberAssignment(partitions)));
-        }
-        final ShareGroupDescription shareGroupDescription =
-            new ShareGroupDescription(groupIdKey.idValue,
-                memberDescriptions,
-                describedGroup.protocolData(),
-                GroupType.CLASSIC,
-                ShareGroupState.parse(describedGroup.groupState()),
-                coordinator,
-                authorizedOperations);
-        completed.put(groupIdKey, shareGroupDescription);
-      } else {
-        failed.put(groupIdKey, new IllegalArgumentException(
-            String.format("GroupId %s is not a consumer group (%s).",
-                groupIdKey.idValue, protocolType)));
-      }
-    }
-
-    return new ApiResult<>(completed, failed, new ArrayList<>(groupsToUnmap));
+      return key.idValue;
+    }).collect(Collectors.toList());
+    DescribeGroupsRequestData data = new DescribeGroupsRequestData()
+        .setGroups(groupIds)
+        .setIncludeAuthorizedOperations(includeAuthorizedOperations);
+    return new DescribeGroupsRequest.Builder(data);
   }
 
   @Override
@@ -202,180 +100,69 @@ public class DescribeShareGroupsHandler implements AdminApiHandler<CoordinatorKe
       Set<CoordinatorKey> groupIds,
       AbstractResponse abstractResponse
   ) {
+    final DescribeGroupsResponse response = (DescribeGroupsResponse) abstractResponse;
     final Map<CoordinatorKey, ShareGroupDescription> completed = new HashMap<>();
     final Map<CoordinatorKey, Throwable> failed = new HashMap<>();
     final Set<CoordinatorKey> groupsToUnmap = new HashSet<>();
 
-    if (abstractResponse instanceof DescribeGroupsResponse) {
-      return handledClassicGroupResponse(
-          coordinator,
-          completed,
-          failed,
-          groupsToUnmap,
-          (DescribeGroupsResponse) abstractResponse
-      );
-    } else if (abstractResponse instanceof ShareGroupDescribeResponse) {
-      return handledShareGroupResponse(
-          coordinator,
-          completed,
-          failed,
-          groupsToUnmap,
-          (ShareGroupDescribeResponse) abstractResponse
-      );
-    } else {
-      throw new IllegalArgumentException("Received an unexpected response type.");
-    }
-  }
-
-  @Override
-  public Map<CoordinatorKey, Throwable> handleUnsupportedVersionException(
-      int coordinator,
-      UnsupportedVersionException exception,
-      Set<CoordinatorKey> keys
-  ) {
-    Map<CoordinatorKey, Throwable> errors = new HashMap<>();
-
-    keys.forEach(key -> {
-      if (!useClassicGroupApi.add(key.idValue)) {
-        // We already tried with the classic group API so we need to fail now.
-        errors.put(key, exception);
-      }
-    });
-
-    return errors;
-  }
-
-  private ApiResult<CoordinatorKey, ShareGroupDescription> handledShareGroupResponse(
-      Node coordinator,
-      Map<CoordinatorKey, ShareGroupDescription> completed,
-      Map<CoordinatorKey, Throwable> failed,
-      Set<CoordinatorKey> groupsToUnmap,
-      ShareGroupDescribeResponse response
-  ) {
-    for (ShareGroupDescribeResponseData.DescribedGroup describedGroup : response.data().groups()) {
-      final CoordinatorKey groupIdKey = CoordinatorKey.byGroupId(describedGroup.groupId());
-      final Errors error = Errors.forCode(describedGroup.errorCode());
+    for (DescribedGroup describedGroup : response.data().groups()) {
+      CoordinatorKey groupIdKey = CoordinatorKey.byGroupId(describedGroup.groupId());
+      Errors error = Errors.forCode(describedGroup.errorCode());
       if (error != Errors.NONE) {
-        handleError(
-            groupIdKey,
-            error,
-            describedGroup.errorMessage(),
-            failed,
-            groupsToUnmap,
-            true
-        );
+        handleError(groupIdKey, error, failed, groupsToUnmap);
         continue;
       }
-
-      final Set<AclOperation> authorizedOperations = validAclOperations(describedGroup.authorizedOperations());
-      final List<MemberDescription> memberDescriptions = new ArrayList<>(describedGroup.members().size());
-
-      describedGroup.members().forEach(groupMember -> {
-        memberDescriptions.add(new MemberDescription(
-            groupMember.memberId(),
-            Optional.ofNullable(groupMember.instanceId()),
-            groupMember.clientId(),
-            groupMember.clientHost(),
-            new MemberAssignment(convertAssignment(groupMember.assignment())),
-            Optional.of(new MemberAssignment(convertAssignment(groupMember.assignment())))
-        ));
-      });
-
-      final ShareGroupDescription shareGroupDescription =
-          new ShareGroupDescription(
-              groupIdKey.idValue,
-              memberDescriptions,
-              describedGroup.assignorName(),
-              GroupType.CONSUMER,
-              ShareGroupState.parse(describedGroup.groupState()),
-              coordinator,
-              authorizedOperations
-          );
-      completed.put(groupIdKey, shareGroupDescription);
+      final String protocolType = describedGroup.protocolType();
+      if (protocolType.equals(ConsumerProtocol.PROTOCOL_TYPE) || protocolType.isEmpty()) {
+        final List<MemberDescription> memberDescriptions = DescribeGroupsHandlerHelper.memberDescriptions(describedGroup.members());
+        final Set<AclOperation> authorizedOperations = DescribeGroupsHandlerHelper.validAclOperations(describedGroup.authorizedOperations());
+        final ShareGroupDescription shareGroupDescription =
+            new ShareGroupDescription(groupIdKey.idValue,
+                memberDescriptions,
+                ShareGroupState.parse(describedGroup.groupState()),
+                coordinator,
+                authorizedOperations);
+        completed.put(groupIdKey, shareGroupDescription);
+      } else {
+        failed.put(groupIdKey, new IllegalArgumentException(
+            String.format("GroupId %s is not a share group (%s).",
+                groupIdKey.idValue, protocolType)));
+      }
     }
 
     return new ApiResult<>(completed, failed, new ArrayList<>(groupsToUnmap));
   }
 
-  private Set<TopicPartition> convertAssignment(ShareGroupDescribeResponseData.Assignment assignment) {
-    return assignment.topicPartitions().stream().flatMap(topic ->
-        topic.partitions().stream().map(partition ->
-            new TopicPartition(topic.topicName(), partition)
-        )
-    ).collect(Collectors.toSet());
-  }
-
   private void handleError(
       CoordinatorKey groupId,
       Errors error,
-      String errorMsg,
       Map<CoordinatorKey, Throwable> failed,
-      Set<CoordinatorKey> groupsToUnmap,
-      boolean isShareGroupResponse
+      Set<CoordinatorKey> groupsToUnmap
   ) {
-    String apiName = isShareGroupResponse ? "ShareGroupDescribe" : "DescribeGroups";
-
     switch (error) {
       case GROUP_AUTHORIZATION_FAILED:
-        log.debug("`{}` request for group id {} failed due to error {}.", apiName, groupId.idValue, error);
-        failed.put(groupId, error.exception(errorMsg));
+        log.debug("`DescribeGroups` request for group id {} failed due to error {}", groupId.idValue, error);
+        failed.put(groupId, error.exception());
         break;
 
       case COORDINATOR_LOAD_IN_PROGRESS:
         // If the coordinator is in the middle of loading, then we just need to retry
-        log.debug("`{}` request for group id {} failed because the coordinator " +
-            "is still in the process of loading state. Will retry.", apiName, groupId.idValue);
+        log.debug("`DescribeGroups` request for group id {} failed because the coordinator " +
+            "is still in the process of loading state. Will retry", groupId.idValue);
         break;
 
       case COORDINATOR_NOT_AVAILABLE:
       case NOT_COORDINATOR:
         // If the coordinator is unavailable or there was a coordinator change, then we unmap
         // the key so that we retry the `FindCoordinator` request
-        log.debug("`{}` request for group id {} returned error {}. " +
-            "Will attempt to find the coordinator again and retry.", apiName, groupId.idValue, error);
+        log.debug("`DescribeGroups` request for group id {} returned error {}. " +
+            "Will attempt to find the coordinator again and retry", groupId.idValue, error);
         groupsToUnmap.add(groupId);
         break;
 
-      case UNSUPPORTED_VERSION:
-        if (isShareGroupResponse) {
-          log.debug("`{}` request for group id {} failed because the API is not " +
-              "supported. Will retry with `DescribeGroups` API.", apiName, groupId.idValue);
-          useClassicGroupApi.add(groupId.idValue);
-        } else {
-          log.error("`{}` request for group id {} failed because the `ShareGroupDescribe` API is not supported.",
-              apiName, groupId.idValue);
-          failed.put(groupId, error.exception(errorMsg));
-        }
-        break;
-
-      case GROUP_ID_NOT_FOUND:
-        if (isShareGroupResponse) {
-          log.debug("`{}` request for group id {} failed because the group is not " +
-              "a new share group. Will retry with `DescribeGroups` API.", apiName, groupId.idValue);
-          useClassicGroupApi.add(groupId.idValue);
-        } else {
-          log.error("`{}` request for group id {} failed because the group does not exist.", apiName, groupId.idValue);
-          failed.put(groupId, error.exception(errorMsg));
-        }
-        break;
-
       default:
-        log.error("`{}` request for group id {} failed due to unexpected error {}.", apiName, groupId.idValue, error);
-        failed.put(groupId, error.exception(errorMsg));
+        log.error("`DescribeGroups` request for group id {} failed due to unexpected error {}", groupId.idValue, error);
+        failed.put(groupId, error.exception());
     }
   }
-
-  private Set<AclOperation> validAclOperations(final int authorizedOperations) {
-    if (authorizedOperations == MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED) {
-      return null;
-    }
-    return Utils.from32BitField(authorizedOperations)
-        .stream()
-        .map(AclOperation::fromCode)
-        .filter(operation -> operation != AclOperation.UNKNOWN
-            && operation != AclOperation.ALL
-            && operation != AclOperation.ANY)
-        .collect(Collectors.toSet());
-  }
-
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -209,7 +209,6 @@ import org.apache.kafka.common.requests.OffsetFetchRequest;
 import org.apache.kafka.common.requests.OffsetFetchResponse;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
 import org.apache.kafka.common.requests.RequestTestUtils;
-import org.apache.kafka.common.requests.ShareGroupDescribeRequest;
 import org.apache.kafka.common.requests.UnregisterBrokerResponse;
 import org.apache.kafka.common.requests.UpdateFeaturesRequest;
 import org.apache.kafka.common.requests.UpdateFeaturesResponse;
@@ -3156,141 +3155,6 @@ public class KafkaAdminClientTest {
     }
 
     @Test
-    public void testDescribeShareGroups() throws Exception {
-        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockCluster(1, 0))) {
-            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-
-            // Retriable FindCoordinatorResponse errors should be retried
-            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.COORDINATOR_NOT_AVAILABLE,  Node.noNode()));
-            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.COORDINATOR_LOAD_IN_PROGRESS,  Node.noNode()));
-
-            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
-
-            // The first request sent will be a ConsumerGroupDescribe request. Let's
-            // fail it in order to fail back to using the classic version.
-            env.kafkaClient().prepareUnsupportedVersionResponse(
-                request -> request instanceof ShareGroupDescribeRequest);
-
-            DescribeGroupsResponseData data = new DescribeGroupsResponseData();
-
-            // Retriable errors should be retried
-            data.groups().add(DescribeGroupsResponse.groupMetadata(
-                GROUP_ID,
-                Errors.COORDINATOR_LOAD_IN_PROGRESS,
-                "",
-                "",
-                "",
-                Collections.emptyList(),
-                Collections.emptySet()));
-            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
-
-            /*
-             * We need to return two responses here, one with NOT_COORDINATOR error when calling describe consumer group
-             * api using coordinator that has moved. This will retry whole operation. So we need to again respond with a
-             * FindCoordinatorResponse.
-             *
-             * And the same reason for COORDINATOR_NOT_AVAILABLE error response
-             */
-            data = new DescribeGroupsResponseData();
-            data.groups().add(DescribeGroupsResponse.groupMetadata(
-                GROUP_ID,
-                Errors.NOT_COORDINATOR,
-                "",
-                "",
-                "",
-                Collections.emptyList(),
-                Collections.emptySet()));
-            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
-            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
-
-            data = new DescribeGroupsResponseData();
-            data.groups().add(DescribeGroupsResponse.groupMetadata(
-                GROUP_ID,
-                Errors.COORDINATOR_NOT_AVAILABLE,
-                "",
-                "",
-                "",
-                Collections.emptyList(),
-                Collections.emptySet()));
-            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
-            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
-
-            data = new DescribeGroupsResponseData();
-            TopicPartition myTopicPartition0 = new TopicPartition("my_topic", 0);
-            TopicPartition myTopicPartition1 = new TopicPartition("my_topic", 1);
-            TopicPartition myTopicPartition2 = new TopicPartition("my_topic", 2);
-
-            final List<TopicPartition> topicPartitions = new ArrayList<>();
-            topicPartitions.add(0, myTopicPartition0);
-            topicPartitions.add(1, myTopicPartition1);
-            topicPartitions.add(2, myTopicPartition2);
-
-            final ByteBuffer memberAssignment = ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(topicPartitions));
-            byte[] memberAssignmentBytes = new byte[memberAssignment.remaining()];
-            memberAssignment.get(memberAssignmentBytes);
-
-            DescribedGroupMember memberOne = DescribeGroupsResponse.groupMember("0", "instance1", "clientId0", "clientHost", memberAssignmentBytes, null);
-            DescribedGroupMember memberTwo = DescribeGroupsResponse.groupMember("1", "instance2", "clientId1", "clientHost", memberAssignmentBytes, null);
-
-            List<MemberDescription> expectedMemberDescriptions = new ArrayList<>();
-            expectedMemberDescriptions.add(convertToMemberDescriptions(memberOne,
-                new MemberAssignment(new HashSet<>(topicPartitions))));
-            expectedMemberDescriptions.add(convertToMemberDescriptions(memberTwo,
-                new MemberAssignment(new HashSet<>(topicPartitions))));
-            data.groups().add(DescribeGroupsResponse.groupMetadata(
-                GROUP_ID,
-                Errors.NONE,
-                "",
-                ConsumerProtocol.PROTOCOL_TYPE,
-                "",
-                asList(memberOne, memberTwo),
-                Collections.emptySet()));
-
-            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
-
-            final DescribeShareGroupsResult result = env.adminClient().describeShareGroups(singletonList(GROUP_ID));
-            final ShareGroupDescription groupDescription = result.describedGroups().get(GROUP_ID).get();
-
-            assertEquals(1, result.describedGroups().size());
-            assertEquals(GROUP_ID, groupDescription.groupId());
-            assertEquals(2, groupDescription.members().size());
-            assertEquals(expectedMemberDescriptions, groupDescription.members());
-        }
-    }
-
-    @Test
-    public void testDescribeShareGroupsWithAuthorizedOperationsOmitted() throws Exception {
-        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockCluster(1, 0))) {
-            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-
-            env.kafkaClient().prepareResponse(
-                prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
-
-            // The first request sent will be a ConsumerGroupDescribe request. Let's
-            // fail it in order to fail back to using the classic version.
-            env.kafkaClient().prepareUnsupportedVersionResponse(
-                request -> request instanceof ShareGroupDescribeRequest);
-
-            DescribeGroupsResponseData data = new DescribeGroupsResponseData();
-            data.groups().add(DescribeGroupsResponse.groupMetadata(
-                GROUP_ID,
-                Errors.NONE,
-                "",
-                ConsumerProtocol.PROTOCOL_TYPE,
-                "",
-                Collections.emptyList(),
-                MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED));
-
-            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
-
-            final DescribeShareGroupsResult result = env.adminClient().describeShareGroups(singletonList(GROUP_ID));
-            final ShareGroupDescription groupDescription = result.describedGroups().get(GROUP_ID).get();
-
-            assertNull(groupDescription.authorizedOperations());
-        }
-    }
-
-    @Test
     public void testDescribeMultipleConsumerGroups() {
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockCluster(1, 0))) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
@@ -3568,6 +3432,188 @@ public class KafkaAdminClientTest {
             ));
 
             assertEquals(expectedResult, result.all().get());
+        }
+    }
+
+    @Test
+    public void testDescribeShareGroups() throws Exception {
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockCluster(1, 0))) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            // Retriable FindCoordinatorResponse errors should be retried
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.COORDINATOR_NOT_AVAILABLE,  Node.noNode()));
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.COORDINATOR_LOAD_IN_PROGRESS,  Node.noNode()));
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            DescribeGroupsResponseData data = new DescribeGroupsResponseData();
+
+            // Retriable errors should be retried
+            data.groups().add(DescribeGroupsResponse.groupMetadata(
+                GROUP_ID,
+                Errors.COORDINATOR_LOAD_IN_PROGRESS,
+                "",
+                "",
+                "",
+                Collections.emptyList(),
+                Collections.emptySet()));
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
+
+            /*
+             * We need to return two responses here, one with NOT_COORDINATOR error when calling describe share group
+             * api using coordinator that has moved. This will retry whole operation. So we need to again respond with a
+             * FindCoordinatorResponse.
+             *
+             * And the same reason for COORDINATOR_NOT_AVAILABLE error response
+             */
+            data = new DescribeGroupsResponseData();
+            data.groups().add(DescribeGroupsResponse.groupMetadata(
+                GROUP_ID,
+                Errors.NOT_COORDINATOR,
+                "",
+                "",
+                "",
+                Collections.emptyList(),
+                Collections.emptySet()));
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            data = new DescribeGroupsResponseData();
+            data.groups().add(DescribeGroupsResponse.groupMetadata(
+                GROUP_ID,
+                Errors.COORDINATOR_NOT_AVAILABLE,
+                "",
+                "",
+                "",
+                Collections.emptyList(),
+                Collections.emptySet()));
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            data = new DescribeGroupsResponseData();
+            TopicPartition myTopicPartition0 = new TopicPartition("my_topic", 0);
+            TopicPartition myTopicPartition1 = new TopicPartition("my_topic", 1);
+            TopicPartition myTopicPartition2 = new TopicPartition("my_topic", 2);
+
+            final List<TopicPartition> topicPartitions = new ArrayList<>();
+            topicPartitions.add(0, myTopicPartition0);
+            topicPartitions.add(1, myTopicPartition1);
+            topicPartitions.add(2, myTopicPartition2);
+
+            final ByteBuffer memberAssignment = ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(topicPartitions));
+            byte[] memberAssignmentBytes = new byte[memberAssignment.remaining()];
+            memberAssignment.get(memberAssignmentBytes);
+
+            DescribedGroupMember memberOne = DescribeGroupsResponse.groupMember("0", "instance1", "clientId0", "clientHost", memberAssignmentBytes, null);
+            DescribedGroupMember memberTwo = DescribeGroupsResponse.groupMember("1", "instance2", "clientId1", "clientHost", memberAssignmentBytes, null);
+
+            List<MemberDescription> expectedMemberDescriptions = new ArrayList<>();
+            expectedMemberDescriptions.add(convertToMemberDescriptions(memberOne,
+                new MemberAssignment(new HashSet<>(topicPartitions))));
+            expectedMemberDescriptions.add(convertToMemberDescriptions(memberTwo,
+                new MemberAssignment(new HashSet<>(topicPartitions))));
+            data.groups().add(DescribeGroupsResponse.groupMetadata(
+                GROUP_ID,
+                Errors.NONE,
+                "",
+                ConsumerProtocol.PROTOCOL_TYPE,
+                "",
+                asList(memberOne, memberTwo),
+                Collections.emptySet()));
+
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
+
+            final DescribeShareGroupsResult result = env.adminClient().describeShareGroups(singletonList(GROUP_ID));
+            final ShareGroupDescription groupDescription = result.describedGroups().get(GROUP_ID).get();
+
+            assertEquals(1, result.describedGroups().size());
+            assertEquals(GROUP_ID, groupDescription.groupId());
+            assertEquals(2, groupDescription.members().size());
+            assertEquals(expectedMemberDescriptions, groupDescription.members());
+        }
+    }
+
+    @Test
+    public void testDescribeShareGroupsWithAuthorizedOperationsOmitted() throws Exception {
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockCluster(1, 0))) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            env.kafkaClient().prepareResponse(
+                prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            DescribeGroupsResponseData data = new DescribeGroupsResponseData();
+            data.groups().add(DescribeGroupsResponse.groupMetadata(
+                GROUP_ID,
+                Errors.NONE,
+                "",
+                ConsumerProtocol.PROTOCOL_TYPE,
+                "",
+                Collections.emptyList(),
+                MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED));
+
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(data));
+
+            final DescribeShareGroupsResult result = env.adminClient().describeShareGroups(singletonList(GROUP_ID));
+            final ShareGroupDescription groupDescription = result.describedGroups().get(GROUP_ID).get();
+
+            assertNull(groupDescription.authorizedOperations());
+        }
+    }
+
+    @Test
+    public void testDescribeMultipleShareGroups() {
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockCluster(1, 0))) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            TopicPartition myTopicPartition0 = new TopicPartition("my_topic", 0);
+            TopicPartition myTopicPartition1 = new TopicPartition("my_topic", 1);
+            TopicPartition myTopicPartition2 = new TopicPartition("my_topic", 2);
+
+            final List<TopicPartition> topicPartitions = new ArrayList<>();
+            topicPartitions.add(0, myTopicPartition0);
+            topicPartitions.add(1, myTopicPartition1);
+            topicPartitions.add(2, myTopicPartition2);
+
+            final ByteBuffer memberAssignment = ConsumerProtocol.serializeAssignment(new ConsumerPartitionAssignor.Assignment(topicPartitions));
+            byte[] memberAssignmentBytes = new byte[memberAssignment.remaining()];
+            memberAssignment.get(memberAssignmentBytes);
+
+            DescribeGroupsResponseData group0Data = new DescribeGroupsResponseData();
+            group0Data.groups().add(DescribeGroupsResponse.groupMetadata(
+                GROUP_ID,
+                Errors.NONE,
+                "",
+                ConsumerProtocol.PROTOCOL_TYPE,
+                "",
+                asList(
+                    DescribeGroupsResponse.groupMember("0", null, "clientId0", "clientHost", memberAssignmentBytes, null),
+                    DescribeGroupsResponse.groupMember("1", null, "clientId1", "clientHost", memberAssignmentBytes, null)
+                ),
+                Collections.emptySet()));
+
+            DescribeGroupsResponseData groupConnectData = new DescribeGroupsResponseData();
+            group0Data.groups().add(DescribeGroupsResponse.groupMetadata(
+                "group-connect-0",
+                Errors.NONE,
+                "",
+                "connect",
+                "",
+                asList(
+                    DescribeGroupsResponse.groupMember("0", null, "clientId0", "clientHost", memberAssignmentBytes, null),
+                    DescribeGroupsResponse.groupMember("1", null, "clientId1", "clientHost", memberAssignmentBytes, null)
+                ),
+                Collections.emptySet()));
+
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(group0Data));
+            env.kafkaClient().prepareResponse(new DescribeGroupsResponse(groupConnectData));
+
+            Collection<String> groups = new HashSet<>();
+            groups.add(GROUP_ID);
+            groups.add("group-connect-0");
+            final DescribeShareGroupsResult result = env.adminClient().describeShareGroups(groups);
+            assertEquals(2, result.describedGroups().size());
+            assertEquals(groups, result.describedGroups().keySet());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -715,6 +715,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    synchronized public DescribeShareGroupsResult describeShareGroups(Collection<String> groupIds, DescribeShareGroupsOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     synchronized public ListConsumerGroupsResult listConsumerGroups(ListConsumerGroupsOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }


### PR DESCRIPTION
### What
- Updated admin client related classes in `clients` module with method impls to support describe share groups.
- Added new share group describe handler class to process server response.

### Why
- User must be able to make calls to describe share groups via admin client

### Testing
- Wrote tests for KafkaAdminClient mirroring ConsumerGroups.

## Note: Must merge this into https://github.com/confluentinc/kafka/pull/1027 first