### PR TITLE
AKCORE-51: Set member ID in share sessions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -279,11 +279,11 @@ public class RequestManagers implements Closeable {
                         backgroundEventHandler,
                         groupRebalanceConfig.groupId);
                 ShareMembershipManager shareMembershipManager = new ShareMembershipManager(
+                        logContext,
                         groupRebalanceConfig.groupId,
                         null,
                         subscriptions,
                         metadata,
-                        logContext,
                         clientTelemetryReporter,
                         backgroundEventHandler);
                 ShareHeartbeatRequestManager shareHeartbeatRequestManager = new ShareHeartbeatRequestManager(
@@ -303,6 +303,7 @@ public class RequestManagers implements Closeable {
                         fetchConfig,
                         fetchBuffer,
                         fetchMetricsManager);
+                shareMembershipManager.registerStateListener(shareFetchRequestManager);
 
                 return new RequestManagers(
                         logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
@@ -233,10 +233,8 @@ public class ShareHeartbeatRequestManager implements RequestManager {
     @Override
     public long maximumTimeToWait(long currentTimeMs) {
         pollTimer.update(currentTimeMs);
-        if (
-                pollTimer.isExpired() ||
-                        (shareMembershipManager.shouldHeartbeatNow() && !heartbeatRequestState.requestInFlight())
-        ) {
+        if (pollTimer.isExpired() ||
+                (shareMembershipManager.shouldHeartbeatNow() && !heartbeatRequestState.requestInFlight())) {
             return 0L;
         }
         return Math.min(pollTimer.remainingMs() / 2, heartbeatRequestState.nextHeartbeatMs(currentTimeMs));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManager.java
@@ -92,6 +92,11 @@ import java.util.stream.Collectors;
 public class ShareMembershipManager implements RequestManager {
 
     /**
+     * Logger.
+     */
+    private final Logger log;
+
+    /**
      * TopicPartition comparator based on topic name and partition id.
      */
     final static TopicPartitionComparator TOPIC_PARTITION_COMPARATOR = new TopicPartitionComparator();
@@ -147,11 +152,6 @@ public class ShareMembershipManager implements RequestManager {
      * Metadata that allows us to create the partitions needed for {@link ConsumerRebalanceListener}.
      */
     private final ConsumerMetadata metadata;
-
-    /**
-     * Logger.
-     */
-    private final Logger log;
 
     /**
      * Local cache of assigned topic IDs and names. Topics are added here when received in a
@@ -212,13 +212,14 @@ public class ShareMembershipManager implements RequestManager {
      */
     private final BackgroundEventHandler backgroundEventHandler;
 
-    public ShareMembershipManager(String groupId,
+    public ShareMembershipManager(LogContext logContext,
+                                  String groupId,
                                   String rackId,
                                   SubscriptionState subscriptions,
                                   ConsumerMetadata metadata,
-                                  LogContext logContext,
                                   Optional<ClientTelemetryReporter> clientTelemetryReporter,
                                   BackgroundEventHandler backgroundEventHandler) {
+        this.log = logContext.logger(ShareMembershipManager.class);
         this.groupId = groupId;
         this.rackId = rackId;
         this.state = MemberState.UNSUBSCRIBED;
@@ -227,7 +228,6 @@ public class ShareMembershipManager implements RequestManager {
         this.assignedTopicNamesCache = new HashMap<>();
         this.currentTargetAssignment = new HashMap<>();
         this.currentAssignment = new HashMap<>();
-        this.log = logContext.logger(MembershipManagerImpl.class);
         this.stateUpdatesListeners = new ArrayList<>();
         this.clientTelemetryReporter = clientTelemetryReporter;
         this.backgroundEventHandler = backgroundEventHandler;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerTestBuilder.java
@@ -155,11 +155,11 @@ public class ShareConsumerTestBuilder implements Closeable {
                 metricsManager));
 
         ShareMembershipManager membershipManager = spy(new ShareMembershipManager(
+                logContext,
                 groupInfo.groupId,
                 null,
                 subscriptions,
                 metadata,
-                logContext,
                 Optional.empty(),
                 backgroundEventHandler));
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManagerTest.java
@@ -79,6 +79,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -636,6 +637,7 @@ public class ShareFetchRequestManagerTest {
                                            ShareFetchCollector<K, V> fetchCollector) {
             super(logContext, groupId, metadata, subscriptions, fetchConfig, shareFetchBuffer, metricsManager);
             this.shareFetchCollector = fetchCollector;
+            onMemberEpochUpdated(Optional.empty(), Optional.of(Uuid.randomUuid().toString()));
         }
 
         private ShareFetch<K, V> collectFetch() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareMembershipManagerTest.java
@@ -100,8 +100,8 @@ public class ShareMembershipManagerTest {
 
     private ShareMembershipManager createMembershipManagerJoiningGroup() {
         ShareMembershipManager manager = spy(new ShareMembershipManager(
-                GROUP_ID, RACK_ID, subscriptionState, metadata,
-                logContext, Optional.empty(), backgroundEventHandler));
+                logContext, GROUP_ID, RACK_ID, subscriptionState, metadata,
+                Optional.empty(), backgroundEventHandler));
         manager.transitionToJoining();
         return manager;
     }
@@ -110,8 +110,8 @@ public class ShareMembershipManagerTest {
     public void testMembershipManagerRegistersForClusterMetadataUpdatesOnFirstJoin() {
         // First join should register to get metadata updates
         ShareMembershipManager manager = new ShareMembershipManager(
-                GROUP_ID, RACK_ID, subscriptionState, metadata,
-                logContext, Optional.empty(), backgroundEventHandler);
+                logContext, GROUP_ID, RACK_ID, subscriptionState, metadata,
+                Optional.empty(), backgroundEventHandler);
         manager.transitionToJoining();
         clearInvocations(metadata);
 
@@ -186,8 +186,8 @@ public class ShareMembershipManagerTest {
     @Test
     public void testTransitionToFailedWhenTryingToJoin() {
         ShareMembershipManager membershipManager = new ShareMembershipManager(
-                GROUP_ID, RACK_ID, subscriptionState, metadata,
-                logContext, Optional.empty(), backgroundEventHandler);
+                logContext, GROUP_ID, RACK_ID, subscriptionState, metadata,
+                Optional.empty(), backgroundEventHandler);
         assertEquals(MemberState.UNSUBSCRIBED, membershipManager.state());
         membershipManager.transitionToJoining();
 


### PR DESCRIPTION
Set the member ID from the group coordinator in the share session handler so that the same UUID is used for group membership and fetching.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
