### PR TITLE
AKCORE-70: Added support for PartitionMaxBytes in share fetch on broker

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
@@ -65,8 +65,12 @@ public class ShareFetchRequest extends AbstractRequest {
                             .setPartitions(new ArrayList<>());
                     data.topics().add(fetchTopic);
                 }
+
+                // TODO: Remove the hardcoded setPartitionMaxBytes once this field is populated correctly by the client.
+                //  It was added to confirm that the integration tests pass and we are able to fetch records
                 ShareFetchRequestData.FetchPartition fetchPartition = new ShareFetchRequestData.FetchPartition()
                         .setPartitionIndex(topicPartition.partition())
+                        .setPartitionMaxBytes(40000)
                         .setCurrentLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH);
 
                 // Get the list of Acknowledgments for the current partition

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -116,9 +116,7 @@ public class SharePartitionManager {
                 ShareFetchPartitionData shareFetchPartitionData = fetchQueue.poll();
                 Map<TopicIdPartition, FetchRequest.PartitionData> topicPartitionData = new HashMap<>();
                 shareFetchPartitionData.topicIdPartitions.forEach(topicIdPartition -> {
-                    Integer partitionMaxBytes = 0;
-                    if (shareFetchPartitionData.partitionMaxBytes.containsKey(topicIdPartition))
-                        partitionMaxBytes = shareFetchPartitionData.partitionMaxBytes.get(topicIdPartition);
+                    Integer partitionMaxBytes = shareFetchPartitionData.partitionMaxBytes.getOrDefault(topicIdPartition, 0);
 
                     // TODO: Fetch inflight and delivery count from config.
                     SharePartition sharePartition = partitionCacheMap.computeIfAbsent(sharePartitionKey(

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -95,12 +95,13 @@ public class SharePartitionManager {
         String groupId,
         String memberId,
         FetchParams fetchParams,
-        List<TopicIdPartition> topicIdPartitions) {
+        List<TopicIdPartition> topicIdPartitions,
+        Map<TopicIdPartition, Integer> partitionMaxBytes) {
         log.trace("Fetch request for topicIdPartitions: {} with groupId: {} fetch params: {}",
                 topicIdPartitions, groupId, fetchParams);
         CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
         ShareFetchPartitionData shareFetchPartitionData = new ShareFetchPartitionData(fetchParams, groupId, memberId,
-                topicIdPartitions, future);
+                topicIdPartitions, future, partitionMaxBytes);
         fetchQueue.add(shareFetchPartitionData);
         maybeProcessFetchQueue();
         return future;
@@ -115,6 +116,10 @@ public class SharePartitionManager {
                 ShareFetchPartitionData shareFetchPartitionData = fetchQueue.poll();
                 Map<TopicIdPartition, FetchRequest.PartitionData> topicPartitionData = new HashMap<>();
                 shareFetchPartitionData.topicIdPartitions.forEach(topicIdPartition -> {
+                    Integer partitionMaxBytes = 0;
+                    if (shareFetchPartitionData.partitionMaxBytes.containsKey(topicIdPartition))
+                        partitionMaxBytes = shareFetchPartitionData.partitionMaxBytes.get(topicIdPartition);
+
                     // TODO: Fetch inflight and delivery count from config.
                     SharePartition sharePartition = partitionCacheMap.computeIfAbsent(sharePartitionKey(
                                     shareFetchPartitionData.groupId, topicIdPartition),
@@ -125,7 +130,7 @@ public class SharePartitionManager {
                                 topicIdPartition.topicId(),
                                 sharePartition.nextFetchOffset(),
                                 -1,
-                                Integer.MAX_VALUE,
+                                partitionMaxBytes,
                                 Optional.empty()));
                         sharePartition.releaseFetchLock();
                     }
@@ -1238,15 +1243,18 @@ public class SharePartitionManager {
         private final String memberId;
         private final List<TopicIdPartition> topicIdPartitions;
         private final CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future;
+        private final Map<TopicIdPartition, Integer> partitionMaxBytes;
 
         public ShareFetchPartitionData(FetchParams fetchParams, String groupId, String memberId,
                                        List<TopicIdPartition> topicIdPartitions,
-                                       CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future) {
+                                       CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future,
+                                       Map<TopicIdPartition, Integer> partitionMaxBytes) {
             this.fetchParams = fetchParams;
             this.groupId = groupId;
             this.memberId = memberId;
             this.topicIdPartitions = topicIdPartitions;
             this.future = future;
+            this.partitionMaxBytes = partitionMaxBytes;
         }
     }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4339,7 +4339,8 @@ class KafkaApisTest extends Logging {
       anyString(),
       anyString(),
       any[FetchParams],
-      any[util.List[TopicIdPartition]]
+      any[util.List[TopicIdPartition]],
+      any[util.LinkedHashMap[TopicIdPartition, Integer]]
     )).thenReturn(CompletableFuture.completedFuture(Map[TopicIdPartition, ShareFetchResponseData.PartitionData](
       new TopicIdPartition(topicId, new TopicPartition(topicName, partitionIndex)) ->
         new ShareFetchResponseData.PartitionData()
@@ -4446,7 +4447,8 @@ class KafkaApisTest extends Logging {
       anyString(),
       anyString(),
       any[FetchParams],
-      any[util.List[TopicIdPartition]]
+      any[util.List[TopicIdPartition]],
+      any[util.LinkedHashMap[TopicIdPartition, Integer]]
     )).thenReturn(CompletableFuture.completedFuture(Map[TopicIdPartition, ShareFetchResponseData.PartitionData](
       new TopicIdPartition(topicId, new TopicPartition(topicName, partitionIndex)) ->
         new ShareFetchResponseData.PartitionData()
@@ -4509,7 +4511,8 @@ class KafkaApisTest extends Logging {
       anyString(),
       anyString(),
       any[FetchParams],
-      any[util.List[TopicIdPartition]]
+      any[util.List[TopicIdPartition]],
+      any[util.LinkedHashMap[TopicIdPartition, Integer]]
     )).thenReturn(future)
 
     val shareFetchRequestData = new ShareFetchRequestData().
@@ -4606,7 +4609,8 @@ class KafkaApisTest extends Logging {
       anyString(),
       anyString(),
       any[FetchParams],
-      any[util.List[TopicIdPartition]]
+      any[util.List[TopicIdPartition]],
+      any[util.LinkedHashMap[TopicIdPartition, Integer]]
     )).thenReturn(CompletableFuture.completedFuture(Map[TopicIdPartition, ShareFetchResponseData.PartitionData](
       new TopicIdPartition(topicId, new TopicPartition(topicName, partitionIndex)) ->
         new ShareFetchResponseData.PartitionData()
@@ -4627,6 +4631,7 @@ class KafkaApisTest extends Logging {
         setPartitions(List(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
+            .setPartitionMaxBytes(200)
             .setCurrentLeaderEpoch(1)).asJava)).asJava)
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)


### PR DESCRIPTION
### About
This PR adds support for PartitionMaxBytes field in the share fetch operation on broker.

**Note** - We should not merge this PR until there is support for this field on the client. Currently it comes as default value 0. Conversation details [here](https://confluent.slack.com/archives/C06E4G1KHDJ/p1710264347976979)
