### PR TITLE
AKCORE-9: Add support for describe share groups in bin script.

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ShareGroupsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ShareGroupsCommand.java
@@ -17,17 +17,19 @@
 package org.apache.kafka.tools;
 
 import joptsimple.OptionException;
-
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AbstractOptions;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeShareGroupsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListShareGroupsOptions;
 import org.apache.kafka.clients.admin.ListShareGroupsResult;
 import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.admin.ShareGroupDescription;
 import org.apache.kafka.clients.admin.ShareGroupListing;
 import org.apache.kafka.common.ShareGroupState;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.util.CommandLineUtils;
 
@@ -36,6 +38,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,215 +51,233 @@ import java.util.stream.Stream;
 
 public class ShareGroupsCommand {
 
-    public static void main(String[] args) {
-        ShareGroupCommandOptions opts = new ShareGroupCommandOptions(args);
-        try {
-            opts.checkArgs();
-            CommandLineUtils.maybePrintHelpOrVersion(opts, "This tool helps to list all share groups, describe a share group, delete share group info, or reset share group offsets.");
+  public static void main(String[] args) {
+    ShareGroupCommandOptions opts = new ShareGroupCommandOptions(args);
+    try {
+      opts.checkArgs();
+      CommandLineUtils.maybePrintHelpOrVersion(opts, "This tool helps to list all share groups, describe a share group, delete share group info, or reset share group offsets.");
 
-            // should have exactly one action
-            long actions = Stream.of(opts.listOpt, opts.describeOpt, opts.deleteOpt, opts.resetOffsetsOpt, opts.deleteOffsetsOpt).filter(opts.options::has).count();
-            if (actions != 1)
-                CommandLineUtils.printUsageAndExit(opts.parser, "Command must include exactly one action: --list, --describe, --delete, --reset-offsets, --delete-offsets");
+      // should have exactly one action
+      long actions = Stream.of(opts.listOpt, opts.describeOpt, opts.deleteOpt, opts.resetOffsetsOpt, opts.deleteOffsetsOpt).filter(opts.options::has).count();
+      if (actions != 1)
+        CommandLineUtils.printUsageAndExit(opts.parser, "Command must include exactly one action: --list, --describe, --delete, --reset-offsets, --delete-offsets");
 
-            run(opts);
-        } catch (OptionException e) {
-            CommandLineUtils.printUsageAndExit(opts.parser, e.getMessage());
-        }
+      run(opts);
+    } catch (OptionException e) {
+      CommandLineUtils.printUsageAndExit(opts.parser, e.getMessage());
+    }
+  }
+
+  public static void run(ShareGroupCommandOptions opts) {
+    try {
+      Admin adminClient = createAdminClient(Collections.emptyMap(), opts);
+      ShareGroupService shareGroupService = new ShareGroupService(opts, Collections.emptyMap(), adminClient);
+      if (opts.options.has(opts.listOpt)) {
+        shareGroupService.listGroups();
+      } else if (opts.options.has(opts.describeOpt)) {
+        shareGroupService.describeGroups();
+      }
+      shareGroupService.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalArgumentException e) {
+      CommandLineUtils.printUsageAndExit(opts.parser, e.getMessage());
+    } catch (Throwable e) {
+      printError("Executing share group command failed due to " + e.getMessage(), Optional.of(e));
+    }
+  }
+
+  static Set<ShareGroupState> shareGroupStatesFromString(String input) {
+    Set<ShareGroupState> parsedStates = Arrays.stream(input.split(",")).map(s -> ShareGroupState.parse(s.trim())).collect(Collectors.toSet());
+    if (parsedStates.contains(ShareGroupState.UNKNOWN)) {
+      Collection<ShareGroupState> validStates = Arrays.stream(ShareGroupState.values()).filter(s -> s != ShareGroupState.UNKNOWN).collect(Collectors.toList());
+      throw new IllegalArgumentException("Invalid state list '" + input + "'. Valid states are: " + Utils.join(validStates, ", "));
+    }
+    return parsedStates;
+  }
+
+  public static void printError(String msg, Optional<Throwable> e) {
+    System.out.println("\nError: " + msg);
+    e.ifPresent(Throwable::printStackTrace);
+  }
+
+  // Visibility for testing
+  public static Admin createAdminClient(Map<String, String> configOverrides, ShareGroupCommandOptions opts) throws IOException {
+    Properties props = opts.options.has(opts.commandConfigOpt) ? Utils.loadProps(opts.options.valueOf(opts.commandConfigOpt)) : new Properties();
+    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt));
+    props.putAll(configOverrides);
+    return Admin.create(props);
+  }
+
+  static class ShareGroupService {
+    final ShareGroupCommandOptions opts;
+    final Map<String, String> configOverrides;
+    private final Admin adminClient;
+
+    public ShareGroupService(ShareGroupCommandOptions opts, Map<String, String> configOverrides, Admin adminClient) {
+      this.opts = opts;
+      this.configOverrides = configOverrides;
+      this.adminClient = adminClient;
     }
 
-    public static void run(ShareGroupCommandOptions opts) {
-        try {
-            Admin adminClient = createAdminClient(Collections.emptyMap(), opts);
-            ShareGroupService shareGroupService = new ShareGroupService(opts, Collections.emptyMap(), adminClient);
-            // Currently the tool only supports listing of share groups
-            if (opts.options.has(opts.listOpt))
-                shareGroupService.listGroups();
-            else if (opts.options.has(opts.describeOpt)) {
-                shareGroupService.describeGroups();
-            }
-            shareGroupService.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalArgumentException e) {
-            CommandLineUtils.printUsageAndExit(opts.parser, e.getMessage());
-        } catch (Throwable e) {
-            printError("Executing share group command failed due to " + e.getMessage(), Optional.of(e));
-        }
+    public void listGroups() throws ExecutionException, InterruptedException {
+      if (opts.options.has(opts.stateOpt)) {
+        String stateValue = opts.options.valueOf(opts.stateOpt);
+        Set<ShareGroupState> states = (stateValue == null || stateValue.isEmpty())
+            ? Collections.emptySet()
+            : shareGroupStatesFromString(stateValue);
+        List<ShareGroupListing> listings = listShareGroupsWithState(states);
+        printGroupStates(listings.stream().map(e -> new Tuple2<>(e.groupId(), e.state().toString())).collect(Collectors.toList()));
+      } else
+        listShareGroups().forEach(System.out::println);
     }
 
-    static Set<ShareGroupState> shareGroupStatesFromString(String input) {
-        Set<ShareGroupState> parsedStates = Arrays.stream(input.split(",")).map(s -> ShareGroupState.parse(s.trim())).collect(Collectors.toSet());
-        if (parsedStates.contains(ShareGroupState.UNKNOWN)) {
-            Collection<ShareGroupState> validStates = Arrays.stream(ShareGroupState.values()).filter(s -> s != ShareGroupState.UNKNOWN).collect(Collectors.toList());
-            throw new IllegalArgumentException("Invalid state list '" + input + "'. Valid states are: " + Utils.join(validStates, ", "));
-        }
-        return parsedStates;
+    List<String> listShareGroups() {
+      try {
+        ListShareGroupsResult result = adminClient.listShareGroups(withTimeoutMs(new ListShareGroupsOptions()));
+        Collection<ShareGroupListing> listings = result.all().get();
+        return listings.stream().map(ShareGroupListing::groupId).collect(Collectors.toList());
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
     }
 
-    public static void printError(String msg, Optional<Throwable> e) {
-        System.out.println("\nError: " + msg);
-        e.ifPresent(Throwable::printStackTrace);
+    List<ShareGroupListing> listShareGroupsWithState(Set<ShareGroupState> states) throws ExecutionException, InterruptedException {
+      ListShareGroupsOptions listShareGroupsOptions = withTimeoutMs(new ListShareGroupsOptions());
+      listShareGroupsOptions.inStates(states);
+      ListShareGroupsResult result = adminClient.listShareGroups(listShareGroupsOptions);
+      return new ArrayList<>(result.all().get());
     }
 
-    // Visibility for testing
-    public static Admin createAdminClient(Map<String, String> configOverrides, ShareGroupCommandOptions opts) throws IOException {
-        Properties props = opts.options.has(opts.commandConfigOpt) ? Utils.loadProps(opts.options.valueOf(opts.commandConfigOpt)) : new Properties();
-        props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt));
-        props.putAll(configOverrides);
-        return Admin.create(props);
+    private void printGroupStates(List<Tuple2<String, String>> groupsAndStates) {
+      // find proper columns width
+      int maxGroupLen = 15;
+      for (Tuple2<String, String> tuple : groupsAndStates) {
+        String groupId = tuple.v1;
+        maxGroupLen = Math.max(maxGroupLen, groupId.length());
+      }
+      System.out.printf("%" + (-maxGroupLen) + "s %s", "GROUP", "STATE");
+      for (Tuple2<String, String> tuple : groupsAndStates) {
+        String groupId = tuple.v1;
+        String state = tuple.v2;
+        System.out.printf("%" + (-maxGroupLen) + "s %s", groupId, state);
+      }
     }
 
-    static class ShareGroupService {
-        final ShareGroupCommandOptions opts;
-        final Map<String, String> configOverrides;
-        private final Admin adminClient;
-
-        public ShareGroupService(ShareGroupCommandOptions opts, Map<String, String> configOverrides, Admin adminClient) {
-            this.opts = opts;
-            this.configOverrides = configOverrides;
-            this.adminClient = adminClient;
-        }
-
-        public void listGroups() throws ExecutionException, InterruptedException {
-            if (opts.options.has(opts.stateOpt)) {
-                String stateValue = opts.options.valueOf(opts.stateOpt);
-                Set<ShareGroupState> states = (stateValue == null || stateValue.isEmpty())
-                        ? Collections.emptySet()
-                        : shareGroupStatesFromString(stateValue);
-                List<ShareGroupListing> listings = listShareGroupsWithState(states);
-                printGroupStates(listings.stream().map(e -> new Tuple2<>(e.groupId(), e.state().toString())).collect(Collectors.toList()));
-            } else
-                listShareGroups().forEach(System.out::println);
-        }
-
-        List<String> listShareGroups() {
-            try {
-                ListShareGroupsResult result = adminClient.listShareGroups(withTimeoutMs(new ListShareGroupsOptions()));
-                Collection<ShareGroupListing> listings = result.all().get();
-                return listings.stream().map(ShareGroupListing::groupId).collect(Collectors.toList());
-            } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        List<ShareGroupListing> listShareGroupsWithState(Set<ShareGroupState> states) throws ExecutionException, InterruptedException {
-            ListShareGroupsOptions listShareGroupsOptions = withTimeoutMs(new ListShareGroupsOptions());
-            listShareGroupsOptions.inStates(states);
-            ListShareGroupsResult result = adminClient.listShareGroups(listShareGroupsOptions);
-            return new ArrayList<>(result.all().get());
-        }
-
-        private void printGroupStates(List<Tuple2<String, String>> groupsAndStates) {
-            // find proper columns width
-            int maxGroupLen = 15;
-            for (Tuple2<String, String> tuple : groupsAndStates) {
-                String groupId = tuple.v1;
-                maxGroupLen = Math.max(maxGroupLen, groupId.length());
-            }
-            System.out.printf("%" + (-maxGroupLen) + "s %s", "GROUP", "STATE");
-            for (Tuple2<String, String> tuple : groupsAndStates) {
-                String groupId = tuple.v1;
-                String state = tuple.v2;
-                System.out.printf("%" + (-maxGroupLen) + "s %s", groupId, state);
-            }
-        }
-
-        void describeGroups() throws ExecutionException, InterruptedException {
-            ShareGroupDescription description = getDescribeGroups();
-            printGroupDescriptionTable(description);
-        }
-        ShareGroupDescription getDescribeGroups() throws ExecutionException, InterruptedException {
-            String group = opts.options.valueOf(opts.groupOpt);
-            DescribeShareGroupsResult result = adminClient.describeShareGroups(Collections.singletonList(group));
-            Map<String, ShareGroupDescription> descriptionMap = result.all().get();
-            if (descriptionMap.containsKey(group)) {
-                return descriptionMap.get(group);
-            }
-            return null;
-        }
-
-        private void printGroupDescriptionTable(ShareGroupDescription description) {
-            boolean shouldPrintState = opts.options.has(opts.stateOpt);
-            boolean shouldPrintMemDetails = opts.options.has(opts.membersOpt);
-            if (description == null) {
-                return;
-            }
-            if (shouldPrintMemDetails) {
-                printMemberDetails(description.members());
-                return;
-            }
-            List<String> lineItem = new ArrayList<>();
-            lineItem.add(description.groupId());
-            System.out.println(description.members());
-            lineItem.add(description.members().stream().map(MemberDescription::consumerId).collect(Collectors.joining(",")));
-            lineItem.add(description.coordinator().idString());
-            if (shouldPrintState) {
-                lineItem.add(description.state().toString());
-            }
-
-            int maxItemLength = 20;
-            for (String item : lineItem) {
-                if (item != null) {
-                    maxItemLength = Math.max(maxItemLength, item.length());
-                }
-            }
-
-            // header
-            String formatAtom = "%" + (-maxItemLength) + "s";
-            String formatHeader = "";
-            if (shouldPrintState) {
-                formatHeader = String.format(formatAtom + " " + formatAtom + " " + formatAtom + " " + formatAtom, "GROUP_ID", "MEMBERS", "COORDINATOR_NODE", "STATE");
-            } else {
-                formatHeader = String.format(formatAtom + " " + formatAtom + " " + formatAtom, "GROUP_ID", "MEMBERS", "COORDINATOR_NODE");
-            }
-            System.out.println(formatHeader);
-            for (String item : lineItem) {
-                System.out.printf(formatAtom + " ", item);
-            }
-            System.out.println();
-        }
-
-        private void printMemberDetails(Collection<MemberDescription> members) {
-            List<List<String>> lineItems = new ArrayList<>();
-            int maxLen = 20;
-            for (MemberDescription member : members) {
-                List<String> lineItem = new ArrayList<>();
-                lineItem.add(member.consumerId());
-                lineItem.add(member.groupInstanceId().isPresent() ? member.groupInstanceId().get() : "");
-                lineItem.add(member.clientId());
-                lineItem.add(member.host());
-                lineItem.add(member.assignment().topicPartitions().stream().map(part -> part.topic() + ":" + part.partition()).collect(Collectors.joining(",")));
-                lineItem.add(member.targetAssignment().isPresent()
-                    ? member.targetAssignment().get().topicPartitions().stream().map(part -> part.topic() + ":" + part.partition()).collect(Collectors.joining(","))
-                    : "");
-                for (String item : lineItem) {
-                    if (item != null) {
-                        maxLen = Math.max(maxLen, item.length());
-                    }
-                }
-                lineItems.add(lineItem);
-            }
-
-            String fmt = "%" + (-maxLen) + "s";
-            String header = fmt + " " + fmt + " " + fmt + " " + fmt + " " + fmt + " " + fmt;
-            System.out.printf(header, "MEMBER_ID", "GRP_INSTANCE_ID", "CLIENT_ID", "HOST", "ASSIGNMENT", "TARGET_ASSIGNMENT");
-            System.out.println();
-            for (List<String> item : lineItems) {
-                for (String atom : item) {
-                    System.out.printf(fmt + " ", atom);
-                }
-                System.out.println();
-            }
-        }
-
-        public void close() {
-            adminClient.close();
-        }
-
-        private <T extends AbstractOptions<T>> T withTimeoutMs(T options) {
-            int t = opts.options.valueOf(opts.timeoutMsOpt).intValue();
-            return options.timeoutMs(t);
-        }
+    private void describeGroups() throws ExecutionException, InterruptedException {
+      String group = opts.options.valueOf(opts.groupOpt);
+      ShareGroupDescription description = getDescribeGroup(group);
+      boolean shouldPrintState = opts.options.has(opts.stateOpt);
+      boolean shouldPrintMemDetails = opts.options.has(opts.membersOpt);
+      printGroupDescriptionTable(description, shouldPrintState, shouldPrintMemDetails);
     }
+
+    ShareGroupDescription getDescribeGroup(String group) throws ExecutionException, InterruptedException {
+      DescribeShareGroupsResult result = adminClient.describeShareGroups(Collections.singletonList(group));
+      Map<String, ShareGroupDescription> descriptionMap = result.all().get();
+      if (descriptionMap.containsKey(group)) {
+        return descriptionMap.get(group);
+      }
+      return null;
+    }
+
+    Map<TopicPartition, Long> getOffsetLag(Collection<MemberDescription> members) throws ExecutionException, InterruptedException {
+      Set<TopicPartition> allTp = new HashSet<>();
+      for (MemberDescription memberDescription : members) {
+        allTp.addAll(memberDescription.assignment().topicPartitions());
+      }
+      // fetch latest and earliest offsets
+      Map<TopicPartition, OffsetSpec> earliest = new HashMap<>();
+      Map<TopicPartition, OffsetSpec> latest = new HashMap<>();
+
+      for (TopicPartition tp : allTp) {
+        earliest.put(tp, OffsetSpec.earliest());
+        latest.put(tp, OffsetSpec.latest());
+      }
+      Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> earliestResult = adminClient.listOffsets(earliest).all().get();
+      Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> latestResult = adminClient.listOffsets(latest).all().get();
+
+      Map<TopicPartition, Long> lag = new HashMap<>();
+      for (Map.Entry<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> tp : earliestResult.entrySet()) {
+        lag.put(tp.getKey(), latestResult.get(tp.getKey()).offset() - earliestResult.get(tp.getKey()).offset());
+      }
+      return lag;
+    }
+
+    private void printGroupDescriptionTable(ShareGroupDescription description, boolean shouldPrintState, boolean shouldPrintMemDetails) throws ExecutionException, InterruptedException {
+      if (description == null) {
+        return;
+      }
+      if (shouldPrintMemDetails) {
+        printMemberDetails(description.members());
+        return;
+      }
+      List<String> lineItem = new ArrayList<>();
+      lineItem.add(description.groupId());
+      lineItem.add(description.coordinator().idString());
+      lineItem.add(getOffsetLag(description.members()).entrySet().stream()
+          .map(entry -> entry.getKey() + "=>" + entry.getValue()).collect(Collectors.joining(", ")));
+
+      if (shouldPrintState) {
+        lineItem.add(description.state().toString());
+      }
+
+      int maxItemLength = 20;
+      for (String item : lineItem) {
+        if (item != null) {
+          maxItemLength = Math.max(maxItemLength, item.length());
+        }
+      }
+
+      // header
+      String formatAtom = "%" + (-maxItemLength) + "s";
+      String formatHeader = String.format(formatAtom + " " + formatAtom + " " + formatAtom, "GROUP_ID", "COORDINATOR_NODE", "OFFSETS");
+      if (shouldPrintState) {
+        formatHeader = String.format(formatAtom + " " + formatAtom + " " + formatAtom + " " + formatAtom, "GROUP_ID", "COORDINATOR_NODE", "OFFSETS", "STATE");
+      }
+      System.out.println(formatHeader);
+      for (String item : lineItem) {
+        System.out.printf(formatAtom + " ", item);
+      }
+      System.out.println();
+    }
+
+    private void printMemberDetails(Collection<MemberDescription> members) {
+      List<List<String>> lineItems = new ArrayList<>();
+      int maxLen = 20;
+      for (MemberDescription member : members) {
+        List<String> lineItem = new ArrayList<>();
+        lineItem.add(member.consumerId());
+        lineItem.add(member.clientId());
+        lineItem.add(member.host());
+        lineItem.add(member.assignment().topicPartitions().stream().map(part -> part.topic() + ":" + part.partition()).collect(Collectors.joining(",")));
+        for (String item : lineItem) {
+          if (item != null) {
+            maxLen = Math.max(maxLen, item.length());
+          }
+        }
+        lineItems.add(lineItem);
+      }
+
+      String fmt = "%" + (-maxLen) + "s";
+      String header = fmt + " " + fmt + " " + fmt + " " + fmt;
+      System.out.printf(header, "MEMBER_ID", "CLIENT_ID", "HOST", "ASSIGNMENT");
+      System.out.println();
+      for (List<String> item : lineItems) {
+        for (String atom : item) {
+          System.out.printf(fmt + " ", atom);
+        }
+        System.out.println();
+      }
+    }
+
+    public void close() {
+      adminClient.close();
+    }
+
+    private <T extends AbstractOptions<T>> T withTimeoutMs(T options) {
+      int t = opts.options.valueOf(opts.timeoutMsOpt).intValue();
+      return options.timeoutMs(t);
+    }
+  }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/ShareGroupsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ShareGroupsCommandTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.DescribeShareGroupsResult;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListShareGroupsOptions;
 import org.apache.kafka.clients.admin.ListShareGroupsResult;
 import org.apache.kafka.clients.admin.MemberAssignment;
@@ -54,137 +55,156 @@ import static org.mockito.Mockito.when;
 
 public class ShareGroupsCommandTest {
 
-    @Test
-    public void testListShareGroups() throws Exception {
-        String firstGroup = "first-group";
-        String secondGroup = "second-group";
-        String bootstrapServer = "localhost:9092";
+  @Test
+  public void testListShareGroups() throws Exception {
+    String firstGroup = "first-group";
+    String secondGroup = "second-group";
+    String bootstrapServer = "localhost:9092";
 
-        String[] cgcArgs = new String[]{"--bootstrap-server", bootstrapServer, "--list"};
-        Admin adminClient = mock(KafkaAdminClient.class);
-        ListShareGroupsResult result = mock(ListShareGroupsResult.class);
-        when(result.all()).thenReturn(KafkaFuture.completedFuture(Arrays.asList(
-                new ShareGroupListing(firstGroup, Optional.of(ShareGroupState.STABLE)),
-                new ShareGroupListing(secondGroup, Optional.of(ShareGroupState.EMPTY))
-        )));
-        when(adminClient.listShareGroups(any(ListShareGroupsOptions.class))).thenReturn(result);
-        ShareGroupService service = getShareGroupService(cgcArgs, adminClient);
-        Set<String> expectedGroups = new HashSet<>(Arrays.asList(firstGroup, secondGroup));
+    String[] cgcArgs = new String[]{"--bootstrap-server", bootstrapServer, "--list"};
+    Admin adminClient = mock(KafkaAdminClient.class);
+    ListShareGroupsResult result = mock(ListShareGroupsResult.class);
+    when(result.all()).thenReturn(KafkaFuture.completedFuture(Arrays.asList(
+        new ShareGroupListing(firstGroup, Optional.of(ShareGroupState.STABLE)),
+        new ShareGroupListing(secondGroup, Optional.of(ShareGroupState.EMPTY))
+    )));
+    when(adminClient.listShareGroups(any(ListShareGroupsOptions.class))).thenReturn(result);
+    ShareGroupService service = getShareGroupService(cgcArgs, adminClient);
+    Set<String> expectedGroups = new HashSet<>(Arrays.asList(firstGroup, secondGroup));
 
-        final Set[] foundGroups = new Set[]{Collections.emptySet()};
-        TestUtils.waitForCondition(() -> {
-            foundGroups[0] = new HashSet<>(service.listShareGroups());
-            return Objects.equals(expectedGroups, foundGroups[0]);
-        }, "Expected --list to show groups " + expectedGroups + ", but found " + foundGroups[0] + ".");
-        service.close();
-    }
+    final Set[] foundGroups = new Set[]{Collections.emptySet()};
+    TestUtils.waitForCondition(() -> {
+      foundGroups[0] = new HashSet<>(service.listShareGroups());
+      return Objects.equals(expectedGroups, foundGroups[0]);
+    }, "Expected --list to show groups " + expectedGroups + ", but found " + foundGroups[0] + ".");
+    service.close();
+  }
 
-    @Test
-    public void testDescribeShareGroups() throws Exception {
-        String firstGroup = "first-group";
-        String bootstrapServer = "localhost:9092";
+  @Test
+  public void testDescribeShareGroups() throws Exception {
+    String firstGroup = "group1";
+    Admin adminClient = mock(KafkaAdminClient.class);
+    DescribeShareGroupsResult result = mock(DescribeShareGroupsResult.class);
+    Map<String, ShareGroupDescription> resultMap = new HashMap<>();
+    ShareGroupDescription exp = new ShareGroupDescription(
+        firstGroup,
+        Collections.singletonList(new MemberDescription("memid1", "clId1", "host1", new MemberAssignment(
+            Collections.singleton(new TopicPartition("topic1", 0))
+        ))),
+        ShareGroupState.STABLE,
+        new Node(0, "host1", 9090));
+    resultMap.put(firstGroup, exp);
 
-        String[] cgcArgs = new String[]{"--bootstrap-server", bootstrapServer, "--describe", "--group", firstGroup};
-        Admin adminClient = mock(KafkaAdminClient.class);
-        DescribeShareGroupsResult result = mock(DescribeShareGroupsResult.class);
-        Map<String, ShareGroupDescription> resultMap = new HashMap<>();
-        resultMap.put(firstGroup, new ShareGroupDescription(
-            firstGroup,
-            Collections.singletonList(new MemberDescription("memid1", "clId1", "host1", new MemberAssignment(
-                Collections.singleton(new TopicPartition("topic1", 0))
-            ))),
-            ShareGroupState.STABLE,
-            new Node(0, "host1", 9090)));
+    when(result.all()).thenReturn(KafkaFuture.completedFuture(resultMap));
+    when(adminClient.describeShareGroups(ArgumentMatchers.anyCollection())).thenReturn(result);
+    ShareGroupService service = new ShareGroupService(null, null, adminClient);
+    assertEquals(exp, service.getDescribeGroup(firstGroup));
+    service.close();
+  }
 
-        when(result.all()).thenReturn(KafkaFuture.completedFuture(resultMap));
-        when(adminClient.describeShareGroups(ArgumentMatchers.anyCollection())).thenReturn(result);
-        ShareGroupService service = getShareGroupService(cgcArgs, adminClient);
+  @Test
+  public void testDescribeShareGroupsGetOffsets() throws Exception {
+    Admin adminClient = mock(KafkaAdminClient.class);
 
-        ShareGroupDescription[] description = new ShareGroupDescription[1];
-        TestUtils.waitForCondition(() -> {
-            description[0] = service.getDescribeGroup(firstGroup);
-            return Objects.equals(resultMap.get(firstGroup), description[0]);
-        }, "Expected --describe to show groups " + resultMap.get(firstGroup) + ", but found " + description[0] + ".");
-        service.close();
-    }
+    ListOffsetsResult startOffset = mock(ListOffsetsResult.class);
+    Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> startOffsetResultMap = new HashMap<>();
+    startOffsetResultMap.put(new TopicPartition("topic1", 0), new ListOffsetsResult.ListOffsetsResultInfo(10, -1, Optional.empty()));
 
-    @Test
-    public void testListWithUnrecognizedNewConsumerOption() {
-        String bootstrapServer = "localhost:9092";
-        String[] cgcArgs = new String[]{"--new-consumer", "--bootstrap-server", bootstrapServer, "--list"};
-        assertThrows(OptionException.class, () -> getShareGroupService(cgcArgs, new MockAdminClient()));
-    }
+    ListOffsetsResult endOffset = mock(ListOffsetsResult.class);
+    Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> endOffsetResultMap = new HashMap<>();
+    endOffsetResultMap.put(new TopicPartition("topic1", 0), new ListOffsetsResult.ListOffsetsResultInfo(30, -1, Optional.empty()));
 
-    @Test
-    public void testListShareGroupsWithStates() throws Exception {
-        String firstGroup = "first-group";
-        String secondGroup = "second-group";
-        String bootstrapServer = "localhost:9092";
+    when(startOffset.all()).thenReturn(KafkaFuture.completedFuture(startOffsetResultMap));
+    when(endOffset.all()).thenReturn(KafkaFuture.completedFuture(endOffsetResultMap));
 
-        String[] cgcArgs = new String[]{"--bootstrap-server", bootstrapServer, "--list", "--state"};
-        Admin adminClient = mock(KafkaAdminClient.class);
-        ListShareGroupsResult resultWithAllStates = mock(ListShareGroupsResult.class);
-        when(resultWithAllStates.all()).thenReturn(KafkaFuture.completedFuture(Arrays.asList(
-                new ShareGroupListing(firstGroup, Optional.of(ShareGroupState.STABLE)),
-                new ShareGroupListing(secondGroup, Optional.of(ShareGroupState.EMPTY))
-        )));
-        when(adminClient.listShareGroups(any(ListShareGroupsOptions.class))).thenReturn(resultWithAllStates);
-        ShareGroupService service = getShareGroupService(cgcArgs, adminClient);
-        Set<ShareGroupListing> expectedListing = new HashSet<>(Arrays.asList(
-                new ShareGroupListing(firstGroup, Optional.of(ShareGroupState.STABLE)),
-                new ShareGroupListing(secondGroup, Optional.of(ShareGroupState.EMPTY))));
+    when(adminClient.listOffsets(ArgumentMatchers.anyMap())).thenReturn(startOffset, endOffset);
 
-        final Set[] foundListing = new Set[]{Collections.emptySet()};
-        TestUtils.waitForCondition(() -> {
-            foundListing[0] = new HashSet<>(service.listShareGroupsWithState(new HashSet<>(Arrays.asList(ShareGroupState.values()))));
-            return Objects.equals(expectedListing, foundListing[0]);
-        }, "Expected to show groups " + expectedListing + ", but found " + foundListing[0]);
+    MemberDescription description = new MemberDescription("", "", "",
+        new MemberAssignment(Collections.singleton(new TopicPartition("topic1", 0))));
+    ShareGroupService service = new ShareGroupService(null, null, adminClient);
+    Map<TopicPartition, Long> lags = service.getOffsetLag(Collections.singletonList(description));
+    assertEquals(1, lags.size());
+    assertEquals(20, lags.get(new TopicPartition("topic1", 0)));
+    service.close();
+  }
 
-        ListShareGroupsResult resultWithStableState = mock(ListShareGroupsResult.class);
-        when(resultWithStableState.all()).thenReturn(KafkaFuture.completedFuture(Arrays.asList(
-                new ShareGroupListing(firstGroup, Optional.of(ShareGroupState.STABLE))
-        )));
-        when(adminClient.listShareGroups(any(ListShareGroupsOptions.class))).thenReturn(resultWithStableState);
-        Set<ShareGroupListing> expectedListingStable = Collections.singleton(
-                new ShareGroupListing(firstGroup, Optional.of(ShareGroupState.STABLE)));
+  @Test
+  public void testListWithUnrecognizedNewConsumerOption() {
+    String bootstrapServer = "localhost:9092";
+    String[] cgcArgs = new String[]{"--new-consumer", "--bootstrap-server", bootstrapServer, "--list"};
+    assertThrows(OptionException.class, () -> getShareGroupService(cgcArgs, new MockAdminClient()));
+  }
 
-        foundListing[0] = Collections.emptySet();
+  @Test
+  public void testListShareGroupsWithStates() throws Exception {
+    String firstGroup = "first-group";
+    String secondGroup = "second-group";
+    String bootstrapServer = "localhost:9092";
 
-        TestUtils.waitForCondition(() -> {
-            foundListing[0] = new HashSet<>(service.listShareGroupsWithState(Collections.singleton(ShareGroupState.STABLE)));
-            return Objects.equals(expectedListingStable, foundListing[0]);
-        }, "Expected to show groups " + expectedListingStable + ", but found " + foundListing[0]);
-        service.close();
-    }
+    String[] cgcArgs = new String[]{"--bootstrap-server", bootstrapServer, "--list", "--state"};
+    Admin adminClient = mock(KafkaAdminClient.class);
+    ListShareGroupsResult resultWithAllStates = mock(ListShareGroupsResult.class);
+    when(resultWithAllStates.all()).thenReturn(KafkaFuture.completedFuture(Arrays.asList(
+        new ShareGroupListing(firstGroup, Optional.of(ShareGroupState.STABLE)),
+        new ShareGroupListing(secondGroup, Optional.of(ShareGroupState.EMPTY))
+    )));
+    when(adminClient.listShareGroups(any(ListShareGroupsOptions.class))).thenReturn(resultWithAllStates);
+    ShareGroupService service = getShareGroupService(cgcArgs, adminClient);
+    Set<ShareGroupListing> expectedListing = new HashSet<>(Arrays.asList(
+        new ShareGroupListing(firstGroup, Optional.of(ShareGroupState.STABLE)),
+        new ShareGroupListing(secondGroup, Optional.of(ShareGroupState.EMPTY))));
 
-    @Test
-    public void testShareGroupStatesFromString() {
-        Set<ShareGroupState> result = ShareGroupsCommand.shareGroupStatesFromString("Stable");
-        assertEquals(Collections.singleton(ShareGroupState.STABLE), result);
+    final Set[] foundListing = new Set[]{Collections.emptySet()};
+    TestUtils.waitForCondition(() -> {
+      foundListing[0] = new HashSet<>(service.listShareGroupsWithState(new HashSet<>(Arrays.asList(ShareGroupState.values()))));
+      return Objects.equals(expectedListing, foundListing[0]);
+    }, "Expected to show groups " + expectedListing + ", but found " + foundListing[0]);
 
-        result = ShareGroupsCommand.shareGroupStatesFromString("stable");
-        assertEquals(new HashSet<>(Arrays.asList(ShareGroupState.STABLE)), result);
+    ListShareGroupsResult resultWithStableState = mock(ListShareGroupsResult.class);
+    when(resultWithStableState.all()).thenReturn(KafkaFuture.completedFuture(Arrays.asList(
+        new ShareGroupListing(firstGroup, Optional.of(ShareGroupState.STABLE))
+    )));
+    when(adminClient.listShareGroups(any(ListShareGroupsOptions.class))).thenReturn(resultWithStableState);
+    Set<ShareGroupListing> expectedListingStable = Collections.singleton(
+        new ShareGroupListing(firstGroup, Optional.of(ShareGroupState.STABLE)));
 
-        result = ShareGroupsCommand.shareGroupStatesFromString("dead");
-        assertEquals(new HashSet<>(Arrays.asList(ShareGroupState.DEAD)), result);
+    foundListing[0] = Collections.emptySet();
 
-        result = ShareGroupsCommand.shareGroupStatesFromString("empty");
-        assertEquals(new HashSet<>(Arrays.asList(ShareGroupState.EMPTY)), result);
+    TestUtils.waitForCondition(() -> {
+      foundListing[0] = new HashSet<>(service.listShareGroupsWithState(Collections.singleton(ShareGroupState.STABLE)));
+      return Objects.equals(expectedListingStable, foundListing[0]);
+    }, "Expected to show groups " + expectedListingStable + ", but found " + foundListing[0]);
+    service.close();
+  }
 
-        assertThrows(IllegalArgumentException.class, () -> ShareGroupsCommand.shareGroupStatesFromString("bad, wrong"));
+  @Test
+  public void testShareGroupStatesFromString() {
+    Set<ShareGroupState> result = ShareGroupsCommand.shareGroupStatesFromString("Stable");
+    assertEquals(Collections.singleton(ShareGroupState.STABLE), result);
 
-        assertThrows(IllegalArgumentException.class, () -> ShareGroupsCommand.shareGroupStatesFromString("  bad, Stable"));
+    result = ShareGroupsCommand.shareGroupStatesFromString("stable");
+    assertEquals(new HashSet<>(Arrays.asList(ShareGroupState.STABLE)), result);
 
-        assertThrows(IllegalArgumentException.class, () -> ShareGroupsCommand.shareGroupStatesFromString("   ,   ,"));
-    }
+    result = ShareGroupsCommand.shareGroupStatesFromString("dead");
+    assertEquals(new HashSet<>(Arrays.asList(ShareGroupState.DEAD)), result);
 
-    ShareGroupService getShareGroupService(String[] args, Admin adminClient) {
-        ShareGroupCommandOptions opts = new ShareGroupCommandOptions(args);
-        ShareGroupService service = new ShareGroupService(
-                opts,
-                Collections.singletonMap(AdminClientConfig.RETRIES_CONFIG, Integer.toString(Integer.MAX_VALUE)),
-                adminClient
-        );
-        return service;
-    }
+    result = ShareGroupsCommand.shareGroupStatesFromString("empty");
+    assertEquals(new HashSet<>(Arrays.asList(ShareGroupState.EMPTY)), result);
+
+    assertThrows(IllegalArgumentException.class, () -> ShareGroupsCommand.shareGroupStatesFromString("bad, wrong"));
+
+    assertThrows(IllegalArgumentException.class, () -> ShareGroupsCommand.shareGroupStatesFromString("  bad, Stable"));
+
+    assertThrows(IllegalArgumentException.class, () -> ShareGroupsCommand.shareGroupStatesFromString("   ,   ,"));
+  }
+
+  ShareGroupService getShareGroupService(String[] args, Admin adminClient) {
+    ShareGroupCommandOptions opts = new ShareGroupCommandOptions(args);
+    ShareGroupService service = new ShareGroupService(
+        opts,
+        Collections.singletonMap(AdminClientConfig.RETRIES_CONFIG, Integer.toString(Integer.MAX_VALUE)),
+        adminClient
+    );
+    return service;
+  }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/ShareGroupsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ShareGroupsCommandTest.java
@@ -102,7 +102,7 @@ public class ShareGroupsCommandTest {
 
         ShareGroupDescription[] description = new ShareGroupDescription[1];
         TestUtils.waitForCondition(() -> {
-            description[0] = service.getDescribeGroups();
+            description[0] = service.getDescribeGroup(firstGroup);
             return Objects.equals(resultMap.get(firstGroup), description[0]);
         }, "Expected --describe to show groups " + resultMap.get(firstGroup) + ", but found " + description[0] + ".");
         service.close();


### PR DESCRIPTION
```
➜  ccs-kafka git:(AKCORE-9-cli) ✗ bin/kafka-share-groups.sh --bootstrap-server localhost:9092 --describe --group group-share-x                                                     [2:05:13]

GROUP_ID             COORDINATOR_NODE     OFFSETS
group-share-x        1                    topic-share-y-0=>878
group-share-x        1                    topic-share-x-0=>665
➜  ccs-kafka git:(AKCORE-9-cli) ✗ bin/kafka-share-groups.sh --bootstrap-server localhost:9092 --describe --group group-share                                                       [2:05:16]

GROUP_ID             COORDINATOR_NODE     OFFSETS
group-share          1
➜  ccs-kafka git:(AKCORE-9-cli) ✗ bin/kafka-share-groups.sh --bootstrap-server localhost:9092 --describe --group group-share-x --offsets                                           [2:05:19]

GROUP_ID             COORDINATOR_NODE     OFFSETS
group-share-x        1                    topic-share-y-0=>883
group-share-x        1                    topic-share-x-0=>670
➜  ccs-kafka git:(AKCORE-9-cli) ✗ bin/kafka-share-groups.sh --bootstrap-server localhost:9092 --describe --group group-share-x --state                                             [2:05:27]

GROUP_ID             COORDINATOR_NODE     OFFSETS              STATE
group-share-x        1                    topic-share-y-0=>886 Stable
group-share-x        1                    topic-share-x-0=>673 Stable
➜  ccs-kafka git:(AKCORE-9-cli) ✗ bin/kafka-share-groups.sh --bootstrap-server localhost:9092 --describe --group group-share-x --members                                           [2:05:32]

MEMBER_ID              CLIENT_ID              HOST                   ASSIGNMENT
eYP6tgjWT3amoKW19QKaUw console-share-consumer /127.0.0.1             topic-share-x:0
rOptwrnfQoibv62vHzfiyw console-share-consumer /127.0.0.1             topic-share-y:0
```

![Screenshot 2024-02-16 at 2 06 43 AM](https://github.com/confluentinc/kafka/assets/787991/f88480ab-1c16-49d0-b714-15eb1e479649)

