### PR TITLE
AKCORE-41: Implemented share sessions on broker (1/N)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidShareSessionEpochException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidShareSessionEpochException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.errors;
+
+public class InvalidShareSessionEpochException extends RetriableException {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidShareSessionEpochException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/ShareSessionIdNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ShareSessionIdNotFoundException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.errors;
+
+public class ShareSessionIdNotFoundException extends RetriableException {
+    private static final long serialVersionUID = 1L;
+
+    public ShareSessionIdNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/ShareSessionNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ShareSessionNotFoundException.java
@@ -17,10 +17,10 @@
 
 package org.apache.kafka.common.errors;
 
-public class ShareSessionIdNotFoundException extends RetriableException {
+public class ShareSessionNotFoundException extends RetriableException {
     private static final long serialVersionUID = 1L;
 
-    public ShareSessionIdNotFoundException(String message) {
+    public ShareSessionNotFoundException(String message) {
         super(message);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -71,6 +71,7 @@ import org.apache.kafka.common.errors.InvalidReplicationFactorException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.InvalidRequiredAcksException;
 import org.apache.kafka.common.errors.InvalidSessionTimeoutException;
+import org.apache.kafka.common.errors.InvalidShareSessionEpochException;
 import org.apache.kafka.common.errors.InvalidTimestampException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.InvalidTxnStateException;
@@ -110,6 +111,7 @@ import org.apache.kafka.common.errors.ResourceNotFoundException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.ShareSessionIdNotFoundException;
 import org.apache.kafka.common.errors.SnapshotNotFoundException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
 import org.apache.kafka.common.errors.StaleMemberEpochException;
@@ -394,7 +396,10 @@ public enum Errors {
     UNKNOWN_SUBSCRIPTION_ID(117, "Client sent a push telemetry request with an invalid or outdated subscription ID.", UnknownSubscriptionIdException::new),
     TELEMETRY_TOO_LARGE(118, "Client sent a push telemetry request larger than the maximum size the broker will accept.", TelemetryTooLargeException::new),
     INVALID_REGISTRATION(119, "The controller has considered the broker registration to be invalid.", InvalidRegistrationException::new),
-    INVALID_RECORD_STATE(120, "The record state is invalid. The acknowledgement of delivery could not be completed.", InvalidRecordStateException::new);
+    INVALID_RECORD_STATE(120, "The record state is invalid. The acknowledgement of delivery could not be completed.", InvalidRecordStateException::new),
+    SHARE_SESSION_ID_NOT_FOUND(121, "The share session ID was not found.", ShareSessionIdNotFoundException::new),
+    INVALID_SHARE_SESSION_EPOCH(122, "The share session epoch is invalid.", InvalidShareSessionEpochException::new);
+
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -111,7 +111,7 @@ import org.apache.kafka.common.errors.ResourceNotFoundException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
-import org.apache.kafka.common.errors.ShareSessionIdNotFoundException;
+import org.apache.kafka.common.errors.ShareSessionNotFoundException;
 import org.apache.kafka.common.errors.SnapshotNotFoundException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
 import org.apache.kafka.common.errors.StaleMemberEpochException;
@@ -397,7 +397,7 @@ public enum Errors {
     TELEMETRY_TOO_LARGE(118, "Client sent a push telemetry request larger than the maximum size the broker will accept.", TelemetryTooLargeException::new),
     INVALID_REGISTRATION(119, "The controller has considered the broker registration to be invalid.", InvalidRegistrationException::new),
     INVALID_RECORD_STATE(120, "The record state is invalid. The acknowledgement of delivery could not be completed.", InvalidRecordStateException::new),
-    SHARE_SESSION_ID_NOT_FOUND(121, "The share session ID was not found.", ShareSessionIdNotFoundException::new),
+    SHARE_SESSION_NOT_FOUND(121, "The share session was not found.", ShareSessionNotFoundException::new),
     INVALID_SHARE_SESSION_EPOCH(122, "The share session epoch is invalid.", InvalidShareSessionEpochException::new);
 
 

--- a/core/src/main/java/kafka/server/ShareFetchContext.java
+++ b/core/src/main/java/kafka/server/ShareFetchContext.java
@@ -17,9 +17,9 @@
 package kafka.server;
 
 import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.ShareFetchRequest;
 import org.apache.kafka.common.requests.ShareFetchResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.Map;
 
 public abstract class ShareFetchContext {
 
@@ -56,8 +55,8 @@ public abstract class ShareFetchContext {
      * Updates the share fetch context with new partition information. Generates response data.
      * The response data may require subsequent down-conversion.
      */
-    abstract ShareFetchResponse updateAndGenerateResponseData(LinkedHashMap<TopicIdPartition, ShareFetchResponseData.PartitionData> updates);
+    abstract ShareFetchResponse updateAndGenerateResponseData(String groupId, Uuid memberId, LinkedHashMap<TopicIdPartition, ShareFetchResponseData.PartitionData> updates);
 
-    abstract Map<TopicIdPartition, ShareFetchRequest.SharePartitionData> cachedPartitions();
+    abstract SharePartitionManager.ErroneousAndValidPartitionData getErroneousAndValidTopicIdPartitions();
 
 }

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -46,10 +46,10 @@ public class SharePartition {
      * offset, or be state persisted to disk.
      */
     public enum RecordState {
-        AVAILABLE ((byte) 0),
-        ACQUIRED ((byte) 1),
-        ACKNOWLEDGED ((byte) 2),
-        ARCHIVED ((byte) 3);
+        AVAILABLE((byte) 0),
+        ACQUIRED((byte) 1),
+        ACKNOWLEDGED((byte) 2),
+        ARCHIVED((byte) 3);
 
         public final byte id;
 

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -50,7 +50,6 @@ import java.util.stream.Collectors;
 import java.util.TreeMap;
 
 import scala.Tuple2;
-import scala.collection.mutable.ArrayBuffer;
 import scala.jdk.javaapi.CollectionConverters;
 import scala.runtime.BoxedUnit;
 
@@ -338,20 +337,20 @@ public class SharePartitionManager {
 
     // Helper class to return the erroneous partitions and valid partition data
     public static class ErroneousAndValidPartitionData {
-        private final ArrayBuffer<Tuple2<TopicIdPartition, ShareFetchResponseData.PartitionData>> erroneous;
-        private final ArrayBuffer<Tuple2<TopicIdPartition, ShareFetchRequest.SharePartitionData>> validTopicIdPartitions;
+        private final List<Tuple2<TopicIdPartition, ShareFetchResponseData.PartitionData>> erroneous;
+        private final List<Tuple2<TopicIdPartition, ShareFetchRequest.SharePartitionData>> validTopicIdPartitions;
 
-        public ErroneousAndValidPartitionData(ArrayBuffer<Tuple2<TopicIdPartition, ShareFetchResponseData.PartitionData>> erroneous,
-                                              ArrayBuffer<Tuple2<TopicIdPartition, ShareFetchRequest.SharePartitionData>> validTopicIdPartitions) {
+        public ErroneousAndValidPartitionData(List<Tuple2<TopicIdPartition, ShareFetchResponseData.PartitionData>> erroneous,
+                                              List<Tuple2<TopicIdPartition, ShareFetchRequest.SharePartitionData>> validTopicIdPartitions) {
             this.erroneous = erroneous;
             this.validTopicIdPartitions = validTopicIdPartitions;
         }
 
-        public ArrayBuffer<Tuple2<TopicIdPartition, ShareFetchResponseData.PartitionData>> erroneous() {
+        public List<Tuple2<TopicIdPartition, ShareFetchResponseData.PartitionData>> erroneous() {
             return erroneous;
         }
 
-        public ArrayBuffer<Tuple2<TopicIdPartition, ShareFetchRequest.SharePartitionData>> validTopicIdPartitions() {
+        public List<Tuple2<TopicIdPartition, ShareFetchRequest.SharePartitionData>> validTopicIdPartitions() {
             return validTopicIdPartitions;
         }
     }
@@ -386,13 +385,13 @@ public class SharePartitionManager {
 
         @Override
         ErroneousAndValidPartitionData getErroneousAndValidTopicIdPartitions() {
-            ArrayBuffer<Tuple2<TopicIdPartition, ShareFetchResponseData.PartitionData>> erroneous = new ArrayBuffer<>();
-            ArrayBuffer<Tuple2<TopicIdPartition, ShareFetchRequest.SharePartitionData>> valid = new ArrayBuffer<>();
+            List<Tuple2<TopicIdPartition, ShareFetchResponseData.PartitionData>> erroneous = new ArrayList<>();
+            List<Tuple2<TopicIdPartition, ShareFetchRequest.SharePartitionData>> valid = new ArrayList<>();
             shareFetchData.forEach((topicIdPartition, sharePartitionData) -> {
                 if (topicIdPartition.topic() == null) {
-                    erroneous.addOne(new Tuple2<>(topicIdPartition, ShareFetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_ID)));
+                    erroneous.add(new Tuple2<>(topicIdPartition, ShareFetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_ID)));
                 } else {
-                    valid.addOne(new Tuple2<>(topicIdPartition, sharePartitionData));
+                    valid.add(new Tuple2<>(topicIdPartition, sharePartitionData));
                 }
             });
             return new ErroneousAndValidPartitionData(erroneous, valid);
@@ -581,14 +580,14 @@ public class SharePartitionManager {
 
         @Override
         ErroneousAndValidPartitionData getErroneousAndValidTopicIdPartitions() {
-            ArrayBuffer<Tuple2<TopicIdPartition, ShareFetchResponseData.PartitionData>> erroneous = new ArrayBuffer<>();
-            ArrayBuffer<Tuple2<TopicIdPartition, ShareFetchRequest.SharePartitionData>> valid = new ArrayBuffer<>();
+            List<Tuple2<TopicIdPartition, ShareFetchResponseData.PartitionData>> erroneous = new ArrayList<>();
+            List<Tuple2<TopicIdPartition, ShareFetchRequest.SharePartitionData>> valid = new ArrayList<>();
             if (!isSubsequent) {
                 shareFetchData.forEach((topicIdPartition, sharePartitionData) -> {
                     if (topicIdPartition.topic() == null) {
-                        erroneous.addOne(new Tuple2<>(topicIdPartition, ShareFetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_ID)));
+                        erroneous.add(new Tuple2<>(topicIdPartition, ShareFetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_ID)));
                     } else {
-                        valid.addOne(new Tuple2<>(topicIdPartition, sharePartitionData));
+                        valid.add(new Tuple2<>(topicIdPartition, sharePartitionData));
                     }
                 });
                 return new ErroneousAndValidPartitionData(erroneous, valid);
@@ -600,9 +599,9 @@ public class SharePartitionManager {
                                 TopicPartition(cachedSharePartition.topic, cachedSharePartition.partition));
                         ShareFetchRequest.SharePartitionData reqData = cachedSharePartition.reqData();
                         if (topicIdPartition.topic() == null) {
-                            erroneous.addOne(new Tuple2<>(topicIdPartition, ShareFetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_ID)));
+                            erroneous.add(new Tuple2<>(topicIdPartition, ShareFetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_ID)));
                         } else {
-                            valid.addOne(new Tuple2<>(topicIdPartition, reqData));
+                            valid.add(new Tuple2<>(topicIdPartition, reqData));
                         }
                     });
                     return new ErroneousAndValidPartitionData(erroneous, valid);
@@ -639,7 +638,7 @@ public class SharePartitionManager {
 
         @Override
         SharePartitionManager.ErroneousAndValidPartitionData getErroneousAndValidTopicIdPartitions() {
-            return new ErroneousAndValidPartitionData(new ArrayBuffer<>(), new ArrayBuffer<>());
+            return new ErroneousAndValidPartitionData(new ArrayList<>(), new ArrayList<>());
         }
     }
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -25,7 +25,7 @@ import kafka.log.remote.RemoteLogManager
 import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.KafkaRaftManager
 import kafka.security.CredentialProvider
-import kafka.server.SharePartitionManager.ShareFetchSessionCache
+import kafka.server.SharePartitionManager.ShareSessionCache
 import kafka.server.metadata.{AclPublisher, BrokerMetadataPublisher, ClientQuotaMetadataManager, DelegationTokenPublisher, DynamicClientQuotaPublisher, DynamicConfigPublisher, KRaftMetadataCache, ScramPublisher}
 import kafka.utils.CoreUtils
 import org.apache.kafka.common.config.ConfigException
@@ -394,7 +394,7 @@ class BrokerServer(
 
       // TODO : add the config max.incremental.share.fetch.session.cache.slots and the variable MIN_INCREMENTAL_SHARE_FETCH_SESSION_EVICTION_MS
       //  which should be used to initialize shareFetchSessionCache
-      val shareFetchSessionCache : ShareFetchSessionCache = new ShareFetchSessionCache(0, 0)
+      val shareFetchSessionCache : ShareSessionCache = new ShareSessionCache(0, 0)
       val sharePartitionManager = new SharePartitionManager(replicaManager, Time.SYSTEM, shareFetchSessionCache);
 
       // Create the request processor objects.

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -22,6 +22,7 @@ import kafka.controller.ReplicaAssignment
 import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinator}
 import kafka.network.RequestChannel
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
+import kafka.server.SharePartitionManager.ErroneousAndValidPartitionData
 import kafka.server.handlers.DescribeTopicPartitionsRequestHandler
 import kafka.server.metadata.{ConfigRepository, KRaftMetadataCache}
 import kafka.utils.Implicits._
@@ -1095,17 +1096,13 @@ class KafkaApis(val requestChannel: RequestChannel,
     // TODO : replace this initialization when share fetch session metadata is sent by the client in the shareFetchRequest
     val newReqMetadata : ShareFetchMetadata = new ShareFetchMetadata(Uuid.ZERO_UUID, -1)
     val shareFetchContext = sharePartitionManager.newContext(groupId, shareFetchData, forgottenTopics, topicNames, newReqMetadata)
-    val erroneous = mutable.ArrayBuffer[(TopicIdPartition, ShareFetchResponseData.PartitionData)]()
+    var erroneous = mutable.ArrayBuffer[(TopicIdPartition, ShareFetchResponseData.PartitionData)]()
     val interesting = mutable.ArrayBuffer[TopicIdPartition]()
     // Regular Kafka consumers need READ permission on each partition they are fetching.
-    val partitionDatas = new mutable.ArrayBuffer[(TopicIdPartition, ShareFetchRequest.SharePartitionData)]
-    val cachedPartitionData = shareFetchContext.cachedPartitions().asScala
-    cachedPartitionData.foreach{ case (topicIdPartition: TopicIdPartition, sharePartitionData: ShareFetchRequest.SharePartitionData) =>
-      if (topicIdPartition.topic == null)
-        erroneous += topicIdPartition -> ShareFetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_ID)
-      else
-        partitionDatas += topicIdPartition -> sharePartitionData
-    }
+    var partitionDatas = new mutable.ArrayBuffer[(TopicIdPartition, ShareFetchRequest.SharePartitionData)]
+    val erroneousAndValidPartitionData : ErroneousAndValidPartitionData = shareFetchContext.getErroneousAndValidTopicIdPartitions
+    erroneous = erroneousAndValidPartitionData.erroneous.asScala
+    partitionDatas = erroneousAndValidPartitionData.validTopicIdPartitions
     val authorizedTopics = authHelper.filterByAuthorized(request.context, READ, TOPIC, partitionDatas)(_._1.topicPartition.topic)
 
     partitionDatas.foreach { case (topicIdPartition, _) =>
@@ -1223,7 +1220,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         unconvertedShareFetchResponse = shareFetchContext.throttleResponse(maxThrottleTimeMs)
       } else {
         // Get the actual response. This will update the fetch context.
-        unconvertedShareFetchResponse = shareFetchContext.updateAndGenerateResponseData(partitions)
+        unconvertedShareFetchResponse = shareFetchContext.updateAndGenerateResponseData(groupId, newReqMetadata.memberId, partitions)
         val responsePartitionsSize = unconvertedShareFetchResponse.data().responses().stream().mapToInt(_.partitions().size()).sum()
         trace(s"Sending Share Fetch response with partitions.size=$responsePartitionsSize")
       }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1101,7 +1101,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     // Regular Kafka consumers need READ permission on each partition they are fetching.
     var partitionDatas = new mutable.ArrayBuffer[(TopicIdPartition, ShareFetchRequest.SharePartitionData)]
     val erroneousAndValidPartitionData : ErroneousAndValidPartitionData = shareFetchContext.getErroneousAndValidTopicIdPartitions
-    erroneous = erroneousAndValidPartitionData.erroneous.asScala
+    erroneous = erroneousAndValidPartitionData.erroneous
     partitionDatas = erroneousAndValidPartitionData.validTopicIdPartitions
     val authorizedTopics = authHelper.filterByAuthorized(request.context, READ, TOPIC, partitionDatas)(_._1.topicPartition.topic)
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1094,7 +1094,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
     // TODO : replace this initialization when share fetch session metadata is sent by the client in the shareFetchRequest
     val newReqMetadata : ShareFetchMetadata = new ShareFetchMetadata(Uuid.ZERO_UUID, -1)
-    val shareFetchContext = sharePartitionManager.newContext(shareFetchData, forgottenTopics, topicNames, newReqMetadata)
+    val shareFetchContext = sharePartitionManager.newContext(groupId, shareFetchData, forgottenTopics, topicNames, newReqMetadata)
     val erroneous = mutable.ArrayBuffer[(TopicIdPartition, ShareFetchResponseData.PartitionData)]()
     val interesting = mutable.ArrayBuffer[TopicIdPartition]()
     // Regular Kafka consumers need READ permission on each partition they are fetching.

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -58,7 +58,7 @@ public class SharePartitionManagerTest {
     @Test
     public void testNewContextReturnsSessionlessShareFetchContext() {
         SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), new SharePartitionManager.ShareFetchSessionCache(10, 1000));
+                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000));
 
         ShareFetchMetadata newReqMetadata = new ShareFetchMetadata(Uuid.ZERO_UUID, -1);
         ShareFetchContext shareFetchContext = sharePartitionManager.newContext(new HashMap<>(), new ArrayList<>(),

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -63,6 +63,6 @@ public class SharePartitionManagerTest {
         ShareFetchMetadata newReqMetadata = new ShareFetchMetadata(Uuid.ZERO_UUID, -1);
         ShareFetchContext shareFetchContext = sharePartitionManager.newContext("grp", new HashMap<>(), new ArrayList<>(),
                 new HashMap<>(), newReqMetadata);
-        assertEquals(shareFetchContext.getClass(), SharePartitionManager.SessionlessShareFetchContext.class);
+        assertEquals(shareFetchContext.getClass(), SharePartitionManager.SessionlessContext.class);
     }
 }

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -61,7 +61,7 @@ public class SharePartitionManagerTest {
                 new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000));
 
         ShareFetchMetadata newReqMetadata = new ShareFetchMetadata(Uuid.ZERO_UUID, -1);
-        ShareFetchContext shareFetchContext = sharePartitionManager.newContext(new HashMap<>(), new ArrayList<>(),
+        ShareFetchContext shareFetchContext = sharePartitionManager.newContext("grp", new HashMap<>(), new ArrayList<>(),
                 new HashMap<>(), newReqMetadata);
         assertEquals(shareFetchContext.getClass(), SharePartitionManager.SessionlessShareFetchContext.class);
     }

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -16,20 +16,41 @@
  */
 package kafka.server;
 
+import org.apache.kafka.common.message.ShareFetchResponseData;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ShareFetchMetadata;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.requests.ShareFetchRequest;
+import org.apache.kafka.common.requests.ShareFetchResponse;
+import org.apache.kafka.common.utils.ImplicitLinkedHashCollection;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Timeout(120)
 public class SharePartitionManagerTest {
 
     @Test
@@ -64,5 +85,310 @@ public class SharePartitionManagerTest {
         ShareFetchContext shareFetchContext = sharePartitionManager.newContext("grp", new HashMap<>(), new ArrayList<>(),
                 new HashMap<>(), newReqMetadata);
         assertEquals(shareFetchContext.getClass(), SharePartitionManager.SessionlessContext.class);
+    }
+
+    private ImplicitLinkedHashCollection<SharePartitionManager.CachedSharePartition> dummyCreate(int size) {
+        ImplicitLinkedHashCollection<SharePartitionManager.CachedSharePartition> cacheMap = new
+                ImplicitLinkedHashCollection<>(size);
+        for (int i = 0; i < size; i++)
+            cacheMap.add(new SharePartitionManager.CachedSharePartition("test", Uuid.randomUuid(), i));
+        return cacheMap;
+    }
+
+    public void assertShareCacheContains(SharePartitionManager.ShareSessionCache cache,
+                                         ArrayList<SharePartitionManager.ShareSessionKey> sessionKeys) {
+        int i = 0;
+        for (SharePartitionManager.ShareSessionKey sessionKey : sessionKeys) {
+            i++;
+            assertFalse(cache.get(sessionKey).isEmpty(),
+                    "Missing session " + i + " out of " + sessionKeys.size() + " ( " + sessionKey + " )");
+        }
+        assertEquals(sessionKeys.size(), cache.size());
+    }
+
+    @Test
+    public void testShareSessionCache() {
+        SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(3, 100);
+        assertEquals(0, cache.size());
+        SharePartitionManager.ShareSessionKey key1 = cache.maybeCreateSession("grp", Uuid.randomUuid(), 0,
+                10, dummyCreate(10));
+        SharePartitionManager.ShareSessionKey key2 = cache.maybeCreateSession("grp", Uuid.randomUuid(), 10,
+                20, dummyCreate(20));
+        SharePartitionManager.ShareSessionKey key3 = cache.maybeCreateSession("grp", Uuid.randomUuid(), 20,
+                30, dummyCreate(30));
+        assertNull(cache.maybeCreateSession("grp", Uuid.randomUuid(), 30,
+                40, dummyCreate(40)));
+        assertNull(cache.maybeCreateSession("grp", Uuid.randomUuid(), 40,
+                5, dummyCreate(5)));
+        assertShareCacheContains(cache, new ArrayList<>(Arrays.asList(key1, key2, key3)));
+        cache.touch(cache.get(key1), 200);
+        SharePartitionManager.ShareSessionKey key4 = cache.maybeCreateSession("grp", Uuid.randomUuid(), 210,
+                11, dummyCreate(11));
+        assertShareCacheContains(cache, new ArrayList<>(Arrays.asList(key1, key3, key4)));
+        cache.touch(cache.get(key1), 400);
+        cache.touch(cache.get(key3), 390);
+        cache.touch(cache.get(key4), 400);
+        SharePartitionManager.ShareSessionKey key5 = cache.maybeCreateSession("grp", Uuid.randomUuid(), 410,
+                50, dummyCreate(50));
+        assertNull(key5);
+    }
+
+    @Test
+    public void testResizeCachedSessions() {
+        SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(2, 100);
+        assertEquals(0, cache.size());
+        assertEquals(0, cache.totalPartitions());
+        SharePartitionManager.ShareSessionKey key1 = cache.maybeCreateSession("grp", Uuid.randomUuid(), 0,
+                2, dummyCreate(2));
+        assertNotNull(key1);
+        assertShareCacheContains(cache, new ArrayList<>(Collections.singletonList(key1)));
+        SharePartitionManager.ShareSession session1 = cache.get(key1);
+        assertEquals(2, session1.size());
+        assertEquals(2, cache.totalPartitions());
+        assertEquals(1, cache.size());
+
+        SharePartitionManager.ShareSessionKey key2 = cache.maybeCreateSession("grp", Uuid.randomUuid(), 0,
+                4, dummyCreate(4));
+        assertNotNull(key2);
+        assertShareCacheContains(cache, new ArrayList<>(Arrays.asList(key1, key2)));
+        SharePartitionManager.ShareSession session2 = cache.get(key2);
+        assertEquals(6, cache.totalPartitions());
+        assertEquals(2, cache.size());
+        cache.touch(session1, 200);
+        cache.touch(session2, 200);
+
+        SharePartitionManager.ShareSessionKey key3 = cache.maybeCreateSession("grp", Uuid.randomUuid(), 200,
+                5, dummyCreate(5));
+        assertNull(key3);
+        assertShareCacheContains(cache, new ArrayList<>(Arrays.asList(key1, key2)));
+        assertEquals(6, cache.totalPartitions());
+        assertEquals(2, cache.size());
+        cache.remove(key1);
+        assertShareCacheContains(cache, new ArrayList<>(Collections.singletonList(key2)));
+        assertEquals(1, cache.size());
+        assertEquals(4, cache.totalPartitions());
+
+        Iterator<SharePartitionManager.CachedSharePartition> iterator = session2.partitionMap().iterator();
+        iterator.next();
+        iterator.remove();
+        assertEquals(3, session2.size());
+        assertEquals(4, session2.cachedSize());
+        cache.touch(session2, session2.lastUsedMs());
+        assertEquals(3, cache.totalPartitions());
+    }
+
+    private final List<TopicIdPartition> emptyPartList = Collections.unmodifiableList(new ArrayList<>());
+
+    private Map<TopicIdPartition, Optional<Integer>> cachedLeaderEpochs(ShareFetchContext context) {
+        Map<TopicIdPartition, Optional<Integer>> cachedLeaderMap = new HashMap<>();
+        if (context.getClass() == SharePartitionManager.SessionlessContext.class) {
+            ((SharePartitionManager.SessionlessContext) context).shareFetchData().forEach((topicIdPartition, sharePartitionData) ->
+                    cachedLeaderMap.put(topicIdPartition, sharePartitionData.currentLeaderEpoch));
+        } else if (context.getClass() == SharePartitionManager.ShareSessionErrorContext.class) {
+            return cachedLeaderMap;
+        } else {
+            SharePartitionManager.ShareSessionContext shareSessionContext = (SharePartitionManager.ShareSessionContext) context;
+            if (!shareSessionContext.isSubsequent()) {
+                shareSessionContext.shareFetchData().forEach((topicIdPartition, sharePartitionData) -> cachedLeaderMap.put(topicIdPartition, sharePartitionData.currentLeaderEpoch));
+            } else {
+                synchronized (shareSessionContext.session()) {
+                    shareSessionContext.session().partitionMap().forEach(cachedSharePartition -> {
+                        TopicIdPartition topicIdPartition = new TopicIdPartition(cachedSharePartition.topicId(), new
+                                TopicPartition(cachedSharePartition.topic(), cachedSharePartition.partition()));
+                        ShareFetchRequest.SharePartitionData reqData = cachedSharePartition.reqData();
+                        cachedLeaderMap.put(topicIdPartition, reqData.currentLeaderEpoch);
+                    });
+                }
+            }
+        }
+        return cachedLeaderMap;
+    }
+
+    @Test
+    public void testCachedLeaderEpoch() {
+        Time time = new MockTime();
+        SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
+                time, cache);
+        Map<Uuid, String> topicNames = new HashMap<>();
+        Uuid tpId0 = Uuid.randomUuid();
+        Uuid tpId1 = Uuid.randomUuid();
+        topicNames.put(tpId0, "foo");
+        topicNames.put(tpId1, "bar");
+        TopicIdPartition tp0 = new TopicIdPartition(tpId0, new TopicPartition("foo", 0));
+        TopicIdPartition tp1 = new TopicIdPartition(tpId0, new TopicPartition("foo", 1));
+        TopicIdPartition tp2 = new TopicIdPartition(tpId1, new TopicPartition("bar", 1));
+
+        Map<TopicIdPartition, ShareFetchRequest.SharePartitionData> requestData1 = new LinkedHashMap<>();
+        requestData1.put(tp0, new ShareFetchRequest.SharePartitionData(tp0.topicId(), 100, Optional.empty()));
+        requestData1.put(tp1, new ShareFetchRequest.SharePartitionData(tp1.topicId(), 100, Optional.of(1)));
+        requestData1.put(tp2, new ShareFetchRequest.SharePartitionData(tp2.topicId(), 100, Optional.of(2)));
+
+        ShareFetchMetadata reqMetadata = new ShareFetchMetadata(Uuid.randomUuid(), ShareFetchMetadata.INITIAL_EPOCH);
+        String groupId = "grp";
+
+        ShareFetchContext context1 = sharePartitionManager.newContext(groupId, requestData1, emptyPartList,
+                topicNames, reqMetadata);
+
+        Map<TopicIdPartition, Optional<Integer>> epochs1 = cachedLeaderEpochs(context1);
+        assertEquals(Optional.empty(), epochs1.get(tp0));
+        assertEquals(Optional.of(1), epochs1.get(tp1));
+        assertEquals(Optional.of(2), epochs1.get(tp2));
+
+        LinkedHashMap<TopicIdPartition, ShareFetchResponseData.PartitionData> response = new LinkedHashMap<>();
+        response.put(tp0, new ShareFetchResponseData.PartitionData().setPartitionIndex(tp0.partition()));
+        response.put(tp1, new ShareFetchResponseData.PartitionData().setPartitionIndex(tp1.partition()));
+        response.put(tp2, new ShareFetchResponseData.PartitionData().setPartitionIndex(tp1.partition()));
+
+        context1.updateAndGenerateResponseData(groupId, reqMetadata.memberId(), response);
+
+        // With no changes, the cached epochs should remain the same
+        Map<TopicIdPartition, ShareFetchRequest.SharePartitionData> requestData2 = new LinkedHashMap<>();
+
+        ShareFetchContext context2 = sharePartitionManager.newContext(groupId, requestData2, emptyPartList,
+                topicNames, new ShareFetchMetadata(reqMetadata.memberId(), 1));
+        Map<TopicIdPartition, Optional<Integer>> epochs2 = cachedLeaderEpochs(context2);
+        assertEquals(Optional.empty(), epochs2.get(tp0));
+        assertEquals(Optional.of(1), epochs2.get(tp1));
+        assertEquals(Optional.of(2), epochs2.get(tp2));
+        context2.updateAndGenerateResponseData(groupId, reqMetadata.memberId(), response);
+
+        // Now verify we can change the leader epoch and the context is updated
+        Map<TopicIdPartition, ShareFetchRequest.SharePartitionData> requestData3 = new LinkedHashMap<>();
+        requestData3.put(tp0, new ShareFetchRequest.SharePartitionData(tp0.topicId(), 100, Optional.of(6)));
+        requestData3.put(tp1, new ShareFetchRequest.SharePartitionData(tp1.topicId(), 100, Optional.empty()));
+        requestData3.put(tp2, new ShareFetchRequest.SharePartitionData(tp2.topicId(), 100, Optional.of(3)));
+        ShareFetchContext context3 = sharePartitionManager.newContext(groupId, requestData3, emptyPartList,
+                topicNames, new ShareFetchMetadata(reqMetadata.memberId(), 2));
+        Map<TopicIdPartition, Optional<Integer>> epochs3 = cachedLeaderEpochs(context3);
+        assertEquals(Optional.of(6), epochs3.get(tp0));
+        assertEquals(Optional.empty(), epochs3.get(tp1));
+        assertEquals(Optional.of(3), epochs3.get(tp2));
+    }
+
+    @Test
+    public void testShareFetchRequests() {
+        Time time = new MockTime();
+        SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
+                time, cache);
+        Map<Uuid, String> topicNames = new HashMap<>();
+        Uuid tpId0 = Uuid.randomUuid();
+        Uuid tpId1 = Uuid.randomUuid();
+        topicNames.put(tpId0, "foo");
+        topicNames.put(tpId1, "bar");
+        Map<String, Uuid> topicIds = topicNames.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+        TopicIdPartition tp0 = new TopicIdPartition(tpId0, new TopicPartition("foo", 0));
+        TopicIdPartition tp1 = new TopicIdPartition(tpId0, new TopicPartition("foo", 1));
+        TopicIdPartition tp2 = new TopicIdPartition(tpId1, new TopicPartition("bar", 0));
+        TopicIdPartition tp3 = new TopicIdPartition(tpId1, new TopicPartition("bar", 1));
+
+        String groupId = "grp";
+
+        // Verify that Sessionless requests get a SessionlessShareContext
+        ShareFetchContext context1 = sharePartitionManager.newContext(groupId, new HashMap<>(), emptyPartList,
+                topicNames, new ShareFetchMetadata(Uuid.randomUuid(), ShareFetchMetadata.FINAL_EPOCH));
+        assertEquals(context1.getClass(), SharePartitionManager.SessionlessContext.class);
+
+        // Create a new share session with an initial share fetch request
+        Map<TopicIdPartition, ShareFetchRequest.SharePartitionData> reqData2 = new LinkedHashMap<>();
+        reqData2.put(tp0, new ShareFetchRequest.SharePartitionData(tp0.topicId(), 100, Optional.empty()));
+        reqData2.put(tp1, new ShareFetchRequest.SharePartitionData(tp1.topicId(), 100, Optional.empty()));
+
+
+        ShareFetchMetadata reqMetadata2 = new ShareFetchMetadata(Uuid.randomUuid(), ShareFetchMetadata.INITIAL_EPOCH);
+        ShareFetchContext context2 = sharePartitionManager.newContext(groupId, reqData2, emptyPartList,
+                topicNames, reqMetadata2);
+        assertEquals(context2.getClass(), SharePartitionManager.ShareSessionContext.class);
+        assertFalse(((SharePartitionManager.ShareSessionContext) context2).isSubsequent());
+
+        Iterator<Map.Entry<TopicIdPartition, ShareFetchRequest.SharePartitionData>> reqData2Iter = reqData2.entrySet().iterator();
+        ((SharePartitionManager.ShareSessionContext) context2).shareFetchData().forEach((topicIdPartition, sharePartitionData) -> {
+            Map.Entry<TopicIdPartition, ShareFetchRequest.SharePartitionData> entry = reqData2Iter.next();
+            assertEquals(entry.getKey().topicPartition(), topicIdPartition.topicPartition());
+            assertEquals(topicIds.get(entry.getKey().topic()), topicIdPartition.topicId());
+            assertEquals(entry.getValue(), sharePartitionData);
+        });
+
+        LinkedHashMap<TopicIdPartition, ShareFetchResponseData.PartitionData> respData2 = new LinkedHashMap<>();
+        respData2.put(tp0, new ShareFetchResponseData.PartitionData().setPartitionIndex(0));
+        respData2.put(tp1, new ShareFetchResponseData.PartitionData().setPartitionIndex(1));
+
+        ShareFetchResponse resp2 = context2.updateAndGenerateResponseData(groupId, reqMetadata2.memberId(), respData2);
+        assertEquals(Errors.NONE, resp2.error());
+        assertEquals(respData2, resp2.responseData(topicNames));
+
+        SharePartitionManager.ShareSessionKey shareSessionKey2 = new SharePartitionManager.ShareSessionKey(groupId,
+                reqMetadata2.memberId());
+
+        // Test trying to create a new session with an invalid epoch
+        ShareFetchContext context3 = sharePartitionManager.newContext(groupId, reqData2, emptyPartList,
+                topicNames, new ShareFetchMetadata(shareSessionKey2.memberId(), 5));
+        assertEquals(context3.getClass(), SharePartitionManager.ShareSessionErrorContext.class);
+        assertEquals(Errors.INVALID_SHARE_SESSION_EPOCH,
+                context3.updateAndGenerateResponseData(groupId, reqMetadata2.memberId(), respData2).error());
+
+        // Test trying to create a new session with a non-existent session key
+        Uuid memberId4 = Uuid.randomUuid();
+        ShareFetchContext context4 = sharePartitionManager.newContext(groupId, reqData2, emptyPartList,
+                topicNames, new ShareFetchMetadata(memberId4, 1));
+        assertEquals(context4.getClass(), SharePartitionManager.ShareSessionErrorContext.class);
+        assertEquals(Errors.SHARE_SESSION_ID_NOT_FOUND,
+                context4.updateAndGenerateResponseData(groupId, memberId4, respData2).error());
+
+        // Continue the first fetch session we created.
+        LinkedHashMap<TopicIdPartition, ShareFetchRequest.SharePartitionData> reqData5 = new LinkedHashMap<>();
+        ShareFetchContext context5 = sharePartitionManager.newContext(groupId, reqData5, emptyPartList,
+                topicNames, new ShareFetchMetadata(shareSessionKey2.memberId(), 1));
+        assertEquals(context5.getClass(), SharePartitionManager.ShareSessionContext.class);
+        assertTrue(((SharePartitionManager.ShareSessionContext) context5).isSubsequent());
+
+        Iterator<Map.Entry<TopicIdPartition, ShareFetchRequest.SharePartitionData>> reqData5Iter = reqData2.entrySet().iterator();
+        SharePartitionManager.ShareSessionContext shareSessionContext5 = (SharePartitionManager.ShareSessionContext) context5;
+        synchronized (shareSessionContext5.session()) {
+            shareSessionContext5.session().partitionMap().forEach(cachedSharePartition -> {
+                Map.Entry<TopicIdPartition, ShareFetchRequest.SharePartitionData> entry = reqData5Iter.next();
+                TopicIdPartition topicIdPartition = new TopicIdPartition(cachedSharePartition.topicId(), new
+                        TopicPartition(cachedSharePartition.topic(), cachedSharePartition.partition()));
+                ShareFetchRequest.SharePartitionData data = cachedSharePartition.reqData();
+                assertEquals(entry.getKey().topicPartition(), topicIdPartition.topicPartition());
+                assertEquals(topicIds.get(entry.getKey().topic()), topicIdPartition.topicId());
+                assertEquals(entry.getValue(), data);
+            });
+        }
+        ShareFetchResponse resp5 = context5.updateAndGenerateResponseData(groupId, reqMetadata2.memberId(), respData2);
+        assertEquals(Errors.NONE, resp5.error());
+        assertEquals(0, resp5.responseData(topicNames).size());
+
+        // Test setting an invalid share session epoch.
+        ShareFetchContext context6 = sharePartitionManager.newContext(groupId, reqData2, emptyPartList,
+                topicNames, new ShareFetchMetadata(shareSessionKey2.memberId(), 5));
+        assertEquals(context6.getClass(), SharePartitionManager.ShareSessionErrorContext.class);
+        assertEquals(Errors.INVALID_SHARE_SESSION_EPOCH,
+                context6.updateAndGenerateResponseData(groupId, reqMetadata2.memberId(), respData2).error());
+
+        // Test generating a throttled response for a subsequent share fetch session
+        LinkedHashMap<TopicIdPartition, ShareFetchRequest.SharePartitionData> reqData7 = new LinkedHashMap<>();
+        ShareFetchContext context7 = sharePartitionManager.newContext(groupId, reqData7, emptyPartList,
+                topicNames, new ShareFetchMetadata(shareSessionKey2.memberId(), 2));
+        ShareFetchResponse resp7 = context7.throttleResponse(100);
+        assertEquals(Errors.NONE, resp7.error());
+        assertEquals(100, resp7.throttleTimeMs());
+
+        // Close the subsequent fetch session.
+        LinkedHashMap<TopicIdPartition, ShareFetchRequest.SharePartitionData> reqData8 = new LinkedHashMap<>();
+        reqData8.put(tp2, new ShareFetchRequest.SharePartitionData(tp2.topicId(), 100, Optional.empty()));
+        reqData8.put(tp3, new ShareFetchRequest.SharePartitionData(tp3.topicId(), 100, Optional.empty()));
+        ShareFetchContext context8 = sharePartitionManager.newContext(groupId, reqData8, emptyPartList,
+                topicNames, new ShareFetchMetadata(reqMetadata2.memberId(), ShareFetchMetadata.FINAL_EPOCH));
+        assertEquals(context8.getClass(), SharePartitionManager.SessionlessContext.class);
+        assertEquals(0, cache.size());
+
+        LinkedHashMap<TopicIdPartition, ShareFetchResponseData.PartitionData> respData8 = new LinkedHashMap<>();
+        respData8.put(tp2, new ShareFetchResponseData.PartitionData().setPartitionIndex(0));
+        respData8.put(tp3, new ShareFetchResponseData.PartitionData().setPartitionIndex(1));
+
+        ShareFetchResponse resp8 = context8.updateAndGenerateResponseData(groupId, reqMetadata2.memberId(), respData8);
+        assertEquals(Errors.NONE, resp8.error());
     }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4326,8 +4326,8 @@ class KafkaApisTest extends Logging {
     val topicIdPartition : TopicIdPartition = new TopicIdPartition(
       topicId, new TopicPartition(topicName, partitionIndex)
     )
-    when(sharePartitionManager.newContext(any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessShareFetchContext(Map(topicIdPartition ->
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
+      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 
@@ -4388,8 +4388,8 @@ class KafkaApisTest extends Logging {
 
     // Name of this topic is set null, so it will be considered as unknown topic by the broker
     val topicIdPartition : TopicIdPartition = new TopicIdPartition(topicId, new TopicPartition(null, partitionIndex))
-    when(sharePartitionManager.newContext(any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessShareFetchContext(Map(topicIdPartition ->
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
+      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 
@@ -4433,8 +4433,8 @@ class KafkaApisTest extends Logging {
     val topicIdPartition : TopicIdPartition = new TopicIdPartition(
       topicId, new TopicPartition(topicName, partitionIndex)
     )
-    when(sharePartitionManager.newContext(any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessShareFetchContext(Map(topicIdPartition ->
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
+      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 
@@ -4492,8 +4492,8 @@ class KafkaApisTest extends Logging {
     val topicIdPartition : TopicIdPartition = new TopicIdPartition(
       topicId, new TopicPartition(topicName, partitionIndex)
     )
-    when(sharePartitionManager.newContext(any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessShareFetchContext(Map(topicIdPartition ->
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
+      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 
@@ -4542,8 +4542,8 @@ class KafkaApisTest extends Logging {
     val topicIdPartition : TopicIdPartition = new TopicIdPartition(
       topicId, new TopicPartition(topicName, partitionIndex)
     )
-    when(sharePartitionManager.newContext(any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessShareFetchContext(Map(topicIdPartition ->
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
+      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 
@@ -4596,8 +4596,8 @@ class KafkaApisTest extends Logging {
     when(partition.leaderReplicaIdOpt).thenAnswer(_ => Some(newLeaderId))
     when(partition.getLeaderEpoch).thenAnswer(_ => newLeaderEpoch)
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessShareFetchContext(Map(topicIdPartition ->
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
+      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -24,6 +24,7 @@ import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinat
 import kafka.log.UnifiedLog
 import kafka.network.{RequestChannel, RequestMetrics}
 import kafka.server.QuotaFactory.QuotaManagers
+import kafka.server.SharePartitionManager.FinalContext
 import kafka.server.metadata.{ConfigRepository, KRaftMetadataCache, MockConfigRepository, ZkMetadataCache}
 import kafka.utils.{CoreUtils, Log4jController, Logging, TestUtils}
 import kafka.zk.KafkaZkClient
@@ -4327,7 +4328,7 @@ class KafkaApisTest extends Logging {
       topicId, new TopicPartition(topicName, partitionIndex)
     )
     when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
+      new FinalContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 
@@ -4389,7 +4390,7 @@ class KafkaApisTest extends Logging {
     // Name of this topic is set null, so it will be considered as unknown topic by the broker
     val topicIdPartition : TopicIdPartition = new TopicIdPartition(topicId, new TopicPartition(null, partitionIndex))
     when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
+      new FinalContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 
@@ -4434,7 +4435,7 @@ class KafkaApisTest extends Logging {
       topicId, new TopicPartition(topicName, partitionIndex)
     )
     when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
+      new FinalContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 
@@ -4493,7 +4494,7 @@ class KafkaApisTest extends Logging {
       topicId, new TopicPartition(topicName, partitionIndex)
     )
     when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
+      new FinalContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 
@@ -4543,7 +4544,7 @@ class KafkaApisTest extends Logging {
       topicId, new TopicPartition(topicName, partitionIndex)
     )
     when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
+      new FinalContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 
@@ -4597,7 +4598,7 @@ class KafkaApisTest extends Logging {
     when(partition.getLeaderEpoch).thenAnswer(_ => newLeaderEpoch)
 
     when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
-      new SharePartitionManager.SessionlessContext(Map(topicIdPartition ->
+      new FinalContext(Map(topicIdPartition ->
         new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava)
     )
 


### PR DESCRIPTION
**About**
This PR houses the code for share sessions on broker side. The eviction strategy for share sessions is as defined in [KIP-932](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka#KIP932:QueuesforKafka-Batching) This PR has an assumption that we are only dealing with topic IDs and not topic names (Reference - Version 13 introduces topic IDs, earlier topic names were used)

**Testing**
Unit tests have been added in `SharePartitionManagerTest.java`

**What's Left**
1. The share sessions functionalities coded in this PR supports all the required operations for a share fetch request. However,  we will need some new functionalities + refractor to accommodate ShareAcknowledge requests
2. The unit tests are not enough in this PR. I'll add more tests in the subsequent PRs.
