### PR TITLE
Fixed ducktape and request lib version

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape<0.9", "requests==2.31.0"],
+      install_requires=["ducktape<0.9", "requests==2.24.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
Fixed ducktape and require version. Both versions are not compatible so we downgraded the versions.
System test was failing due to
`Installed /home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/paramiko-2.7.2-py3.7.egg
09:38:34  error: requests 2.31.0 is installed but requests==2.24.0 is required by {'ducktape'}
09:38:34  Traceback (most recent call last):
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/bin/ducktape", line 10, in <module>
09:38:34      from importlib.metadata import distribution
09:38:34  ModuleNotFoundError: No module named 'importlib.metadata'
09:38:34  
09:38:34  During handling of the above exception, another exception occurred:
09:38:34  
09:38:34  Traceback (most recent call last):
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/bin/ducktape", line 13, in <module>
09:38:34      from importlib_metadata import distribution
09:38:34  ModuleNotFoundError: No module named 'importlib_metadata'
09:38:34  
09:38:34  During handling of the above exception, another exception occurred:
09:38:34  
09:38:34  Traceback (most recent call last):
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 573, in _build_master
09:38:34      ws.require(__requires__)
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 891, in require
09:38:34      needed = self.resolve(parse_requirements(requirements))
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 782, in resolve
09:38:34      raise VersionConflict(dist, req).with_context(dependent_req)
09:38:34  pkg_resources.ContextualVersionConflict: (requests 2.31.0 (/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/requests-2.31.0-py3.7.egg), Requirement.parse('requests==2.24.0'), {'ducktape'})
09:38:34  
09:38:34  During handling of the above exception, another exception occurred:
09:38:34  
09:38:34  Traceback (most recent call last):
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/bin/ducktape", line 15, in <module>
09:38:34      from pkg_resources import load_entry_point
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3316, in <module>
09:38:34      @_call_aside
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3291, in _call_aside
09:38:34      f(*args, **kwargs)
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3329, in _initialize_master_working_set
09:38:34      working_set = WorkingSet._build_master()
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 575, in _build_master
09:38:34      return cls._build_from_requirements(__requires__)
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 588, in _build_from_requirements
09:38:34      dists = ws.resolve(reqs, Environment())
09:38:34    File "/home/jenkins/workspace/system-test-kafka_3.3/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 777, in resolve
09:38:34      raise DistributionNotFound(req, requirers)
09:38:34  pkg_resources.DistributionNotFound: The 'requests==2.24.0' distribution was not found and is required by ducktape`

### Test
https://jenkins.confluent.io/job/system-test-kafka/job/fix-ducktape-3.3/2/

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
