### PR TITLE
AKCORE-81: Experiment with read-committed share groups

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareMemberStateListener.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareMemberStateListener.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.common.IsolationLevel;
+
+import java.util.Optional;
+
+/**
+ * Listener for getting notified of member ID and epoch changes.
+ */
+public interface ShareMemberStateListener {
+
+    /**
+     * Called whenever member ID or epoch change with new values received from the broker or
+     * cleared if the member is not part of the group anymore (when it gets fenced, leaves the
+     * group or fails).
+     *
+     * @param memberEpoch New member epoch received from the broker. Empty if the member is
+     *                    not part of the group anymore.
+     * @param memberId    Current member ID. Empty if the member is not part of the group.
+     * @param isolationLevel Isolation level of the group. Empty if the member is not part
+     *                       of the group.
+     */
+    void onMemberEpochUpdated(Optional<Integer> memberEpoch,
+                              Optional<String> memberId,
+                              Optional<IsolationLevel> isolationLevel);
+}

--- a/clients/src/main/resources/common/message/ShareFetchResponse.json
+++ b/clients/src/main/resources/common/message/ShareFetchResponse.json
@@ -52,6 +52,13 @@
             "The last offset of this batch of acquired records." },
           { "name": "DeliveryCount", "type": "int16", "versions": "0+",
             "about": "The delivery count of this batch of acquired records." }
+        ]},
+        { "name": "AbortedTransactions", "type": "[]AbortedTransaction", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+          "about": "The aborted transactions.",  "fields": [
+          { "name": "ProducerId", "type": "int64", "versions": "0+", "entityType": "producerId",
+            "about": "The producer id associated with the aborted transaction." },
+          { "name": "FirstOffset", "type": "int64", "versions": "0+",
+            "about": "The first offset in the aborted transaction." }
         ]}
       ]}
     ]},

--- a/clients/src/main/resources/common/message/ShareGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/ShareGroupHeartbeatResponse.json
@@ -40,6 +40,8 @@
       "about": "The member epoch." },
     { "name": "HeartbeatIntervalMs", "type": "int32", "versions": "0+",
       "about": "The heartbeat interval in milliseconds." },
+    { "name": "IsolationLevel", "type": "int8", "versions": "0+", "default": "0", "ignorable": true,
+      "about": "This setting controls the visibility of transactional records. Using READ_UNCOMMITTED (isolation_level = 0) makes all records visible. With READ_COMMITTED (isolation_level = 1), non-transactional and COMMITTED transactional records are visible. To be more concrete, READ_COMMITTED returns all data from offsets smaller than the current LSO (last stable offset), and enables the inclusion of the list of aborted transactions in the result, which allows consumers to discard ABORTED transactional records" },
     { "name": "Assignment", "type": "Assignment", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "null if not provided; the assignment otherwise.", "fields": [
       { "name": "Error", "type": "int8", "versions": "0+",

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetchTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareFetchResponseData;
@@ -263,6 +264,7 @@ public class ShareCompletedFetchTest {
                 BufferSupplier.create(),
                 TIP,
                 partitionData,
+                IsolationLevel.READ_UNCOMMITTED,
                 ApiKeys.SHARE_FETCH.latestVersion());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchBufferTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareFetchResponseData;
@@ -152,6 +153,7 @@ public class ShareFetchBufferTest {
                 BufferSupplier.create(),
                 tp,
                 partitionData,
+                IsolationLevel.READ_UNCOMMITTED,
                 ApiKeys.SHARE_FETCH.latestVersion());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollectorTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
@@ -335,6 +336,7 @@ public class ShareFetchCollectorTest {
                     BufferSupplier.create(),
                     topicAPartition0,
                     partitionData,
+                    IsolationLevel.READ_UNCOMMITTED,
                     ApiKeys.SHARE_FETCH.latestVersion());
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManagerTest.java
@@ -637,7 +637,7 @@ public class ShareFetchRequestManagerTest {
                                            ShareFetchCollector<K, V> fetchCollector) {
             super(logContext, groupId, metadata, subscriptions, fetchConfig, shareFetchBuffer, metricsManager);
             this.shareFetchCollector = fetchCollector;
-            onMemberEpochUpdated(Optional.empty(), Optional.of(Uuid.randomUuid().toString()));
+            onMemberEpochUpdated(Optional.empty(), Optional.of(Uuid.randomUuid().toString()), Optional.of(IsolationLevel.READ_UNCOMMITTED));
         }
 
         private ShareFetch<K, V> collectFetch() {

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -19,6 +19,7 @@ package kafka.server;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.protocol.Errors;
@@ -202,6 +203,18 @@ public class SharePartitionManager {
                             .setErrorCode(fetchPartitionData.error.code())
                             .setAcquiredRecords(acquiredRecords)
                             .setAcknowledgeErrorCode(Errors.NONE.code());
+
+                        if (fetchPartitionData.abortedTransactions.isPresent()) {
+                            List<FetchResponseData.AbortedTransaction> fetchedTransactions = fetchPartitionData.abortedTransactions.get();
+                            List<ShareFetchResponseData.AbortedTransaction> abortedTransactions = new ArrayList<>(fetchedTransactions.size());
+                            fetchedTransactions.forEach(fetchedTransaction -> {
+                                ShareFetchResponseData.AbortedTransaction abortedTransaction = new ShareFetchResponseData.AbortedTransaction();
+                                abortedTransaction.setProducerId(fetchedTransaction.producerId());
+                                abortedTransaction.setFirstOffset(fetchedTransaction.firstOffset());
+                                abortedTransactions.add(abortedTransaction);
+                            });
+                            partitionData.setAbortedTransactions(abortedTransactions);
+                        }
                     }
                     result.put(topicIdPartition, partitionData);
                 });

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group;
 
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
@@ -1574,6 +1575,10 @@ public class GroupMetadataManager {
                 .setMemberId(updatedMember.memberId())
                 .setMemberEpoch(updatedMember.memberEpoch())
                 .setHeartbeatIntervalMs(shareGroupHeartbeatIntervalMs);
+
+        if (groupId.equals("read-committed")) {
+            response.setIsolationLevel(IsolationLevel.READ_COMMITTED.id());
+        }
 
         // The assignment is only provided in the following cases:
         // 1. The member just joined or rejoined to group (epoch equals to zero);


### PR DESCRIPTION
RPC and code changes to enable read-committed share groups with client-side record filtering.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
