### PR TITLE
AKCORE-24: More testing of subscribe and unsubscribe

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManager.java
@@ -453,7 +453,9 @@ public class ShareMembershipManager implements RequestManager {
     private void updateSubscription(SortedSet<TopicIdPartition> assignedPartitions,
                                     boolean clearAssignments) {
         Collection<TopicPartition> assignedTopicPartitions = toTopicPartitionSet(assignedPartitions);
-        subscriptions.assignFromSubscribed(assignedTopicPartitions);
+        if (subscriptions.hasAutoAssignedPartitions()) {
+            subscriptions.assignFromSubscribed(assignedTopicPartitions);
+        }
         updateAssignmentLocally(assignedPartitions, clearAssignments);
     }
 


### PR DESCRIPTION
Add integration tests which exercise the various situations in which subscribe and unsubscribe can be called. Fixed a bug found by the tests too.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
