### PR TITLE
AKCORE-58: Ensure transactional control records are skipped

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
@@ -50,6 +50,10 @@ public class ShareInFlightBatch<K, V> {
         inFlightRecords.add(record);
     }
 
+    public void addGap(long offset) {
+        // To be implemented
+    }
+
     public void merge(ShareInFlightBatch<K, V> other) {
         inFlightRecords.addAll(other.inFlightRecords);
         acknowledgements.merge(other.acknowledgements);

--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -164,6 +164,53 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
     records
   }
 
+  protected def consumeAndVerifyRecords(shareConsumer: ShareConsumer[Array[Byte], Array[Byte]],
+                                        numRecords: Int,
+                                        startingOffset: Int,
+                                        startingKeyAndValueIndex: Int,
+                                        startingTimestamp: Long,
+                                        timestampType: TimestampType,
+                                        tp: TopicPartition,
+                                        maxPollRecords: Int): Unit = {
+    val records = consumeRecords(shareConsumer, numRecords, maxPollRecords = maxPollRecords)
+    val now = System.currentTimeMillis()
+    for (i <- 0 until numRecords) {
+      val record = records(i)
+      val offset = startingOffset + i
+      assertEquals(tp.topic, record.topic)
+      assertEquals(tp.partition, record.partition)
+      if (timestampType == TimestampType.CREATE_TIME) {
+        assertEquals(timestampType, record.timestampType)
+        val timestamp = startingTimestamp + i
+        assertEquals(timestamp, record.timestamp)
+      } else
+        assertTrue(record.timestamp >= startingTimestamp && record.timestamp <= now,
+          s"Got unexpected timestamp ${record.timestamp}. Timestamp should be between [$startingTimestamp, $now}]")
+      assertEquals(offset.toLong, record.offset)
+      val keyAndValueIndex = startingKeyAndValueIndex + i
+      assertEquals(s"key $keyAndValueIndex", new String(record.key))
+      assertEquals(s"value $keyAndValueIndex", new String(record.value))
+      // this is true only because K and V are byte arrays
+      assertEquals(s"key $keyAndValueIndex".length, record.serializedKeySize)
+      assertEquals(s"value $keyAndValueIndex".length, record.serializedValueSize)
+    }
+  }
+
+  protected def consumeRecords[K, V](shareConsumer: ShareConsumer[K, V],
+                                     numRecords: Int,
+                                     maxPollRecords: Int): ArrayBuffer[ConsumerRecord[K, V]] = {
+    val records = new ArrayBuffer[ConsumerRecord[K, V]]
+    def pollAction(polledRecords: ConsumerRecords[K, V]): Boolean = {
+      assertTrue(polledRecords.asScala.size <= maxPollRecords)
+      records ++= polledRecords.asScala
+      records.size >= numRecords
+    }
+    TestUtils.pollRecordsUntilTrue(shareConsumer, pollAction, waitTimeMs = 60000,
+      msg = s"Timed out before consuming expected $numRecords records. " +
+        s"The number consumed was ${records.size}.")
+    records
+  }
+
 
   /**
    * Creates topic 'topicName' with 'numPartitions' partitions and produces 'recordsPerPartition'

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1135,6 +1135,16 @@ object TestUtils extends Logging {
     }, msg = msg, pause = 0L, waitTimeMs = waitTimeMs)
   }
 
+  def pollRecordsUntilTrue[K, V](shareConsumer: ShareConsumer[K, V],
+                                 action: ConsumerRecords[K, V] => Boolean,
+                                 msg: => String,
+                                 waitTimeMs: Long): Unit = {
+    waitUntilTrue(() => {
+      val records = shareConsumer.poll(Duration.ofMillis(100))
+      action(records)
+    }, msg = msg, pause = 0L, waitTimeMs = waitTimeMs)
+  }
+
   def subscribeAndWaitForRecords(topic: String,
                                  consumer: Consumer[Array[Byte], Array[Byte]],
                                  waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {


### PR DESCRIPTION
Enhance the ShareCompletedFetch so that it handles records with gaps and acquired record sets with gaps. This enables the code to handle control records which should be filtered out, and also will work for compacted topics.

Added more integration tests which consume records, including transactional records.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
