### PR TITLE
AKCORE-22: Implementation of ShareFetch/Acknowledge request classes (1/N)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidRecordStateException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidRecordStateException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+/**
+ * Thrown when the acknowledgement of delivery of a record could not be completed because the record
+ * state is invalid.
+ */
+public class InvalidRecordStateException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidRecordStateException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -120,7 +120,9 @@ public enum ApiKeys {
     LIST_CLIENT_METRICS_RESOURCES(ApiMessageType.LIST_CLIENT_METRICS_RESOURCES),
     DESCRIBE_TOPIC_PARTITIONS(ApiMessageType.DESCRIBE_TOPIC_PARTITIONS),
     SHARE_GROUP_HEARTBEAT(ApiMessageType.SHARE_GROUP_HEARTBEAT),
-    SHARE_GROUP_DESCRIBE(ApiMessageType.SHARE_GROUP_DESCRIBE);
+    SHARE_GROUP_DESCRIBE(ApiMessageType.SHARE_GROUP_DESCRIBE),
+    SHARE_FETCH(ApiMessageType.SHARE_FETCH),
+    SHARE_ACKNOWLEDGE(ApiMessageType.SHARE_ACKNOWLEDGE);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -64,6 +64,7 @@ import org.apache.kafka.common.errors.InvalidPartitionsException;
 import org.apache.kafka.common.errors.InvalidPidMappingException;
 import org.apache.kafka.common.errors.InvalidPrincipalTypeException;
 import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.InvalidRecordStateException;
 import org.apache.kafka.common.errors.InvalidRegistrationException;
 import org.apache.kafka.common.errors.InvalidReplicaAssignmentException;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
@@ -392,7 +393,8 @@ public enum Errors {
     UNKNOWN_CONTROLLER_ID(116, "This controller ID is not known.", UnknownControllerIdException::new),
     UNKNOWN_SUBSCRIPTION_ID(117, "Client sent a push telemetry request with an invalid or outdated subscription ID.", UnknownSubscriptionIdException::new),
     TELEMETRY_TOO_LARGE(118, "Client sent a push telemetry request larger than the maximum size the broker will accept.", TelemetryTooLargeException::new),
-    INVALID_REGISTRATION(119, "The controller has considered the broker registration to be invalid.", InvalidRegistrationException::new);
+    INVALID_REGISTRATION(119, "The controller has considered the broker registration to be invalid.", InvalidRegistrationException::new),
+    INVALID_RECORD_STATE(120, "The record state is invalid. The acknowledgement of delivery could not be completed.", InvalidRecordStateException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ShareAcknowledgeRequestData;
+import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+
+public class ShareAcknowledgeRequest extends AbstractRequest {
+
+    public static class Builder extends AbstractRequest.Builder<ShareAcknowledgeRequest> {
+
+        private final ShareAcknowledgeRequestData data;
+
+        public Builder(ShareAcknowledgeRequestData data) {
+            this(data, false);
+        }
+
+        public Builder(ShareAcknowledgeRequestData data, boolean enableUnstableLastVersion) {
+            super(ApiKeys.SHARE_ACKNOWLEDGE, enableUnstableLastVersion);
+            this.data = data;
+        }
+
+        @Override
+        public ShareAcknowledgeRequest build(short version) {
+            return new ShareAcknowledgeRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final ShareAcknowledgeRequestData data;
+
+    public ShareAcknowledgeRequest(ShareAcknowledgeRequestData data, short version) {
+        super(ApiKeys.SHARE_ACKNOWLEDGE, version);
+        this.data = data;
+    }
+
+    @Override
+    public ShareAcknowledgeRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        return new ShareAcknowledgeResponse(new ShareAcknowledgeResponseData()
+            .setThrottleTimeMs(throttleTimeMs)
+            .setErrorCode(error.code()));
+    }
+
+    public static ShareAcknowledgeRequest parse(ByteBuffer buffer, short version) {
+        return new ShareAcknowledgeRequest(
+                new ShareAcknowledgeRequestData(new ByteBufferAccessor(buffer), version),
+                version
+        );
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeResponse.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Possible error codes.
+ * - {@link Errors#GROUP_AUTHORIZATION_FAILED}
+ * - {@link Errors#TOPIC_AUTHORIZATION_FAILED}
+ * - {@link Errors#UNKNOWN_TOPIC_OR_PARTITION}
+ * - {@link Errors#NOT_LEADER_OR_FOLLOWER}
+ * - {@link Errors#UNKNOWN_TOPIC_ID}
+ * - {@link Errors#INVALID_RECORD_STATE}
+ * - {@link Errors#KAFKA_STORAGE_ERROR}
+ * - {@link Errors#INVALID_REQUEST}
+ * - {@link Errors#UNKNOWN_SERVER_ERROR}
+ */
+public class ShareAcknowledgeResponse extends AbstractResponse {
+
+    private final ShareAcknowledgeResponseData data;
+
+    public ShareAcknowledgeResponse(ShareAcknowledgeResponseData data) {
+        super(ApiKeys.SHARE_ACKNOWLEDGE);
+        this.data = data;
+    }
+
+    @Override
+    public ShareAcknowledgeResponseData data() {
+        return data;
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        HashMap<Errors, Integer> counts = new HashMap<>();
+        data.responses().forEach(
+            topic -> topic.partitions().forEach(
+                partition -> updateErrorCounts(counts, Errors.forCode(partition.errorCode()))
+            )
+        );
+        return counts;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    public static ShareAcknowledgeResponse parse(ByteBuffer buffer, short version) {
+        return new ShareAcknowledgeResponse(
+            new ShareAcknowledgeResponseData(new ByteBufferAccessor(buffer), version)
+        );
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ShareFetchRequestData;
+import org.apache.kafka.common.message.ShareFetchResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+
+public class ShareFetchRequest extends AbstractRequest {
+
+    public static class Builder extends AbstractRequest.Builder<ShareFetchRequest> {
+
+        private final ShareFetchRequestData data;
+
+        public Builder(ShareFetchRequestData data) {
+            this(data, false);
+        }
+
+        public Builder(ShareFetchRequestData data, boolean enableUnstableLastVersion) {
+            super(ApiKeys.SHARE_FETCH, enableUnstableLastVersion);
+            this.data = data;
+        }
+
+        @Override
+        public ShareFetchRequest build(short version) {
+            return new ShareFetchRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final ShareFetchRequestData data;
+
+    public ShareFetchRequest(ShareFetchRequestData data, short version) {
+        super(ApiKeys.SHARE_FETCH, version);
+        this.data = data;
+    }
+
+    @Override
+    public ShareFetchRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        return new ShareFetchResponse(new ShareFetchResponseData()
+                .setThrottleTimeMs(throttleTimeMs)
+                .setErrorCode(error.code()));
+    }
+
+    public static ShareFetchRequest parse(ByteBuffer buffer, short version) {
+        return new ShareFetchRequest(
+            new ShareFetchRequestData(new ByteBufferAccessor(buffer), version),
+            version
+        );
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchResponse.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ShareFetchResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Possible error codes.
+ * - {@link Errors#GROUP_AUTHORIZATION_FAILED}
+ * - {@link Errors#TOPIC_AUTHORIZATION_FAILED}
+ * - {@link Errors#UNKNOWN_TOPIC_OR_PARTITION}
+ * - {@link Errors#NOT_LEADER_OR_FOLLOWER}
+ * - {@link Errors#UNKNOWN_TOPIC_ID}
+ * - {@link Errors#INVALID_RECORD_STATE}
+ * - {@link Errors#KAFKA_STORAGE_ERROR}
+ * - {@link Errors#CORRUPT_MESSAGE}
+ * - {@link Errors#INVALID_REQUEST}
+ * - {@link Errors#UNKNOWN_SERVER_ERROR}
+ */
+public class ShareFetchResponse extends AbstractResponse {
+
+    private final ShareFetchResponseData data;
+
+    public ShareFetchResponse(ShareFetchResponseData data) {
+        super(ApiKeys.SHARE_FETCH);
+        this.data = data;
+    }
+
+    @Override
+    public ShareFetchResponseData data() {
+        return data;
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        HashMap<Errors, Integer> counts = new HashMap<>();
+        data.responses().forEach(
+                topic -> topic.partitions().forEach(
+                        partition -> updateErrorCounts(counts, Errors.forCode(partition.errorCode()))
+                )
+        );
+        return counts;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    public static ShareFetchResponse parse(ByteBuffer buffer, short version) {
+        return new ShareFetchResponse(
+                new ShareFetchResponseData(new ByteBufferAccessor(buffer), version)
+        );
+    }
+}


### PR DESCRIPTION
Implementation of ShareFetch and ShareAcknowledge request and response classes to enable them to be referenced in dependent code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
