### PR TITLE
AKCORE-56: Brokers: Bug fix for epoch update twice when fetch and acknowledge both are present

### DIFF
--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -242,20 +242,24 @@ public class SharePartitionManager {
         return new ShareSessionKey(groupId, memberId);
     }
 
-    public Errors acknowledgeShareSessionCacheUpdate(String groupId, Uuid memberId, int reqEpoch) {
+    public Errors acknowledgeShareSessionCacheUpdate(String groupId, Uuid memberId, int reqEpoch, boolean isAcknowledgementPiggybackedOnFetch) {
         Errors shareAcknowledgeRequestError = shareAcknowledgeError(groupId, memberId, reqEpoch);
         if (shareAcknowledgeRequestError != Errors.NONE)
             return shareAcknowledgeRequestError;
         ShareSessionKey key = shareSessionKey(groupId, memberId);
         ShareSession shareSession = cache.get(new ShareSessionKey(groupId, memberId));
-        if (reqEpoch == ShareFetchMetadata.FINAL_EPOCH) {
-            if (cache.remove(key) != null)
-                log.info("Removed share session with key " + key);
-            return Errors.NONE;
+        // if acknowledgement is piggybacked on fetch, newContext function takes care of updating the share session epoch
+        // and share session cache. However, if the acknowledgement is standalone, the updates are handled in the if block
+        if (!isAcknowledgementPiggybackedOnFetch) {
+            if (reqEpoch == ShareFetchMetadata.FINAL_EPOCH) {
+                if (cache.remove(key) != null)
+                    log.info("Removed share session with key " + key);
+                return Errors.NONE;
+            }
+            // Update session's position in the cache
+            cache.touch(shareSession, time.milliseconds());
+            shareSession.epoch = ShareFetchMetadata.nextEpoch(shareSession.epoch);
         }
-        // Update session's position in the cache
-        cache.touch(shareSession, time.milliseconds());
-        shareSession.epoch = ShareFetchMetadata.nextEpoch(shareSession.epoch);
         return Errors.NONE;
     }
 
@@ -339,7 +343,9 @@ public class SharePartitionManager {
         private final ImplicitLinkedHashCollection<CachedSharePartition> partitionMap;
         private final long creationMs;
         private long lastUsedMs;
-        private int epoch;
+
+        // visible for testing
+        public int epoch;
 
         // This is used by the ShareSessionCache to store the last known size of this session.
         // If this is -1, the Session is not in the cache.


### PR DESCRIPTION
### About
This PR aims to fix the bug on broker share sessions that the share session epoch gets updated twice when the share fetch request contains acknowledgements.
We have fixed it by considering the 2 cases - 
1. Acknowledgement as a standalone request - Updates to the share session epoch and share session cache are taken care in `acknowledgeShareSessionCacheUpdate` function
2. Acknowledgement piggybacked on share fetch request - `newContext` function takes care of updating the share session epoch and share session cache