### PR TITLE
AKCORE-18: Update console share consumer to share code with console consumer

### DIFF
--- a/bin/kafka-console-share-consumer
+++ b/bin/kafka-console-share-consumer
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,8 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
-    export KAFKA_HEAP_OPTS="-Xmx512M"
-fi
-
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.consumer.ConsoleShareConsumer "$@"
+exec "$0.sh" "$@"

--- a/bin/windows/kafka-console-share-consumer.bat
+++ b/bin/windows/kafka-console-share-consumer.bat
@@ -16,5 +16,5 @@ rem limitations under the License.
 
 SetLocal
 set KAFKA_HEAP_OPTS=-Xmx512M
-"%~dp0kafka-run-class.bat" org.apache.kafka.tools.ConsoleShareConsumer %*
+"%~dp0kafka-run-class.bat" org.apache.kafka.tools.consumer.ConsoleShareConsumer %*
 EndLocal

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumer.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.tools;
+package org.apache.kafka.tools.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaShareConsumer;
@@ -42,7 +42,7 @@ import java.util.concurrent.CountDownLatch;
  */
 public class ConsoleShareConsumer {
 
-    private static final Logger LOG = LoggerFactory.getLogger(org.apache.kafka.tools.ConsoleShareConsumer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConsoleShareConsumer.class);
     private static final CountDownLatch SHUTDOWN_LATCH = new CountDownLatch(1);
 
     static int messageCount = 0;

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
@@ -14,30 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.tools;
+package org.apache.kafka.tools.consumer;
 
 import joptsimple.OptionException;
 import joptsimple.OptionSpec;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.MessageFormatter;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.record.TimestampType;
-import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.util.CommandDefaultOptions;
 import org.apache.kafka.server.util.CommandLineUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -75,7 +65,7 @@ public final class ConsoleShareConsumerOptions extends CommandDefaultOptions {
                 .withRequiredArg()
                 .describedAs("class")
                 .ofType(String.class)
-                .defaultsTo(DefaultMessageFormatterTemporary.class.getName());
+                .defaultsTo(DefaultMessageFormatter.class.getName());
         messageFormatterArgOpt = parser.accepts("property",
                         "The properties to initialize the message formatter. Default properties include: \n" +
                                 " print.timestamp=true|false\n" +
@@ -255,186 +245,4 @@ public final class ConsoleShareConsumerOptions extends CommandDefaultOptions {
     MessageFormatter formatter() {
         return formatter;
     }
-
-    /**
-     * TEMPORARY - The classes below are defined as separate classes
-     * in the open PR - <a href="https://github.com/apache/kafka/pull/15274/files#">...</a>
-     * These inner classes are temporary and will be removed once the above PR gets merged.
-     */
-    public static class DefaultMessageFormatterTemporary implements MessageFormatter {
-        private static final Logger LOG = LoggerFactory.getLogger(DefaultMessageFormatterTemporary.class);
-
-        private boolean printTimestamp = false;
-        private boolean printKey = false;
-        private boolean printValue = true;
-        private boolean printPartition = false;
-        private boolean printOffset = false;
-        private boolean printHeaders = false;
-        private byte[] keySeparator = utfBytes("\t");
-        private byte[] lineSeparator = utfBytes("\n");
-        private byte[] headersSeparator = utfBytes(",");
-        private byte[] nullLiteral = utfBytes("null");
-
-        private Optional<Deserializer<?>> keyDeserializer = Optional.empty();
-        private Optional<Deserializer<?>> valueDeserializer = Optional.empty();
-        private Optional<Deserializer<?>> headersDeserializer = Optional.empty();
-
-        @Override
-        public void configure(Map<String, ?> configs) {
-            if (configs.containsKey("print.timestamp")) {
-                printTimestamp = getBoolProperty(configs, "print.timestamp");
-            }
-            if (configs.containsKey("print.key")) {
-                printKey = getBoolProperty(configs, "print.key");
-            }
-            if (configs.containsKey("print.offset")) {
-                printOffset = getBoolProperty(configs, "print.offset");
-            }
-            if (configs.containsKey("print.partition")) {
-                printPartition = getBoolProperty(configs, "print.partition");
-            }
-            if (configs.containsKey("print.headers")) {
-                printHeaders = getBoolProperty(configs, "print.headers");
-            }
-            if (configs.containsKey("print.value")) {
-                printValue = getBoolProperty(configs, "print.value");
-            }
-            if (configs.containsKey("key.separator")) {
-                keySeparator = getByteProperty(configs, "key.separator");
-            }
-            if (configs.containsKey("line.separator")) {
-                lineSeparator = getByteProperty(configs, "line.separator");
-            }
-            if (configs.containsKey("headers.separator")) {
-                headersSeparator = getByteProperty(configs, "headers.separator");
-            }
-            if (configs.containsKey("null.literal")) {
-                nullLiteral = getByteProperty(configs, "null.literal");
-            }
-
-            keyDeserializer = getDeserializerProperty(configs, true, "key.deserializer");
-            valueDeserializer = getDeserializerProperty(configs, false, "value.deserializer");
-            headersDeserializer = getDeserializerProperty(configs, false, "headers.deserializer");
-        }
-
-        // for testing
-        public boolean printValue() {
-            return printValue;
-        }
-
-        // for testing
-        public Optional<Deserializer<?>> keyDeserializer() {
-            return keyDeserializer;
-        }
-
-        private void writeSeparator(PrintStream output, boolean columnSeparator) {
-            try {
-                if (columnSeparator) {
-                    output.write(keySeparator);
-                } else {
-                    output.write(lineSeparator);
-                }
-            } catch (IOException ioe) {
-                LOG.error("Unable to write the separator to the output", ioe);
-            }
-        }
-
-        private byte[] deserialize(ConsumerRecord<byte[], byte[]> consumerRecord, Optional<Deserializer<?>> deserializer, byte[] sourceBytes, String topic) {
-            byte[] nonNullBytes = sourceBytes != null ? sourceBytes : nullLiteral;
-            return deserializer.map(value -> utfBytes(value.deserialize(topic, consumerRecord.headers(), nonNullBytes).toString())).orElse(nonNullBytes);
-        }
-
-        @Override
-        public void writeTo(ConsumerRecord<byte[], byte[]> consumerRecord, PrintStream output) {
-            try {
-                if (printTimestamp) {
-                    if (consumerRecord.timestampType() != TimestampType.NO_TIMESTAMP_TYPE) {
-                        output.print(consumerRecord.timestampType() + ":" + consumerRecord.timestamp());
-                    } else {
-                        output.print("NO_TIMESTAMP");
-                    }
-                    writeSeparator(output, printOffset || printPartition || printHeaders || printKey || printValue);
-                }
-
-                if (printPartition) {
-                    output.print("Partition:");
-                    output.print(consumerRecord.partition());
-                    writeSeparator(output, printOffset || printHeaders || printKey || printValue);
-                }
-
-                if (printOffset) {
-                    output.print("Offset:");
-                    output.print(consumerRecord.offset());
-                    writeSeparator(output, printHeaders || printKey || printValue);
-                }
-
-                if (printHeaders) {
-                    Iterator<Header> headersIt = consumerRecord.headers().iterator();
-                    if (!headersIt.hasNext()) {
-                        output.print("NO_HEADERS");
-                    } else {
-                        while (headersIt.hasNext()) {
-                            Header header = headersIt.next();
-                            output.print(header.key() + ":");
-                            output.write(deserialize(consumerRecord, headersDeserializer, header.value(), consumerRecord.topic()));
-                            if (headersIt.hasNext()) {
-                                output.write(headersSeparator);
-                            }
-                        }
-                    }
-                    writeSeparator(output, printKey || printValue);
-                }
-
-                if (printKey) {
-                    output.write(deserialize(consumerRecord, keyDeserializer, consumerRecord.key(), consumerRecord.topic()));
-                    writeSeparator(output, printValue);
-                }
-
-                if (printValue) {
-                    output.write(deserialize(consumerRecord, valueDeserializer, consumerRecord.value(), consumerRecord.topic()));
-                    output.write(lineSeparator);
-                }
-            } catch (IOException ioe) {
-                LOG.error("Unable to write the consumer record to the output", ioe);
-            }
-        }
-
-        private Map<String, ?> propertiesWithKeyPrefixStripped(String prefix, Map<String, ?> configs) {
-            final Map<String, Object> newConfigs = new HashMap<>();
-            for (Map.Entry<String, ?> entry : configs.entrySet()) {
-                if (entry.getKey().startsWith(prefix) && entry.getKey().length() > prefix.length()) {
-                    newConfigs.put(entry.getKey().substring(prefix.length()), entry.getValue());
-                }
-            }
-            return newConfigs;
-        }
-
-        private byte[] utfBytes(String str) {
-            return str.getBytes(StandardCharsets.UTF_8);
-        }
-
-        private byte[] getByteProperty(Map<String, ?> configs, String key) {
-            return utfBytes((String) configs.get(key));
-        }
-
-        private boolean getBoolProperty(Map<String, ?> configs, String key) {
-            return ((String) configs.get(key)).trim().equalsIgnoreCase("true");
-        }
-
-        private Optional<Deserializer<?>> getDeserializerProperty(Map<String, ?> configs, boolean isKey, String key) {
-            if (configs.containsKey(key)) {
-                String name = (String) configs.get(key);
-                try {
-                    Deserializer<?> deserializer = (Deserializer<?>) Class.forName(name).getDeclaredConstructor().newInstance();
-                    Map<String, ?> deserializerConfig = propertiesWithKeyPrefixStripped(key + ".", configs);
-                    deserializer.configure(deserializerConfig, isKey);
-                    return Optional.of(deserializer);
-                } catch (Exception e) {
-                    LOG.error("Unable to instantiate a deserializer from " + name, e);
-                }
-            }
-            return Optional.empty();
-        }
-    }
-
 }

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptionsTest.java
@@ -14,10 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.tools;
+package org.apache.kafka.tools.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.tools.ToolsTestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -89,7 +90,7 @@ public class ConsoleShareConsumerOptionsTest {
         Map<String, String> configs = new HashMap<>();
         configs.put("request.timeout.ms", "1000");
         configs.put("group.id", "group1");
-        File propsFile = tempPropertiesFile(configs);
+        File propsFile = ToolsTestUtils.tempPropertiesFile(configs);
         String[] args = new String[]{
                 "--bootstrap-server", "localhost:9092",
                 "--topic", "test",
@@ -109,7 +110,7 @@ public class ConsoleShareConsumerOptionsTest {
         });
 
         // different in all three places
-        File propsFile = tempPropertiesFile(Collections.singletonMap("group.id", "group-from-file"));
+        File propsFile = ToolsTestUtils.tempPropertiesFile(Collections.singletonMap("group.id", "group-from-file"));
         final String[] args = new String[]{
                 "--bootstrap-server", "localhost:9092",
                 "--topic", "test",
@@ -121,7 +122,7 @@ public class ConsoleShareConsumerOptionsTest {
         assertThrows(IllegalArgumentException.class, () -> new ConsoleShareConsumerOptions(args));
 
         // the same in all three places
-        propsFile = tempPropertiesFile(Collections.singletonMap("group.id", "test-group"));
+        propsFile = ToolsTestUtils.tempPropertiesFile(Collections.singletonMap("group.id", "test-group"));
         final String[] args1 = new String[]{
                 "--bootstrap-server", "localhost:9092",
                 "--topic", "test",
@@ -135,7 +136,7 @@ public class ConsoleShareConsumerOptionsTest {
         assertEquals("test-group", props.getProperty("group.id"));
 
         // different via --consumer-property and --consumer.config
-        propsFile = tempPropertiesFile(Collections.singletonMap("group.id", "group-from-file"));
+        propsFile = ToolsTestUtils.tempPropertiesFile(Collections.singletonMap("group.id", "group-from-file"));
         final String[] args2 = new String[]{
                 "--bootstrap-server", "localhost:9092",
                 "--topic", "test",
@@ -156,7 +157,7 @@ public class ConsoleShareConsumerOptionsTest {
         assertThrows(IllegalArgumentException.class, () -> new ConsoleShareConsumerOptions(args3));
 
         // different via --group and --consumer.config
-        propsFile = tempPropertiesFile(Collections.singletonMap("group.id", "group-from-file"));
+        propsFile = ToolsTestUtils.tempPropertiesFile(Collections.singletonMap("group.id", "group-from-file"));
         final String[] args4 = new String[]{
                 "--bootstrap-server", "localhost:9092",
                 "--topic", "test",
@@ -221,19 +222,5 @@ public class ConsoleShareConsumerOptionsTest {
         Properties consumerProperties = config.consumerProps();
 
         assertEquals("console-share-consumer", consumerProperties.getProperty(ConsumerConfig.CLIENT_ID_CONFIG));
-    }
-
-    /**
-     * Temporary - This function is part of ToolsTestUtils in the PR -
-     * <a href="https://github.com/apache/kafka/pull/15274/files#">...</a>
-     * This function will be removed once the PR gets merged
-     */
-
-    private File tempPropertiesFile(Map<String, String> properties) throws IOException {
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            sb.append(entry.getKey() + "=" + entry.getValue() + System.lineSeparator());
-        }
-        return org.apache.kafka.test.TestUtils.tempFile(sb.toString());
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.tools;
+package org.apache.kafka.tools.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;


### PR DESCRIPTION
Since the console share consumer was originally written, the console consumer has been converted from Scala to Java. This means there is now the opportunity to use common code, such as the default formatter.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
