### PR TITLE
AKCORE-23: Require acquired records list from broker

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetch.java
@@ -52,14 +52,12 @@ import java.util.Optional;
  */
 public class ShareCompletedFetch {
 
-    final TopicIdPartition partition;
-
-    final ShareFetchResponseData.PartitionData partitionData;
-
-    final short requestVersion;
-
     private final Logger log;
     private final BufferSupplier decompressionBufferSupplier;
+    final TopicIdPartition partition;
+    final ShareFetchResponseData.PartitionData partitionData;
+    final short requestVersion;
+
     private final Iterator<? extends RecordBatch> batches;
     private RecordBatch currentBatch;
     private Record lastRecord;
@@ -161,10 +159,8 @@ public class ShareCompletedFetch {
                 TimestampType timestampType = currentBatch.timestampType();
                 ConsumerRecord<K, V> record = parseRecord(deserializers, partition, leaderEpoch, timestampType, lastRecord);
 
-                // Temporarily treat all records as ACQUIRED if the list of acquired records is empty.
-                // This just indicates that the broker doesn't yet have the support needed.
                 // Check if the record is in acquired records.
-                if (acquiredRecords.isEmpty() || isAcquired(record)) {
+                if (isAcquired(record)) {
                     shareInFlightBatch.addRecord(record);
                 }
             }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollector.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollector.java
@@ -159,29 +159,28 @@ public class ShareFetchCollector<K, V> {
             log.debug("Error in fetch for partition {}: {}", tp, error.exceptionName());
             requestMetadataUpdate(metadata, subscriptions, tp.topicPartition());
         } else if (error == Errors.UNKNOWN_TOPIC_OR_PARTITION) {
-            log.warn("Received unknown topic or partition error in fetch for partition {}", tp);
+            log.warn("Received unknown topic or partition error in fetch for partition {}.", tp);
             requestMetadataUpdate(metadata, subscriptions, tp.topicPartition());
         } else if (error == Errors.UNKNOWN_TOPIC_ID) {
-            log.warn("Received unknown topic ID error in fetch for partition {}", tp);
+            log.warn("Received unknown topic ID error in fetch for partition {}.", tp);
             requestMetadataUpdate(metadata, subscriptions, tp.topicPartition());
         } else if (error == Errors.INCONSISTENT_TOPIC_ID) {
-            log.warn("Received inconsistent topic ID error in fetch for partition {}", tp);
+            log.warn("Received inconsistent topic ID error in fetch for partition {}.", tp);
             requestMetadataUpdate(metadata, subscriptions, tp.topicPartition());
         } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
             // Log the actual partition and not just the topic to help with ACL propagation issues in large clusters
             log.warn("Not authorized to read from partition {}.", tp.topicPartition());
             throw new TopicAuthorizationException(Collections.singleton(tp.topic()));
         } else if (error == Errors.UNKNOWN_LEADER_EPOCH) {
-            log.debug("Received unknown leader epoch error in fetch for partition {}", tp);
+            log.debug("Received unknown leader epoch error in fetch for partition {}.", tp);
         } else if (error == Errors.UNKNOWN_SERVER_ERROR) {
-            log.warn("Unknown server error while fetching topic-partition {}",
+            log.warn("Unknown server error while fetching topic-partition {}.",
                     tp.topicPartition());
         } else if (error == Errors.CORRUPT_MESSAGE) {
             throw new KafkaException("Encountered corrupt message when fetching topic-partition "
                     + tp.topicPartition());
         } else {
-            throw new IllegalStateException("Unexpected error code "
-                    + error.code()
+            throw new IllegalStateException("Unexpected error code " + error.code()
                     + " while fetching from topic-partition " + tp.topicPartition());
         }
     }


### PR DESCRIPTION
Remove temporary code to acquire all records in a batch when no acquired record information is provided by the broker. Now the broker supports the acquired record, the client requires it. This is in accordance with KIP-932.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
