### PR TITLE
AKCORE-1: Fixing partition assignment for share group (5/N)

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
@@ -25,7 +25,7 @@ import org.apache.kafka.common.message.{ShareGroupHeartbeatRequestData, ShareGro
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull}
-import org.junit.jupiter.api.{Disabled, Tag, Timeout}
+import org.junit.jupiter.api.{Tag, Timeout}
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.util.stream.Collectors
@@ -50,7 +50,6 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
   // TODO: The below test runs fine for consumers joining and leaving the group but fails when checking for expected partition assignment.
   //  It should be enabled once the partition assignment in share groups is fixed
-  @Disabled
   @ClusterTest(serverProperties = Array(
     new ClusterConfigProperty(key = "group.coordinator.new.enable", value = "true"),
     new ClusterConfigProperty(key = "group.share.enable", value = "true"),


### PR DESCRIPTION
- Fixes the partition assignment and bumping of target assignment epoch.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
