### PR TITLE
AKCORE-71: Support for partition max bytes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManager.java
@@ -151,9 +151,9 @@ public class ShareFetchRequestManager implements RequestManager {
 
     private ShareFetchRequest.Builder createShareFetchRequest(Node fetchTarget, ShareSessionHandler.ShareFetchRequestData requestData) {
         final ShareFetchRequest.Builder request = ShareFetchRequest.Builder
-                .forConsumer(fetchConfig.maxWaitMs, fetchConfig.minBytes, requestData.toSend(), acknowledgementBatches(requestData.acknowledgements()))
-                .forShareSession(groupId, requestData.metadata())
-                .setMaxBytes(fetchConfig.maxBytes);
+                .forConsumer(fetchConfig.maxWaitMs, fetchConfig.minBytes, fetchConfig.maxBytes, fetchConfig.fetchSize,
+                        requestData.toSend(), acknowledgementBatches(requestData.acknowledgements()))
+                .forShareSession(groupId, requestData.metadata());
 
         nodesWithPendingRequests.add(fetchTarget.id());
 


### PR DESCRIPTION
Added support for MAX_PARTITION_FETCH_BYTES configuration. Reworked the code to build up the ShareFetch request to remove the restriction about the arrangement of the incoming data. Also ready for piggybacking acknowledgements when no data is required for when that is supported later on.

Added an integration test for this configuration property.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
