### PR TITLE
AKCORE-90: Persist share group member information

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -345,7 +345,7 @@
     <suppress checks="ParameterNumber"
               files="(ConsumerGroupMember|GroupMetadataManager|GroupCoordinatorConfig).java"/>
     <suppress checks="ClassDataAbstractionCouplingCheck"
-              files="(RecordHelpersTest|GroupMetadataManager|GroupMetadataManagerTest|OffsetMetadataManagerTest|GroupCoordinatorServiceTest|GroupCoordinatorShardTest).java"/>
+              files="(RecordHelpersTest|GroupMetadataManager|GroupMetadataManagerTest|OffsetMetadataManagerTest|GroupCoordinatorServiceTest|GroupCoordinatorShardTest|RecordHelpers).java"/>
     <suppress checks="JavaNCSS"
               files="GroupMetadataManagerTest.java"/>
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -49,12 +49,16 @@ import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.Group.GroupType;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.GroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.metrics.CoordinatorMetrics;
 import org.apache.kafka.coordinator.group.metrics.CoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
@@ -717,6 +721,18 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
                 groupMetadataManager.replay(
                     (ConsumerGroupMetadataKey) key.message(),
                     (ConsumerGroupMetadataValue) Utils.messageOrNull(value)
+                );
+                break;
+            case 5:
+                groupMetadataManager.replay(
+                    (ConsumerGroupMemberMetadataKey) key.message(),
+                    (ConsumerGroupMemberMetadataValue) Utils.messageOrNull(value)
+                );
+                break;
+            case 10:
+                groupMetadataManager.replay(
+                    (ShareGroupMemberMetadataKey) key.message(),
+                    (ShareGroupMemberMetadataValue) Utils.messageOrNull(value)
                 );
                 break;
             default:

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
@@ -39,6 +39,8 @@ import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
 import org.apache.kafka.coordinator.group.classic.ClassicGroup;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.share.ShareGroupMember;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -94,37 +96,6 @@ public class RecordHelpers {
                             .setVersion(assignorState.metadata().version())
                             .setMetadata(assignorState.metadata().metadata().array())
                     ).collect(Collectors.toList())),
-                (short) 0
-            )
-        );
-    }
-
-    /**
-     * Creates a ConsumerGroupMemberMetadata record.
-     *
-     * @param groupId   The consumer group id.
-     * @param member    The consumer group member.
-     * @return The record.
-     */
-    public static Record newMemberSubscriptionRecord(
-        String groupId,
-        ShareGroupMember member
-    ) {
-        return new Record(
-            new ApiMessageAndVersion(
-                new ConsumerGroupMemberMetadataKey()
-                    .setGroupId(groupId)
-                    .setMemberId(member.memberId()),
-                (short) 5
-            ),
-            new ApiMessageAndVersion(
-                new ConsumerGroupMemberMetadataValue()
-                    .setRackId(member.rackId())
-                    .setInstanceId(member.instanceId())
-                    .setClientId(member.clientId())
-                    .setClientHost(member.clientHost())
-                    .setSubscribedTopicNames(member.subscribedTopicNames())
-                    .setRebalanceTimeoutMs(member.rebalanceTimeoutMs()),
                 (short) 0
             )
         );
@@ -429,8 +400,6 @@ public class RecordHelpers {
                     .setPreviousMemberEpoch(member.previousMemberEpoch())
                     .setTargetMemberEpoch(member.targetMemberEpoch())
                     .setAssignedPartitions(toTopicPartitions(member.assignedPartitions())),
-//                    .setPartitionsPendingRevocation(toTopicPartitions(member.partitionsPendingRevocation()))
-//                    .setPartitionsPendingAssignment(toTopicPartitions(member.partitionsPendingAssignment())),
                 (short) 0
             )
         );
@@ -627,6 +596,58 @@ public class RecordHelpers {
                 (short) 1
             ),
             null
