### PR TITLE
KSECURITY-2349 Fix CVE-2024-22201 for jetty

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -106,7 +106,7 @@ versions += [
   jackson: "2.16.1",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
-  jetty: "9.4.53.v20231009",
+  jetty: "9.4.54.v20240208",
   jersey: "2.39.1",
   jline: "3.22.0",
   jmh: "1.37",


### PR DESCRIPTION
Update jetty to version [9.4.54.v20240208](https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.54.v20240208) to fix CVE-2024-22201

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
