### PR TITLE
AKCORE-83: Handle lock timeout on messages in share partition (2/N)

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -44,6 +44,7 @@
     <suppress checks="CyclomaticComplexity" files="(SharePartition).java"/>
     <suppress checks="MethodLength"
               files="(KafkaClusterTestKit|SharePartition).java"/>
+    <suppress checks="JavaNCSS" files="(SharePartition).java"/>
 
     <!-- server tests -->
     <suppress checks="MethodLength|JavaNCSS|NPath" files="DescribeTopicPartitionsRequestHandlerTest.java"/>

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -804,6 +804,7 @@ public class SharePartition {
                 try {
                     InFlightBatch inFlightBatch = cachedStateEntry.getValue();
                     long localNextFetchOffset = nextFetchOffset;
+                    // Case when the state of complete batch is valid
                     if (inFlightBatch.offsetState == null) {
                         if (inFlightBatch.batchState() == RecordState.ACQUIRED) {
                             InFlightState updateResult = inFlightBatch.tryUpdateBatchState(RecordState.AVAILABLE, false);

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -817,7 +817,7 @@ public class SharePartition {
                             log.trace("The batch is not in acquired state while release of acquisition lock on timeout, skipping, batch: {}"
                                             + " for the share group: {}-{}-{}", inFlightBatch, groupId, memberId, topicIdPartition);
                         }
-                    } else { // Case when batch has a valid offset state map
+                    } else { // Case when batch has a valid offset state map.
                         for (Map.Entry<Long, InFlightState> offsetState : inFlightBatch.offsetState.entrySet()) {
                             // For the first batch which might have offsets prior to the request base
                             // offset i.e. cached batch of 10-14 offsets and request batch of 12-13.

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -813,9 +813,8 @@ public class SharePartition {
                             } else {
                                 localNextFetchOffset = Math.min(cachedStateEntry.getKey(), localNextFetchOffset);
                             }
-                        }
-                        else {
-                            log.trace("The batch is not acquired while release of acquisition lock on timeout, skipping, batch: {}"
+                        } else {
+                            log.trace("The batch is not in acquired state while release of acquisition lock on timeout, skipping, batch: {}"
                                             + " for the share group: {}-{}-{}", inFlightBatch, groupId, memberId, topicIdPartition);
                         }
                     } else { // Case when batch has a valid offset state map
@@ -832,7 +831,7 @@ public class SharePartition {
                             }
 
                             if (offsetState.getValue().state != RecordState.ACQUIRED) {
-                                log.trace("The offset is not acquired while release of acquisition lock on timeout, skipping, offset: {} batch: {}"
+                                log.trace("The offset is not in acquired state while release of acquisition lock on timeout, skipping, offset: {} batch: {}"
                                                 + " for the share group: {}-{}-{}", offsetState.getKey(), inFlightBatch,
                                         groupId, memberId, topicIdPartition);
                                 continue;

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -326,7 +326,7 @@ public class SharePartition {
                     groupId, topicIdPartition);
                 AcquiredRecords acquiredRecords = acquireNewBatchRecords(memberId, firstBatch.baseOffset(), lastBatch.lastOffset(),
                         lastBatch.nextOffset());
-                startAcquisitionLockTimer(memberId, firstBatch.baseOffset(), lastBatch.lastOffset(), cachedState.floorEntry(firstBatch.baseOffset()));
+                scheduleAcquisitionLockTimeout(memberId, firstBatch.baseOffset(), lastBatch.lastOffset(), cachedState.floorEntry(firstBatch.baseOffset()));
                 return CompletableFuture.completedFuture(Collections.singletonList(acquiredRecords));
             }
 
@@ -365,7 +365,7 @@ public class SharePartition {
                     }
                     boolean atLeastOneAcquired = acquireSubsetBatchRecords(firstBatch.baseOffset(), lastBatch.lastOffset(), inFlightBatch, result);
                     if (atLeastOneAcquired)
-                        startAcquisitionLockTimer(memberId, firstBatch.baseOffset(), lastBatch.lastOffset(), entry);
+                        scheduleAcquisitionLockTimeout(memberId, firstBatch.baseOffset(), lastBatch.lastOffset(), entry);
                     continue;
                 }
 
@@ -382,7 +382,7 @@ public class SharePartition {
                         inFlightBatch, groupId, topicIdPartition);
                     continue;
                 }
-                startAcquisitionLockTimer(memberId, inFlightBatch.baseOffset(), inFlightBatch.lastOffset(), entry);
+                scheduleAcquisitionLockTimeout(memberId, inFlightBatch.baseOffset(), inFlightBatch.lastOffset(), entry);
 
                 findNextFetchOffset.set(true);
                 result.add(new AcquiredRecords()
@@ -397,7 +397,7 @@ public class SharePartition {
                 log.trace("There exists another batch which needs to be acquired as well");
                 result.add(acquireNewBatchRecords(memberId, subMap.lastEntry().getValue().lastOffset() + 1,
                     lastBatch.lastOffset(), lastBatch.nextOffset()));
-                startAcquisitionLockTimer(memberId, subMap.lastEntry().getValue().lastOffset() + 1, lastBatch.lastOffset(),
+                scheduleAcquisitionLockTimeout(memberId, subMap.lastEntry().getValue().lastOffset() + 1, lastBatch.lastOffset(),
                         cachedState.floorEntry(subMap.lastEntry().getValue().lastOffset() + 1));
             }
             return CompletableFuture.completedFuture(result);
@@ -796,64 +796,74 @@ public class SharePartition {
      * @param cachedStateEntry The cached state map entry for the acquired records which contains the entire batch
      *                         from base offset to last offset.
      */
-    private void startAcquisitionLockTimer(String memberId, long baseOffset, long lastOffset, Map.Entry<Long, InFlightBatch> cachedStateEntry) {
-        timer.add(new TimerTask(recordLockDurationMs) {
+    private void scheduleAcquisitionLockTimeout(String memberId, long baseOffset, long lastOffset, Map.Entry<Long, InFlightBatch> cachedStateEntry) {
+        TimerTask timerTask = acquisitionLockTimerTask(memberId, baseOffset, lastOffset, cachedStateEntry);
+        timer.add(timerTask);
+    }
+
+    private TimerTask acquisitionLockTimerTask(String memberId, long baseOffset, long lastOffset, Map.Entry<Long, InFlightBatch> cachedStateEntry) {
+        TimerTask timerTask = new TimerTask(recordLockDurationMs) {
             // Runs when the acquisition lock timer expires. We would then be releasing the acquired records.
             @Override
             public void run() {
-                lock.writeLock().lock();
-                try {
-                    InFlightBatch inFlightBatch = cachedStateEntry.getValue();
-                    long localNextFetchOffset = nextFetchOffset;
-                    // Case when the state of complete batch is valid
-                    if (inFlightBatch.offsetState == null) {
-                        if (inFlightBatch.batchState() == RecordState.ACQUIRED) {
-                            InFlightState updateResult = inFlightBatch.tryUpdateBatchState(RecordState.AVAILABLE, false);
-                            if (updateResult == null) {
-                                log.debug("Unable to release acquisition lock on timeout for the batch: {}"
-                                        + " for the share partition: {}-{}-{}", inFlightBatch, groupId, memberId, topicIdPartition);
-                            } else {
-                                localNextFetchOffset = Math.min(cachedStateEntry.getKey(), localNextFetchOffset);
-                            }
-                        } else {
-                            log.trace("The batch is not in acquired state while release of acquisition lock on timeout, skipping, batch: {}"
-                                            + " for the share group: {}-{}-{}", inFlightBatch, groupId, memberId, topicIdPartition);
-                        }
-                    } else { // Case when batch has a valid offset state map.
-                        for (Map.Entry<Long, InFlightState> offsetState : inFlightBatch.offsetState.entrySet()) {
-                            // For the first batch which might have offsets prior to the request base
-                            // offset i.e. cached batch of 10-14 offsets and request batch of 12-13.
-                            if (offsetState.getKey() < baseOffset) {
-                                continue;
-                            }
+                releaseAcquisitionLockOnTimeout(memberId, baseOffset, lastOffset, cachedStateEntry);
+            }
+        };
+        return timerTask;
+    }
 
-                            if (offsetState.getKey() > lastOffset) {
-                                // No further offsets to process.
-                                break;
-                            }
-
-                            if (offsetState.getValue().state != RecordState.ACQUIRED) {
-                                log.trace("The offset is not in acquired state while release of acquisition lock on timeout, skipping, offset: {} batch: {}"
-                                                + " for the share group: {}-{}-{}", offsetState.getKey(), inFlightBatch,
-                                        groupId, memberId, topicIdPartition);
-                                continue;
-                            }
-                            InFlightState updateResult = offsetState.getValue().tryUpdateState(RecordState.AVAILABLE, false);
-                            if (updateResult == null) {
-                                log.debug("Unable to release acquisition lock on timeout for the offset: {} in batch: {}"
-                                                + " for the share group: {}-{}-{}", offsetState.getKey(), inFlightBatch,
-                                        groupId, memberId, topicIdPartition);
-                                continue;
-                            }
-                            localNextFetchOffset = Math.min(offsetState.getKey(), localNextFetchOffset);
-                        }
+    private void releaseAcquisitionLockOnTimeout(String memberId, long baseOffset, long lastOffset, Map.Entry<Long, InFlightBatch> cachedStateEntry) {
+        lock.writeLock().lock();
+        try {
+            InFlightBatch inFlightBatch = cachedStateEntry.getValue();
+            long localNextFetchOffset = nextFetchOffset;
+            // Case when the state of complete batch is valid
+            if (inFlightBatch.offsetState == null) {
+                if (inFlightBatch.batchState() == RecordState.ACQUIRED) {
+                    InFlightState updateResult = inFlightBatch.tryUpdateBatchState(RecordState.AVAILABLE, false);
+                    if (updateResult == null) {
+                        log.debug("Unable to release acquisition lock on timeout for the batch: {}"
+                                + " for the share partition: {}-{}-{}", inFlightBatch, groupId, memberId, topicIdPartition);
+                    } else {
+                        localNextFetchOffset = Math.min(cachedStateEntry.getKey(), localNextFetchOffset);
                     }
-                    nextFetchOffset = localNextFetchOffset;
-                } finally {
-                    lock.writeLock().unlock();
+                } else {
+                    log.trace("The batch is not in acquired state while release of acquisition lock on timeout, skipping, batch: {}"
+                            + " for the share group: {}-{}-{}", inFlightBatch, groupId, memberId, topicIdPartition);
+                }
+            } else { // Case when batch has a valid offset state map.
+                for (Map.Entry<Long, InFlightState> offsetState : inFlightBatch.offsetState.entrySet()) {
+                    // For the first batch which might have offsets prior to the request base
+                    // offset i.e. cached batch of 10-14 offsets and request batch of 12-13.
+                    if (offsetState.getKey() < baseOffset) {
+                        continue;
+                    }
+
+                    if (offsetState.getKey() > lastOffset) {
+                        // No further offsets to process.
+                        break;
+                    }
+
+                    if (offsetState.getValue().state != RecordState.ACQUIRED) {
+                        log.trace("The offset is not in acquired state while release of acquisition lock on timeout, skipping, offset: {} batch: {}"
+                                        + " for the share group: {}-{}-{}", offsetState.getKey(), inFlightBatch,
+                                groupId, memberId, topicIdPartition);
+                        continue;
+                    }
+                    InFlightState updateResult = offsetState.getValue().tryUpdateState(RecordState.AVAILABLE, false);
+                    if (updateResult == null) {
+                        log.debug("Unable to release acquisition lock on timeout for the offset: {} in batch: {}"
+                                        + " for the share group: {}-{}-{}", offsetState.getKey(), inFlightBatch,
+                                groupId, memberId, topicIdPartition);
+                        continue;
+                    }
+                    localNextFetchOffset = Math.min(offsetState.getKey(), localNextFetchOffset);
                 }
             }
-        });
+            nextFetchOffset = localNextFetchOffset;
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     /**

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -331,8 +331,8 @@ public class SharePartition {
                 log.trace("No cached data exists for the share partition for requested fetch batch: {}-{}",
                     groupId, topicIdPartition);
                 return CompletableFuture.completedFuture(Collections.singletonList(
-                        acquireNewBatchRecords(memberId, firstBatch.baseOffset(), lastBatch.lastOffset(),
-                        lastBatch.nextOffset())));
+                            acquireNewBatchRecords(memberId, firstBatch.baseOffset(), lastBatch.lastOffset(),
+                            lastBatch.nextOffset())));
             }
 
             log.trace("Overlap exists with in-flight records. Acquire the records if available for"
@@ -368,7 +368,7 @@ public class SharePartition {
                         // the offsets state in the in-flight batch.
                         inFlightBatch.maybeInitializeOffsetStateUpdate();
                     }
-                    acquireSubsetBatchRecords(firstBatch.baseOffset(), lastBatch.lastOffset(), inFlightBatch, result, memberId);
+                    acquireSubsetBatchRecords(memberId, firstBatch.baseOffset(), lastBatch.lastOffset(), inFlightBatch, result);
                     continue;
                 }
 
@@ -742,8 +742,8 @@ public class SharePartition {
         }
     }
 
-    private void acquireSubsetBatchRecords(long requestBaseOffset, long requestLastOffset,
-        InFlightBatch inFlightBatch, List<AcquiredRecords> result, String memberId) {
+    private void acquireSubsetBatchRecords(String memberId, long requestBaseOffset, long requestLastOffset,
+        InFlightBatch inFlightBatch, List<AcquiredRecords> result) {
         lock.writeLock().lock();
         try {
             for (Map.Entry<Long, InFlightState> offsetState : inFlightBatch.offsetState.entrySet()) {

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -132,7 +132,7 @@ public class SharePartitionManager {
                 SharePartition sharePartition = partitionCacheMap.computeIfAbsent(sharePartitionKey(
                     shareFetchPartitionData.groupId, topicIdPartition),
                     k -> new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, 100, 5,
-                            recordLockDurationMs, timer));
+                            recordLockDurationMs, timer, time));
                 int partitionMaxBytes = shareFetchPartitionData.partitionMaxBytes.getOrDefault(topicIdPartition, 0);
                 // Add the share partition to the list of partitions to be fetched only if we can
                 // acquire the fetch lock on it.

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -1319,13 +1319,13 @@ public class SharePartitionManagerTest {
 
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp0),
-                k -> new SharePartition(groupId, tp0, 100, 5, RECORD_LOCK_DURATION_MS, TIMER));
+                k -> new SharePartition(groupId, tp0, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, time));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp1),
-                k -> new SharePartition(groupId, tp1, 100, 5, RECORD_LOCK_DURATION_MS, TIMER));
+                k -> new SharePartition(groupId, tp1, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, time));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp2),
-                k -> new SharePartition(groupId, tp2, 100, 5, RECORD_LOCK_DURATION_MS, TIMER));
+                k -> new SharePartition(groupId, tp2, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, time));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp3),
-                k -> new SharePartition(groupId, tp3, 100, 5, RECORD_LOCK_DURATION_MS, TIMER));
+                k -> new SharePartition(groupId, tp3, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, time));
 
         SharePartitionManager sharePartitionManager = new SharePartitionManager(replicaManager, time,
                 new SharePartitionManager.ShareSessionCache(10, 1000), partitionCacheMap, RECORD_LOCK_DURATION_MS);

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -1262,7 +1262,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(0, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(0, sharePartition.cachedState().get(0L).baseOffset());
@@ -1301,7 +1301,7 @@ public class SharePartitionTest {
         assertNotNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(10, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(10, sharePartition.cachedState().get(10L).baseOffset());
@@ -1348,7 +1348,7 @@ public class SharePartitionTest {
         assertEquals(2, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(0, sharePartition.nextFetchOffset());
         assertEquals(2, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
@@ -1377,7 +1377,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(10, sharePartition.nextFetchOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
         assertEquals(0, sharePartition.timer().size());
@@ -1425,7 +1425,7 @@ public class SharePartitionTest {
         assertNull(sharePartition.cachedState().get(0L).offsetState());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(1, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(0L).batchState());
@@ -1467,7 +1467,7 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(15, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(5L).batchState());
@@ -1536,7 +1536,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(1, sharePartition.nextFetchOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(1L).batchState());
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(5L).batchState());
@@ -1569,7 +1569,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(10, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
@@ -1606,7 +1606,7 @@ public class SharePartitionTest {
         assertEquals(3, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(10, sharePartition.nextFetchOffset());
         assertNotNull(sharePartition.cachedState().get(10L).offsetState());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).offsetState().get(10L).state());
@@ -1718,7 +1718,7 @@ public class SharePartitionTest {
         assertEquals(new HashSet<>(Arrays.asList(12L, 13L, 15L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(5, sharePartition.nextFetchOffset());
         // Check cached state.
         expectedOffsetStateMap = new HashMap<>();
@@ -1778,7 +1778,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(5, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
@@ -1834,7 +1834,7 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(5, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
@@ -1960,7 +1960,7 @@ public class SharePartitionTest {
         assertEquals(new HashSet<>(Arrays.asList(12L, 13L, 15L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
 
         // Allowing acquisition lock to expire. This won't change the state since the batches have been released.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(5, sharePartition.nextFetchOffset());
         // Check cached state.
         assertEquals(expectedOffsetStateMap1, sharePartition.cachedState().get(5L).offsetState());
@@ -2020,7 +2020,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(200);
+        Thread.sleep(110);
         assertEquals(5, sharePartition.nextFetchOffset());
         // Check cached state.
         expectedOffsetStateMap = new HashMap<>();

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -1262,7 +1262,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(0, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(0, sharePartition.cachedState().get(0L).baseOffset());
@@ -1301,7 +1301,7 @@ public class SharePartitionTest {
         assertNotNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(10, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(10, sharePartition.cachedState().get(10L).baseOffset());
@@ -1348,7 +1348,7 @@ public class SharePartitionTest {
         assertEquals(2, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(0, sharePartition.nextFetchOffset());
         assertEquals(2, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
@@ -1377,7 +1377,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(10, sharePartition.nextFetchOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
         assertEquals(0, sharePartition.timer().size());
@@ -1425,7 +1425,7 @@ public class SharePartitionTest {
         assertNull(sharePartition.cachedState().get(0L).offsetState());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(1, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(0L).batchState());
@@ -1467,7 +1467,7 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(15, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(5L).batchState());
@@ -1536,7 +1536,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(1, sharePartition.nextFetchOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(1L).batchState());
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(5L).batchState());
@@ -1569,7 +1569,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(10, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
@@ -1606,7 +1606,7 @@ public class SharePartitionTest {
         assertEquals(3, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(10, sharePartition.nextFetchOffset());
         assertNotNull(sharePartition.cachedState().get(10L).offsetState());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).offsetState().get(10L).state());
@@ -1718,7 +1718,7 @@ public class SharePartitionTest {
         assertEquals(new HashSet<>(Arrays.asList(12L, 13L, 15L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(5, sharePartition.nextFetchOffset());
         // Check cached state.
         expectedOffsetStateMap = new HashMap<>();
@@ -1778,7 +1778,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(5, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
@@ -1834,7 +1834,7 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(5, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
@@ -1960,7 +1960,7 @@ public class SharePartitionTest {
         assertEquals(new HashSet<>(Arrays.asList(12L, 13L, 15L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
 
         // Allowing acquisition lock to expire. This won't change the state since the batches have been released.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(5, sharePartition.nextFetchOffset());
         // Check cached state.
         assertEquals(expectedOffsetStateMap1, sharePartition.cachedState().get(5L).offsetState());
@@ -2020,7 +2020,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Allowing acquisition lock to expire.
-        Thread.sleep(110);
+        Thread.sleep(180);
         assertEquals(5, sharePartition.nextFetchOffset());
         // Check cached state.
         expectedOffsetStateMap = new HashMap<>();

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -849,7 +849,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         assertEquals("key_2", new String(records1.iterator().next().key()));
         assertEquals("value_2", new String(records1.iterator().next().value()));
         // Allowing acquisition lock to expire.
-        Thread.sleep(8000);
+        Thread.sleep(12000);
         records2 = shareConsumer1.poll(Duration.ofMillis(2000));
         assertEquals(1, records2.count());
         assertEquals("key_2", new String(records2.iterator().next().key()));

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -812,4 +812,52 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
             fail("Exception occurred : " + e.getMessage());
         }
     }
+
+    @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
+    @ValueSource(strings = {"kraft+kip932"})
+    public void testAcquisitionLockTimeoutOnConsumer(String quorum) throws InterruptedException {
+        ProducerRecord<byte[], byte[]> producerRecord1 = new ProducerRecord<>(tp().topic(), tp().partition(), null,
+                "key_1".getBytes(), "value_1".getBytes());
+        ProducerRecord<byte[], byte[]> producerRecord2 = new ProducerRecord<>(tp().topic(), tp().partition(), null,
+                "key_2".getBytes(), "value_2".getBytes());
+        KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
+        Properties props = new Properties();
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "group1");
+        KafkaShareConsumer<byte[], byte[]> shareConsumer1 = createShareConsumer(new ByteArrayDeserializer(), new ByteArrayDeserializer(),
+                props, CollectionConverters.asScala(Collections.<String>emptyList()).toList());
+        shareConsumer1.subscribe(Collections.singleton(tp().topic()));
+
+        producer.send(producerRecord1);
+
+        // Poll two times to receive records. The first poll puts the acquisition lock and fetches the record.
+        // Since, we are only sending one record and acquisition lock hasn't timed out, the second poll only acknowledges the
+        // record from the first poll and no more fetch.
+        ConsumerRecords<byte[], byte[]> records1 = shareConsumer1.poll(Duration.ofMillis(2000));
+        assertEquals(1, records1.count());
+        assertEquals("key_1", new String(records1.iterator().next().key()));
+        assertEquals("value_1", new String(records1.iterator().next().value()));
+        ConsumerRecords<byte[], byte[]> records2 = shareConsumer1.poll(Duration.ofMillis(2000));
+        assertEquals(0, records2.count());
+
+        producer.send(producerRecord2);
+
+        // Poll three times. The first poll acquires the lock and fetches the record. Before the second poll,
+        // acquisition lock times out and hence the consumer needs to fetch the record again. Since, the acquisition lock
+        // hasn't timed out this time, the third poll only acknowledges the record from the second poll and no more fetch.
+        records1 = shareConsumer1.poll(Duration.ofMillis(2000));
+        assertEquals(1, records1.count());
+        assertEquals("key_2", new String(records1.iterator().next().key()));
+        assertEquals("value_2", new String(records1.iterator().next().value()));
+        // Allowing acquisition lock to expire.
+        Thread.sleep(8000);
+        records2 = shareConsumer1.poll(Duration.ofMillis(2000));
+        assertEquals(1, records2.count());
+        assertEquals("key_2", new String(records2.iterator().next().key()));
+        assertEquals("value_2", new String(records2.iterator().next().value()));
+        ConsumerRecords<byte[], byte[]> records3 = shareConsumer1.poll(Duration.ofMillis(2000));
+        assertEquals(0, records3.count());
+
+        producer.close();
+        shareConsumer1.close();
+    }
 }

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -841,9 +841,9 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
 
         producer.send(producerRecord2);
 
-        // Poll three times. The first poll acquires the lock and fetches the record. Before the second poll,
+        // Poll three times. The first poll puts the acquisition lock and fetches the record. Before the second poll,
         // acquisition lock times out and hence the consumer needs to fetch the record again. Since, the acquisition lock
-        // hasn't timed out this time, the third poll only acknowledges the record from the second poll and no more fetch.
+        // hasn't timed out before the third poll, the third poll only acknowledges the record from the second poll and no more fetch.
         records1 = shareConsumer1.poll(Duration.ofMillis(2000));
         assertEquals(1, records1.count());
         assertEquals("key_2", new String(records1.iterator().next().key()));

--- a/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
@@ -58,7 +58,7 @@ abstract class AbstractShareConsumerTest extends BaseRequestTest {
     properties.setProperty(KafkaConfig.GroupMinSessionTimeoutMsProp, "100") // set small enough session timeout
     properties.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, groupMaxSessionTimeoutMs.toString)
     properties.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "10")
-    properties.setProperty(KafkaConfig.ShareGroupRecordLockDurationMsProp, "8000")
+    properties.setProperty(KafkaConfig.ShareGroupRecordLockDurationMsProp, "10000")
   }
 
   @BeforeEach

--- a/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
@@ -58,6 +58,7 @@ abstract class AbstractShareConsumerTest extends BaseRequestTest {
     properties.setProperty(KafkaConfig.GroupMinSessionTimeoutMsProp, "100") // set small enough session timeout
     properties.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, groupMaxSessionTimeoutMs.toString)
     properties.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "10")
+    properties.setProperty(KafkaConfig.ShareGroupRecordLockDurationMsProp, "8000")
   }
 
   @BeforeEach


### PR DESCRIPTION
### About
Implemented the acquisition lock timeout using `SystemTimerReaper`. I have added unit tests and an integration test to confirm the working of acquisition lock.

I am not 100% sure about the way I have set the `ShareGroupRecordLockDurationMs` property for the integration test. Right now, its applied to all the integration tests by using `brokerPropertyOverrides()`. Please comment if it should be applied to all integration test or if there is a better way to applying it only for the new integration test.
