### PR TITLE
AKCORE-86: Add functionality to release records acquired by member when share session is closed (2/N) 

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1487,6 +1487,14 @@ class KafkaApis(val requestChannel: RequestChannel,
     val shareFetchData = shareFetchRequest.shareFetchData(topicNames)
     val forgottenTopics = shareFetchRequest.forgottenTopics(topicNames)
 
+    var cachedTopicPartitions : util.List[TopicIdPartition] = new util.ArrayList[TopicIdPartition]
+    try {
+      cachedTopicPartitions = sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, Uuid.fromString(memberId))
+    } catch {
+        // Exception handling is needed when this value is being utilized on receiving FINAL_EPOCH.
+        case _: ShareSessionNotFoundException => cachedTopicPartitions = null
+    }
+
     def isAcknowledgeDataPresentInFetchRequest() : Boolean = {
       var isAcknowledgeDataPresent = false
       shareFetchRequest.data().topics().forEach ( topic => {
@@ -1661,6 +1669,30 @@ class KafkaApis(val requestChannel: RequestChannel,
           topicData.partitions().add(fetchPartitionData)
         }
         shareFetchResponse.data().responses().add(topicData)
+      }
+
+      if (shareSessionEpoch == ShareFetchMetadata.FINAL_EPOCH) {
+        if (cachedTopicPartitions == null)
+          shareFetchResponse.data().setErrorCode(Errors.SHARE_SESSION_NOT_FOUND.code())
+        else {
+          sharePartitionManager.releaseAcquiredRecords(groupId,
+              memberId, cachedTopicPartitions).
+            whenComplete((releaseAcquiredRecordsData, throwable) => {
+              if (throwable != null) {
+                debug(s"Release acquired records on share session close with correlation from client $clientId  " +
+                  s"failed with error ${throwable.getMessage}")
+                requestHelper.handleError(request, throwable)
+              } else {
+                info(s"Release acquired records on share session close $releaseAcquiredRecordsData succeeded")
+                releaseAcquiredRecordsData.forEach((_, partitionData) => {
+                  if(partitionData.errorCode() != Errors.NONE.code()) {
+                    shareFetchResponse.data().setErrorCode(partitionData.errorCode())
+                    break()
+                  }
+                })
+              }
+            })
+        }
       }
       shareFetchResponse
     }
@@ -4539,6 +4571,8 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   }
 
+  // TODO: Release acquired record functionality (which is added in share fetch request handling) should be added. Can't add it
+  //  right now since this function's implementation is incomplete
   def handleShareAcknowledgeRequest(request: RequestChannel.Request): Unit = {
     val shareAcknowledgeRequest = request.body[ShareAcknowledgeRequest]
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
 import org.apache.kafka.common.acl.AclOperation
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, BROKER_LOGGER}
-import org.apache.kafka.common.errors.UnsupportedVersionException
+import org.apache.kafka.common.errors.{ShareSessionNotFoundException, UnsupportedVersionException}
 import org.apache.kafka.common.internals.{KafkaFutureImpl, Topic}
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.AddPartitionsToTxnRequestData.{AddPartitionsToTxnTopic, AddPartitionsToTxnTopicCollection, AddPartitionsToTxnTransaction, AddPartitionsToTxnTransactionCollection}
@@ -5257,6 +5257,21 @@ class KafkaApisTest extends Logging {
           .setErrorCode(Errors.NONE.code())
     ).asJava))
 
+    when(sharePartitionManager.releaseAcquiredRecords(
+      anyString(),
+      anyString(),
+      any()
+    )).thenReturn(CompletableFuture.completedFuture(Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData](
+      new TopicIdPartition(topicId, new TopicPartition(topicName, 0)) ->
+        new ShareAcknowledgeResponseData.PartitionData()
+          .setPartitionIndex(0)
+          .setErrorCode(Errors.NONE.code()),
+      new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("bar", 0)) ->
+        new ShareAcknowledgeResponseData.PartitionData()
+          .setPartitionIndex(0)
+          .setErrorCode(Errors.NONE.code())
+    ).asJava))
+
     val shareFetchRequestData = new ShareFetchRequestData().
       setGroupId("group").
       setMemberId(memberId.toString).
