### PR TITLE
AKCORE-45: Add delivery count to ConsumerRecord

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
@@ -50,6 +50,7 @@ public class ConsumerRecord<K, V> {
     private final K key;
     private final V value;
     private final Optional<Integer> leaderEpoch;
+    private final Optional<Short> deliveryCount;
 
     /**
      * Creates a record to be received from a specified topic and partition (provided for
@@ -97,6 +98,38 @@ public class ConsumerRecord<K, V> {
                           V value,
                           Headers headers,
                           Optional<Integer> leaderEpoch) {
+        this(topic, partition, offset, timestamp, timestampType, serializedKeySize, serializedValueSize,
+                key, value, headers, leaderEpoch, Optional.empty());
+    }
+
+    /**
+     * Creates a record to be received from a specified topic and partition
+     *
+     * @param topic The topic this record is received from
+     * @param partition The partition of the topic this record is received from
+     * @param offset The offset of this record in the corresponding Kafka partition
+     * @param timestamp The timestamp of the record.
+     * @param timestampType The timestamp type
+     * @param serializedKeySize The length of the serialized key
+     * @param serializedValueSize The length of the serialized value
+     * @param key The key of the record, if one exists (null is allowed)
+     * @param value The record contents
+     * @param headers The headers of the record
+     * @param leaderEpoch Optional leader epoch of the record (may be empty for legacy record formats)
+     * @param deliveryCount Optional delivery count of the record (may be empty when deliveries not counted)
+     */
+    public ConsumerRecord(String topic,
+                          int partition,
+                          long offset,
+                          long timestamp,
+                          TimestampType timestampType,
+                          int serializedKeySize,
+                          int serializedValueSize,
+                          K key,
+                          V value,
+                          Headers headers,
+                          Optional<Integer> leaderEpoch,
+                          Optional<Short> deliveryCount) {
         if (topic == null)
             throw new IllegalArgumentException("Topic cannot be null");
         if (headers == null)
@@ -113,6 +146,7 @@ public class ConsumerRecord<K, V> {
         this.value = value;
         this.headers = headers;
         this.leaderEpoch = leaderEpoch;
+        this.deliveryCount = deliveryCount;
     }
 
     /**
@@ -296,6 +330,15 @@ public class ConsumerRecord<K, V> {
         return leaderEpoch;
     }
 
+    /**
+     * Get the delivery count for the record if available
+     *
+     * @return the delivery count or empty when deliveries not counted
+     */
+    public Optional<Short> deliveryCount() {
+        return deliveryCount;
+    }
+
     @Override
     public String toString() {
         return "ConsumerRecord(topic = " + topic
@@ -303,6 +346,7 @@ public class ConsumerRecord<K, V> {
                + ", leaderEpoch = " + leaderEpoch.orElse(null)
                + ", offset = " + offset
                + ", " + timestampType + " = " + timestamp
+               + ", deliveryCount = " + deliveryCount.orElse(null)
                + ", serialized key size = "  + serializedKeySize
                + ", serialized value size = " + serializedValueSize
                + ", headers = " + headers

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordTest.java
@@ -47,6 +47,7 @@ public class ConsumerRecordTest {
         assertEquals(ConsumerRecord.NULL_SIZE, record.serializedKeySize());
         assertEquals(ConsumerRecord.NULL_SIZE, record.serializedValueSize());
         assertEquals(Optional.empty(), record.leaderEpoch());
+        assertEquals(Optional.empty(), record.deliveryCount());
         assertEquals(new RecordHeaders(), record.headers());
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
@@ -71,6 +71,7 @@ public final class ConsoleShareConsumerOptions extends CommandDefaultOptions {
                                 " print.timestamp=true|false\n" +
                                 " print.key=true|false\n" +
                                 " print.offset=true|false\n" +
+                                " print.delivery=true|false\n" +
                                 " print.partition=true|false\n" +
                                 " print.headers=true|false\n" +
                                 " print.value=true|false\n" +

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/DefaultMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/DefaultMessageFormatter.java
@@ -41,6 +41,7 @@ class DefaultMessageFormatter implements MessageFormatter {
     private boolean printValue = true;
     private boolean printPartition = false;
     private boolean printOffset = false;
+    private boolean printDelivery = false;
     private boolean printHeaders = false;
     private byte[] keySeparator = utfBytes("\t");
     private byte[] lineSeparator = utfBytes("\n");
@@ -61,6 +62,9 @@ class DefaultMessageFormatter implements MessageFormatter {
         }
         if (configs.containsKey("print.offset")) {
             printOffset = getBoolProperty(configs, "print.offset");
+        }
+        if (configs.containsKey("print.delivery")) {
+            printDelivery = getBoolProperty(configs, "print.delivery");
         }
         if (configs.containsKey("print.partition")) {
             printPartition = getBoolProperty(configs, "print.partition");
@@ -125,18 +129,28 @@ class DefaultMessageFormatter implements MessageFormatter {
                 } else {
                     output.print("NO_TIMESTAMP");
                 }
-                writeSeparator(output, printOffset || printPartition || printHeaders || printKey || printValue);
+                writeSeparator(output, printPartition || printOffset || printDelivery || printHeaders || printKey || printValue);
             }
 
             if (printPartition) {
                 output.print("Partition:");
                 output.print(consumerRecord.partition());
-                writeSeparator(output, printOffset || printHeaders || printKey || printValue);
+                writeSeparator(output, printOffset || printDelivery || printHeaders || printKey || printValue);
             }
 
             if (printOffset) {
                 output.print("Offset:");
                 output.print(consumerRecord.offset());
+                writeSeparator(output, printDelivery || printHeaders || printKey || printValue);
+            }
+
+            if (printDelivery) {
+                output.print("Delivery:");
+                if (consumerRecord.deliveryCount().isPresent()) {
+                    output.print(consumerRecord.deliveryCount().get());
+                } else {
+                    output.print("NONE");
+                }
                 writeSeparator(output, printHeaders || printKey || printValue);
             }
 

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/DefaultMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/DefaultMessageFormatterTest.java
@@ -70,59 +70,65 @@ public class DefaultMessageFormatterTest {
         formatter.writeTo(record, new PrintStream(out));
         assertEquals("NO_TIMESTAMP\tPartition:0\tOffset:123\tkey\tvalue\n", out.toString());
 
+        configs.put("print.delivery", "true");
+        formatter.configure(configs);
+        out = new ByteArrayOutputStream();
+        formatter.writeTo(record, new PrintStream(out));
+        assertEquals("NO_TIMESTAMP\tPartition:0\tOffset:123\tDelivery:NONE\tkey\tvalue\n", out.toString());
+
         configs.put("print.headers", "true");
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("NO_TIMESTAMP\tPartition:0\tOffset:123\tNO_HEADERS\tkey\tvalue\n", out.toString());
+        assertEquals("NO_TIMESTAMP\tPartition:0\tOffset:123\tDelivery:NONE\tNO_HEADERS\tkey\tvalue\n", out.toString());
 
         RecordHeaders headers = new RecordHeaders();
         headers.add("h1", "v1".getBytes());
         headers.add("h2", "v2".getBytes());
         record = new ConsumerRecord<>("topic", 0, 123, 123L, TimestampType.CREATE_TIME, -1, -1, "key".getBytes(), "value".getBytes(),
-                headers, Optional.empty());
+                headers, Optional.empty(), Optional.of((short) 0));
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123\tPartition:0\tOffset:123\th1:v1,h2:v2\tkey\tvalue\n", out.toString());
+        assertEquals("CreateTime:123\tPartition:0\tOffset:123\tDelivery:0\th1:v1,h2:v2\tkey\tvalue\n", out.toString());
 
         configs.put("print.value", "false");
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123\tPartition:0\tOffset:123\th1:v1,h2:v2\tkey\n", out.toString());
+        assertEquals("CreateTime:123\tPartition:0\tOffset:123\tDelivery:0\th1:v1,h2:v2\tkey\n", out.toString());
 
         configs.put("key.separator", "<sep>");
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>h1:v1,h2:v2<sep>key\n", out.toString());
+        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>Delivery:0<sep>h1:v1,h2:v2<sep>key\n", out.toString());
 
         configs.put("line.separator", "<end>");
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>h1:v1,h2:v2<sep>key<end>", out.toString());
+        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>Delivery:0<sep>h1:v1,h2:v2<sep>key<end>", out.toString());
 
         configs.put("headers.separator", "|");
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>h1:v1|h2:v2<sep>key<end>", out.toString());
+        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>Delivery:0<sep>h1:v1|h2:v2<sep>key<end>", out.toString());
 
         record = new ConsumerRecord<>("topic", 0, 123, 123L, TimestampType.CREATE_TIME, -1, -1, "key".getBytes(), "value".getBytes(),
-                headers, Optional.empty());
+                headers, Optional.empty(), Optional.of((short) 1));
 
         configs.put("key.deserializer", UpperCaseDeserializer.class.getName());
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>h1:v1|h2:v2<sep>KEY<end>", out.toString());
+        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>Delivery:1<sep>h1:v1|h2:v2<sep>KEY<end>", out.toString());
 
         configs.put("headers.deserializer", UpperCaseDeserializer.class.getName());
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>h1:V1|h2:V2<sep>KEY<end>", out.toString());
+        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>Delivery:1<sep>h1:V1|h2:V2<sep>KEY<end>", out.toString());
 
         record = new ConsumerRecord<>("topic", 0, 123, 123L, TimestampType.CREATE_TIME, -1, -1, "key".getBytes(), null,
                 headers, Optional.empty());
@@ -132,7 +138,7 @@ public class DefaultMessageFormatterTest {
         formatter.configure(configs);
         out = new ByteArrayOutputStream();
         formatter.writeTo(record, new PrintStream(out));
-        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>h1:V1|h2:V2<sep>KEY<sep><null><end>", out.toString());
+        assertEquals("CreateTime:123<sep>Partition:0<sep>Offset:123<sep>Delivery:NONE<sep>h1:V1|h2:V2<sep>KEY<sep><null><end>", out.toString());
         formatter.close();
     }
 


### PR DESCRIPTION
Add optional delivery count to ConsumerRecord so share group deliveries can reveal the delivery count.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
