### PR TITLE
AKCORE-26-3: added handleShareAcknowledgeRequest RPC handle

### DIFF
--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareAcknowledgeRequestData;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
-import org.apache.kafka.common.message.ShareFetchResponseData.PartitionData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.ShareFetchMetadata;
@@ -69,11 +68,11 @@ public class SharePartitionManager {
 
     // TODO: Move some part in share session context and change method signature to accept share
     //  partition data along TopicIdPartition.
-    public CompletableFuture<Map<TopicIdPartition, PartitionData>> fetchMessages(FetchParams fetchParams,
+    public CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> fetchMessages(FetchParams fetchParams,
         List<TopicIdPartition> topicIdPartitions, String groupId) {
         log.debug("Fetch request for topicIdPartitions: {} with groupId: {} fetch params: {}",
             topicIdPartitions, groupId, fetchParams);
-        CompletableFuture<Map<TopicIdPartition, PartitionData>> future = new CompletableFuture<>();
+        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
 
         synchronized (this) {
             Map<TopicIdPartition, FetchRequest.PartitionData> topicPartitionData = new HashMap<>();
@@ -98,12 +97,12 @@ public class SharePartitionManager {
                 responsePartitionData -> {
                     List<Tuple2<TopicIdPartition, FetchPartitionData>> responseData = CollectionConverters.asJava(
                         responsePartitionData);
-                    Map<TopicIdPartition, PartitionData> result = new HashMap<>();
+                    Map<TopicIdPartition, ShareFetchResponseData.PartitionData> result = new HashMap<>();
                     responseData.forEach(data -> {
                         TopicIdPartition topicIdPartition = data._1;
                         FetchPartitionData fetchPartitionData = data._2;
 
-                        PartitionData partitionData = new PartitionData()
+                        ShareFetchResponseData.PartitionData partitionData = new ShareFetchResponseData.PartitionData()
                             .setPartitionIndex(topicIdPartition.partition())
                             .setRecords(fetchPartitionData.records)
                             .setErrorCode(fetchPartitionData.error.code())
@@ -122,8 +121,11 @@ public class SharePartitionManager {
         return future;
     }
 
-    public CompletableFuture<ShareAcknowledgeResponseData> acknowledge(String groupId, TopicIdPartition topicIdPartition,
-                                                                       List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackBatches) {
+    public CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> acknowledge(
+            String groupId,
+            Map<TopicIdPartition,
+                    ShareAcknowledgeRequestData.AcknowledgePartition> acknowledgeTopics
+    ) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -123,8 +123,7 @@ public class SharePartitionManager {
 
     public CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> acknowledge(
             String groupId,
-            Map<TopicIdPartition,
-                    ShareAcknowledgeRequestData.AcknowledgePartition> acknowledgeTopics
+            Map<TopicIdPartition, ShareAcknowledgeRequestData.AcknowledgePartition> acknowledgeTopics
     ) {
         throw new UnsupportedOperationException("Not implemented yet");
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -4230,7 +4230,6 @@ class KafkaApis(val requestChannel: RequestChannel,
       var unconvertedShareAcknowledgeResponse: ShareAcknowledgeResponse = null
 
       def createResponse(): ShareAcknowledgeResponse = {
-        // Down-convert messages for each partition if required
         val convertedData = new util.LinkedHashMap[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]
         unconvertedShareAcknowledgeResponse.data().responses().forEach { topicResponse =>
           topicResponse.partitions().forEach { unconvertedPartitionData =>
@@ -4263,7 +4262,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     if (interesting.isEmpty) {
       processResponseCallback(Map.empty)
-    }else{
+    } else {
       // call the share partition manager to acknowledge messages in the share partition
       sharePartitionManager.acknowledge(
         groupId,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -260,6 +260,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.LIST_CLIENT_METRICS_RESOURCES => handleListClientMetricsResources(request)
         case ApiKeys.SHARE_GROUP_HEARTBEAT => handleShareGroupHeartbeat(request).exceptionally(handleError)
         case ApiKeys.SHARE_GROUP_DESCRIBE => handleShareGroupDescribe(request).exceptionally(handleError)
+        case ApiKeys.SHARE_ACKNOWLEDGE => handleShareAcknowledgeRequest(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -1264,8 +1265,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         if (throwable != null) {
           debug(s"Share fetch request with correlation from client $clientId  " +
             s"failed with error ${throwable.getMessage}")
-          val errResponse: AbstractResponse = shareFetchRequest.getErrorResponse(AbstractResponse.DEFAULT_THROTTLE_TIME, throwable)
-          requestChannel.sendResponse(request, errResponse, None)
+          requestHelper.handleError(request, throwable)
         } else {
           processResponseCallback(responsePartitionData.asScala.toMap)
         }
@@ -4130,6 +4130,145 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
     }
 
+  }
+
+  def handleShareAcknowledgeRequest(request: RequestChannel.Request): Unit = {
+    val clientId = request.header.clientId
+    val shareAcknowledgeRequest = request.body[ShareAcknowledgeRequest]
+    val shareAcknowledgeRequestData = shareAcknowledgeRequest.data()
+    val groupId = shareAcknowledgeRequest.data().groupId()
+    val topicNames = metadataCache.topicIdsToNames()
+    val sharePartitionManager : SharePartitionManager = sharePartitionManagerOption match {
+      case Some(manager) => manager
+      case None => throw new IllegalStateException("ShareFetchRequest received but SharePartitionManager is not initialized")
+    }
+    if (!authHelper.authorize(request.context, READ, GROUP, groupId))
+      requestHelper.sendMaybeThrottle(
+        request,
+        shareAcknowledgeRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception)
+      )
+    val requestPartitionAcknowledgements = mutable.Map[TopicIdPartition, ShareAcknowledgeRequestData.AcknowledgePartition]()
+    val partitionAcknowledgements = mutable.Map[TopicIdPartition, ShareAcknowledgeRequestData.AcknowledgePartition]()
+    val interesting = mutable.Map[TopicIdPartition, ShareAcknowledgeRequestData.AcknowledgePartition]()
+    val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
+    shareAcknowledgeRequestData.topics.forEach((acknowledgeTopic: ShareAcknowledgeRequestData.AcknowledgeTopic) => {
+      val name = topicNames.get(acknowledgeTopic.topicId)
+      acknowledgeTopic.partitions.forEach((acknowledgePartition: ShareAcknowledgeRequestData.AcknowledgePartition) =>
+        requestPartitionAcknowledgements +=
+          new TopicIdPartition(
+            acknowledgeTopic.topicId,
+            new TopicPartition(name, acknowledgePartition.partitionIndex)) ->
+          acknowledgePartition
+        // Topic name may be null here if the topic name was unable to be resolved using the topicNames map.
+      )
+    })
+
+    requestPartitionAcknowledgements.foreach{
+      case (topicIdPartition: TopicIdPartition, acknowledgePartition : ShareAcknowledgeRequestData.AcknowledgePartition) =>
+        if (topicIdPartition.topic == null)
+          erroneous += topicIdPartition ->
+            ShareAcknowledgeResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_ID)
+        else
+          partitionAcknowledgements += topicIdPartition -> acknowledgePartition
+    }
+    val authorizedTopics = authHelper.filterByAuthorized(
+      request.context,
+      READ,
+      TOPIC,
+      partitionAcknowledgements
+    )(_._1.topicPartition.topic)
+
+    partitionAcknowledgements.foreach {
+      case (topicIdPartition : TopicIdPartition, acknowledgePartition : ShareAcknowledgeRequestData.AcknowledgePartition) =>
+        if (!authorizedTopics.contains(topicIdPartition.topic))
+          erroneous += topicIdPartition ->
+            ShareAcknowledgeResponse.partitionResponse(topicIdPartition, Errors.TOPIC_AUTHORIZATION_FAILED)
+        else if (!metadataCache.contains(topicIdPartition.topicPartition))
+          erroneous += topicIdPartition ->
+            ShareAcknowledgeResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_OR_PARTITION)
+        else
+          interesting += topicIdPartition -> acknowledgePartition
+    }
+
+    // the callback for processing a share fetch response, invoked before throttling
+    def processResponseCallback(
+                                 responseAcknowledgeData: Map[TopicIdPartition,
+                                   ShareAcknowledgeResponseData.PartitionData]
+                               ): Unit = {
+      val partitions = new util.LinkedHashMap[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]
+      val nodeEndpoints = new mutable.HashMap[Int, Node]
+      responseAcknowledgeData.foreach { case(tp, data) =>
+        val partitionData = new ShareAcknowledgeResponseData.PartitionData()
+          .setPartitionIndex(tp.partition)
+          .setErrorCode(data.errorCode())
+
+        data.errorCode() match {
+          case errCode if errCode == Errors.NOT_LEADER_OR_FOLLOWER.code | errCode == Errors.FENCED_LEADER_EPOCH.code =>
+            val leaderNode = getCurrentLeader(tp.topicPartition(), request.context.listenerName)
+            leaderNode.node.foreach { node =>
+              nodeEndpoints.put(node.id(), node)
+            }
+            partitionData.currentLeader()
+              .setLeaderId(leaderNode.leaderId)
+              .setLeaderEpoch(leaderNode.leaderEpoch)
+          case _ =>
+        }
+
+        partitions.put(tp, partitionData)
+      }
+      erroneous.foreach { case (tp, data) => partitions.put(tp, data) }
+
+      var unconvertedShareAcknowledgeResponse: ShareAcknowledgeResponse = null
+
+      def createResponse(): ShareAcknowledgeResponse = {
+        // Down-convert messages for each partition if required
+        val convertedData = new util.LinkedHashMap[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]
+        unconvertedShareAcknowledgeResponse.data().responses().forEach { topicResponse =>
+          topicResponse.partitions().forEach { unconvertedPartitionData =>
+            val tp = new TopicIdPartition(
+              topicResponse.topicId,
+              new TopicPartition(topicNames.get(topicResponse.topicId()), unconvertedPartitionData.partitionIndex())
+            )
+            val error = Errors.forCode(unconvertedPartitionData.errorCode)
+            if (error != Errors.NONE)
+              debug(s"Share Acknowledge request with correlation id ${request.header.correlationId} from client $clientId " +
+                s"on partition $tp failed due to ${error.exceptionName}")
+            convertedData.put(tp, unconvertedPartitionData)
+          }
+        }
+
+        // Prepare share fetch response from converted data
+        ShareAcknowledgeResponse.of(
+          unconvertedShareAcknowledgeResponse.error,
+          0,
+          convertedData,
+          nodeEndpoints.values.toList.asJava
+        )
+      }
+      unconvertedShareAcknowledgeResponse = new ShareAcknowledgeResponse(
+        ShareAcknowledgeResponse.toMessage(Errors.NONE, 0, partitions.entrySet().iterator(), Collections.emptyList())
+      )
+
+      requestHelper.sendMaybeThrottle(request, createResponse())
+    }
+
+    if (interesting.isEmpty) {
+      processResponseCallback(Map.empty)
+    }else{
+      // call the share partition manager to acknowledge messages in the share partition
+      sharePartitionManager.acknowledge(
+        groupId,
+        interesting.asJava
+      ).whenComplete((responseAcknowledgeData, throwable) => {
+        if (throwable != null) {
+          debug(s"Share acknowledge request with correlation from client $clientId  " +
+            s"failed with error ${throwable.getMessage}")
+          requestHelper.handleError(request, throwable)
+        } else {
+          processResponseCallback(responseAcknowledgeData.asScala.toMap)
+        }
+      })
+    }
   }
 
   def handleGetTelemetrySubscriptionsRequest(request: RequestChannel.Request): Unit = {


### PR DESCRIPTION
This PR includes `handleShareAcknowledgeRequest` in KafkaApis.scala and the unit tests. This RPC is for handling the ShareAknowledgeRequest. 

Reference - [AKCORE-26](https://confluentinc.atlassian.net/jira/software/c/projects/AKCORE/issues/AKCORE-26)

[AKCORE-26]: https://confluentinc.atlassian.net/browse/AKCORE-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