### PR TITLE
[2.8] KSECURITY-2349 Update jetty to 9.4.54.v20240208 for CVE-2024-22201 fix (#1064)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -72,7 +72,7 @@ versions += [
   jacksonDatabind: "2.13.4.2",
   jacoco: "0.8.5",
   javassist: "3.27.0-GA",
-  jetty: "9.4.53.v20231009",
+  jetty: "9.4.54.v20240208",
   jersey: "2.34",
   jgit: "5.12.0.202106070339-r",
   jline: "3.12.1",


### PR DESCRIPTION
Update jetty to version [9.4.54.v20240208](https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.54.v20240208) to fix CVE-2024-22201

Cherry-pick [commit](https://github.com/confluentinc/kafka/commit/0b30dc2e8276bb044ab31cb31e518997071aceee) from trunk to 2.8

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
