### PR TITLE
KAFKA-16210: Update jose4j to 0.9.4 (#15284)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -234,7 +234,7 @@ jetty-util-9.4.53.v20231009
 jetty-util-ajax-9.4.53.v20231009
 jersey-common-2.39.1
 jersey-server-2.39.1
-jose4j-0.9.3
+jose4j-0.9.4
 lz4-java-1.8.0
 maven-artifact-3.8.4
 metrics-core-4.1.12.1

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -81,7 +81,7 @@ versions += [
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
-  jose4j: "0.9.3",
+  jose4j: "0.9.4",
   junit: "5.9.3",
   jqwik: "1.7.2",
   kafka_0100: "0.10.0.1",


### PR DESCRIPTION
Cherrypick https://github.com/confluentinc/kafka/pull/1103