### PR TITLE
AKCORE-59: Debug console message for acknowledgement failure

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -18,6 +18,7 @@ package kafka.server;
 
 import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.errors.InvalidRecordStateException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.message.ShareFetchResponseData.AcquiredRecords;
 import org.apache.kafka.common.record.RecordBatch;
@@ -542,7 +543,7 @@ public class SharePartition {
                     if (inFlightBatch.batchState() != RecordState.ACQUIRED) {
                         log.debug("The batch is not in the acquired state: {} for share partition: {}-{}",
                             inFlightBatch, groupId, topicIdPartition);
-                        throwable = new InvalidRequestException("The batch cannot be acknowledged. The batch is not in the acquired state.");
+                        throwable = new InvalidRecordStateException("The batch cannot be acknowledged. The batch is not in the acquired state.");
                         break;
                     }
 
@@ -578,6 +579,7 @@ public class SharePartition {
             }
 
             if (throwable != null) {
+                // the log should be DEBUG to avoid flooding of logs for a faulty client
                 log.debug("Acknowledgement batch request failed for share partition, rollback any changed state"
                     + " for the share partition: {}-{}", groupId, topicIdPartition);
                 updatedStates.forEach(state -> state.completeStateTransition(false));

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -578,7 +578,7 @@ public class SharePartition {
             }
 
             if (throwable != null) {
-                log.info("Acknowledgement batch request failed for share partition, rollback any changed state"
+                log.debug("Acknowledgement batch request failed for share partition, rollback any changed state"
                     + " for the share partition: {}-{}", groupId, topicIdPartition);
                 updatedStates.forEach(state -> state.completeStateTransition(false));
             } else {

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -485,7 +485,7 @@ public class SharePartition {
                             if (inFlightBatch.batchState() != RecordState.ACQUIRED) {
                                 log.debug("The batch is not in the acquired state: {} for share partition: {}-{}",
                                     inFlightBatch, groupId, topicIdPartition);
-                                throwable = new InvalidRequestException("The batch cannot be acknowledged. The subset batch is not in the acquired state.");
+                                throwable = new InvalidRecordStateException("The batch cannot be acknowledged. The subset batch is not in the acquired state.");
                                 break;
                             }
                             // The request batch is a subset or per offset state is managed hence update
@@ -516,7 +516,7 @@ public class SharePartition {
                             if (offsetState.getValue().state != RecordState.ACQUIRED) {
                                 log.debug("The offset is not acquired, offset: {} batch: {} for the share"
                                     + " partition: {}-{}", offsetState.getKey(), inFlightBatch, groupId, topicIdPartition);
-                                throwable = new InvalidRequestException("The batch cannot be acknowledged. The offset is not acquired.");
+                                throwable = new InvalidRecordStateException("The batch cannot be acknowledged. The offset is not acquired.");
                                 break;
                             }
 
@@ -525,7 +525,7 @@ public class SharePartition {
                                 log.debug("Unable to acknowledge records for the offset: {} in batch: {}"
                                         + " for the share partition: {}-{}", offsetState.getKey(),
                                     inFlightBatch, groupId, topicIdPartition);
-                                throwable = new InvalidRequestException("Unable to acknowledge records for the batch");
+                                throwable = new InvalidRecordStateException("Unable to acknowledge records for the batch");
                                 break;
                             }
                             // Successfully updated the state of the offset.
@@ -551,7 +551,7 @@ public class SharePartition {
                     if (updateResult == null) {
                         log.debug("Unable to acknowledge records for the batch: {} with state: {}"
                             + " for the share partition: {}-{}", inFlightBatch, recordState, groupId, topicIdPartition);
-                        throwable = new InvalidRequestException("Unable to acknowledge records for the batch");
+                        throwable = new InvalidRecordStateException("Unable to acknowledge records for the batch");
                         break;
                     }
 

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -482,13 +482,13 @@ public class SharePartitionTest {
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
-        // Re-acknowledge the subset batch with ACCEPT type.
+        // Re-acknowledge the subset batch with REJECT type.
         ackResult = sharePartition.acknowledge(
             MEMBER_ID,
             Collections.singletonList(new AcknowledgementBatch(6, 8, null, AcknowledgeType.REJECT)));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
-        assertEquals(InvalidRequestException.class, ackResult.join().get().getClass());
+        assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
     }
 
     @Test
@@ -578,7 +578,7 @@ public class SharePartitionTest {
                 new AcknowledgementBatch(16, 19, null, AcknowledgeType.ACCEPT)));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
-        assertEquals(InvalidRequestException.class, ackResult.join().get().getClass());
+        assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
 
         // Check the state of the cache. The state should be acquired itself.
         assertEquals(3, sharePartition.cachedState().size());

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -22,6 +22,7 @@ import kafka.server.SharePartition.RecordState;
 import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.InvalidRecordStateException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.message.ShareFetchResponseData.AcquiredRecords;
 import org.apache.kafka.common.protocol.Errors;
@@ -465,7 +466,7 @@ public class SharePartitionTest {
             Collections.singletonList(new AcknowledgementBatch(5, 9, null, AcknowledgeType.ACCEPT)));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
-        assertEquals(InvalidRequestException.class, ackResult.join().get().getClass());
+        assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
 
         // Re-acquire the same batch and then acknowledge subset with ACCEPT type.
         result = sharePartition.acquire(
@@ -529,7 +530,7 @@ public class SharePartitionTest {
                 new AcknowledgementBatch(15, 19, null, AcknowledgeType.ACCEPT)));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
-        assertEquals(InvalidRequestException.class, ackResult.join().get().getClass());
+        assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
 
         // Check the state of the cache. The state should be acquired itself.
         assertEquals(3, sharePartition.cachedState().size());


### PR DESCRIPTION
### About
Made minor changes to the broker code to tackle log message "rollback in share partition for acknowledgement". Changed the exception because `InvalidRequestException` could encompass a variety of other cases like invalid offsets in request, malformed requests etc.