### PR TITLE
AKCORE-26-2: Added unit tests for handleShareFetchRequest

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1114,6 +1114,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       val unconvertedRecords = ShareFetchResponse.recordsOrFail(partitionData)
           new ShareFetchResponseData.PartitionData()
             .setPartitionIndex(tp.partition)
+            .setErrorCode(Errors.forCode(partitionData.errorCode).code)
             .setRecords(unconvertedRecords)
             .setCurrentLeader(partitionData.currentLeader())
     }


### PR DESCRIPTION
This pr contains unit tests for `handleShareFetchRequest` RPC in KafksApis.scala

Reference - [AKCORE-26](https://confluentinc.atlassian.net/jira/software/c/projects/AKCORE/issues/AKCORE-26)