+        );
+    }
+
+    /**
+     * Creates a ShareGroupMemberMetadata record.
+     *
+     * @param groupId   The consumer group id.
+     * @param member    The consumer group member.
+     * @return The record.
+     */
+    public static Record newShareMemberSubscriptionRecord(
+        String groupId,
+        ShareGroupMember member
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ShareGroupMemberMetadataKey()
+                    .setGroupId(groupId)
+                    .setMemberId(member.memberId()),
+                (short) 10
+            ),
+            new ApiMessageAndVersion(
+                new ShareGroupMemberMetadataValue()
+                    .setRackId(member.rackId())
+                    .setClientId(member.clientId())
+                    .setClientHost(member.clientHost())
+                    .setSubscribedTopicNames(member.subscribedTopicNames())
+                    .setRebalanceTimeoutMs(member.rebalanceTimeoutMs()),
+                (short) 0
+            )
+        );
+    }
+
+    /**
+     * Creates a ShareGroupMemberMetadata tombstone.
+     *
+     * @param groupId   The consumer group id.
+     * @param memberId  The consumer group member id.
+     * @return The record.
+     */
+    public static Record newShareMemberSubscriptionTombstoneRecord(
+        String groupId,
+        String memberId
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ShareGroupMemberMetadataKey()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId),
+                (short) 10
+            ),
+            null // Tombstone.
         );
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareGroupMember.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.coordinator.group.GroupMember;
 import org.apache.kafka.coordinator.group.Utils;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataValue;
 import org.apache.kafka.image.TopicsImage;
 
 import java.util.ArrayList;
@@ -139,7 +139,7 @@ public class ShareGroupMember extends GroupMember {
       return this;
     }
 
-    public Builder updateWith(ConsumerGroupMemberMetadataValue record) {
+    public Builder updateWith(ShareGroupMemberMetadataValue record) {
       setRackId(record.rackId());
       setClientId(record.clientId());
       setClientHost(record.clientHost());

--- a/group-coordinator/src/main/resources/common/message/ShareGroupMemberMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupMemberMetadataKey.json
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ShareGroupMemberMetadataKey",
+  "validVersions": "10",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "10",
+      "about": "The group id." },
+    { "name": "MemberId", "type": "string", "versions": "10",
+      "about": "The member id." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/ShareGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupMemberMetadataValue.json
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "ShareGroupMemberMetadataValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "RackId", "versions": "0+", "nullableVersions": "0+", "type": "string",
+      "about": "The (optional) rack id." },
+    { "name": "ClientId", "versions": "0+", "type": "string",
+      "about": "The client id." },
+    { "name": "ClientHost", "versions": "0+", "type": "string",
+      "about": "The client host." },
+    { "name": "SubscribedTopicNames", "versions": "0+", "type": "[]string",
+      "about": "The list of subscribed topic names." },
+    { "name": "RebalanceTimeoutMs", "type": "int32", "versions": "0+", "default": -1,
+      "about": "The rebalance timeout" }
+  ]
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -582,7 +582,7 @@ public class GroupCoordinatorShardTest {
         );
         coordinator.replay(0L, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, record);
 
-        verify(groupMetadataManager, times(1)).replay(record, GroupType.CONSUMER);
+        verify(groupMetadataManager, times(1)).replay(key, value);
     }
 
     @Test
@@ -610,7 +610,7 @@ public class GroupCoordinatorShardTest {
         );
         coordinator.replay(0L, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, record);
 
