### PR TITLE
Fixed ducktape and request lib version

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.8.18", "requests==2.31.0"],
+      install_requires=["ducktape<0.9", "requests==2.24.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
Fixed ducktape and require version. Both versions are not compatible so we downgraded the versions.
System test was failing due to

`During handling of the above exception, another exception occurred:
09:46:21  
09:46:21  Traceback (most recent call last):
09:46:21    File "/home/jenkins/workspace/system-test-kafka_3.5/kafka/venv/bin/ducktape", line 15, in <module>
09:46:21      from pkg_resources import load_entry_point
09:46:21    File "/home/jenkins/workspace/system-test-kafka_3.5/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3316, in <module>
09:46:21      @_call_aside
09:46:21    File "/home/jenkins/workspace/system-test-kafka_3.5/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3291, in _call_aside
09:46:21      f(*args, **kwargs)
09:46:21    File "/home/jenkins/workspace/system-test-kafka_3.5/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3329, in _initialize_master_working_set
09:46:21      working_set = WorkingSet._build_master()
09:46:21    File "/home/jenkins/workspace/system-test-kafka_3.5/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 575, in _build_master
09:46:21      return cls._build_from_requirements(__requires__)
09:46:21    File "/home/jenkins/workspace/system-test-kafka_3.5/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 588, in _build_from_requirements
09:46:21      dists = ws.resolve(reqs, Environment())
09:46:21    File "/home/jenkins/workspace/system-test-kafka_3.5/kafka/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 782, in resolve
09:46:21      raise VersionConflict(dist, req).with_context(dependent_req)
09:46:21  pkg_resources.ContextualVersionConflict: (urllib3 2.2.1 (/home/jenkins/workspace/system-test-kafka_3.5/kafka/venv/lib/python3.7/site-packages/urllib3-2.2.1-py3.7.egg), Requirement.parse('urllib3<1.26,>=1.20'), {'botocore'})`

### Test
https://jenkins.confluent.io/job/system-test-kafka/job/fix-ducktape-3.5/5/

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
