### PR TITLE
AKCORE-82: Fix flaky test ShareGroupHeartbeatRequestTest.testMemberJoiningAndExpiring

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
@@ -601,11 +601,6 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       numPartitions = 2
     )
 
-    val barId = TestUtils.createTopicWithAdminRaw(
-      admin = admin,
-      topic = "bar"
-    )
-
     // This is the expected assignment.
     var expectedAssignment = new ShareGroupHeartbeatResponseData.Assignment()
       .setAssignedTopicPartitions(List(new ShareGroupHeartbeatResponseData.TopicPartitions()
@@ -637,6 +632,11 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         .setMemberEpoch(2)
         .setSubscribedTopicNames(List("foo", "bar").asJava), true
     ).build()
+
+    val barId = TestUtils.createTopicWithAdminRaw(
+      admin = admin,
+      topic = "bar"
+    )
 
     expectedAssignment = new ShareGroupHeartbeatResponseData.Assignment()
       .setAssignedTopicPartitions(List(
@@ -707,7 +707,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         shareGroupHeartbeatResponse.data.assignment.assignedTopicPartitions.containsAll(expectedAssignment.assignedTopicPartitions)
     }, msg = s"Could not get bar partitions assigned upon rejoining. Last response $shareGroupHeartbeatResponse.")
 
-    // Epoch should have been bumped when a member is removed and agin when it joins back.
+    // Epoch should have been bumped when a member is removed and again when it joins back.
     assertEquals(6, shareGroupHeartbeatResponse.data.memberEpoch)
   }
 


### PR DESCRIPTION
### About
Fixing flaky GC integration [test](https://jenkins.confluent.io/job/confluentinc-pr/job/kafka/job/PR-1133/3/testReport/kafka.server/ShareGroupHeartbeatRequestTest/testMemberJoiningAndExpiring__1__Type_Raft_Isolated__MetadataVersion_3_8_IV0__Security_PLAINTEXT/) `ShareGroupHeartbeatRequestTest.testMemberJoiningAndExpiring`. The flakiness was caused due to the variation in time that it was taking to sync the metadata for topic `bar` with GC. If it was able to complete before we ran `TestUtils.waitUntilTrue()` [here](https://github.com/confluentinc/kafka/blob/kip-932/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala#L650), there was no need of an extra member epoch bump before partition reassignment and hence the actual value [here](https://github.com/confluentinc/kafka/blob/kip-932/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala#L659) was sometimes 3 . In the expected scenario, the member epoch was bumped during `TestUtils.waitUntilTrue()` due to the metadata sync before partition reassignment, and hence the expected value was 4.