### PR TITLE
AKCORE-38-2: Refactor share fetching

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
@@ -223,10 +223,6 @@ public class KafkaShareConsumer<K, V> implements ShareConsumer<K, V> {
      * {@link #commitAsync()} or {@link #poll(Duration)} call. By using this method, the consumer is using
      * <b>explicit acknowledgement</b>.
      *
-     * <p>
-     * Records for each topic-partition must be acknowledged in the order they were returned from
-     * {@link #poll(Duration)}.
-     *
      * @param record The record to acknowledge
      * @param type The acknowledge type which indicates whether it was processed successfully
      *

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetch.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+
+public class ShareFetch<K, V> {
+    private final Map<TopicIdPartition, List<ConsumerRecord<K, V>>> records;
+    private int numRecords;
+
+    public static <K, V> ShareFetch<K, V> empty() {
+        return new ShareFetch<>(new HashMap<>(), 0);
+    }
+
+    public static <K, V> ShareFetch<K, V> forPartition(
+            TopicIdPartition partition,
+            List<ConsumerRecord<K, V>> records
+    ) {
+        Map<TopicIdPartition, List<ConsumerRecord<K, V>>> recordsMap = records.isEmpty()
+                ? new HashMap<>()
+                : mkMap(mkEntry(partition, records));
+        return new ShareFetch<>(recordsMap, records.size());
+    }
+
+    private ShareFetch(
+            Map<TopicIdPartition, List<ConsumerRecord<K, V>>> records,
+            int numRecords
+    ) {
+        this.records = records;
+        this.numRecords = numRecords;
+    }
+
+    /**
+     * Add another {@link ShareFetch} to this one; all of its records will be added to this object's
+     * {@link #records() records}.
+     *
+     * @param fetch the other fetch to add; may not be null
+     */
+    public void add(ShareFetch<K, V> fetch) {
+        Objects.requireNonNull(fetch);
+        addRecords(fetch.records);
+    }
+
+    /**
+     * @return all the non-control messages for this fetch, grouped by partition
+     */
+    public Map<TopicPartition, List<ConsumerRecord<K, V>>> records() {
+        final LinkedHashMap<TopicPartition, List<ConsumerRecord<K, V>>> result = new LinkedHashMap<>();
+        records.forEach((tip, records) -> result.put(tip.topicPartition(), records));
+        return Collections.unmodifiableMap(result);
+    }
+
+    /**
+     * @return the total number of non-control messages for this fetch, across all partitions
+     */
+    public int numRecords() {
+        return numRecords;
+    }
+
+    /**
+     * @return {@code true} if and only if this fetch did not return any user-visible (i.e., non-control) records, and
+     * did not cause the consumer position to advance for any topic partitions
+     */
+    public boolean isEmpty() {
+        return numRecords == 0;
+    }
+
+    private void addRecords(Map<TopicIdPartition, List<ConsumerRecord<K, V>>> records) {
+        records.forEach((partition, partRecords) -> {
+            this.numRecords += partRecords.size();
+            List<ConsumerRecord<K, V>> currentRecords = this.records.get(partition);
+            if (currentRecords == null) {
+                this.records.put(partition, partRecords);
+            } else {
+                // this case shouldn't usually happen because we only send one fetch at a time per partition,
+                // but it might conceivably happen in some rare cases (such as partition leader changes).
+                // we have to copy to a new list because the old one may be immutable
+                List<ConsumerRecord<K, V>> newRecords = new ArrayList<>(currentRecords.size() + partRecords.size());
+                newRecords.addAll(currentRecords);
+                newRecords.addAll(partRecords);
+                this.records.put(partition, newRecords);
+            }
+        });
+    }
+
+    public void acknowledgeAll() {
+        // This is where we hook into building the acknowledgement batches
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
@@ -129,7 +129,7 @@ public class ShareConsumerImplTest {
     public void testWakeupBeforeCallingPoll() {
         consumer = newConsumer();
         final String topicName = "foo";
-        doReturn(Fetch.empty()).when(fetchCollector).collectFetch(any(ShareFetchBuffer.class));
+        doReturn(ShareFetch.empty()).when(fetchCollector).collect(any(ShareFetchBuffer.class));
         consumer.subscribe(singletonList(topicName));
 
         consumer.wakeup();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchBufferTest.java
@@ -131,27 +131,6 @@ public class ShareFetchBufferTest {
         }
     }
 
-    /**
-     * Tests that the buffer manipulates partitions for both the queue and the next-in-line buffer.
-     */
-    @Test
-    public void testAddAllAndRetainAll() {
-        try (ShareFetchBuffer fetchBuffer = new ShareFetchBuffer(logContext)) {
-            fetchBuffer.setNextInLineFetch(completedFetch(topicAPartition0));
-            fetchBuffer.addAll(Arrays.asList(completedFetch(topicAPartition1), completedFetch(topicAPartition2)));
-            assertEquals(allPartitions, fetchBuffer.bufferedPartitions());
-
-            fetchBuffer.retainAll(partitions(topicAPartition1, topicAPartition2));
-            assertEquals(partitions(topicAPartition1, topicAPartition2), fetchBuffer.bufferedPartitions());
-
-            fetchBuffer.retainAll(partitions(topicAPartition2));
-            assertEquals(partitions(topicAPartition2), fetchBuffer.bufferedPartitions());
-
-            fetchBuffer.retainAll(partitions());
-            assertEquals(partitions(), fetchBuffer.bufferedPartitions());
-        }
-    }
-
     @Test
     public void testWakeup() throws Exception {
         try (ShareFetchBuffer fetchBuffer = new ShareFetchBuffer(logContext)) {


### PR DESCRIPTION
Refactoring the share fetching logic in preparation for supporting acknowledgements. Removed some unnecessary cruft to do with maintaining the position, which doesn't apply for share groups and was only being used to keep the subscription state happy.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
