### PR TITLE
AKCORE-22-8: Send topic-partitions on all ShareFetch requests (8/N)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
@@ -212,10 +212,12 @@ public class ShareSessionHandler {
                         topicIdPartitionsToLogString(replaced),
                         topicIdPartitionsToLogString(sessionPartitions.values()));
             }
-            Map<TopicPartition, TopicIdPartition> toSend = Collections.unmodifiableMap(next);
+            // Temporarily the broker is sessionless so we need to repeat all topic-partitions on every request
+//            Map<TopicPartition, TopicIdPartition> toSend = Collections.unmodifiableMap(next);
             Map<TopicPartition, TopicIdPartition> curSessionPartitions = Collections.unmodifiableMap(sessionPartitions);
             next = null;
-            return new ShareFetchRequestData(toSend, removed, replaced, curSessionPartitions, nextMetadata);
+//            return new ShareFetchRequestData(toSend, removed, replaced, curSessionPartitions, nextMetadata);
+            return new ShareFetchRequestData(curSessionPartitions, removed, replaced, curSessionPartitions, nextMetadata);
         }
     }
 


### PR DESCRIPTION
Temporarily send a complete list of topic-partitions on all ShareFetch requests. The broker is currently sessionless. Also adjust the tests for this.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
