### PR TITLE
Fixed ducktape and request lib version

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape<0.9", "requests==2.31.0"],
+      install_requires=["ducktape<0.9", "requests==2.24.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
Fixed ducktape and require version. Both versions are not compatible so we downgraded the versions.
System test was failing due to

```
  Installed /home/jenkins/workspace/system-test-kafka_3.1/kafka/venv/lib/python3.7/site-packages/paramiko-2.7.2-py3.7.egg
09:43:49  error: requests 2.31.0 is installed but requests==2.24.0 is required by {'ducktape'}
09:43:50  Traceback (most recent call last):
09:43:50    File "/home/jenkins/workspace/system-test-kafka_3.1/kafka/venv/bin/ducktape", line 10, in <module>
09:43:50      from importlib.metadata import distribution
09:43:50  ModuleNotFoundError: No module named 'importlib.metadata'
09:43:50  
09:43:50  During handling of the above exception, another exception occurred:
09:43:50  
09:43:50  Traceback (most recent call last):
09:43:50    File "/home/jenkins/workspace/system-test-kafka_3.1/kafka/venv/bin/ducktape", line 13, in <module>
09:43:50      from importlib_metadata import distribution
09:43:50  ModuleNotFoundError: No module named 'importlib_metadata'
09:43:50  
09:43:50  During handling of the above exception, another exception occurred:
09:43:50  
09:43:50  Traceback (most recent call last):
09:43:50    File "/home/jenkins/workspace/system-test-kafka_3.1/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 573, in _build_master
09:43:50      ws.require(__requires__)
09:43:50    File "/home/jenkins/workspace/system-test-kafka_3.1/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 891, in require
09:43:50      needed = self.resolve(parse_requirements(requirements))
09:43:50    File "/home/jenkins/workspace/system-test-kafka_3.1/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 782, in resolve
09:43:50      raise VersionConflict(dist, req).with_context(dependent_req)
09:43:50  pkg_resources.ContextualVersionConflict: (requests 2.31.0 (/home/jenkins/workspace/system-test-kafka_3.1/kafka/venv/lib/python3.7/site-packages/requests-2.31.0-py3.7.egg), Requirement.parse('requests==2.24.0'), {'ducktape'})
09:43:50 
```
### Test
https://jenkins.confluent.io/job/system-test-kafka/job/fix-ducktape-3.1/2/

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