@@ -5284,6 +5299,156 @@ class KafkaApisTest extends Logging {
     val topicResponses = response.data().responses()
 
     assertEquals(Errors.NONE.code(), responseData.errorCode())
+    assertEquals(1, topicResponses.size())
+    assertEquals(1, topicResponses.get(0).partitions().size())
+    assertEquals(Errors.NONE.code(), topicResponses.get(0).partitions().get(0).acknowledgeErrorCode())
+  }
+
+  @Test
+  def testHandleShareFetchRequestFinalFetchWithErroneousReleaseRecords(): Unit = {
+    val topicName = "foo"
+    val topicId = Uuid.randomUuid()
+    addTopicToMetadataCache(topicName, 1, topicId = topicId)
+    val memberId: Uuid = Uuid.ZERO_UUID
+
+    when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
+      any(),
+      any(),
+      any(),
+      any()
+    )).thenReturn(Errors.NONE)
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
+      new FinalContext(new mutable.HashMap[TopicIdPartition, ShareFetchRequest.SharePartitionData]().asJava)
+    )
+
+    when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
+      any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+
+    when(sharePartitionManager.acknowledge(
+      anyString(),
+      anyString(),
+      any()
+    )).thenReturn(CompletableFuture.completedFuture(Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData](
+      new TopicIdPartition(topicId, new TopicPartition(topicName, 0)) ->
+        new ShareAcknowledgeResponseData.PartitionData()
+          .setPartitionIndex(0)
+          .setErrorCode(Errors.NONE.code())
+    ).asJava))
+
+    when(sharePartitionManager.releaseAcquiredRecords(
+      anyString(),
+      anyString(),
+      any()
+    )).thenReturn(CompletableFuture.completedFuture(Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData](
+      new TopicIdPartition(topicId, new TopicPartition(topicName, 0)) ->
+        new ShareAcknowledgeResponseData.PartitionData()
+          .setPartitionIndex(0)
+          .setErrorCode(Errors.NONE.code()),
+      new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("bar", 0)) ->
+        new ShareAcknowledgeResponseData.PartitionData()
+          .setPartitionIndex(0)
+          .setErrorCode(Errors.INVALID_RECORD_STATE.code()),
+      new TopicIdPartition(topicId, new TopicPartition(topicName, 0)) ->
+        new ShareAcknowledgeResponseData.PartitionData()
+          .setPartitionIndex(0)
+          .setErrorCode(Errors.NONE.code())
+    ).asJava))
+
+    val shareFetchRequestData = new ShareFetchRequestData().
+      setGroupId("group").
+      setMemberId(memberId.toString).
+      setShareSessionEpoch(ShareFetchMetadata.FINAL_EPOCH).
+      setTopics(List(new ShareFetchRequestData.FetchTopic().
+        setTopicId(topicId).
+        setPartitions(List(
+          new ShareFetchRequestData.FetchPartition()
+            .setPartitionIndex(0)
+            .setPartitionMaxBytes(0)
+            .setAcknowledgementBatches(List(
+              new ShareFetchRequestData.AcknowledgementBatch()
+                .setBaseOffset(11)
+                .setLastOffset(20)
+            ).asJava)
+        ).asJava)
+      ).asJava)
+
+    val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
+    val request = buildRequest(shareFetchRequest)
+    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis.handleShareFetchRequest(request)
+    val response = verifyNoThrottling[ShareFetchResponse](request)
+    val responseData = response.data()
+    val topicResponses = response.data().responses()
+
+    assertEquals(Errors.INVALID_RECORD_STATE.code(), responseData.errorCode())
+    assertEquals(1, topicResponses.size())
+    assertEquals(1, topicResponses.get(0).partitions().size())
+    assertEquals(Errors.NONE.code(), topicResponses.get(0).partitions().get(0).acknowledgeErrorCode())
+  }
+
+  @Test
+  def testHandleShareFetchRequestFinalFetchWithErroneousCachedPartitionsData(): Unit = {
+    val topicName = "foo"
+    val topicId = Uuid.randomUuid()
+    addTopicToMetadataCache(topicName, 1, topicId = topicId)
+    val memberId: Uuid = Uuid.ZERO_UUID
+
+    when(sharePartitionManager.acknowledgeShareSessionCacheUpdate(
+      any(),
+      any(),
+      any(),
+      any()
+    )).thenReturn(Errors.NONE)
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any())).thenReturn(
+      new FinalContext(new mutable.HashMap[TopicIdPartition, ShareFetchRequest.SharePartitionData]().asJava)
+    )
+
+    when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
+      any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+
+    when(sharePartitionManager.acknowledge(
+      anyString(),
+      anyString(),
+      any()
+    )).thenReturn(CompletableFuture.completedFuture(Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData](
+      new TopicIdPartition(topicId, new TopicPartition(topicName, 0)) ->
+        new ShareAcknowledgeResponseData.PartitionData()
+          .setPartitionIndex(0)
+          .setErrorCode(Errors.NONE.code())
+    ).asJava))
+
+    when(sharePartitionManager.cachedTopicIdPartitionsInShareSession(
+      anyString(),
+      any()
+    )).thenThrow(new ShareSessionNotFoundException("share session does not exist"))
+
+    val shareFetchRequestData = new ShareFetchRequestData().
+      setGroupId("group").
+      setMemberId(memberId.toString).
+      setShareSessionEpoch(ShareFetchMetadata.FINAL_EPOCH).
+      setTopics(List(new ShareFetchRequestData.FetchTopic().
+        setTopicId(topicId).
+        setPartitions(List(
+          new ShareFetchRequestData.FetchPartition()
+            .setPartitionIndex(0)
+            .setPartitionMaxBytes(0)
+            .setAcknowledgementBatches(List(
+              new ShareFetchRequestData.AcknowledgementBatch()
+                .setBaseOffset(11)
+                .setLastOffset(20)
+            ).asJava)
+        ).asJava)
+      ).asJava)
+
+    val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
+    val request = buildRequest(shareFetchRequest)
+    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis.handleShareFetchRequest(request)
+    val response = verifyNoThrottling[ShareFetchResponse](request)
+    val responseData = response.data()
+    val topicResponses = response.data().responses()
+
+    assertEquals(Errors.SHARE_SESSION_NOT_FOUND.code(), responseData.errorCode())
     assertEquals(1, topicResponses.size())
     assertEquals(1, topicResponses.get(0).partitions().size())
     assertEquals(Errors.NONE.code(), topicResponses.get(0).partitions().get(0).acknowledgeErrorCode())


### PR DESCRIPTION
### About
Added "Release acquired records on session close" functionality to ShareFetch RPC handling on brokers