### PR TITLE
AKCORE-37: Support for share sessions in client

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
@@ -51,7 +51,7 @@ public class ShareFetchRequest extends AbstractRequest {
 
         public static Builder forConsumer(String groupId, ShareFetchMetadata metadata,
                                           int maxWait, int minBytes, int maxBytes, int fetchSize,
-                                          Map<TopicPartition, TopicIdPartition> send,
+                                          List<TopicIdPartition> send,
                                           Map<TopicIdPartition, List<ShareFetchRequestData.AcknowledgementBatch>> acknowledgementsMap) {
             ShareFetchRequestData data = new ShareFetchRequestData();
             data.setGroupId(groupId);
@@ -74,7 +74,7 @@ public class ShareFetchRequest extends AbstractRequest {
 
             // First, start by adding the list of topic-partitions we are fetching
             if (!isClosingShareSession) {
-                for (TopicIdPartition tip : send.values()) {
+                for (TopicIdPartition tip : send) {
                     Map<Integer, ShareFetchRequestData.FetchPartition> partMap = fetchMap.computeIfAbsent(tip.topicId(), k -> new HashMap<>());
                     ShareFetchRequestData.FetchPartition fetchPartition = new ShareFetchRequestData.FetchPartition()
                             .setPartitionIndex(tip.partition())

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchResponse.java
@@ -93,10 +93,8 @@ public class ShareFetchResponse extends AbstractResponse {
                     data.responses().forEach(topicResponse -> {
                         String name = topicNames.get(topicResponse.topicId());
                         if (name != null) {
-                            topicResponse.partitions().forEach(partitionData -> {
-                                responseDataTmp.put(new TopicIdPartition(topicResponse.topicId(),
-                                        new TopicPartition(name, partitionData.partitionIndex())), partitionData);
-                            });
+                            topicResponse.partitions().forEach(partitionData -> responseDataTmp.put(new TopicIdPartition(topicResponse.topicId(),
+                                    new TopicPartition(name, partitionData.partitionIndex())), partitionData));
                         }
                     });
                     responseData = responseDataTmp;
@@ -120,12 +118,6 @@ public class ShareFetchResponse extends AbstractResponse {
         return new ShareFetchResponse(
                 new ShareFetchResponseData(new ByteBufferAccessor(buffer), version)
         );
-    }
-
-    private static boolean matchingTopic(ShareFetchResponseData.ShareFetchableTopicResponse previousTopic, TopicIdPartition currentTopic) {
-        if (previousTopic == null)
-            return false;
-        return previousTopic.topicId().equals(currentTopic.topicId());
     }
 
     /**
@@ -174,10 +166,11 @@ public class ShareFetchResponse extends AbstractResponse {
                                    List<Node> nodeEndpoints) {
         return new ShareFetchResponse(toMessage(error, throttleTimeMs, responseData.entrySet().iterator(), nodeEndpoints));
     }
+
     public static ShareFetchResponseData toMessage(Errors error, int throttleTimeMs,
                                                     Iterator<Map.Entry<TopicIdPartition, ShareFetchResponseData.PartitionData>> partIterator,
                                                     List<Node> nodeEndpoints) {
-        Map<Uuid, ShareFetchResponseData.ShareFetchableTopicResponse> topicResponseList = new HashMap<>();
+        Map<Uuid, ShareFetchResponseData.ShareFetchableTopicResponse> topicResponseList = new LinkedHashMap<>();
         while (partIterator.hasNext()) {
             Map.Entry<TopicIdPartition, ShareFetchResponseData.PartitionData> entry = partIterator.next();
             ShareFetchResponseData.PartitionData partitionData = entry.getValue();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandlerTest.java
@@ -37,7 +37,6 @@ import java.util.Map;
 
 import static org.apache.kafka.common.requests.ShareFetchMetadata.INITIAL_EPOCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -137,10 +136,10 @@ public class ShareSessionHandlerTest {
         builder.add(foo0, null);
         builder.add(foo1, null);
         ShareSessionHandler.ShareFetchRequestData data = builder.build();
-        assertMapsEqual(reqMap(
-                        new TopicIdPartition(fooId, 0, "foo"),
-                        new TopicIdPartition(fooId, 1, "foo")),
-                data.toSend(), data.sessionPartitions());
+        ArrayList<TopicIdPartition> expectedToSend1 = new ArrayList<>();
+        expectedToSend1.add(new TopicIdPartition(fooId, 0, "foo"));
+        expectedToSend1.add(new TopicIdPartition(fooId, 1, "foo"));
+        assertListEquals(expectedToSend1, data.toSend());
         assertEquals(memberId, data.metadata().memberId());
 
         ShareFetchResponse resp = new ShareFetchResponse(
@@ -164,13 +163,9 @@ public class ShareSessionHandlerTest {
                         new TopicIdPartition(fooId, 1, "foo"),
                         new TopicIdPartition(barId, 0, "bar")),
                 data2.sessionPartitions());
-        // Temporarily the broker is sessionless, so we need to repeat all topic-partitions on every request
-        assertMapsEqual(reqMap(new TopicIdPartition(fooId, 0, "foo"),
-                        new TopicIdPartition(fooId, 1, "foo"),
-                        new TopicIdPartition(barId, 0, "bar")),
-                data2.toSend());
-//        assertMapsEqual(reqMap(new TopicIdPartition(barId, 0, "bar")),
-//                data2.toSend());
+        ArrayList<TopicIdPartition> expectedToSend2 = new ArrayList<>();
+        expectedToSend2.add(new TopicIdPartition(barId, 0, "bar"));
+        assertListEquals(expectedToSend2, data2.toSend());
 
         ShareFetchResponse resp2 = new ShareFetchResponse(
                 new ShareFetchResponseData()
@@ -196,7 +191,13 @@ public class ShareSessionHandlerTest {
         assertMapsEqual(reqMap(new TopicIdPartition(fooId, 0, "foo"),
                         new TopicIdPartition(fooId, 1, "foo"),
                         new TopicIdPartition(barId, 0, "bar")),
-                data4.sessionPartitions(), data4.toSend());
+                data4.sessionPartitions());
+        ArrayList<TopicIdPartition> expectedToSend4 = new ArrayList<>();
+        expectedToSend4.add(new TopicIdPartition(fooId, 0, "foo"));
+        expectedToSend4.add(new TopicIdPartition(fooId, 1, "foo"));
+        expectedToSend4.add(new TopicIdPartition(barId, 0, "bar"));
+        assertListEquals(expectedToSend4, data4.toSend());
+
     }
 
     @Test
@@ -240,7 +241,12 @@ public class ShareSessionHandlerTest {
                         new TopicIdPartition(fooId, 0, "foo"),
                         new TopicIdPartition(fooId, 1, "foo"),
                         new TopicIdPartition(barId, 0, "bar")),
-                data.toSend(), data.sessionPartitions());
+                data.sessionPartitions());
+        ArrayList<TopicIdPartition> expectedToSend1 = new ArrayList<>();
+        expectedToSend1.add(new TopicIdPartition(fooId, 0, "foo"));
+        expectedToSend1.add(new TopicIdPartition(fooId, 1, "foo"));
+        expectedToSend1.add(new TopicIdPartition(barId, 0, "bar"));
+        assertListEquals(expectedToSend1, data.toSend());
         assertEquals(memberId, data.metadata().memberId());
 
         ShareFetchResponse resp = new ShareFetchResponse(
@@ -261,7 +267,7 @@ public class ShareSessionHandlerTest {
         assertEquals(1, data2.metadata().epoch());
         assertMapsEqual(reqMap(new TopicIdPartition(fooId, 1, "foo")),
                 data2.sessionPartitions());
-        assertFalse(data2.toSend().isEmpty());
+        assertTrue(data2.toSend().isEmpty());
         ArrayList<TopicIdPartition> expectedToForget2 = new ArrayList<>();
         expectedToForget2.add(new TopicIdPartition(fooId, 0, "foo"));
         expectedToForget2.add(new TopicIdPartition(barId, 0, "bar"));
@@ -279,7 +285,10 @@ public class ShareSessionHandlerTest {
         assertEquals(memberId, data3.metadata().memberId());
         assertEquals(INITIAL_EPOCH, data3.metadata().epoch());
         assertMapsEqual(reqMap(new TopicIdPartition(fooId, 0, "foo")),
-                data3.sessionPartitions(), data3.toSend());
+                data3.sessionPartitions());
+        ArrayList<TopicIdPartition> expectedToSend3 = new ArrayList<>();
+        expectedToSend3.add(new TopicIdPartition(fooId, 0, "foo"));
+        assertListEquals(expectedToSend3, data3.toSend());
     }
 
     @Test
@@ -293,7 +302,10 @@ public class ShareSessionHandlerTest {
         builder.add(tp, null);
         ShareSessionHandler.ShareFetchRequestData data = builder.build();
         assertMapsEqual(reqMap(new TopicIdPartition(topicId1, 0, "foo")),
-                data.toSend(), data.sessionPartitions());
+                data.sessionPartitions());
+        ArrayList<TopicIdPartition> expectedToSend1 = new ArrayList<>();
+        expectedToSend1.add(new TopicIdPartition(topicId1, 0, "foo"));
+        assertListEquals(expectedToSend1, data.toSend());
 
         ShareFetchResponse resp = new ShareFetchResponse(
                 new ShareFetchResponseData()
@@ -315,7 +327,10 @@ public class ShareSessionHandlerTest {
         // The old topic ID partition should be in toReplace, and the new one should be in toSend.
         assertEquals(Collections.singletonList(tp), data2.toReplace());
         assertMapsEqual(reqMap(new TopicIdPartition(topicId2, 0, "foo")),
-                data2.toSend(), data2.sessionPartitions());
+                data2.sessionPartitions());
+        ArrayList<TopicIdPartition> expectedToSend2 = new ArrayList<>();
+        expectedToSend2.add(new TopicIdPartition(topicId2, 0, "foo"));
+        assertListEquals(expectedToSend2, data2.toSend());
 
         // Should have the same session ID, and next epoch and can use topic IDs if it ended with topic IDs.
         assertEquals(memberId, data2.metadata().memberId(), "Did not use same session");
@@ -333,7 +348,10 @@ public class ShareSessionHandlerTest {
         TopicIdPartition foo0 = new TopicIdPartition(topicId, 0, "foo");
         builder.add(foo0, null);
         ShareSessionHandler.ShareFetchRequestData data = builder.build();
-        assertMapsEqual(reqMap(foo0), data.toSend(), data.sessionPartitions());
+        assertMapsEqual(reqMap(foo0), data.sessionPartitions());
+        ArrayList<TopicIdPartition> expectedToSend1 = new ArrayList<>();
+        expectedToSend1.add(new TopicIdPartition(topicId, 0, "foo"));
+        assertListEquals(expectedToSend1, data.toSend());
 
         ShareFetchResponse resp = new ShareFetchResponse(
                 new ShareFetchResponseData()
@@ -363,7 +381,10 @@ public class ShareSessionHandlerTest {
         builder.add(new TopicIdPartition(topicId, 0, "foo"), null);
         ShareSessionHandler.ShareFetchRequestData data = builder.build();
         assertMapsEqual(reqMap(new TopicIdPartition(topicId, 0, "foo")),
-                data.toSend(), data.sessionPartitions());
+                data.sessionPartitions());
+        ArrayList<TopicIdPartition> expectedToSend1 = new ArrayList<>();
+        expectedToSend1.add(new TopicIdPartition(topicId, 0, "foo"));
+        assertListEquals(expectedToSend1, data.toSend());
 
         ShareFetchResponse resp = new ShareFetchResponse(
                 new ShareFetchResponseData()

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -651,7 +651,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         for (int i = 0; i < consumerCount; i++) {
             final int consumerNumber = i + 1;
             consumerExecutorService.submit(() -> {
-                CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumed, producerCount * messagesPerProducer, "group1", consumerNumber, 25);
+                CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumed, producerCount * messagesPerProducer, "group1", consumerNumber, 30);
                 futures.add(future);
             });
         }

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -621,7 +621,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
                 retries++;
             }
         } catch (Exception e) {
-            fail("Consumer : " + consumerNumber + " failed ! with exception : " + e);
+            fail("Consumer " + consumerNumber + " failed with exception: " + e);
         } finally {
             shareConsumer.close();
             future.complete(messagesConsumed);
@@ -673,7 +673,6 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
-    @Disabled // This test is unreliable and needs more investigation
     public void testMultipleConsumersInMultipleGroupsConcurrentConsumption(String quorum) {
         AtomicInteger totalMessagesConsumedGroup1 = new AtomicInteger(0);
         AtomicInteger totalMessagesConsumedGroup2 = new AtomicInteger(0);
@@ -684,10 +683,10 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         int messagesPerProducer = 10000;
         final int totalMessagesSent = producerCount * messagesPerProducer;
 
+        ExecutorService producerExecutorService = Executors.newFixedThreadPool(producerCount);
         ExecutorService shareGroupExecutorService1 = Executors.newFixedThreadPool(consumerCount);
         ExecutorService shareGroupExecutorService2 = Executors.newFixedThreadPool(consumerCount);
         ExecutorService shareGroupExecutorService3 = Executors.newFixedThreadPool(consumerCount);
-        ExecutorService producerExecutorService = Executors.newFixedThreadPool(producerCount);
 
         ConcurrentLinkedQueue<CompletableFuture<Integer>> producerFutures = new ConcurrentLinkedQueue<>();
 
@@ -709,7 +708,6 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
             for (CompletableFuture<Integer> future : producerFutures) {
                 actualMessagesSent += future.get();
             }
-            System.out.println("Sent " + actualMessagesSent + "messages.");
         } catch (Exception e) {
             fail("Exception occurred : " + e.getMessage());
         }
@@ -722,15 +720,15 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         for (int i = 0; i < consumerCount; i++) {
             final int consumerNumber = i + 1;
             shareGroupExecutorService1.submit(() -> {
-                CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumedGroup1, totalMessagesSent, "group1", consumerNumber, 25);
+                CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumedGroup1, totalMessagesSent, "group1", consumerNumber, 100);
                 futures1.add(future);
             });
             shareGroupExecutorService2.submit(() -> {
-                CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumedGroup2, totalMessagesSent, "group2", consumerNumber, 25);
+                CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumedGroup2, totalMessagesSent, "group2", consumerNumber, 100);
                 futures2.add(future);
             });
             shareGroupExecutorService3.submit(() -> {
-                CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumedGroup3, totalMessagesSent, "group3", consumerNumber, 25);
+                CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumedGroup3, totalMessagesSent, "group3", consumerNumber, 100);
                 futures3.add(future);
             });
         }
@@ -738,9 +736,9 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         shareGroupExecutorService2.shutdown();
         shareGroupExecutorService3.shutdown();
         try {
-            shareGroupExecutorService1.awaitTermination(60, TimeUnit.SECONDS); // Wait for all consumer threads for group 1 to complete
-            shareGroupExecutorService2.awaitTermination(60, TimeUnit.SECONDS); // Wait for all consumer threads for group 2 to complete
-            shareGroupExecutorService3.awaitTermination(60, TimeUnit.SECONDS); // Wait for all consumer threads for group 3 to complete
+            shareGroupExecutorService1.awaitTermination(120, TimeUnit.SECONDS); // Wait for all consumer threads for group 1 to complete
+            shareGroupExecutorService2.awaitTermination(120, TimeUnit.SECONDS); // Wait for all consumer threads for group 2 to complete
+            shareGroupExecutorService3.awaitTermination(120, TimeUnit.SECONDS); // Wait for all consumer threads for group 3 to complete
 
             int totalResult1 = 0;
             for (CompletableFuture<Integer> future : futures1) {


### PR DESCRIPTION
Implement the proper rules for a share session in the client. This means that the list of topic-partitions contains changes or operations on the topic-partitions in the session only. If two requests are fetching from the same topic-partitions, only the first request will list the topic-partitions, while the second will have an empty list.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
