### PR TITLE
AKCORE-73: Initial code for KafkaShareConsumer.acknowledge

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgeType.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgeType.java
@@ -16,8 +16,11 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 import java.util.Locale;
 
+@InterfaceStability.Evolving
 public enum AcknowledgeType {
     ACCEPT((byte) 0), RELEASE((byte) 1), REJECT((byte) 2);
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgementCommitCallback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgementCommitCallback.java
@@ -18,26 +18,29 @@ package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidRecordStateException;
 import org.apache.kafka.common.errors.WakeupException;
 
 import java.util.Map;
-import java.util.Optional;
+import java.util.Set;
 
 /**
  * A callback interface that the user can implement to trigger custom actions when an acknowledge request completes.
  * The callback may be executed in any thread calling {@link ShareConsumer#poll(java.time.Duration)}.
  */
+@InterfaceStability.Evolving
 public interface AcknowledgementCommitCallback {
 
     /**
      * A callback method the user can implement to provide asynchronous handling of commit request completion.
      * This method will be called when the commit request sent to the server has been acknowledged.
      *
-     * @param results A map of the results for each topic-partition for which delivery was acknowledged.
-     *                If the acknowledgement failed for a topic-partition, an exception is present.
+     * @param offsets A map of the offsets that this callback applies to.
+     *
+     * @param exception The exception thrown during processing of the request, or null if the acknowledgement completed successfully.
      *
      * @throws InvalidRecordStateException The record state is invalid. The acknowledgement of delivery
      *             could not be completed.
@@ -48,5 +51,5 @@ public interface AcknowledgementCommitCallback {
      * @throws AuthorizationException if not authorized to the topic of group
      * @throws KafkaException for any other unrecoverable errors
      */
-    void onComplete(Map<TopicIdPartition, Optional<KafkaException>> results);
+    void onComplete(Map<TopicIdPartition, Set<OffsetAndMetadata>> offsets, Exception exception);
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
@@ -201,14 +201,8 @@ public class KafkaShareConsumer<K, V> implements ShareConsumer<K, V> {
      * The acknowledgement is committed on the next {@link #commitSync()}, {@link #commitAsync()} or
      * {@link #poll(Duration)} call.
      *
-     * <p>
-     * Records for each topic-partition must be acknowledged in the order they were returned from
-     * {@link #poll(Duration)}. By using this method, the consumer is using
-     * <b>explicit acknowledgement</b>.
-     *
      * @param record The record to acknowledge
      *
-     * @throws IllegalArgumentException if the record being acknowledged doesn't meet the ordering requirement
      * @throws IllegalStateException if the record is not waiting to be acknowledged, or the consumer has already
      *                               used implicit acknowledgement
      */
@@ -226,7 +220,6 @@ public class KafkaShareConsumer<K, V> implements ShareConsumer<K, V> {
      * @param record The record to acknowledge
      * @param type The acknowledge type which indicates whether it was processed successfully
      *
-     * @throws IllegalArgumentException if the record being acknowledged doesn't meet the ordering requirement
      * @throws IllegalStateException if the record is not waiting to be acknowledged, or the consumer has already
      *                               used implicit acknowledgement
      */
@@ -240,6 +233,7 @@ public class KafkaShareConsumer<K, V> implements ShareConsumer<K, V> {
      * the acknowledgements to commit have been indicated using {@link #acknowledge(ConsumerRecord)} or
      * {@link #acknowledge(ConsumerRecord, AcknowledgeType)}. If the consumer is using implicit acknowledgement,
      * all the records returned by the latest call to {@link #poll(Duration)} are acknowledged.
+     *
      * <p>
      * This is a synchronous commit and will block until either the commit succeeds, an unrecoverable error is
      * encountered (in which case it is thrown to the caller), or the timeout expires.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.InterruptException;
@@ -38,6 +39,7 @@ import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.propsToMap;
 
+@InterfaceStability.Evolving
 public class KafkaShareConsumer<K, V> implements ShareConsumer<K, V> {
 
     private final static ShareConsumerDelegateCreator CREATOR = new ShareConsumerDelegateCreator();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
@@ -222,4 +222,16 @@ public class Acknowledgements {
         batches.add(currentBatch);
         return batches;
     }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer("Acknowledgements(");
+        sb.append(acknowledgements);
+        if (acknowledgeErrorCode != null) {
+            sb.append(", errorCode=");
+            sb.append(acknowledgeErrorCode.code());
+        }
+        sb.append(")");
+        return sb.toString();
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -515,7 +515,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
         acquireAndEnsureOpen();
         try {
             ensureExplicitAcknowledgement();
-            throw new UnsupportedOperationException();
+            currentFetch.acknowledge(record, type);
         } finally {
             release();
         }
@@ -721,8 +721,6 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
         } else if (acknowledgementMode == AcknowledgementMode.PENDING) {
             // The second call to poll(Duration) if PENDING moves into IMPLICIT
             acknowledgementMode = AcknowledgementMode.IMPLICIT;
-        } else if (acknowledgementMode == AcknowledgementMode.EXPLICIT) {
-            throw new IllegalStateException("Explicit acknowledgement of delivery is being used.");
         }
 
         if (currentFetch != null) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -433,7 +433,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
             handleCompletedAcknowledgements();
 
             // If using implicit acknowledgement, acknowledge the previously fetched records
-            maybeImplicitlyAcknowledge();
+            maybeSendAcknowledgements();
 
             kafkaConsumerMetrics.recordPollStart(timer.currentTimeMs());
 
@@ -515,7 +515,11 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
         acquireAndEnsureOpen();
         try {
             ensureExplicitAcknowledgement();
-            currentFetch.acknowledge(record, type);
+            if (currentFetch != null) {
+                currentFetch.acknowledge(record, type);
+            } else {
+                throw new IllegalStateException("The record cannot be acknowledged.");
+            }
         } finally {
             release();
         }
@@ -713,8 +717,10 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
      * Called to progressively moves the acknowledgement mode into IMPLICIT if it is not known to be EXPLICIT.
      * If the acknowledgement mode is IMPLICIT, acknowledges the current batch and puts them into the fetch
      * buffer for the background thread to pick up.
+     * If the acknowledgement mode is EXPLICIT, puts any ready acknowledgements into the fetch buffer for the
+     * background thread to pick up.
      */
-    private void maybeImplicitlyAcknowledge() {
+    private void maybeSendAcknowledgements() {
         if (acknowledgementMode == AcknowledgementMode.UNKNOWN) {
             // The first call to poll(Duration) moves into PENDING
             acknowledgementMode = AcknowledgementMode.PENDING;
@@ -724,8 +730,12 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
         }
 
         if (currentFetch != null) {
+            // If IMPLICIT, acknowledge all records and send
             if (acknowledgementMode == AcknowledgementMode.IMPLICIT) {
                 currentFetch.acknowledgeAll(AcknowledgeType.ACCEPT);
+                fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
+            } else if (acknowledgementMode == AcknowledgementMode.EXPLICIT) {
+                // If EXPLICIT, send any acknowledgements which are ready
                 fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
             }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManager.java
@@ -166,7 +166,7 @@ public class ShareFetchRequestManager implements RequestManager {
             final ShareSessionHandler handler = sessionHandler(fetchTarget.id());
 
             if (handler == null) {
-                log.error("Unable to find ShareSessionHandler for node {}. Ignoring fetch response.",
+                log.error("Unable to find ShareSessionHandler for node {}. Ignoring share fetch response.",
                         fetchTarget.id());
                 return;
             }
@@ -174,7 +174,7 @@ public class ShareFetchRequestManager implements RequestManager {
             final short requestVersion = resp.requestHeader().apiVersion();
 
             if (!handler.handleResponse(response, requestVersion)) {
-                if (response.error() == Errors.FETCH_SESSION_TOPIC_ID_ERROR) {
+                if (response.error() == Errors.UNKNOWN_TOPIC_ID) {
                     metadata.requestUpdate(false);
                 }
 
@@ -211,7 +211,7 @@ public class ShareFetchRequestManager implements RequestManager {
 
             metricsManager.recordLatency(resp.requestLatencyMs());
         } finally {
-            log.debug("Removing pending request for node {}", fetchTarget);
+            log.debug("Removing pending request for node {} - success", fetchTarget);
             nodesWithPendingRequests.remove(fetchTarget.id());
         }
     }
@@ -226,6 +226,7 @@ public class ShareFetchRequestManager implements RequestManager {
                 handler.handleError(error);
             }
         } finally {
+            log.debug("Removing pending request for node {} - failed", fetchTarget);
             nodesWithPendingRequests.remove(fetchTarget.id());
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 public class ShareInFlightBatch<K, V> {
@@ -38,6 +39,18 @@ public class ShareInFlightBatch<K, V> {
 
     public void addAcknowledgement(long offset, AcknowledgeType acknowledgeType) {
         acknowledgements.add(offset, acknowledgeType);
+    }
+
+    public void acknowledge(ConsumerRecord<K, V> record, AcknowledgeType type) {
+        Iterator<ConsumerRecord<K, V>> recordIterator = inFlightRecords.iterator();
+        while (recordIterator.hasNext()) {
+            ConsumerRecord<K, V> currentRecord = recordIterator.next();
+            if (currentRecord.offset() == record.offset()) {
+                acknowledgements.add(record.offset(), type);
+                return;
+            }
+        }
+        throw new IllegalStateException("The record cannot be acknowledged.");
     }
 
     public void acknowledgeAll(AcknowledgeType type) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
@@ -65,7 +65,7 @@ public class ShareSessionHandler {
     private LinkedHashMap<TopicPartition, TopicIdPartition> sessionPartitions;
 
     /**
-     * All of the topic names mapped to topic ids for topics which exist in the fetch request session.
+     * All the topic names mapped to topic ids for topics which exist in the fetch request session.
      */
     private Map<Uuid, String> sessionTopicNames = new HashMap<>(0);
     private final Map<TopicIdPartition, Acknowledgements> nextAcknowledgements = new LinkedHashMap<>();
@@ -172,6 +172,8 @@ public class ShareSessionHandler {
             topicNames.putIfAbsent(topicIdPartition.topicId(), topicIdPartition.topic());
             if (partitionAcknowledgements != null) {
                 nextAcknowledgements.put(topicIdPartition, partitionAcknowledgements);
+            } else {
+                nextAcknowledgements.remove(topicIdPartition);
             }
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManagerTest.java
@@ -362,14 +362,14 @@ public class ShareFetchRequestManagerTest {
     }
 
     @Test
-    public void testFetchSessionIdError() {
+    public void testUnknownTopicIdError() {
         buildFetcher();
         assignFromSubscribed(singleton(tp0));
 
         assertEquals(1, sendFetches());
-        client.prepareResponse(fetchResponseWithTopLevelError(tip0, Errors.FETCH_SESSION_TOPIC_ID_ERROR));
+        client.prepareResponse(fetchResponseWithTopLevelError(tip0, Errors.UNKNOWN_TOPIC_ID));
         networkClientDelegate.poll(time.timer(0));
-        assertEmptyFetch("Should not return records or advance position on fetch error");
+        assertEmptyFetch("Should not return records on fetch error");
         assertEquals(0L, metadata.timeToNextUpdate(time.milliseconds()));
     }
 
@@ -410,8 +410,7 @@ public class ShareFetchRequestManagerTest {
         return Stream.of(
                 Arguments.of(Errors.NOT_LEADER_OR_FOLLOWER, false, true),
                 Arguments.of(Errors.UNKNOWN_TOPIC_OR_PARTITION, false, true),
-                Arguments.of(Errors.UNKNOWN_TOPIC_ID, false, true),
-                Arguments.of(Errors.FETCH_SESSION_TOPIC_ID_ERROR, true, true),
+                Arguments.of(Errors.UNKNOWN_TOPIC_ID, true, true),
                 Arguments.of(Errors.INCONSISTENT_TOPIC_ID, false, true),
                 Arguments.of(Errors.FENCED_LEADER_EPOCH, false, true),
                 Arguments.of(Errors.UNKNOWN_LEADER_EPOCH, false, false)

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -377,7 +377,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         shareConsumer.acknowledge(consumedRecord);
         records = shareConsumer.poll(Duration.ofMillis(5000));
         assertEquals(0, records.count());
-        shareConsumer.acknowledge(consumedRecord);
+        assertThrows(IllegalStateException.class, () -> shareConsumer.acknowledge(consumedRecord));
         shareConsumer.close();
     }
 
@@ -395,7 +395,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         ConsumerRecord<byte[], byte[]> consumedRecord = records.records(tp()).get(0);
         records = shareConsumer.poll(Duration.ofMillis(5000));
         assertEquals(0, records.count());
-        shareConsumer.acknowledge(consumedRecord);
+        assertThrows(IllegalStateException.class, () -> shareConsumer.acknowledge(consumedRecord));
         shareConsumer.close();
     }
 }

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -18,6 +18,7 @@ package kafka.test.api;
 
 import kafka.api.AbstractShareConsumerTest;
 import kafka.api.BaseConsumerTest;
+import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -286,6 +287,115 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
 
         records = shareConsumer.poll(Duration.ofMillis(5000));
         assertEquals(0, records.count());
+        shareConsumer.close();
+    }
+
+    @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
+    @ValueSource(strings = {"kraft+kip932"})
+    public void testExplicitAcknowledgeSuccess(String quorum) throws Exception {
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp().topic(), tp().partition(), null, "key".getBytes(), "value".getBytes());
+        KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
+        producer.send(record);
+        KafkaShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
+                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
+        shareConsumer.subscribe(Collections.singleton(tp().topic()));
+        ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(1, records.count());
+        records.forEach(consumedRecord -> shareConsumer.acknowledge(consumedRecord));
+        producer.send(record);
+        records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(1, records.count());
+        shareConsumer.close();
+    }
+
+    @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
+    @ValueSource(strings = {"kraft+kip932"})
+    public void testExplicitAcknowledgeReleasePollAccept(String quorum) throws Exception {
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp().topic(), tp().partition(), null, "key".getBytes(), "value".getBytes());
+        KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
+        producer.send(record);
+        KafkaShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
+                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
+        shareConsumer.subscribe(Collections.singleton(tp().topic()));
+        ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(1, records.count());
+        records.forEach(consumedRecord -> shareConsumer.acknowledge(consumedRecord, AcknowledgeType.RELEASE));
+        records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(1, records.count());
+        records.forEach(consumedRecord -> shareConsumer.acknowledge(consumedRecord, AcknowledgeType.ACCEPT));
+        records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(0, records.count());
+        shareConsumer.close();
+    }
+
+    @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
+    @ValueSource(strings = {"kraft+kip932"})
+    public void testExplicitAcknowledgeReleaseAccept(String quorum) throws Exception {
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp().topic(), tp().partition(), null, "key".getBytes(), "value".getBytes());
+        KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
+        producer.send(record);
+        KafkaShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
+                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
+        shareConsumer.subscribe(Collections.singleton(tp().topic()));
+        ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(1, records.count());
+        records.forEach(consumedRecord -> shareConsumer.acknowledge(consumedRecord, AcknowledgeType.RELEASE));
+        records.forEach(consumedRecord -> shareConsumer.acknowledge(consumedRecord, AcknowledgeType.ACCEPT));
+        records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(0, records.count());
+        shareConsumer.close();
+    }
+
+    @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
+    @ValueSource(strings = {"kraft+kip932"})
+    public void testExplicitAcknowledgeReleaseClose(String quorum) throws Exception {
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp().topic(), tp().partition(), null, "key".getBytes(), "value".getBytes());
+        KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
+        producer.send(record);
+        KafkaShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
+                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
+        shareConsumer.subscribe(Collections.singleton(tp().topic()));
+        ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(1, records.count());
+        records.forEach(consumedRecord -> shareConsumer.acknowledge(consumedRecord, AcknowledgeType.RELEASE));
+        shareConsumer.close();
+    }
+
+
+    @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
+    @ValueSource(strings = {"kraft+kip932"})
+    public void testExplicitAcknowledgeThrowsNotInBatch(String quorum) throws Exception {
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp().topic(), tp().partition(), null, "key".getBytes(), "value".getBytes());
+        KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
+        producer.send(record);
+        KafkaShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
+                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
+        shareConsumer.subscribe(Collections.singleton(tp().topic()));
+        ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(1, records.count());
+        ConsumerRecord<byte[], byte[]> consumedRecord = records.records(tp()).get(0);
+        shareConsumer.acknowledge(consumedRecord);
+        records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(0, records.count());
+        shareConsumer.acknowledge(consumedRecord);
+        shareConsumer.close();
+    }
+
+    @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
+    @ValueSource(strings = {"kraft+kip932"})
+    public void testImplicitAcknowledgeFailsExplicit(String quorum) throws Exception {
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp().topic(), tp().partition(), null, "key".getBytes(), "value".getBytes());
+        KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
+        producer.send(record);
+        KafkaShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
+                new Properties(), CollectionConverters.asScala(Collections.<String>emptyList()).toList());
+        shareConsumer.subscribe(Collections.singleton(tp().topic()));
+        ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(1, records.count());
+        ConsumerRecord<byte[], byte[]> consumedRecord = records.records(tp()).get(0);
+        records = shareConsumer.poll(Duration.ofMillis(5000));
+        assertEquals(0, records.count());
+        shareConsumer.acknowledge(consumedRecord);
         shareConsumer.close();
     }
 }

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -442,6 +442,13 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <!-- Suppress inconsistent synchronization warnings about currentFetch.
+             Locking is consistent but does not use synchronized methods.-->
+        <Class name="org.apache.kafka.clients.consumer.internals.ShareConsumerImpl"/>
+        <Bug pattern="IS2_INCONSISTENT_SYNC"/>
+    </Match>
+
+    <Match>
         <!-- Suppress a warning about ignoring the return value of await.
              This is done intentionally because we use other clues to determine
              if the wait was cut short.  -->


### PR DESCRIPTION
Initial code for KafkaShareConsumer.acknowledge. This method is most useful for writing integration tests that exercise the various scenarios for using share groups.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
