### PR TITLE
AKCORE-53: Close share session on consumer close

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
@@ -37,7 +37,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * ShareSessionHandler maintains the share session state for connecting to a broker.
@@ -74,8 +73,8 @@ public class ShareSessionHandler {
         return sessionTopicNames;
     }
 
-    public Set<TopicPartition> sessionTopics() {
-        return sessionPartitions.keySet();
+    public Collection<TopicIdPartition> sessionPartitions() {
+        return sessionPartitions.values();
     }
 
     public ShareSessionHandler(LogContext logContext, int node, Uuid memberId) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchMetadata.java
@@ -102,6 +102,10 @@ public class ShareFetchMetadata {
         return epoch;
     }
 
+    public boolean isFinalEpoch() {
+        return epoch == FINAL_EPOCH;
+    }
+
     public String toString() {
         StringBuilder bld = new StringBuilder();
         bld.append("(memberId=").append(memberId).append(", ");


### PR DESCRIPTION
Added missing code to close share session when the consumer is closed. Enhanced integration tests to reduce flakiness.

The complete story depends upon a change in the broker to release records automatically. The integration tests will be enabled once this is complete.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
