### PR TITLE
AKCORE-50: Handle gaps in batches

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
@@ -21,9 +21,9 @@ import org.apache.kafka.common.message.ShareFetchRequestData;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * This class maintains the acknowledgement and gap information for a set of records on a single
@@ -37,7 +37,7 @@ public class Acknowledgements {
     private Errors acknowledgeErrorCode;
 
     public static Acknowledgements empty() {
-        return new Acknowledgements(new LinkedHashMap<>());
+        return new Acknowledgements(new TreeMap<>());
     }
 
     private Acknowledgements(Map<Long, AcknowledgeType> acknowledgements) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.message.ShareFetchRequestData;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -145,22 +146,79 @@ public class Acknowledgements {
 
     public List<ShareFetchRequestData.AcknowledgementBatch> getAcknowledgmentBatches() {
         List<ShareFetchRequestData.AcknowledgementBatch> batches = new ArrayList<>();
-        ShareFetchRequestData.AcknowledgementBatch currentBatch = new ShareFetchRequestData.AcknowledgementBatch();
         if (acknowledgements.isEmpty()) return batches;
-        acknowledgements.forEach((offset, acknowledgeType) -> {
-            if (batches.isEmpty()) {
-                currentBatch.setBaseOffset(offset);
-                currentBatch.setAcknowledgeType(acknowledgeType.id);
-                currentBatch.setLastOffset(offset);
-            } else if (acknowledgeType.id == currentBatch.acknowledgeType()) {
-                currentBatch.setLastOffset(offset);
+        Iterator<Map.Entry<Long, AcknowledgeType>> iterator = acknowledgements.entrySet().iterator();
+        ShareFetchRequestData.AcknowledgementBatch currentBatch = null;
+        while (iterator.hasNext()) {
+            Map.Entry<Long, AcknowledgeType> entry = iterator.next();
+            if (currentBatch == null) {
+                currentBatch = new ShareFetchRequestData.AcknowledgementBatch();
+                currentBatch.setBaseOffset(entry.getKey());
+                currentBatch.setLastOffset(entry.getKey());
+                if (entry.getValue() != null) {
+                    currentBatch.setAcknowledgeType(entry.getValue().id);
+                } else {
+                    // Put a marker value of -1 while this batch only has gaps
+                    currentBatch.setAcknowledgeType((byte) -1);
+                    currentBatch.gapOffsets().add(entry.getKey());
+                }
             } else {
-                batches.add(currentBatch);
-                currentBatch.setBaseOffset(offset);
-                currentBatch.setAcknowledgeType(acknowledgeType.id);
-                currentBatch.setLastOffset(offset);
+                if (entry.getValue() != null) {
+                    if (entry.getKey() == currentBatch.lastOffset() + 1) {
+                        if (entry.getValue().id == currentBatch.acknowledgeType()) {
+                            currentBatch.setLastOffset(entry.getKey());
+                        } else if (currentBatch.acknowledgeType() == (byte) -1) {
+                            currentBatch.setAcknowledgeType(entry.getValue().id);
+                            currentBatch.setLastOffset(entry.getKey());
+                        } else {
+                            if (currentBatch.acknowledgeType() == -1) {
+                                // Even though this batch is just gaps, we mark it as ACCEPT.
+                                currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
+                            }
+                            batches.add(currentBatch);
+
+                            currentBatch = new ShareFetchRequestData.AcknowledgementBatch();
+                            currentBatch.setBaseOffset(entry.getKey());
+                            currentBatch.setLastOffset(entry.getKey());
+                            currentBatch.setAcknowledgeType(entry.getValue().id);
+                        }
+                    } else {
+                        if (currentBatch.acknowledgeType() == -1) {
+                            // Even though this batch is just gaps, we mark it as ACCEPT.
+                            currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
+                        }
+                        batches.add(currentBatch);
+
+                        currentBatch = new ShareFetchRequestData.AcknowledgementBatch();
+                        currentBatch.setBaseOffset(entry.getKey());
+                        currentBatch.setLastOffset(entry.getKey());
+                        currentBatch.setAcknowledgeType(entry.getValue().id);
+                    }
+                } else {
+                    if (entry.getKey() == currentBatch.lastOffset() + 1) {
+                        currentBatch.setLastOffset(entry.getKey());
+                        currentBatch.gapOffsets().add(entry.getKey());
+                    } else {
+                        if (currentBatch.acknowledgeType() == -1) {
+                            // Even though this batch is just gaps, we mark it as ACCEPT.
+                            currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
+                        }
+                        batches.add(currentBatch);
+
+                        currentBatch = new ShareFetchRequestData.AcknowledgementBatch();
+                        currentBatch.setBaseOffset(entry.getKey());
+                        currentBatch.setLastOffset(entry.getKey());
+                        // Put a marker value of -1 while this batch only has gaps
+                        currentBatch.setAcknowledgeType((byte) -1);
+                        currentBatch.gapOffsets().add(entry.getKey());
+                    }
+                }
             }
-        });
+        }
+        if (currentBatch.acknowledgeType() == -1) {
+            // Even though this batch is just gaps, we mark it as ACCEPT.
+            currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
+        }
         batches.add(currentBatch);
         return batches;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetch.java
@@ -197,6 +197,7 @@ public class ShareCompletedFetch {
                 }
             }
         } catch (SerializationException se) {
+            nextAcquired = nextAcquiredRecord();
             if (inFlightBatch.isEmpty()) {
                 inFlightBatch.addAcknowledgement(lastRecord.offset(), AcknowledgeType.RELEASE);
                 inFlightBatch.setException(se);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
@@ -51,7 +51,7 @@ public class ShareInFlightBatch<K, V> {
     }
 
     public void addGap(long offset) {
-        // To be implemented
+        acknowledgements.addGap(offset);
     }
 
     public void merge(ShareInFlightBatch<K, V> other) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
@@ -69,6 +69,7 @@ public class ShareSessionHandler {
      */
     private Map<Uuid, String> sessionTopicNames = new HashMap<>(0);
     private final Map<TopicIdPartition, Acknowledgements> nextAcknowledgements = new LinkedHashMap<>();
+
     public Map<Uuid, String> sessionTopicNames() {
         return sessionTopicNames;
     }
@@ -111,6 +112,10 @@ public class ShareSessionHandler {
          * The metadata to use in this fetch request.
          */
         private final ShareFetchMetadata metadata;
+
+        /**
+         * A map of the acknowledgements to send.
+         */
         private final Map<TopicIdPartition, Acknowledgements> acknowledgements;
 
         ShareFetchRequestData(Map<TopicPartition, TopicIdPartition> toSend,

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
@@ -74,12 +74,11 @@ public class ShareFetchRequest extends AbstractRequest {
                         .setPartitionMaxBytes(40000)
                         .setCurrentLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH);
 
-                // Get the list of Acknowledgments for the current partition
+                // Get the list of acknowledgements for the current partition
                 List<ShareFetchRequestData.AcknowledgementBatch> acknowledgementBatches = acknowledgements.get(topicPartition);
                 if (acknowledgementBatches != null) {
                     fetchPartition.setAcknowledgementBatches(acknowledgementBatches);
                 }
-
 
                 fetchTopic.partitions().add(fetchPartition);
             }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AcknowledgementsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AcknowledgementsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.AcknowledgeType;
+import org.apache.kafka.common.message.ShareFetchRequestData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AcknowledgementsTest {
+
+    private final Acknowledgements acks = Acknowledgements.empty();
+    @BeforeEach
+    public void setup() {
+
+    }
+
+    @Test
+    public void testSingleBatchSingleRecord() {
+        acks.add(0L, AcknowledgeType.ACCEPT);
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(1, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(0L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT, ackList.get(0).acknowledgeType());
+        assertTrue(ackList.get(0).gapOffsets().isEmpty());
+    }
+
+    @Test
+    public void testSingleBatchMultiRecord() {
+        acks.add(0L, AcknowledgeType.ACCEPT);
+        acks.add(1L, AcknowledgeType.ACCEPT);
+        acks.add(2L, AcknowledgeType.ACCEPT);
+        acks.add(3L, AcknowledgeType.ACCEPT);
+        acks.add(4L, AcknowledgeType.ACCEPT);
+    }
+
+    @Test
+    public void testMultiBatchMultiRecord() {
+        acks.add(0L, AcknowledgeType.ACCEPT);
+        acks.add(1L, AcknowledgeType.ACCEPT);
+        acks.add(2L, AcknowledgeType.ACCEPT);
+        acks.add(3L, AcknowledgeType.RELEASE);
+        acks.add(4L, AcknowledgeType.RELEASE);
+    }
+
+    @Test
+    public void testMultiBatchSingleMultiRecord() {
+        acks.add(0L, AcknowledgeType.ACCEPT);
+        acks.add(1L, AcknowledgeType.RELEASE);
+        acks.add(2L, AcknowledgeType.RELEASE);
+        acks.add(3L, AcknowledgeType.RELEASE);
+        acks.add(4L, AcknowledgeType.RELEASE);
+    }
+
+    @Test
+    public void testMultiBatchMultiSingleRecord() {
+        acks.add(0L, AcknowledgeType.ACCEPT);
+        acks.add(1L, AcknowledgeType.ACCEPT);
+        acks.add(2L, AcknowledgeType.ACCEPT);
+        acks.add(3L, AcknowledgeType.ACCEPT);
+        acks.add(4L, AcknowledgeType.RELEASE);
+    }
+
+    @Test
+    public void testSingleBatchSingleGap() {
+        acks.addGap(0L);
+    }
+
+    @Test
+    public void testSingleBatchMultiGap() {
+        acks.addGap(0L);
+        acks.addGap(1L);
+    }
+
+    @Test
+    public void testSingleBatchSingleGapSingleRecord() {
+        acks.addGap(0L);
+        acks.add(1L, AcknowledgeType.ACCEPT);
+    }
+
+    @Test
+    public void testSingleBatchSingleRecordSingleGap() {
+        acks.add(0L, AcknowledgeType.ACCEPT);
+        acks.addGap(1L);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AcknowledgementsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AcknowledgementsTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.common.message.ShareFetchRequestData;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -29,19 +28,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AcknowledgementsTest {
 
     private final Acknowledgements acks = Acknowledgements.empty();
-    @BeforeEach
-    public void setup() {
 
+    @Test
+    public void testEmptyBatch() {
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertTrue(ackList.isEmpty());
     }
 
     @Test
     public void testSingleBatchSingleRecord() {
         acks.add(0L, AcknowledgeType.ACCEPT);
+
         List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).baseOffset());
         assertEquals(0L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT, ackList.get(0).acknowledgeType());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertTrue(ackList.get(0).gapOffsets().isEmpty());
     }
 
@@ -52,6 +54,13 @@ public class AcknowledgementsTest {
         acks.add(2L, AcknowledgeType.ACCEPT);
         acks.add(3L, AcknowledgeType.ACCEPT);
         acks.add(4L, AcknowledgeType.ACCEPT);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(1, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(4L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertTrue(ackList.get(0).gapOffsets().isEmpty());
     }
 
     @Test
@@ -61,6 +70,17 @@ public class AcknowledgementsTest {
         acks.add(2L, AcknowledgeType.ACCEPT);
         acks.add(3L, AcknowledgeType.RELEASE);
         acks.add(4L, AcknowledgeType.RELEASE);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(2, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(2L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(3L, ackList.get(1).baseOffset());
+        assertEquals(4L, ackList.get(1).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
+        assertTrue(ackList.get(1).gapOffsets().isEmpty());
     }
 
     @Test
@@ -70,6 +90,17 @@ public class AcknowledgementsTest {
         acks.add(2L, AcknowledgeType.RELEASE);
         acks.add(3L, AcknowledgeType.RELEASE);
         acks.add(4L, AcknowledgeType.RELEASE);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(2, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(0L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(1L, ackList.get(1).baseOffset());
+        assertEquals(4L, ackList.get(1).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
+        assertTrue(ackList.get(1).gapOffsets().isEmpty());
     }
 
     @Test
@@ -79,28 +110,153 @@ public class AcknowledgementsTest {
         acks.add(2L, AcknowledgeType.ACCEPT);
         acks.add(3L, AcknowledgeType.ACCEPT);
         acks.add(4L, AcknowledgeType.RELEASE);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(2, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(3L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(4L, ackList.get(1).baseOffset());
+        assertEquals(4L, ackList.get(1).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
+        assertTrue(ackList.get(1).gapOffsets().isEmpty());
     }
 
     @Test
     public void testSingleBatchSingleGap() {
         acks.addGap(0L);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(1, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(0L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertEquals(1, ackList.get(0).gapOffsets().size());
     }
 
     @Test
     public void testSingleBatchMultiGap() {
         acks.addGap(0L);
         acks.addGap(1L);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(1, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(1L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertEquals(2, ackList.get(0).gapOffsets().size());
     }
 
     @Test
     public void testSingleBatchSingleGapSingleRecord() {
         acks.addGap(0L);
         acks.add(1L, AcknowledgeType.ACCEPT);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(1, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(1L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertEquals(1, ackList.get(0).gapOffsets().size());
     }
 
     @Test
     public void testSingleBatchSingleRecordSingleGap() {
         acks.add(0L, AcknowledgeType.ACCEPT);
         acks.addGap(1L);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(1, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(1L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertEquals(1, ackList.get(0).gapOffsets().size());
+    }
+
+    @Test
+    public void testMultiBatchSingleMultiGapRecords() {
+        acks.add(0L, AcknowledgeType.RELEASE);
+        acks.addGap(1L);
+        acks.addGap(2L);
+        acks.add(3L, AcknowledgeType.ACCEPT);
+        acks.add(4L, AcknowledgeType.ACCEPT);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(2, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(2L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeType());
+        assertEquals(2, ackList.get(0).gapOffsets().size());
+        assertEquals(3L, ackList.get(1).baseOffset());
+        assertEquals(4L, ackList.get(1).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeType());
+        assertTrue(ackList.get(1).gapOffsets().isEmpty());
+    }
+
+    @Test
+    public void testMultiBatchSingleMultiRecordGaps() {
+        acks.add(0L, AcknowledgeType.ACCEPT);
+        acks.add(1L, AcknowledgeType.RELEASE);
+        acks.addGap(2L);
+        acks.add(3L, AcknowledgeType.RELEASE);
+        acks.addGap(4L);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(2, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(0L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(1L, ackList.get(1).baseOffset());
+        assertEquals(4L, ackList.get(1).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
+        assertEquals(2, ackList.get(1).gapOffsets().size());
+    }
+
+    @Test
+    public void testNoncontiguousBatches() {
+        acks.add(0L, AcknowledgeType.ACCEPT);
+        acks.add(1L, AcknowledgeType.RELEASE);
+        acks.add(3L, AcknowledgeType.REJECT);
+        acks.add(4L, AcknowledgeType.REJECT);
+        acks.add(6L, AcknowledgeType.REJECT);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(4, ackList.size());
+        assertEquals(0L, ackList.get(0).baseOffset());
+        assertEquals(0L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(1L, ackList.get(1).baseOffset());
+        assertEquals(1L, ackList.get(1).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
+        assertTrue(ackList.get(1).gapOffsets().isEmpty());
+        assertEquals(3L, ackList.get(2).baseOffset());
+        assertEquals(4L, ackList.get(2).lastOffset());
+        assertEquals(AcknowledgeType.REJECT.id, ackList.get(2).acknowledgeType());
+        assertTrue(ackList.get(2).gapOffsets().isEmpty());
+        assertEquals(6L, ackList.get(3).baseOffset());
+        assertEquals(6L, ackList.get(3).lastOffset());
+        assertEquals(AcknowledgeType.REJECT.id, ackList.get(3).acknowledgeType());
+        assertTrue(ackList.get(3).gapOffsets().isEmpty());
+    }
+
+
+    @Test
+    public void testNoncontiguousGaps() {
+        acks.addGap(2L);
+        acks.addGap(4L);
+
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        assertEquals(2, ackList.size());
+        assertEquals(2L, ackList.get(0).baseOffset());
+        assertEquals(2L, ackList.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
+        assertEquals(1, ackList.get(0).gapOffsets().size());
+        assertEquals(4L, ackList.get(1).baseOffset());
+        assertEquals(4L, ackList.get(1).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeType());
+        assertEquals(1, ackList.get(1).gapOffsets().size());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetchTest.java
@@ -285,7 +285,8 @@ public class ShareCompletedFetchTest {
     public static List<ShareFetchResponseData.AcquiredRecords> acquiredRecords(long baseOffset, int count) {
         ShareFetchResponseData.AcquiredRecords acquiredRecords = new ShareFetchResponseData.AcquiredRecords()
                 .setBaseOffset(baseOffset)
-                .setLastOffset(baseOffset + count - 1);
+                .setLastOffset(baseOffset + count - 1)
+                .setDeliveryCount((short) 1);
         return Collections.singletonList(acquiredRecords);
     }
 

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -16,10 +16,8 @@
  */
 package kafka.test.api;
 
-import kafka.api.AbstractConsumerTest;
+import kafka.api.AbstractShareConsumerTest;
 import kafka.api.BaseConsumerTest;
-import kafka.utils.TestUtils;
-import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -28,7 +26,6 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -36,19 +33,14 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import scala.Function0;
 import scala.collection.mutable.ArrayBuffer;
 import scala.jdk.javaapi.CollectionConverters;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.Iterator;
 import java.util.Properties;
@@ -56,10 +48,9 @@ import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 
 @Timeout(600)
-public class PlaintextShareConsumerTest extends AbstractConsumerTest {
+public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
     public static final String TEST_WITH_PARAMETERIZED_QUORUM_NAME = "{displayName}.quorum={argumentsWithNames}";
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
@@ -253,96 +244,6 @@ public class PlaintextShareConsumerTest extends AbstractConsumerTest {
                 TimestampType.CREATE_TIME, tp(), maxPollRecords);
     }
 
-    @Disabled("TODO: The consumer needs to be converted to share consumers once the functionality for this test is available")
-    @Test
-    public void testMaxPollIntervalMs() throws InterruptedException {
-        consumerConfig().setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, String.valueOf(1000));
-        consumerConfig().setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, String.valueOf(500));
-        consumerConfig().setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, String.valueOf(2000));
-
-        Consumer<byte[], byte[]> consumer = createConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
-                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
-
-        TestConsumerReassignmentListener listener = new TestConsumerReassignmentListener();
-        consumer.subscribe(Collections.singleton(topic()), listener);
-
-        // rebalance to get the initial assignment
-        awaitRebalance(consumer, listener);
-        assertEquals(1, listener.callsToAssigned());
-        assertEquals(0, listener.callsToRevoked());
-
-        // after we extend longer than max.poll a rebalance should be triggered
-        // NOTE we need to have a relatively much larger value than max.poll to let heartbeat expired for sure
-        Thread.sleep(3000);
-
-        awaitRebalance(consumer, listener);
-        assertEquals(2, listener.callsToAssigned());
-        assertEquals(1, listener.callsToRevoked());
-    }
-
-    @Disabled("TODO: The consumer needs to be converted to share consumers once the functionality for this test is available")
-    @Test
-    public void testAutoCommitOnClose() {
-        consumerConfig().setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
-        Consumer<byte[], byte[]> consumer = createConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
-                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
-
-        int numRecords = 10000;
-        KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
-        sendRecords(producer, numRecords, tp(), System.currentTimeMillis());
-
-        consumer.subscribe(Collections.singleton(topic()));
-        awaitAssignment(consumer, new HashSet<>(Arrays.asList(tp(), tp2())));
-
-        // should auto-commit sought positions before closing
-        consumer.seek(tp(), 300);
-        consumer.seek(tp2(), 500);
-        consumer.close();
-
-        // now we should see the committed positions from another consumer
-        Consumer<byte[], byte[]> anotherConsumer = createConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
-                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
-        assertEquals(300, anotherConsumer.committed(new HashSet<>(Collections.singletonList(tp()))).get(tp()).offset());
-        assertEquals(500, anotherConsumer.committed(new HashSet<>(Collections.singletonList(tp2()))).get(tp2()).offset());
-    }
-
-    @Disabled("TODO: The consumer needs to be converted to share consumers once the functionality for this test is available")
-    @Test
-    public void testAutoCommitOnCloseAfterWakeup() {
-        consumerConfig().setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
-        Consumer<byte[], byte[]> consumer = createConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
-                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
-
-        int numRecords = 10000;
-        KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
-        sendRecords(producer, numRecords, tp(), System.currentTimeMillis());
-
-        consumer.subscribe(Collections.singleton(topic()));
-        awaitAssignment(consumer, new HashSet<>(Arrays.asList(tp(), tp2())));
-
-        // should auto-commit sought positions before closing
-        consumer.seek(tp(), 300);
-        consumer.seek(tp2(), 500);
-
-        // wakeup the consumer before closing to simulate trying to break a poll
-        // loop from another thread
-        consumer.wakeup();
-        consumer.close();
-
-        // now we should see the committed positions from another consumer
-        Consumer<byte[], byte[]> anotherConsumer = createConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
-                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
-        assertEquals(300, anotherConsumer.committed(new HashSet<>(Collections.singletonList(tp()))).get(tp()).offset());
-        assertEquals(500, anotherConsumer.committed(new HashSet<>(Collections.singletonList(tp2()))).get(tp2()).offset());
-    }
-
-    private void awaitAssignment(Consumer<byte[], byte[]> consumer, Set<TopicPartition> expectedAssignment) {
-        Function0<Object> action = () -> consumer.assignment().equals(expectedAssignment);
-        Function0<String> messageSupplier = () -> String.format("Timed out while awaiting expected assignment %s. " +
-                "The current assignment is %s", expectedAssignment, consumer.assignment());
-        TestUtils.pollUntilTrue(consumer, action, messageSupplier, DEFAULT_MAX_WAIT_MS);
-    }
-
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
     public void testControlRecordsSkipped(String quorum) throws Exception {
@@ -382,6 +283,9 @@ public class PlaintextShareConsumerTest extends AbstractConsumerTest {
         // There will be control records on the topic-partition, so the offsets of the non-control records
         // are not 0, 1, 2, 3. Just assert that the offset of the final one is not 3.
         assertNotEquals(3, nonTransactional2.offset());
+
+        records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(0, records.count());
         shareConsumer.close();
     }
 }

--- a/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.api
+
+import java.util.Properties
+
+import org.apache.kafka.clients.consumer._
+import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
+import org.apache.kafka.common.record.TimestampType
+import org.apache.kafka.common.TopicPartition
+import kafka.utils.TestUtils
+import kafka.server.{BaseRequestTest, KafkaConfig}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{BeforeEach, TestInfo}
+
+import scala.jdk.CollectionConverters._
+import scala.collection.mutable.ArrayBuffer
+import org.apache.kafka.clients.producer.KafkaProducer
+
+/**
+ * Extension point for share consumer integration tests.
+ */
+abstract class AbstractShareConsumerTest extends BaseRequestTest {
+
+  val epsilon = 0.1
+  override def brokerCount: Int = 3
+
+  val topic = "topic"
+  val part = 0
+  val tp = new TopicPartition(topic, part)
+  val group = "share"
+  val producerClientId = "ConsumerTestProducer"
+  val consumerClientId = "ConsumerTestShareConsumer"
+  val groupMaxSessionTimeoutMs = 60000L
+
+  this.producerConfig.setProperty(ProducerConfig.CLIENT_ID_CONFIG, producerClientId)
+  this.consumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, consumerClientId)
+  this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, group)
+
+  override protected def brokerPropertyOverrides(properties: Properties): Unit = {
+    properties.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false") // speed up shutdown
+    properties.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp, "3") // don't want to lose offset
+    properties.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "1")
+    properties.setProperty(KafkaConfig.GroupMinSessionTimeoutMsProp, "100") // set small enough session timeout
+    properties.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, groupMaxSessionTimeoutMs.toString)
+    properties.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "10")
+  }
+
+  @BeforeEach
+  override def setUp(testInfo: TestInfo): Unit = {
+    super.setUp(testInfo)
+
+    // create the test topic with all the brokers as replicas
+    createTopic(topic, 1, brokerCount, adminClientConfig = this.adminClientConfig)
+  }
+
+  protected def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]], numRecords: Int,
+                            tp: TopicPartition,
+                            startingTimestamp: Long = System.currentTimeMillis()): Seq[ProducerRecord[Array[Byte], Array[Byte]]] = {
+    val records = (0 until numRecords).map { i =>
+      val timestamp = startingTimestamp + i.toLong
+      val record = new ProducerRecord(tp.topic(), tp.partition(), timestamp, s"key $i".getBytes, s"value $i".getBytes)
+      producer.send(record)
+      record
+    }
+    producer.flush()
+
+    records
+  }
+
+  protected def consumeAndVerifyRecords(consumer: ShareConsumer[Array[Byte], Array[Byte]],
+                                        numRecords: Int,
+                                        startingOffset: Int,
+                                        startingKeyAndValueIndex: Int = 0,
+                                        startingTimestamp: Long = 0L,
+                                        timestampType: TimestampType = TimestampType.CREATE_TIME,
+                                        tp: TopicPartition = tp,
+                                        maxPollRecords: Int = Int.MaxValue): Unit = {
+    val records = consumeRecords(consumer, numRecords, maxPollRecords = maxPollRecords)
+    val now = System.currentTimeMillis()
+    for (i <- 0 until numRecords) {
+      val record = records(i)
+      val offset = startingOffset + i
+      assertEquals(tp.topic, record.topic)
+      assertEquals(tp.partition, record.partition)
+      if (timestampType == TimestampType.CREATE_TIME) {
+        assertEquals(timestampType, record.timestampType)
+        val timestamp = startingTimestamp + i
+        assertEquals(timestamp, record.timestamp)
+      } else
+        assertTrue(record.timestamp >= startingTimestamp && record.timestamp <= now,
+          s"Got unexpected timestamp ${record.timestamp}. Timestamp should be between [$startingTimestamp, $now}]")
+      assertEquals(offset.toLong, record.offset)
+      val keyAndValueIndex = startingKeyAndValueIndex + i
+      assertEquals(s"key $keyAndValueIndex", new String(record.key))
+      assertEquals(s"value $keyAndValueIndex", new String(record.value))
+      // this is true only because K and V are byte arrays
+      assertEquals(s"key $keyAndValueIndex".length, record.serializedKeySize)
+      assertEquals(s"value $keyAndValueIndex".length, record.serializedValueSize)
+    }
+  }
+
+  protected def consumeRecords[K, V](consumer: ShareConsumer[K, V],
+                                     numRecords: Int,
+                                     maxPollRecords: Int = Int.MaxValue): ArrayBuffer[ConsumerRecord[K, V]] = {
+    val records = new ArrayBuffer[ConsumerRecord[K, V]]
+    def pollAction(polledRecords: ConsumerRecords[K, V]): Boolean = {
+      assertTrue(polledRecords.asScala.size <= maxPollRecords)
+      records ++= polledRecords.asScala
+      records.size >= numRecords
+    }
+    TestUtils.pollRecordsUntilTrue(consumer, pollAction, waitTimeMs = 60000,
+      msg = s"Timed out before consuming expected $numRecords records. " +
+        s"The number consumed was ${records.size}.")
+    records
+  }
+
+  /**
+   * Creates topic 'topicName' with 'numPartitions' partitions and produces 'recordsPerPartition'
+   * records to each partition
+   */
+  protected def createTopicAndSendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]],
+                                          topicName: String,
+                                          numPartitions: Int,
+                                          recordsPerPartition: Int): Set[TopicPartition] = {
+    createTopic(topicName, numPartitions, brokerCount)
+    var parts = Set[TopicPartition]()
+    for (partition <- 0 until numPartitions) {
+      val tp = new TopicPartition(topicName, partition)
+      sendRecords(producer, recordsPerPartition, tp)
+      parts = parts + tp
+    }
+    parts
+  }
+
+}


### PR DESCRIPTION
There was a problem with the Acknowledgements code for anything other than very simple batches. Added a comprehensive unit test for all the variations of records and gaps, and then updated the code to pass. Added gap support for sending in piggybacked acknowledgements and reworked an integration test that exercises this code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