-        verify(groupMetadataManager, times(1)).replay(record, GroupType.CONSUMER);
+        verify(groupMetadataManager, times(1)).replay(key, null);
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -9946,7 +9946,15 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        List<Record> expectedRecords = Collections.singletonList(
+        ShareGroupMember expectedMember = new ShareGroupMember.Builder(memberId)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setRebalanceTimeoutMs(5000)
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .build();
+
+        List<Record> expectedRecords = Arrays.asList(
+            RecordHelpers.newShareMemberSubscriptionRecord(groupId, expectedMember),
             RecordHelpers.newGroupEpochRecord(groupId, 1, GroupType.SHARE)
         );
 
@@ -10008,7 +10016,8 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        List<Record> expectedRecords = Collections.singletonList(
+        List<Record> expectedRecords = Arrays.asList(
+            RecordHelpers.newShareMemberSubscriptionTombstoneRecord(groupId, memberId2),
             RecordHelpers.newGroupEpochRecord(groupId, 103, GroupType.SHARE)
         );
 
@@ -10090,7 +10099,7 @@ public class GroupMetadataManagerTest {
 
         assertEquals(ShareGroup.ShareGroupState.EMPTY, context.shareGroupState(groupId));
 
-        context.replay(RecordHelpers.newMemberSubscriptionRecord(groupId, new ShareGroupMember.Builder(memberId1)
+        context.replay(RecordHelpers.newShareMemberSubscriptionRecord(groupId, new ShareGroupMember.Builder(memberId1)
             .setSubscribedTopicNames(Collections.singletonList(fooTopicName))
             .build()), GroupType.SHARE);
         context.replay(RecordHelpers.newGroupEpochRecord(groupId, 11, GroupType.SHARE), GroupType.SHARE);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -66,6 +66,8 @@ import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmen
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.generated.GroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.runtime.CoordinatorResult;
 import org.apache.kafka.coordinator.group.share.ShareGroup;
@@ -1286,8 +1288,7 @@ public class GroupMetadataManagerTestContext {
             case ConsumerGroupMemberMetadataKey.HIGHEST_SUPPORTED_VERSION:
                 groupMetadataManager.replay(
                     (ConsumerGroupMemberMetadataKey) key.message(),
-                    (ConsumerGroupMemberMetadataValue) messageOrNull(value),
-                    groupType
+                    (ConsumerGroupMemberMetadataValue) messageOrNull(value)
                 );
                 break;
 
@@ -1327,6 +1328,13 @@ public class GroupMetadataManagerTestContext {
                     (ConsumerGroupCurrentMemberAssignmentKey) key.message(),
                     (ConsumerGroupCurrentMemberAssignmentValue) messageOrNull(value),
                     groupType
+                );
+                break;
+
+            case ShareGroupMemberMetadataKey.HIGHEST_SUPPORTED_VERSION:
+                groupMetadataManager.replay(
+                    (ShareGroupMemberMetadataKey) key.message(),
+                    (ShareGroupMemberMetadataValue) messageOrNull(value)
                 );
                 break;
 


### PR DESCRIPTION
Corrected unit tests to check additional persisted records and tested manually as well and verified the records on offsets topic:

```
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Reload4jLoggerFactory]
share-T1:xIO7QZkyTn6nKycw2heWIw::ShareGroupMemberMetadataValue(rackId=null, clientId='console-share-consumer', clientHost='/127.0.0.1', subscribedTopicNames=[T1], rebalanceTimeoutMs=300000)
share-T1::ConsumerGroupMetadataValue(epoch=1, type='SHARE')
share-T1:ERf0KxbYSzSZkd3PvC9i0A::ShareGroupMemberMetadataValue(rackId=null, clientId='console-share-consumer', clientHost='/127.0.0.1', subscribedTopicNames=[T1], rebalanceTimeoutMs=300000)
share-T1::ConsumerGroupMetadataValue(epoch=2, type='SHARE')
share-T1:ERf0KxbYSzSZkd3PvC9i0A::NULL
share-T1::ConsumerGroupMetadataValue(epoch=3, type='SHARE')
share-T1:xIO7QZkyTn6nKycw2heWIw::NULL
share-T1::ConsumerGroupMetadataValue(epoch=4, type='SHARE')
share-T1:zc5e65yFTHiXl222mNSqYg::ShareGroupMemberMetadataValue(rackId=null, clientId='console-share-consumer', clientHost='/127.0.0.1', subscribedTopicNames=[T1], rebalanceTimeoutMs=300000)
share-T1::ConsumerGroupMetadataValue(epoch=5, type='SHARE')
share-T1:kxTp90xsQDSuFH05-j5jsg::ShareGroupMemberMetadataValue(rackId=null, clientId='console-share-consumer', clientHost='/127.0.0.1', subscribedTopicNames=[T1], rebalanceTimeoutMs=300000)
share-T1::ConsumerGroupMetadataValue(epoch=6, type='SHARE')
share-T1:kxTp90xsQDSuFH05-j5jsg::NULL
share-T1::ConsumerGroupMetadataValue(epoch=7, type='SHARE')
share-T1:zc5e65yFTHiXl222mNSqYg::NULL
share-T1::ConsumerGroupMetadataValue(epoch=8, type='SHARE')
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
