### PR TITLE
AKCORE-80: Remove CurrentLeaderEpoch from ShareFetch

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.record.RecordBatch;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -34,7 +33,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 public class ShareFetchRequest extends AbstractRequest {
 
@@ -67,8 +65,7 @@ public class ShareFetchRequest extends AbstractRequest {
                 Map<Integer, ShareFetchRequestData.FetchPartition> partMap = fetchMap.computeIfAbsent(tip.topicId(), k -> new HashMap<>());
                 ShareFetchRequestData.FetchPartition fetchPartition = new ShareFetchRequestData.FetchPartition()
                         .setPartitionIndex(tip.partition())
-                        .setPartitionMaxBytes(fetchSize)
-                        .setCurrentLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH);
+                        .setPartitionMaxBytes(fetchSize);
                 partMap.put(tip.partition(), fetchPartition);
             }
 
@@ -82,8 +79,7 @@ public class ShareFetchRequest extends AbstractRequest {
                     // This topic-partition is only used for acknowledging, so fetch zero bytes
                     fetchPartition = new ShareFetchRequestData.FetchPartition()
                             .setPartitionIndex(tip.partition())
-                            .setPartitionMaxBytes(0)
-                            .setCurrentLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH);
+                            .setPartitionMaxBytes(0);
                     partMap.put(tip.partition(), fetchPartition);
                 }
                 fetchPartition.setAcknowledgementBatches(acknowledgeEntry.getValue());
@@ -169,16 +165,13 @@ public class ShareFetchRequest extends AbstractRequest {
     public static final class SharePartitionData {
         public final Uuid topicId;
         public final int maxBytes;
-        public final Optional<Integer> currentLeaderEpoch;
 
         public SharePartitionData(
                 Uuid topicId,
-                int maxBytes,
-                Optional<Integer> currentLeaderEpoch
+                int maxBytes
         ) {
             this.topicId = topicId;
             this.maxBytes = maxBytes;
-            this.currentLeaderEpoch = currentLeaderEpoch;
         }
 
         @Override
@@ -187,13 +180,12 @@ public class ShareFetchRequest extends AbstractRequest {
             if (o == null || getClass() != o.getClass()) return false;
             ShareFetchRequest.SharePartitionData that = (ShareFetchRequest.SharePartitionData) o;
             return Objects.equals(topicId, that.topicId) &&
-                    maxBytes == that.maxBytes &&
-                    Objects.equals(currentLeaderEpoch, that.currentLeaderEpoch);
+                    maxBytes == that.maxBytes;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(topicId, maxBytes, currentLeaderEpoch);
+            return Objects.hash(topicId, maxBytes);
         }
 
         @Override
@@ -201,7 +193,6 @@ public class ShareFetchRequest extends AbstractRequest {
             return "SharePartitionData(" +
                     "topicId=" + topicId +
                     ", maxBytes=" + maxBytes +
-                    ", currentLeaderEpoch=" + currentLeaderEpoch +
                     ')';
         }
     }
@@ -218,14 +209,6 @@ public class ShareFetchRequest extends AbstractRequest {
         return data.maxWaitMs();
     }
 
-    private static Optional<Integer> optionalEpoch(int rawEpochValue) {
-        if (rawEpochValue < 0) {
-            return Optional.empty();
-        } else {
-            return Optional.of(rawEpochValue);
-        }
-    }
-
     public Map<TopicIdPartition, ShareFetchRequest.SharePartitionData> shareFetchData(Map<Uuid, String> topicNames) {
         if (shareFetchData == null) {
             synchronized (this) {
@@ -240,8 +223,7 @@ public class ShareFetchRequest extends AbstractRequest {
                                 shareFetchDataTmp.put(new TopicIdPartition(shareFetchTopic.topicId(), new TopicPartition(name, shareFetchPartition.partitionIndex())),
                                     new ShareFetchRequest.SharePartitionData(
                                         shareFetchTopic.topicId(),
-                                        shareFetchPartition.partitionMaxBytes(),
-                                        optionalEpoch(shareFetchPartition.currentLeaderEpoch())
+                                        shareFetchPartition.partitionMaxBytes()
                                     )
                                 );
                             }

--- a/clients/src/main/resources/common/message/ShareFetchRequest.json
+++ b/clients/src/main/resources/common/message/ShareFetchRequest.json
@@ -44,8 +44,6 @@
         "about": "The partitions to fetch.", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
-        { "name": "CurrentLeaderEpoch", "type": "int32", "versions": "0+", "default": "-1", "ignorable": true,
-          "about": "The current leader epoch of the partition." },
         { "name": "PartitionMaxBytes", "type": "int32", "versions": "0+",
           "about": "The maximum bytes to fetch from this partition. See KIP-74 for cases where this limit may not be honored." },
         { "name": "AcknowledgementBatches", "type": "[]AcknowledgementBatch", "versions": "0+",

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1409,8 +1409,7 @@ public class RequestResponseTest {
                 .setTopics(singletonList(new ShareFetchRequestData.FetchTopic()
                         .setTopicId(Uuid.randomUuid())
                         .setPartitions(singletonList(new ShareFetchRequestData.FetchPartition()
-                                .setPartitionIndex(0)
-                                .setCurrentLeaderEpoch(1)))));
+                                .setPartitionIndex(0)))));
         return new ShareFetchRequest.Builder(data).build(version);
     }
 

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -1082,7 +1082,7 @@ public class SharePartitionManager {
 
         /**
          * Try to evict an entry from the session cache.
-         *
+         * <p>
          * A proposed new element A may evict an existing element B if:
          * B is considered "stale" because it has been inactive for a long time.
          *
@@ -1141,8 +1141,9 @@ public class SharePartitionManager {
     public static class CachedSharePartition implements ImplicitLinkedHashCollection.Element {
         private final String topic;
         private final Uuid topicId;
-        private int partition, maxBytes;
-        private Optional<Integer> leaderEpoch;
+        private final int partition;
+        private int maxBytes;
+        private final Optional<Integer> leaderEpoch;
         private boolean requiresUpdateInResponse;
 
         private int cachedNext = ImplicitLinkedHashCollection.INVALID_INDEX;
@@ -1169,7 +1170,7 @@ public class SharePartitionManager {
         public CachedSharePartition(TopicIdPartition topicIdPartition, ShareFetchRequest.SharePartitionData reqData,
                                     boolean requiresUpdateInResponse) {
             this(topicIdPartition.topic(), topicIdPartition.topicId(), topicIdPartition.partition(), reqData.maxBytes,
-                    reqData.currentLeaderEpoch, requiresUpdateInResponse);
+                    Optional.empty(), requiresUpdateInResponse);
         }
 
         public Uuid topicId() {
@@ -1185,13 +1186,12 @@ public class SharePartitionManager {
         }
 
         public ShareFetchRequest.SharePartitionData reqData() {
-            return new ShareFetchRequest.SharePartitionData(topicId, maxBytes, leaderEpoch);
+            return new ShareFetchRequest.SharePartitionData(topicId, maxBytes);
         }
 
         public void updateRequestParams(ShareFetchRequest.SharePartitionData reqData) {
             // Update our cached request parameters.
             maxBytes = reqData.maxBytes;
-            leaderEpoch = reqData.currentLeaderEpoch;
         }
 
         /**

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4333,7 +4333,7 @@ class KafkaApisTest extends Logging {
     val shareSessionEpoch = ShareFetchMetadata.INITIAL_EPOCH
     val requestMetadata = new ShareFetchMetadata(memberId, shareSessionEpoch)
     val shareFetchData = Map(topicIdPartition ->
-      new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava
+      new ShareFetchRequest.SharePartitionData(topicId, 1000)).asJava
 
     when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
       any(),
@@ -4374,8 +4374,7 @@ class KafkaApisTest extends Logging {
         setPartitions(List(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
-            .setPartitionMaxBytes(40000)
-            .setCurrentLeaderEpoch(1)).asJava)).asJava)
+            .setPartitionMaxBytes(40000)).asJava)).asJava)
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4410,7 +4409,7 @@ class KafkaApisTest extends Logging {
     val shareSessionEpoch = ShareFetchMetadata.INITIAL_EPOCH
     val requestMetadata = new ShareFetchMetadata(memberId, shareSessionEpoch)
     val shareFetchData = Map(topicIdPartition ->
-      new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava
+      new ShareFetchRequest.SharePartitionData(topicId, 1000)).asJava
 
     when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
       any(),
@@ -4433,8 +4432,7 @@ class KafkaApisTest extends Logging {
         setPartitions(List(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
-            .setPartitionMaxBytes(40000)
-            .setCurrentLeaderEpoch(1)).asJava)).asJava)
+            .setPartitionMaxBytes(40000)).asJava)).asJava)
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4469,7 +4467,7 @@ class KafkaApisTest extends Logging {
     val shareSessionEpoch = ShareFetchMetadata.INITIAL_EPOCH
     val requestMetadata = new ShareFetchMetadata(memberId, shareSessionEpoch)
     val shareFetchData = Map(topicIdPartition ->
-      new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava
+      new ShareFetchRequest.SharePartitionData(topicId, 1000)).asJava
 
     when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
       any(),
@@ -4507,8 +4505,7 @@ class KafkaApisTest extends Logging {
         setPartitions(List(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
-            .setPartitionMaxBytes(40000)
-            .setCurrentLeaderEpoch(1)).asJava)).asJava)
+            .setPartitionMaxBytes(40000)).asJava)).asJava)
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4543,7 +4540,7 @@ class KafkaApisTest extends Logging {
     val shareSessionEpoch = ShareFetchMetadata.INITIAL_EPOCH
     val requestMetadata = new ShareFetchMetadata(memberId, shareSessionEpoch)
     val shareFetchData = Map(topicIdPartition ->
-      new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava
+      new ShareFetchRequest.SharePartitionData(topicId, 1000)).asJava
 
     when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
       any(),
@@ -4578,8 +4575,7 @@ class KafkaApisTest extends Logging {
         setPartitions(List(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
-            .setPartitionMaxBytes(40000)
-            .setCurrentLeaderEpoch(1)).asJava)).asJava)
+            .setPartitionMaxBytes(40000)).asJava)).asJava)
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4608,7 +4604,7 @@ class KafkaApisTest extends Logging {
     val shareSessionEpoch = ShareFetchMetadata.INITIAL_EPOCH
     val requestMetadata = new ShareFetchMetadata(memberId, shareSessionEpoch)
     val shareFetchData = Map(topicIdPartition ->
-      new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava
+      new ShareFetchRequest.SharePartitionData(topicId, 1000)).asJava
 
     when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
       any(),
@@ -4631,8 +4627,7 @@ class KafkaApisTest extends Logging {
         setPartitions(List(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
-            .setPartitionMaxBytes(40000)
-            .setCurrentLeaderEpoch(1)).asJava)).asJava)
+            .setPartitionMaxBytes(40000)).asJava)).asJava)
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4676,7 +4671,7 @@ class KafkaApisTest extends Logging {
     val shareSessionEpoch = ShareFetchMetadata.INITIAL_EPOCH
     val requestMetadata = new ShareFetchMetadata(memberId, shareSessionEpoch)
     val shareFetchData = Map(topicIdPartition ->
-      new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava
+      new ShareFetchRequest.SharePartitionData(topicId, 1000)).asJava
 
     when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
       any(),
@@ -4714,8 +4709,7 @@ class KafkaApisTest extends Logging {
         setPartitions(List(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
-            .setPartitionMaxBytes(40000)
-            .setCurrentLeaderEpoch(1)).asJava)).asJava)
+            .setPartitionMaxBytes(40000)).asJava)).asJava)
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4764,8 +4758,7 @@ class KafkaApisTest extends Logging {
         setPartitions(List(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
-            .setPartitionMaxBytes(40000)
-            .setCurrentLeaderEpoch(1)).asJava)).asJava)
+            .setPartitionMaxBytes(40000)).asJava)).asJava)
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4807,11 +4800,11 @@ class KafkaApisTest extends Logging {
     val requestMetadata = new ShareFetchMetadata(memberId, shareSessionEpoch)
     val shareFetchData = Map(
       topicIdPartition_1 ->
-        new ShareFetchRequest.SharePartitionData(topicId_1, 1000, Optional.empty()),
+        new ShareFetchRequest.SharePartitionData(topicId_1, 1000),
       topicIdPartition_2 ->
-        new ShareFetchRequest.SharePartitionData(topicId_2, 1000, Optional.empty()),
+        new ShareFetchRequest.SharePartitionData(topicId_2, 1000),
       topicIdPartition_3 ->
-        new ShareFetchRequest.SharePartitionData(topicId_2, 1000, Optional.empty())
+        new ShareFetchRequest.SharePartitionData(topicId_2, 1000)
     ).asJava
 
     when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
@@ -4894,7 +4887,6 @@ class KafkaApisTest extends Logging {
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
             .setPartitionMaxBytes(40000)
-            .setCurrentLeaderEpoch(1)
             .setAcknowledgementBatches(List(
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setBaseOffset(11)
@@ -4907,7 +4899,6 @@ class KafkaApisTest extends Logging {
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setPartitionMaxBytes(40000)
-              .setCurrentLeaderEpoch(1)
               .setAcknowledgementBatches(List(
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(21)
@@ -4916,7 +4907,6 @@ class KafkaApisTest extends Logging {
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
               .setPartitionMaxBytes(40000)
-              .setCurrentLeaderEpoch(1)
               .setAcknowledgementBatches(List(
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(54)
@@ -4990,9 +4980,9 @@ class KafkaApisTest extends Logging {
     val requestMetadata = new ShareFetchMetadata(memberId, shareSessionEpoch)
     val shareFetchData = Map(
       topicIdPartition_1 ->
-        new ShareFetchRequest.SharePartitionData(topicId_1, 1000, Optional.empty()),
+        new ShareFetchRequest.SharePartitionData(topicId_1, 1000),
       topicIdPartition_2 ->
-        new ShareFetchRequest.SharePartitionData(topicId_2, 1000, Optional.empty()),
+        new ShareFetchRequest.SharePartitionData(topicId_2, 1000),
     ).asJava
 
     when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
@@ -5077,7 +5067,6 @@ class KafkaApisTest extends Logging {
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setPartitionMaxBytes(40000)
-              .setCurrentLeaderEpoch(1)
               .setAcknowledgementBatches(List(
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(11)
@@ -5090,7 +5079,6 @@ class KafkaApisTest extends Logging {
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setPartitionMaxBytes(40000)
-              .setCurrentLeaderEpoch(1)
               .setAcknowledgementBatches(List(
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(21)
@@ -5103,7 +5091,6 @@ class KafkaApisTest extends Logging {
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
               .setPartitionMaxBytes(40000)
-              .setCurrentLeaderEpoch(1)
               .setAcknowledgementBatches(List(
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(34)
@@ -5116,7 +5103,6 @@ class KafkaApisTest extends Logging {
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setPartitionMaxBytes(40000)
-              .setCurrentLeaderEpoch(1)
               .setAcknowledgementBatches(List(
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(23)
@@ -5179,7 +5165,7 @@ class KafkaApisTest extends Logging {
     val shareSessionEpoch = ShareFetchMetadata.INITIAL_EPOCH
     val requestMetadata = new ShareFetchMetadata(memberId, shareSessionEpoch)
     val shareFetchData = Map(topicIdPartition ->
-        new ShareFetchRequest.SharePartitionData(topicId, 1000, Optional.empty())).asJava
+        new ShareFetchRequest.SharePartitionData(topicId, 1000)).asJava
 
     when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
       any(),
@@ -5222,7 +5208,6 @@ class KafkaApisTest extends Logging {
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
             .setPartitionMaxBytes(40000)
-            .setCurrentLeaderEpoch(1)
             .setAcknowledgementBatches(List(
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setBaseOffset(11)
@@ -5282,7 +5267,6 @@ class KafkaApisTest extends Logging {
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
             .setPartitionMaxBytes(0)
-            .setCurrentLeaderEpoch(1)
             .setAcknowledgementBatches(List(
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setBaseOffset(11)
@@ -5339,11 +5323,11 @@ class KafkaApisTest extends Logging {
     val requestMetadata = new ShareFetchMetadata(memberId, shareSessionEpoch)
     val shareFetchData = Map(
       topicIdPartition_1 ->
-        new ShareFetchRequest.SharePartitionData(topicId_1, 1000, Optional.empty()),
+        new ShareFetchRequest.SharePartitionData(topicId_1, 1000),
       topicIdPartition_2 ->
-        new ShareFetchRequest.SharePartitionData(topicId_2, 1000, Optional.empty()),
+        new ShareFetchRequest.SharePartitionData(topicId_2, 1000),
       topicIdPartition_3 ->
-        new ShareFetchRequest.SharePartitionData(topicId_3, 1000, Optional.empty()),
+        new ShareFetchRequest.SharePartitionData(topicId_3, 1000),
     ).asJava
 
     when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
@@ -5421,7 +5405,6 @@ class KafkaApisTest extends Logging {
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setPartitionMaxBytes(40000)
-              .setCurrentLeaderEpoch(1)
               .setAcknowledgementBatches(List(
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(11)
@@ -5434,7 +5417,6 @@ class KafkaApisTest extends Logging {
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setPartitionMaxBytes(40000)
-              .setCurrentLeaderEpoch(1)
               .setAcknowledgementBatches(List(
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(21)
@@ -5443,7 +5425,6 @@ class KafkaApisTest extends Logging {
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
               .setPartitionMaxBytes(40000)
-              .setCurrentLeaderEpoch(1)
               .setAcknowledgementBatches(List(
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(24)
@@ -5459,7 +5440,6 @@ class KafkaApisTest extends Logging {
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setPartitionMaxBytes(40000)
-              .setCurrentLeaderEpoch(1)
               .setAcknowledgementBatches(List(
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(23)


### PR DESCRIPTION
Updating ShareFetch request to match KIP by removing CurrentLeaderEpoch.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
