### PR TITLE
Fixed ducktape and request lib version

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape<0.9", "requests==2.31.0"],
+      install_requires=["ducktape==0.8.14", "requests==2.24.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.8.14", "requests==2.24.0"],
+      install_requires=["ducktape<0.9", "requests==2.24.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
Fixed ducktape and require version. Both versions are not compatible so we downgraded the versions.
System test was failing due to 

```
ModuleNotFoundError: No module named 'importlib.metadata'
07:34:41  
07:34:41  During handling of the above exception, another exception occurred:
07:34:41  
07:34:41  Traceback (most recent call last):
07:34:41    File "/home/jenkins/workspace/system-test-kafka_3.0/kafka/venv/bin/ducktape", line 13, in <module>
07:34:41      from importlib_metadata import distribution
07:34:41  ModuleNotFoundError: No module named 'importlib_metadata'
07:34:41  
07:34:41  During handling of the above exception, another exception occurred:
07:34:41  
07:34:41  Traceback (most recent call last):
07:34:41    File "/home/jenkins/workspace/system-test-kafka_3.0/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 573, in _build_master
07:34:41      ws.require(__requires__)
07:34:41    File "/home/jenkins/workspace/system-test-kafka_3.0/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 891, in require
07:34:41      needed = self.resolve(parse_requirements(requirements))
07:34:41    File "/home/jenkins/workspace/system-test-kafka_3.0/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 782, in resolve
07:34:41      raise VersionConflict(dist, req).with_context(dependent_req)
07:34:41  pkg_resources.ContextualVersionConflict: (requests 2.31.0 (/home/jenkins/workspace/system-test-kafka_3.0/kafka/venv/lib/python3.7/site-packages/requests-2.31.0-py3.7.egg), Requirement.parse('requests==2.24.0'), {'ducktape'})
```
### Test
https://jenkins.confluent.io/job/system-test-kafka/job/fix-ducktape-3.0/4/

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
