### PR TITLE
AKCORE-74: Incorporated KIP changes to RPC schemas for share coord.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupStateResponse.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class DeleteShareGroupStateResponse extends AbstractResponse {
@@ -41,7 +41,13 @@ public class DeleteShareGroupStateResponse extends AbstractResponse {
 
   @Override
   public Map<Errors, Integer> errorCounts() {
-    return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+    Map<Errors, Integer> counts = new HashMap<>();
+    data.results().forEach(
+        result -> result.partitions().forEach(
+            partitionResult -> updateErrorCounts(counts, Errors.forCode(partitionResult.errorCode()))
+        )
+    );
+    return counts;
   }
 
   @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/InitializeShareGroupStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/InitializeShareGroupStateResponse.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class InitializeShareGroupStateResponse extends AbstractResponse {
@@ -41,7 +41,13 @@ public class InitializeShareGroupStateResponse extends AbstractResponse {
 
   @Override
   public Map<Errors, Integer> errorCounts() {
-    return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+    Map<Errors, Integer> counts = new HashMap<>();
+    data.results().forEach(
+        result -> result.partitions().forEach(
+            partitionResult -> updateErrorCounts(counts, Errors.forCode(partitionResult.errorCode()))
+        )
+    );
+    return counts;
   }
 
   @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupOffsetsStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupOffsetsStateResponse.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class ReadShareGroupOffsetsStateResponse extends AbstractResponse {
@@ -41,7 +41,13 @@ public class ReadShareGroupOffsetsStateResponse extends AbstractResponse {
 
   @Override
   public Map<Errors, Integer> errorCounts() {
-    return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+    Map<Errors, Integer> counts = new HashMap<>();
+    data.results().forEach(
+        result -> result.partitions().forEach(
+            partitionResult -> updateErrorCounts(counts, Errors.forCode(partitionResult.errorCode()))
+        )
+    );
+    return counts;
   }
 
   @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupStateResponse.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class ReadShareGroupStateResponse extends AbstractResponse {
@@ -41,7 +41,13 @@ public class ReadShareGroupStateResponse extends AbstractResponse {
 
   @Override
   public Map<Errors, Integer> errorCounts() {
-    return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+    Map<Errors, Integer> counts = new HashMap<>();
+    data.results().forEach(
+        result -> result.partitions().forEach(
+            partitionResult -> updateErrorCounts(counts, Errors.forCode(partitionResult.errorCode()))
+        )
+    );
+    return counts;
   }
 
   @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteShareGroupStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteShareGroupStateResponse.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class WriteShareGroupStateResponse extends AbstractResponse {
@@ -41,7 +41,13 @@ public class WriteShareGroupStateResponse extends AbstractResponse {
 
   @Override
   public Map<Errors, Integer> errorCounts() {
-    return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+    Map<Errors, Integer> counts = new HashMap<>();
+    data.results().forEach(
+        result -> result.partitions().forEach(
+            partitionResult -> updateErrorCounts(counts, Errors.forCode(partitionResult.errorCode()))
+        )
+    );
+    return counts;
   }
 
   @Override

--- a/clients/src/main/resources/common/message/DeleteShareGroupStateRequest.json
+++ b/clients/src/main/resources/common/message/DeleteShareGroupStateRequest.json
@@ -20,6 +20,7 @@
   "name": "DeleteShareGroupStateRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
+  "latestVersionUnstable": true,
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+",
       "about":"The group identifier." },

--- a/clients/src/main/resources/common/message/DeleteShareGroupStateRequest.json
+++ b/clients/src/main/resources/common/message/DeleteShareGroupStateRequest.json
@@ -20,13 +20,18 @@
   "name": "DeleteShareGroupStateRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
-  "latestVersionUnstable": true,
   "fields": [
-    {"name": "GroupId", "type": "string", "versions": "0+",
-      "about": "The group identifier." },
-    {"name": "TopicId", "type": "uuid", "versions": "0+",
-      "about": "The topic identifier." },
-    {"name": "Partition", "type": "int32", "versions": "0+",
-      "about": "The partition index." }
+    { "name": "GroupId", "type": "string", "versions": "0+",
+      "about":"The group identifier." },
+    { "name": "Topics", "type": "[]DeleteStateData", "versions": "0+",
+      "about": "The data for the topics.", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic identifier." },
+      { "name": "Partitions", "type": "[]PartitionData", "versions": "0+",
+        "about":  "The data for the partitions.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." }
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/DeleteShareGroupStateResponse.json
+++ b/clients/src/main/resources/common/message/DeleteShareGroupStateResponse.json
@@ -27,7 +27,17 @@
   // - FENCED_STATE_EPOCH (version 0+)
   // - INVALID_REQUEST (version 0+)
   "fields": [
-    { "name": "ErrorCode", "type": "int16", "versions": "0+",
-      "about": "The error code, or 0 if there was no error." }
+    { "name": "Results", "type": "[]DeleteStateResult", "versions": "0+",
+      "about": "The delete results", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic identifier" },
+      { "name": "Partitions", "type": "[]PartitionResult", "versions": "0+",
+        "about" : "The results for the partitions.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The error code, or 0 if there was no error." }
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/InitializeShareGroupStateRequest.json
+++ b/clients/src/main/resources/common/message/InitializeShareGroupStateRequest.json
@@ -20,17 +20,22 @@
   "name": "InitializeShareGroupStateRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
-  "latestVersionUnstable": true,
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+",
       "about": "The group identifier." },
-    { "name": "TopicId", "type": "uuid", "versions": "0+",
-      "about": "The topic identifier." },
-    { "name": "Partition", "type": "int32", "versions": "0+",
-      "about": "The partition index." },
-    { "name": "StateEpoch", "type": "int32", "versions": "0+",
-      "about": "The state epoch for this share-partition." },
-    { "name": "StartOffset", "type": "int64", "versions": "0+",
-      "about": "The share-partition start offset, or -1 if the start offset is not being initialized." }
+    { "name": "Topics", "type": "[]InitializeStateData", "versions": "0+",
+      "about": "The data for the topics.", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic identifier." },
+      { "name": "Partitions", "type": "[]PartitionData", "versions": "0+",
+        "about":  "The data for the partitions.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "StateEpoch", "type": "int32", "versions": "0+",
+          "about": "The state epoch for this share-partition." },
+        { "name": "StartOffset", "type": "int64", "versions": "0+",
+          "about": "The share-partition start offset, or -1 if the start offset is not being initialized." }
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/InitializeShareGroupStateRequest.json
+++ b/clients/src/main/resources/common/message/InitializeShareGroupStateRequest.json
@@ -20,6 +20,7 @@
   "name": "InitializeShareGroupStateRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
+  "latestVersionUnstable": true,
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+",
       "about": "The group identifier." },

--- a/clients/src/main/resources/common/message/InitializeShareGroupStateResponse.json
+++ b/clients/src/main/resources/common/message/InitializeShareGroupStateResponse.json
@@ -25,7 +25,17 @@
   // - FENCED_STATE_EPOCH (version 0+)
   // - INVALID_REQUEST (version 0+)
   "fields": [
-    { "name": "ErrorCode", "type": "int16", "versions": "0+",
-      "about": "The error code, or 0 if there was no error." }
+    { "name": "Results", "type": "[]InitializeStateResult", "versions": "0+",
+      "about": "The initialization results", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic identifier" },
+      { "name": "Partitions", "type": "[]PartitionResult", "versions": "0+",
+        "about" : "The results for the partitions.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The error code, or 0 if there was no error." }
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/ReadShareGroupOffsetsStateRequest.json
+++ b/clients/src/main/resources/common/message/ReadShareGroupOffsetsStateRequest.json
@@ -20,13 +20,18 @@
   "name": "ReadShareGroupOffsetsStateRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
-  "latestVersionUnstable": true,
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+",
       "about":"The group identifier." },
-    { "name": "TopicId", "type": "uuid", "versions": "0+",
-      "about": "The topic identifier." },
-    { "name": "Partition", "type": "int32", "versions": "0+",
-      "about": "The partition index." }
+    { "name": "Topics", "type": "[]ReadOffsetsStateData", "versions": "0+",
+      "about": "The data for the topics.", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic identifier." },
+      { "name": "Partitions", "type": "[]PartitionData", "versions": "0+",
+        "about":  "The data for the partitions.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." }
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/ReadShareGroupOffsetsStateRequest.json
+++ b/clients/src/main/resources/common/message/ReadShareGroupOffsetsStateRequest.json
@@ -20,6 +20,7 @@
   "name": "ReadShareGroupOffsetsStateRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
+  "latestVersionUnstable": true,
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+",
       "about":"The group identifier." },

--- a/clients/src/main/resources/common/message/ReadShareGroupOffsetsStateResponse.json
+++ b/clients/src/main/resources/common/message/ReadShareGroupOffsetsStateResponse.json
@@ -26,11 +26,21 @@
   // - UNKNOWN_TOPIC_OR_PARTITION (version 0+)
   // - INVALID_REQUEST (version 0+)
   "fields": [
-    { "name": "ErrorCode", "type": "int16", "versions": "0+",
-      "about": "The error code, or 0 if there was no error." },
-    { "name": "StateEpoch", "type": "int32", "versions": "0+",
-      "about": "The state epoch for this share-partition." },
-    { "name": "StartOffset", "type": "int64", "versions": "0+",
-      "about": "The share-partition start offset." }
+    { "name": "Results", "type": "[]ReadOffsetsStateResult", "versions": "0+",
+      "about": "The read results", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic identifier" },
+      { "name": "Partitions", "type": "[]PartitionResult", "versions": "0+",
+        "about" : "The results for the partitions.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The error code, or 0 if there was no error." },
+        { "name": "StateEpoch", "type": "int32", "versions": "0+",
+          "about": "The state epoch for this share-partition." },
+        { "name": "StartOffset", "type": "int64", "versions": "0+",
+          "about": "The share-partition start offset." }
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/ReadShareGroupStateRequest.json
+++ b/clients/src/main/resources/common/message/ReadShareGroupStateRequest.json
@@ -20,13 +20,18 @@
   "name": "ReadShareGroupStateRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
-  "latestVersionUnstable": true,
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+",
       "about":"The group identifier." },
-    { "name": "TopicId", "type": "uuid", "versions": "0+",
-      "about": "The topic identifier." },
-    { "name": "Partition", "type": "int32", "versions": "0+",
-      "about": "The partition index." }
+    { "name": "Topics", "type": "[]ReadStateData", "versions": "0+",
+      "about": "The data for the topics.", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic identifier." },
+      { "name": "Partitions", "type": "[]PartitionData", "versions": "0+",
+        "about":  "The data for the partitions.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." }
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/ReadShareGroupStateRequest.json
+++ b/clients/src/main/resources/common/message/ReadShareGroupStateRequest.json
@@ -20,6 +20,7 @@
   "name": "ReadShareGroupStateRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
+  "latestVersionUnstable": true,
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+",
       "about":"The group identifier." },

--- a/clients/src/main/resources/common/message/ReadShareGroupStateResponse.json
+++ b/clients/src/main/resources/common/message/ReadShareGroupStateResponse.json
@@ -26,21 +26,31 @@
   // - UNKNOWN_TOPIC_OR_PARTITION (version 0+)
   // - INVALID_REQUEST (version 0+)
   "fields": [
-    { "name": "ErrorCode", "type": "int16", "versions": "0+",
-      "about": "The error code, or 0 if there was no error." },
-    { "name": "StateEpoch", "type": "int32", "versions": "0+",
-      "about": "The state epoch for this share-partition." },
-    { "name": "StartOffset", "type": "int64", "versions": "0+",
-      "about": "The share-partition start offset." },
-    { "name": "StateBatches", "type": "[]StateBatch", "versions": "0+", "fields":[
-      { "name": "BaseOffset", "type": "int64", "versions": "0+",
-        "about": "The base offset of this state batch." },
-      { "name": "LastOffset", "type": "int64", "versions": "0+",
-        "about": "The last offset of this state batch." },
-      { "name": "State", "type": "int8", "versions": "0+",
-        "about": "The state - 0:Available,2:Acked,4:Archived." },
-      { "name": "DeliveryCount", "type": "int16", "versions": "0+",
-        "about": "The delivery count." }
+    { "name": "Results", "type": "[]ReadStateResult", "versions": "0+",
+      "about": "The read results", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic identifier" },
+      { "name": "Partitions", "type": "[]PartitionResult", "versions": "0+",
+        "about" : "The results for the partitions.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The error code, or 0 if there was no error." },
+        { "name": "StateEpoch", "type": "int32", "versions": "0+",
+          "about": "The state epoch for this share-partition." },
+        { "name": "StartOffset", "type": "int64", "versions": "0+",
+          "about": "The share-partition start offset, which can be -1 if it is not yet initialized." },
+        { "name": "StateBatches", "type": "[]StateBatch", "versions": "0+", "fields":[
+          { "name": "BaseOffset", "type": "int64", "versions": "0+",
+            "about": "The base offset of this state batch." },
+          { "name": "LastOffset", "type": "int64", "versions": "0+",
+            "about": "The last offset of this state batch." },
+          { "name": "State", "type": "int8", "versions": "0+",
+            "about": "The state - 0:Available,2:Acked,4:Archived." },
+          { "name": "DeliveryCount", "type": "int16", "versions": "0+",
+            "about": "The delivery count." }
+        ]}
+      ]}
     ]}
   ]
 }

--- a/clients/src/main/resources/common/message/WriteShareGroupStateRequest.json
+++ b/clients/src/main/resources/common/message/WriteShareGroupStateRequest.json
@@ -20,27 +20,32 @@
   "name": "WriteShareGroupStateRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
-  "latestVersionUnstable": true,
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+",
-      "about": "The group identifier." },
-    { "name": "TopicId", "type": "uuid", "versions": "0+",
-      "about": "The topic identifier." },
-    { "name": "Partition", "type": "int32", "versions": "0+",
-      "about": "The partition index." },
-    { "name": "StateEpoch", "type": "int32", "versions": "0+",
-      "about": "The state epoch for this share-partition." },
-    { "name": "StartOffset", "type": "int64", "versions": "0+",
-      "about": "The share-partition start offset, or -1 if the start offset is not being written." },
-    { "name": "StateBatches", "type": "[]StateBatch", "versions": "0+", "fields": [
-      { "name": "BaseOffset", "type": "int64", "versions": "0+",
-        "about": "The base offset of this state batch." },
-      { "name": "LastOffset", "type": "int64", "versions": "0+",
-        "about": "The last offset of this state batch." },
-      { "name": "State", "type": "int8", "versions": "0+",
-        "about": "The state - 0:Available,2:Acked,4:Archived" },
-      { "name": "DeliveryCount", "type": "int16", "versions": "0+",
-        "about": "The delivery count." }
+      "about":"The group identifier." },
+    { "name": "Topics", "type": "[]WriteStateData", "versions": "0+",
+      "about": "The data for the topics.", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic identifier." },
+      { "name": "Partitions", "type": "[]PartitionData", "versions": "0+",
+        "about":  "The data for the partitions.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "StateEpoch", "type": "int32", "versions": "0+",
+          "about": "The state epoch for this share-partition." },
+        { "name": "StartOffset", "type": "int64", "versions": "0+",
+          "about": "The share-partition start offset, or -1 if the start offset is not being written." },
+        { "name": "StateBatches", "type": "[]StateBatch", "versions": "0+", "fields": [
+          { "name": "BaseOffset", "type": "int64", "versions": "0+",
+            "about": "The base offset of this state batch." },
+          { "name": "LastOffset", "type": "int64", "versions": "0+",
+            "about": "The last offset of this state batch." },
+          { "name": "State", "type": "int8", "versions": "0+",
+            "about": "The state - 0:Available,2:Acked,4:Archived" },
+          { "name": "DeliveryCount", "type": "int16", "versions": "0+",
+            "about": "The delivery count." }
+        ]}
+      ]}
     ]}
   ]
 }

--- a/clients/src/main/resources/common/message/WriteShareGroupStateRequest.json
+++ b/clients/src/main/resources/common/message/WriteShareGroupStateRequest.json
@@ -20,6 +20,7 @@
   "name": "WriteShareGroupStateRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
+  "latestVersionUnstable": true,
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+",
       "about":"The group identifier." },

--- a/clients/src/main/resources/common/message/WriteShareGroupStateResponse.json
+++ b/clients/src/main/resources/common/message/WriteShareGroupStateResponse.json
@@ -27,7 +27,17 @@
   // - FENCED_STATE_EPOCH (version 0+)
   // - INVALID_REQUEST (version 0+)
   "fields": [
-    { "name": "ErrorCode", "type": "int16", "versions": "0+",
-      "about": "The error code, or 0 if there was no error." }
+    { "name": "Results", "type": "[]WriteStateResult", "versions": "0+",
+      "about": "The write results", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic identifier" },
+      { "name": "Partitions", "type": "[]PartitionResult", "versions": "0+",
+        "about" : "The results for the partitions.", "fields": [
+        { "name": "Partition", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The error code, or 0 if there was no error." }
+      ]}
+    ]}
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -3826,88 +3826,118 @@ public class RequestResponseTest {
     private InitializeShareGroupStateRequest createInitializeShareGroupStateRequest(short version) {
         InitializeShareGroupStateRequestData data = new InitializeShareGroupStateRequestData()
             .setGroupId("group")
-            .setTopicId(Uuid.randomUuid())
-            .setPartition(0)
-            .setStateEpoch(0)
-            .setStartOffset(0);
+            .setTopics(Collections.singletonList(new InitializeShareGroupStateRequestData.InitializeStateData()
+                .setTopicId(Uuid.randomUuid())
+                .setPartitions(Collections.singletonList(new InitializeShareGroupStateRequestData.PartitionData()
+                    .setPartition(0)
+                    .setStateEpoch(0)
+                    .setStartOffset(0)))));
         return new InitializeShareGroupStateRequest.Builder(data).build(version);
     }
 
     private InitializeShareGroupStateResponse createInitializeShareGroupStateResponse() {
         InitializeShareGroupStateResponseData data = new InitializeShareGroupStateResponseData();
-        data.setErrorCode(Errors.NONE.code());
+        data.setResults(Collections.singletonList(new InitializeShareGroupStateResponseData.InitializeStateResult()
+            .setTopicId(Uuid.randomUuid())
+            .setPartitions(Collections.singletonList(new InitializeShareGroupStateResponseData.PartitionResult()
+                .setPartition(0)
+                .setErrorCode(Errors.NONE.code())))));
         return new InitializeShareGroupStateResponse(data);
     }
 
     private ReadShareGroupStateRequest createReadShareGroupStateRequest(short version) {
         ReadShareGroupStateRequestData data = new ReadShareGroupStateRequestData()
             .setGroupId("group")
-            .setTopicId(Uuid.randomUuid())
-            .setPartition(0);
+            .setTopics(Collections.singletonList(new ReadShareGroupStateRequestData.ReadStateData()
+                .setTopicId(Uuid.randomUuid())
+                .setPartitions(Collections.singletonList(new ReadShareGroupStateRequestData.PartitionData()
+                    .setPartition(0)))));
         return new ReadShareGroupStateRequest.Builder(data).build(version);
     }
 
     private ReadShareGroupStateResponse createReadShareGroupStateResponse() {
         ReadShareGroupStateResponseData data = new ReadShareGroupStateResponseData()
-            .setErrorCode(Errors.NONE.code())
-            .setStateEpoch(0)
-            .setStartOffset(0)
-            .setStateBatches(singletonList(new ReadShareGroupStateResponseData.StateBatch()
-                .setBaseOffset(0)
-                .setLastOffset(0)
-                .setState((byte) 0x0)
-                .setDeliveryCount((short) 0)));
+            .setResults(Collections.singletonList(new ReadShareGroupStateResponseData.ReadStateResult()
+                .setTopicId(Uuid.randomUuid())
+                .setPartitions(Collections.singletonList(new ReadShareGroupStateResponseData.PartitionResult()
+                    .setPartition(0)
+                    .setErrorCode(Errors.NONE.code())
+                    .setStateEpoch(0)
+                    .setStartOffset(0)
+                    .setStateBatches(Collections.singletonList(new ReadShareGroupStateResponseData.StateBatch()
+                        .setBaseOffset(0)
+                        .setLastOffset(0)
+                        .setState((byte) 0x0)
+                        .setDeliveryCount((short) 0)))))));
         return new ReadShareGroupStateResponse(data);
     }
 
     private WriteShareGroupStateRequest createWriteShareGroupStateRequest(short version) {
         WriteShareGroupStateRequestData data = new WriteShareGroupStateRequestData()
             .setGroupId("group")
-            .setTopicId(Uuid.randomUuid())
-            .setPartition(0)
-            .setStateEpoch(0)
-            .setStartOffset(0)
-            .setStateBatches(singletonList(new WriteShareGroupStateRequestData.StateBatch()
-                .setBaseOffset(0)
-                .setLastOffset(0)
-                .setState((byte) 0x0)
-                .setDeliveryCount((short) 0)));
+            .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+                .setTopicId(Uuid.randomUuid())
+                .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                    .setPartition(0)
+                    .setStateEpoch(0)
+                    .setStartOffset(0)
+                    .setStateBatches(singletonList(new WriteShareGroupStateRequestData.StateBatch()
+                        .setBaseOffset(0)
+                        .setLastOffset(0)
+                        .setState((byte) 0x0)
+                        .setDeliveryCount((short) 0)))))));
         return new WriteShareGroupStateRequest.Builder(data).build(version);
     }
 
     private WriteShareGroupStateResponse createWriteShareGroupStateResponse() {
         WriteShareGroupStateResponseData data = new WriteShareGroupStateResponseData()
-            .setErrorCode(Errors.NONE.code());
+            .setResults(Collections.singletonList(new WriteShareGroupStateResponseData.WriteStateResult()
+                .setTopicId(Uuid.randomUuid())
+                .setPartitions(Collections.singletonList(new WriteShareGroupStateResponseData.PartitionResult()
+                    .setPartition(0)
+                    .setErrorCode(Errors.NONE.code())))));
         return new WriteShareGroupStateResponse(data);
     }
 
     private DeleteShareGroupStateRequest createDeleteShareGroupStateRequest(short version) {
         DeleteShareGroupStateRequestData data = new DeleteShareGroupStateRequestData()
             .setGroupId("group")
-            .setTopicId(Uuid.randomUuid())
-            .setPartition(0);
+            .setTopics(Collections.singletonList(new DeleteShareGroupStateRequestData.DeleteStateData()
+                .setTopicId(Uuid.randomUuid())
+                .setPartitions(Collections.singletonList(new DeleteShareGroupStateRequestData.PartitionData()
+                    .setPartition(0)))));
         return new DeleteShareGroupStateRequest.Builder(data).build(version);
     }
 
     private DeleteShareGroupStateResponse createDeleteShareGroupStateResponse() {
         DeleteShareGroupStateResponseData data = new DeleteShareGroupStateResponseData()
-            .setErrorCode(Errors.NONE.code());
+            .setResults(Collections.singletonList(new DeleteShareGroupStateResponseData.DeleteStateResult()
+                .setTopicId(Uuid.randomUuid())
+                .setPartitions(Collections.singletonList(new DeleteShareGroupStateResponseData.PartitionResult()
+                    .setPartition(0)
+                    .setErrorCode(Errors.NONE.code())))));
         return new DeleteShareGroupStateResponse(data);
     }
 
     private ReadShareGroupOffsetsStateRequest createReadShareGroupOffsetsStateRequest(short version) {
         ReadShareGroupOffsetsStateRequestData data = new ReadShareGroupOffsetsStateRequestData()
             .setGroupId("group")
-            .setTopicId(Uuid.randomUuid())
-            .setPartition(0);
+            .setTopics(Collections.singletonList(new ReadShareGroupOffsetsStateRequestData.ReadOffsetsStateData()
+                .setTopicId(Uuid.randomUuid())
+                .setPartitions(Collections.singletonList(new ReadShareGroupOffsetsStateRequestData.PartitionData()
+                    .setPartition(0)))));
         return new ReadShareGroupOffsetsStateRequest.Builder(data).build(version);
     }
 
     private ReadShareGroupOffsetsStateResponse createReadShareGroupOffsetsStateResponse() {
         ReadShareGroupOffsetsStateResponseData data = new ReadShareGroupOffsetsStateResponseData()
-            .setErrorCode(Errors.NONE.code())
-            .setStateEpoch(0)
-            .setStartOffset(0);
+            .setResults(Collections.singletonList(new ReadShareGroupOffsetsStateResponseData.ReadOffsetsStateResult()
+                .setTopicId(Uuid.randomUuid())
+                .setPartitions(Collections.singletonList(new ReadShareGroupOffsetsStateResponseData.PartitionResult()
+                    .setPartition(0)
+                    .setErrorCode(Errors.NONE.code())
+                    .setStartOffset(0)
+                    .setStateEpoch(0)))));
         return new ReadShareGroupOffsetsStateResponse(data);
     }
 

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/DefaultStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/DefaultStatePersister.java
@@ -19,6 +19,7 @@ package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -36,7 +37,7 @@ public class DefaultStatePersister implements Persister {
    * @param request InitializeShareGroupStateParameters
    * @return InitializeShareGroupStateResult
    */
-  public CompletableFuture<InitializeShareGroupStateResult> initializeState(InitializeShareGroupStateParameters request) {
+  public CompletableFuture<List<InitializeShareGroupStateResult>> initializeState(InitializeShareGroupStateParameters request) {
     throw new RuntimeException("not implemented");
   }
 
@@ -47,7 +48,7 @@ public class DefaultStatePersister implements Persister {
    * @param request ReadShareGroupStateParameters
    * @return ReadShareGroupStateResult
    */
-  public CompletableFuture<ReadShareGroupStateResult> readState(ReadShareGroupStateParameters request) {
+  public CompletableFuture<List<ReadShareGroupStateResult>> readState(ReadShareGroupStateParameters request) {
     throw new RuntimeException("not implemented");
   }
 
@@ -58,7 +59,7 @@ public class DefaultStatePersister implements Persister {
    * @param request WriteShareGroupStateParameters
    * @return WriteShareGroupStateResult
    */
-  public CompletableFuture<WriteShareGroupStateResult> writeState(WriteShareGroupStateParameters request) {
+  public CompletableFuture<List<WriteShareGroupStateResult>> writeState(WriteShareGroupStateParameters request) {
     throw new RuntimeException("not implemented");
   }
 
@@ -69,7 +70,7 @@ public class DefaultStatePersister implements Persister {
    * @param request DeleteShareGroupStateParameters
    * @return DeleteShareGroupStateResult
    */
-  public CompletableFuture<DeleteShareGroupStateResult> deleteState(DeleteShareGroupStateParameters request) {
+  public CompletableFuture<List<DeleteShareGroupStateResult>> deleteState(DeleteShareGroupStateParameters request) {
     throw new RuntimeException("not implemented");
   }
 
@@ -80,7 +81,7 @@ public class DefaultStatePersister implements Persister {
    * @param request ReadShareGroupOffsetsStateParameters
    * @return ReadShareGroupOffsetsStateResult
    */
-  public CompletableFuture<ReadShareGroupOffsetsStateResult> readOffsets(ReadShareGroupOffsetsStateParameters request) {
+  public CompletableFuture<List<ReadShareGroupOffsetsStateResult>> readOffsets(ReadShareGroupOffsetsStateParameters request) {
     throw new RuntimeException("not implemented");
   }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/DeleteShareGroupStateParameters.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/DeleteShareGroupStateParameters.java
@@ -18,6 +18,9 @@
 package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.message.DeleteShareGroupStateRequestData;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.util.stream.Collectors;
 
 public class DeleteShareGroupStateParameters implements PersisterParameters {
 
@@ -28,8 +31,12 @@ public class DeleteShareGroupStateParameters implements PersisterParameters {
   }
 
   public static DeleteShareGroupStateParameters from(DeleteShareGroupStateRequestData data) {
-    return new DeleteShareGroupStateParameters.Builder()
-        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topicId(), data.partition()))
+    return new Builder()
+        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topics().stream()
+            .map(deleteStateData -> new TopicData(deleteStateData.topicId(), deleteStateData.partitions().stream()
+                .map(partitionData -> new PartitionData(partitionData.partition(), -1, -1, Errors.NONE.code(), null))
+                .collect(Collectors.toList())))
+            .collect(Collectors.toList())))
         .build();
   }
 

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/DeleteShareGroupStateParameters.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/DeleteShareGroupStateParameters.java
@@ -18,36 +18,35 @@
 package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.message.DeleteShareGroupStateRequestData;
-import org.apache.kafka.common.protocol.Errors;
 
 import java.util.stream.Collectors;
 
 public class DeleteShareGroupStateParameters implements PersisterParameters {
 
-  private final GroupTopicPartitionData groupTopicPartitionData;
+  private final GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData;
 
-  private DeleteShareGroupStateParameters(GroupTopicPartitionData groupTopicPartitionData) {
+  private DeleteShareGroupStateParameters(GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData) {
     this.groupTopicPartitionData = groupTopicPartitionData;
   }
 
   public static DeleteShareGroupStateParameters from(DeleteShareGroupStateRequestData data) {
     return new Builder()
-        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topics().stream()
-            .map(deleteStateData -> new TopicData(deleteStateData.topicId(), deleteStateData.partitions().stream()
-                .map(partitionData -> new PartitionData(partitionData.partition(), -1, -1, Errors.NONE.code(), null))
+        .setGroupTopicPartitionData(new GroupTopicPartitionData<>(data.groupId(), data.topics().stream()
+            .map(deleteStateData -> new TopicData<>(deleteStateData.topicId(), deleteStateData.partitions().stream()
+                .map(partitionData -> PartitionFactory.newPartitionIdData(partitionData.partition()))
                 .collect(Collectors.toList())))
             .collect(Collectors.toList())))
         .build();
   }
 
-  public GroupTopicPartitionData groupTopicPartitionData() {
+  public GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData() {
     return groupTopicPartitionData;
   }
 
   public static class Builder {
-    private GroupTopicPartitionData groupTopicPartitionData;
+    private GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData;
 
-    public Builder setGroupTopicPartitionData(GroupTopicPartitionData groupTopicPartitionData) {
+    public Builder setGroupTopicPartitionData(GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData) {
       this.groupTopicPartitionData = groupTopicPartitionData;
       return this;
     }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/DeleteShareGroupStateResult.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/DeleteShareGroupStateResult.java
@@ -23,30 +23,30 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class DeleteShareGroupStateResult implements PersisterResult {
-  private final List<TopicData> topicsData;
+  private final List<TopicData<PartitionErrorData>> topicsData;
 
-  private DeleteShareGroupStateResult(List<TopicData> topicsData) {
+  private DeleteShareGroupStateResult(List<TopicData<PartitionErrorData>> topicsData) {
     this.topicsData = topicsData;
   }
 
-  public List<TopicData> topicsData() {
+  public List<TopicData<PartitionErrorData>> topicsData() {
     return topicsData;
   }
 
   public static DeleteShareGroupStateResult from(DeleteShareGroupStateResponseData data) {
     return new Builder()
         .setTopicsData(data.results().stream()
-            .map(deleteStateResult -> new TopicData(deleteStateResult.topicId(), deleteStateResult.partitions().stream()
-                .map(partitionResult -> new PartitionData(partitionResult.partition(), -1, -1, partitionResult.errorCode(), null))
+            .map(deleteStateResult -> new TopicData<>(deleteStateResult.topicId(), deleteStateResult.partitions().stream()
+                .map(partitionResult -> PartitionFactory.newPartitionErrorData(partitionResult.partition(), partitionResult.errorCode()))
                 .collect(Collectors.toList())))
             .collect(Collectors.toList()))
         .build();
   }
 
   public static class Builder {
-    private List<TopicData> topicsData;
+    private List<TopicData<PartitionErrorData>> topicsData;
 
-    public Builder setTopicsData(List<TopicData> topicsData) {
+    public Builder setTopicsData(List<TopicData<PartitionErrorData>> topicsData) {
       this.topicsData = topicsData;
       return this;
     }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/DeleteShareGroupStateResult.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/DeleteShareGroupStateResult.java
@@ -19,33 +19,40 @@ package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.message.DeleteShareGroupStateResponseData;
 
-public class DeleteShareGroupStateResult implements PersisterResult {
-  private final short errorCode;
+import java.util.List;
+import java.util.stream.Collectors;
 
-  private DeleteShareGroupStateResult(short errorCode) {
-    this.errorCode = errorCode;
+public class DeleteShareGroupStateResult implements PersisterResult {
+  private final List<TopicData> topicsData;
+
+  private DeleteShareGroupStateResult(List<TopicData> topicsData) {
+    this.topicsData = topicsData;
   }
 
-  public short errorCode() {
-    return errorCode;
+  public List<TopicData> topicsData() {
+    return topicsData;
   }
 
   public static DeleteShareGroupStateResult from(DeleteShareGroupStateResponseData data) {
     return new Builder()
-        .setErrorCode(data.errorCode())
+        .setTopicsData(data.results().stream()
+            .map(deleteStateResult -> new TopicData(deleteStateResult.topicId(), deleteStateResult.partitions().stream()
+                .map(partitionResult -> new PartitionData(partitionResult.partition(), -1, -1, partitionResult.errorCode(), null))
+                .collect(Collectors.toList())))
+            .collect(Collectors.toList()))
         .build();
   }
 
   public static class Builder {
-    private short errorCode;
+    private List<TopicData> topicsData;
 
-    public Builder setErrorCode(short errorCode) {
-      this.errorCode = errorCode;
+    public Builder setTopicsData(List<TopicData> topicsData) {
+      this.topicsData = topicsData;
       return this;
     }
 
     public DeleteShareGroupStateResult build() {
-      return new DeleteShareGroupStateResult(errorCode);
+      return new DeleteShareGroupStateResult(topicsData);
     }
   }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/GroupTopicPartitionData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/GroupTopicPartitionData.java
@@ -17,31 +17,24 @@
 
 package org.apache.kafka.server.group.share;
 
-import org.apache.kafka.common.Uuid;
-
+import java.util.List;
 import java.util.Objects;
 
 public class GroupTopicPartitionData {
   private final String groupId;
-  private final Uuid topicId;
-  private final int partition;
+  private final List<TopicData> topicsData;
 
-  public GroupTopicPartitionData(String groupId, Uuid topicId, int partition) {
+  public GroupTopicPartitionData(String groupId, List<TopicData> topicsData) {
     this.groupId = groupId;
-    this.topicId = topicId;
-    this.partition = partition;
+    this.topicsData = topicsData;
   }
 
   public String groupId() {
     return groupId;
   }
 
-  public Uuid topicId() {
-    return topicId;
-  }
-
-  public int partition() {
-    return partition;
+  public List<TopicData> topicsData() {
+    return topicsData;
   }
 
   @Override
@@ -49,43 +42,36 @@ public class GroupTopicPartitionData {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     GroupTopicPartitionData that = (GroupTopicPartitionData) o;
-    return partition == that.partition && Objects.equals(groupId, that.groupId) && Objects.equals(topicId, that.topicId);
+    return Objects.equals(groupId, that.groupId) && Objects.equals(topicsData, that.topicsData);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(groupId, topicId, partition);
+    return Objects.hash(groupId, topicsData);
   }
 
   public static class Builder {
     private String groupId;
-    private Uuid topicId;
-    private int partition;
+    private List<TopicData> topicsData;
 
     public Builder setGroupId(String groupId) {
       this.groupId = groupId;
       return this;
     }
 
-    public Builder setTopicId(Uuid topicId) {
-      this.topicId = topicId;
-      return this;
-    }
-
-    public Builder setPartition(int partition) {
-      this.partition = partition;
+    public Builder setTopicsData(List<TopicData> topicsData) {
+      this.topicsData = topicsData;
       return this;
     }
 
     public Builder setGroupTopicPartition(GroupTopicPartitionData groupTopicPartitionData) {
       this.groupId = groupTopicPartitionData.groupId();
-      this.topicId = groupTopicPartitionData.topicId();
-      this.partition = groupTopicPartitionData.partition();
+      this.topicsData = groupTopicPartitionData.topicsData();
       return this;
     }
 
     public GroupTopicPartitionData build() {
-      return new GroupTopicPartitionData(this.groupId, this.topicId, this.partition);
+      return new GroupTopicPartitionData(this.groupId, this.topicsData);
     }
   }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/GroupTopicPartitionData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/GroupTopicPartitionData.java
@@ -20,11 +20,11 @@ package org.apache.kafka.server.group.share;
 import java.util.List;
 import java.util.Objects;
 
-public class GroupTopicPartitionData {
+public class GroupTopicPartitionData<P extends PartitionInfoData> {
   private final String groupId;
-  private final List<TopicData> topicsData;
+  private final List<TopicData<P>> topicsData;
 
-  public GroupTopicPartitionData(String groupId, List<TopicData> topicsData) {
+  public GroupTopicPartitionData(String groupId, List<TopicData<P>> topicsData) {
     this.groupId = groupId;
     this.topicsData = topicsData;
   }
@@ -33,7 +33,7 @@ public class GroupTopicPartitionData {
     return groupId;
   }
 
-  public List<TopicData> topicsData() {
+  public List<TopicData<P>> topicsData() {
     return topicsData;
   }
 
@@ -41,7 +41,7 @@ public class GroupTopicPartitionData {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    GroupTopicPartitionData that = (GroupTopicPartitionData) o;
+    GroupTopicPartitionData<?> that = (GroupTopicPartitionData<?>) o;
     return Objects.equals(groupId, that.groupId) && Objects.equals(topicsData, that.topicsData);
   }
 
@@ -50,28 +50,28 @@ public class GroupTopicPartitionData {
     return Objects.hash(groupId, topicsData);
   }
 
-  public static class Builder {
+  public static class Builder<P extends PartitionInfoData> {
     private String groupId;
-    private List<TopicData> topicsData;
+    private List<TopicData<P>> topicsData;
 
-    public Builder setGroupId(String groupId) {
+    public Builder<P> setGroupId(String groupId) {
       this.groupId = groupId;
       return this;
     }
 
-    public Builder setTopicsData(List<TopicData> topicsData) {
+    public Builder<P> setTopicsData(List<TopicData<P>> topicsData) {
       this.topicsData = topicsData;
       return this;
     }
 
-    public Builder setGroupTopicPartition(GroupTopicPartitionData groupTopicPartitionData) {
+    public Builder<P> setGroupTopicPartition(GroupTopicPartitionData<P> groupTopicPartitionData) {
       this.groupId = groupTopicPartitionData.groupId();
       this.topicsData = groupTopicPartitionData.topicsData();
       return this;
     }
 
-    public GroupTopicPartitionData build() {
-      return new GroupTopicPartitionData(this.groupId, this.topicsData);
+    public GroupTopicPartitionData<P> build() {
+      return new GroupTopicPartitionData<P>(this.groupId, this.topicsData);
     }
   }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/InitializeShareGroupStateParameters.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/InitializeShareGroupStateParameters.java
@@ -18,38 +18,36 @@
 package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.message.InitializeShareGroupStateRequestData;
-import org.apache.kafka.common.protocol.Errors;
 
 import java.util.stream.Collectors;
 
 public class InitializeShareGroupStateParameters implements PersisterParameters {
 
-  private final GroupTopicPartitionData groupTopicPartitionData;
+  private final GroupTopicPartitionData<PartitionStateData> groupTopicPartitionData;
 
-  private InitializeShareGroupStateParameters(GroupTopicPartitionData groupTopicPartitionData) {
+  private InitializeShareGroupStateParameters(GroupTopicPartitionData<PartitionStateData> groupTopicPartitionData) {
     this.groupTopicPartitionData = groupTopicPartitionData;
   }
 
-  public GroupTopicPartitionData groupTopicPartitionData() {
+  public GroupTopicPartitionData<PartitionStateData> groupTopicPartitionData() {
     return groupTopicPartitionData;
   }
 
   public static InitializeShareGroupStateParameters from(InitializeShareGroupStateRequestData data) {
-
     return new Builder()
-        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topics().stream()
-            .map(readStateData -> new TopicData(readStateData.topicId(),
+        .setGroupTopicPartitionData(new GroupTopicPartitionData<>(data.groupId(), data.topics().stream()
+            .map(readStateData -> new TopicData<>(readStateData.topicId(),
                 readStateData.partitions().stream()
-                    .map(partitionData -> new PartitionData(partitionData.partition(), partitionData.stateEpoch(), partitionData.startOffset(), Errors.NONE.code(), null))
+                    .map(partitionData -> PartitionFactory.newPartitionStateData(partitionData.partition(), partitionData.stateEpoch(), partitionData.startOffset()))
                     .collect(Collectors.toList())))
             .collect(Collectors.toList())))
         .build();
   }
 
   public static class Builder {
-    private GroupTopicPartitionData groupTopicPartitionData;
+    private GroupTopicPartitionData<PartitionStateData> groupTopicPartitionData;
 
-    public Builder setGroupTopicPartitionData(GroupTopicPartitionData groupTopicPartitionData) {
+    public Builder setGroupTopicPartitionData(GroupTopicPartitionData<PartitionStateData> groupTopicPartitionData) {
       this.groupTopicPartitionData = groupTopicPartitionData;
       return this;
     }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/InitializeShareGroupStateResult.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/InitializeShareGroupStateResult.java
@@ -23,31 +23,31 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class InitializeShareGroupStateResult implements PersisterResult {
-  private final List<TopicData> topicsData;
+  private final List<TopicData<PartitionErrorData>> topicsData;
 
-  private InitializeShareGroupStateResult(List<TopicData> topicsData) {
+  private InitializeShareGroupStateResult(List<TopicData<PartitionErrorData>> topicsData) {
     this.topicsData = topicsData;
   }
 
-  public List<TopicData> topicsData() {
+  public List<TopicData<PartitionErrorData>> topicsData() {
     return topicsData;
   }
 
   public static InitializeShareGroupStateResult from(InitializeShareGroupStateResponseData data) {
     return new Builder()
         .setTopicsData(data.results().stream()
-            .map(initializeStateResult -> new TopicData(initializeStateResult.topicId(),
+            .map(initializeStateResult -> new TopicData<>(initializeStateResult.topicId(),
                 initializeStateResult.partitions().stream()
-                    .map(partitionResult -> new PartitionData(partitionResult.partition(), -1, -1, partitionResult.errorCode(), null))
+                    .map(partitionResult -> PartitionFactory.newPartitionErrorData(partitionResult.partition(), partitionResult.errorCode()))
                     .collect(Collectors.toList())))
             .collect(Collectors.toList()))
         .build();
   }
 
   public static class Builder {
-    private List<TopicData> topicsData;
+    private List<TopicData<PartitionErrorData>> topicsData;
 
-    public Builder setTopicsData(List<TopicData> topicsData) {
+    public Builder setTopicsData(List<TopicData<PartitionErrorData>> topicsData) {
       this.topicsData = topicsData;
       return this;
     }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionAllData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionAllData.java
@@ -17,38 +17,16 @@
 
 package org.apache.kafka.server.group.share;
 
-import org.apache.kafka.common.Uuid;
-
 import java.util.List;
-import java.util.Objects;
 
-public class TopicData<P extends PartitionInfoData> {
-  private final Uuid topicId;
-  private final List<P> partitions;
+public interface PartitionAllData extends PartitionInfoData {
+  int partition();
 
-  public TopicData(Uuid topicId, List<P> partitions) {
-    this.topicId = topicId;
-    this.partitions = partitions;
-  }
+  int stateEpoch();
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    TopicData<?> topicData = (TopicData<?>) o;
-    return Objects.equals(topicId, topicData.topicId) && Objects.equals(partitions, topicData.partitions);
-  }
+  long startOffset();
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(topicId, partitions);
-  }
+  short errorCode();
 
-  public Uuid topicId() {
-    return topicId;
-  }
-
-  public List<P> partitions() {
-    return partitions;
-  }
+  List<PersisterStateBatch> stateBatches();
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionData.java
@@ -20,7 +20,8 @@ package org.apache.kafka.server.group.share;
 import java.util.List;
 import java.util.Objects;
 
-public class PartitionData {
+public class PartitionData implements
+    PartitionIdData, PartitionStateData, PartitionErrorData, PartitionStateErrorData, PartitionStateBatchData, PartitionAllData {
   private final int partition;
   private final int stateEpoch;
   private final long startOffset;

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionData.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.kafka.server.group.share;
 
 import java.util.List;

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionData.java
@@ -1,0 +1,91 @@
+package org.apache.kafka.server.group.share;
+
+import java.util.List;
+import java.util.Objects;
+
+public class PartitionData {
+  private final int partition;
+  private final int stateEpoch;
+  private final long startOffset;
+  private final short errorCode;
+  private final List<PersisterStateBatch> stateBatches;
+
+  public PartitionData(int partition, int stateEpoch, long startOffset, short errorCode, List<PersisterStateBatch> stateBatches) {
+    this.partition = partition;
+    this.stateEpoch = stateEpoch;
+    this.startOffset = startOffset;
+    this.errorCode = errorCode;
+    this.stateBatches = stateBatches;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PartitionData that = (PartitionData) o;
+    return partition == that.partition && stateEpoch == that.stateEpoch && startOffset == that.startOffset && this.errorCode == that.errorCode && this.stateBatches == that
+        .stateBatches;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(partition, stateEpoch, startOffset, errorCode, stateBatches);
+  }
+
+  public int partition() {
+    return partition;
+  }
+
+  public int stateEpoch() {
+    return stateEpoch;
+  }
+
+  public long startOffset() {
+    return startOffset;
+  }
+
+  public short errorCode() {
+    return errorCode;
+  }
+
+  public List<PersisterStateBatch> stateBatches() {
+    return stateBatches;
+  }
+
+  public static class Builder {
+    private int partition;
+    private int stateEpoch;
+    private long startOffset;
+    private short errorCode;
+    private List<PersisterStateBatch> stateBatches;
+
+    public Builder setPartition(int partition) {
+      this.partition = partition;
+      return this;
+    }
+
+    public Builder setStateEpoch(int stateEpoch) {
+      this.stateEpoch = stateEpoch;
+      return this;
+    }
+
+    public Builder setStartOffset(long startOffset) {
+      this.startOffset = startOffset;
+      return this;
+    }
+
+    public Builder setErrorCode(short errorCode) {
+      this.errorCode = errorCode;
+      return this;
+    }
+
+    public Builder setStateBatches(List<PersisterStateBatch> stateBatches) {
+      this.stateBatches = stateBatches;
+      return this;
+    }
+
+    public PartitionData build() {
+      return new PartitionData(partition, stateEpoch, startOffset, errorCode, stateBatches);
+    }
+  }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionErrorData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionErrorData.java
@@ -17,38 +17,8 @@
 
 package org.apache.kafka.server.group.share;
 
-import org.apache.kafka.common.Uuid;
+public interface PartitionErrorData extends PartitionInfoData {
+  int partition();
 
-import java.util.List;
-import java.util.Objects;
-
-public class TopicData<P extends PartitionInfoData> {
-  private final Uuid topicId;
-  private final List<P> partitions;
-
-  public TopicData(Uuid topicId, List<P> partitions) {
-    this.topicId = topicId;
-    this.partitions = partitions;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    TopicData<?> topicData = (TopicData<?>) o;
-    return Objects.equals(topicId, topicData.topicId) && Objects.equals(partitions, topicData.partitions);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(topicId, partitions);
-  }
-
-  public Uuid topicId() {
-    return topicId;
-  }
-
-  public List<P> partitions() {
-    return partitions;
-  }
+  short errorCode();
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionFactory.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.group.share;
+
+import org.apache.kafka.common.protocol.Errors;
+
+import java.util.List;
+
+public class PartitionFactory {
+  public static PartitionIdData newPartitionIdData(int partition) {
+    return new PartitionData(partition, -1, -1, Errors.NONE.code(), null);
+  }
+
+  public static PartitionStateData newPartitionStateData(int partition, int stateEpoch, long startOffset) {
+    return new PartitionData(partition, stateEpoch, startOffset, Errors.NONE.code(), null);
+  }
+
+  public static PartitionErrorData newPartitionErrorData(int partition, short errorCode) {
+    return new PartitionData(partition, -1, -1, errorCode, null);
+  }
+
+  public static PartitionStateErrorData newPartitionStateErrorData(int partition, int stateEpoch, long startOffset, short errorCode) {
+    return new PartitionData(partition, stateEpoch, startOffset, errorCode, null);
+  }
+
+  public static PartitionStateBatchData newPartitionStateBatchData(int partition, int stateEpoch, long startOffset, List<PersisterStateBatch> stateBatches) {
+    return new PartitionData(partition, stateEpoch, startOffset, Errors.NONE.code(), stateBatches);
+  }
+
+  public static PartitionAllData newPartitionAllData(int partition, int stateEpoch, long startOffset, short errorCode, List<PersisterStateBatch> stateBatches) {
+    return new PartitionData(partition, stateEpoch, startOffset, errorCode, stateBatches);
+  }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionIdData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionIdData.java
@@ -17,38 +17,6 @@
 
 package org.apache.kafka.server.group.share;
 
-import org.apache.kafka.common.Uuid;
-
-import java.util.List;
-import java.util.Objects;
-
-public class TopicData<P extends PartitionInfoData> {
-  private final Uuid topicId;
-  private final List<P> partitions;
-
-  public TopicData(Uuid topicId, List<P> partitions) {
-    this.topicId = topicId;
-    this.partitions = partitions;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    TopicData<?> topicData = (TopicData<?>) o;
-    return Objects.equals(topicId, topicData.topicId) && Objects.equals(partitions, topicData.partitions);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(topicId, partitions);
-  }
-
-  public Uuid topicId() {
-    return topicId;
-  }
-
-  public List<P> partitions() {
-    return partitions;
-  }
+public interface PartitionIdData extends PartitionInfoData {
+  int partition();
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionInfoData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionInfoData.java
@@ -17,38 +17,5 @@
 
 package org.apache.kafka.server.group.share;
 
-import org.apache.kafka.common.Uuid;
-
-import java.util.List;
-import java.util.Objects;
-
-public class TopicData<P extends PartitionInfoData> {
-  private final Uuid topicId;
-  private final List<P> partitions;
-
-  public TopicData(Uuid topicId, List<P> partitions) {
-    this.topicId = topicId;
-    this.partitions = partitions;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    TopicData<?> topicData = (TopicData<?>) o;
-    return Objects.equals(topicId, topicData.topicId) && Objects.equals(partitions, topicData.partitions);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(topicId, partitions);
-  }
-
-  public Uuid topicId() {
-    return topicId;
-  }
-
-  public List<P> partitions() {
-    return partitions;
-  }
+public interface PartitionInfoData {
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateBatchData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateBatchData.java
@@ -17,38 +17,14 @@
 
 package org.apache.kafka.server.group.share;
 
-import org.apache.kafka.common.Uuid;
-
 import java.util.List;
-import java.util.Objects;
 
-public class TopicData<P extends PartitionInfoData> {
-  private final Uuid topicId;
-  private final List<P> partitions;
+public interface PartitionStateBatchData extends PartitionInfoData {
+  int partition();
 
-  public TopicData(Uuid topicId, List<P> partitions) {
-    this.topicId = topicId;
-    this.partitions = partitions;
-  }
+  int stateEpoch();
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    TopicData<?> topicData = (TopicData<?>) o;
-    return Objects.equals(topicId, topicData.topicId) && Objects.equals(partitions, topicData.partitions);
-  }
+  long startOffset();
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(topicId, partitions);
-  }
-
-  public Uuid topicId() {
-    return topicId;
-  }
-
-  public List<P> partitions() {
-    return partitions;
-  }
+  List<PersisterStateBatch> stateBatches();
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateData.java
@@ -17,38 +17,8 @@
 
 package org.apache.kafka.server.group.share;
 
-import org.apache.kafka.common.Uuid;
-
-import java.util.List;
-import java.util.Objects;
-
-public class TopicData<P extends PartitionInfoData> {
-  private final Uuid topicId;
-  private final List<P> partitions;
-
-  public TopicData(Uuid topicId, List<P> partitions) {
-    this.topicId = topicId;
-    this.partitions = partitions;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    TopicData<?> topicData = (TopicData<?>) o;
-    return Objects.equals(topicId, topicData.topicId) && Objects.equals(partitions, topicData.partitions);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(topicId, partitions);
-  }
-
-  public Uuid topicId() {
-    return topicId;
-  }
-
-  public List<P> partitions() {
-    return partitions;
-  }
+public interface PartitionStateData extends PartitionInfoData {
+  int partition();
+  int stateEpoch();
+  long startOffset();
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateErrorData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateErrorData.java
@@ -17,38 +17,12 @@
 
 package org.apache.kafka.server.group.share;
 
-import org.apache.kafka.common.Uuid;
+public interface PartitionStateErrorData extends PartitionInfoData {
+  int partition();
 
-import java.util.List;
-import java.util.Objects;
+  int stateEpoch();
 
-public class TopicData<P extends PartitionInfoData> {
-  private final Uuid topicId;
-  private final List<P> partitions;
+  long startOffset();
 
-  public TopicData(Uuid topicId, List<P> partitions) {
-    this.topicId = topicId;
-    this.partitions = partitions;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    TopicData<?> topicData = (TopicData<?>) o;
-    return Objects.equals(topicId, topicData.topicId) && Objects.equals(partitions, topicData.partitions);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(topicId, partitions);
-  }
-
-  public Uuid topicId() {
-    return topicId;
-  }
-
-  public List<P> partitions() {
-    return partitions;
-  }
+  short errorCode();
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/Persister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/Persister.java
@@ -19,6 +19,7 @@ package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -35,7 +36,7 @@ public interface Persister {
    * @param request InitializeShareGroupStateParameters
    * @return InitializeShareGroupStateResult
    */
-  CompletableFuture<InitializeShareGroupStateResult> initializeState(InitializeShareGroupStateParameters request);
+  CompletableFuture<List<InitializeShareGroupStateResult>> initializeState(InitializeShareGroupStateParameters request);
 
   /**
    * Read share-partition state from a persistence impl.
@@ -43,15 +44,15 @@ public interface Persister {
    * @param request ReadShareGroupStateParameters
    * @return ReadShareGroupStateResult
    */
-  CompletableFuture<ReadShareGroupStateResult> readState(ReadShareGroupStateParameters request);
+  CompletableFuture<List<ReadShareGroupStateResult>> readState(ReadShareGroupStateParameters request);
 
   /**
    * Write share-partition state to a persistence impl.
    *
-   * @param requestDTO WriteShareGroupStateParameters
+   * @param request WriteShareGroupStateParameters
    * @return WriteShareGroupStateResult
    */
-  CompletableFuture<WriteShareGroupStateResult> writeState(WriteShareGroupStateParameters requestDTO);
+  CompletableFuture<List<WriteShareGroupStateResult>> writeState(WriteShareGroupStateParameters request);
 
   /**
    * Delete share-partition state from a persistence impl.
@@ -59,7 +60,7 @@ public interface Persister {
    * @param request DeleteShareGroupStateParameters
    * @return DeleteShareGroupStateResult
    */
-  CompletableFuture<DeleteShareGroupStateResult> deleteState(DeleteShareGroupStateParameters request);
+  CompletableFuture<List<DeleteShareGroupStateResult>> deleteState(DeleteShareGroupStateParameters request);
 
   /**
    * Read the offset information from share-partition state from a persistence impl.
@@ -67,5 +68,5 @@ public interface Persister {
    * @param request ReadShareGroupOffsetsStateParameters
    * @return ReadShareGroupOffsetsStateResult
    */
-  CompletableFuture<ReadShareGroupOffsetsStateResult> readOffsets(ReadShareGroupOffsetsStateParameters request);
+  CompletableFuture<List<ReadShareGroupOffsetsStateResult>> readOffsets(ReadShareGroupOffsetsStateParameters request);
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupOffsetsStateParameters.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupOffsetsStateParameters.java
@@ -18,6 +18,9 @@
 package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.message.ReadShareGroupOffsetsStateRequestData;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.util.stream.Collectors;
 
 public class ReadShareGroupOffsetsStateParameters implements PersisterParameters {
   private final GroupTopicPartitionData groupTopicPartitionData;
@@ -32,7 +35,12 @@ public class ReadShareGroupOffsetsStateParameters implements PersisterParameters
 
   public static ReadShareGroupOffsetsStateParameters from(ReadShareGroupOffsetsStateRequestData data) {
     return new Builder()
-        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topicId(), data.partition()))
+        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topics().stream()
+            .map(topicData -> new TopicData(topicData.topicId(),
+                topicData.partitions().stream()
+                    .map(partitionData -> new PartitionData(partitionData.partition(), -1, -1, Errors.NONE.code(), null))
+                    .collect(Collectors.toList())))
+            .collect(Collectors.toList())))
         .build();
   }
 

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupOffsetsStateParameters.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupOffsetsStateParameters.java
@@ -18,36 +18,35 @@
 package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.message.ReadShareGroupOffsetsStateRequestData;
-import org.apache.kafka.common.protocol.Errors;
 
 import java.util.stream.Collectors;
 
 public class ReadShareGroupOffsetsStateParameters implements PersisterParameters {
-  private final GroupTopicPartitionData groupTopicPartitionData;
+  private final GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData;
 
-  private ReadShareGroupOffsetsStateParameters(GroupTopicPartitionData groupTopicPartitionData) {
+  private ReadShareGroupOffsetsStateParameters(GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData) {
     this.groupTopicPartitionData = groupTopicPartitionData;
   }
 
-  public GroupTopicPartitionData groupTopicPartitionData() {
+  public GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData() {
     return groupTopicPartitionData;
   }
 
   public static ReadShareGroupOffsetsStateParameters from(ReadShareGroupOffsetsStateRequestData data) {
     return new Builder()
-        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topics().stream()
-            .map(topicData -> new TopicData(topicData.topicId(),
+        .setGroupTopicPartitionData(new GroupTopicPartitionData<>(data.groupId(), data.topics().stream()
+            .map(topicData -> new TopicData<>(topicData.topicId(),
                 topicData.partitions().stream()
-                    .map(partitionData -> new PartitionData(partitionData.partition(), -1, -1, Errors.NONE.code(), null))
+                    .map(partitionData -> PartitionFactory.newPartitionIdData(partitionData.partition()))
                     .collect(Collectors.toList())))
             .collect(Collectors.toList())))
         .build();
   }
 
   public static class Builder {
-    private GroupTopicPartitionData groupTopicPartitionData;
+    private GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData;
 
-    public Builder setGroupTopicPartitionData(GroupTopicPartitionData groupTopicPartitionData) {
+    public Builder setGroupTopicPartitionData(GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData) {
       this.groupTopicPartitionData = groupTopicPartitionData;
       return this;
     }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupOffsetsStateResult.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupOffsetsStateResult.java
@@ -23,27 +23,27 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ReadShareGroupOffsetsStateResult implements PersisterResult {
-  private final List<TopicData> topicsData;
+  private final List<TopicData<PartitionStateErrorData>> topicsData;
 
-  private ReadShareGroupOffsetsStateResult(List<TopicData> topicsData) {
+  private ReadShareGroupOffsetsStateResult(List<TopicData<PartitionStateErrorData>> topicsData) {
     this.topicsData = topicsData;
   }
 
   public static ReadShareGroupOffsetsStateResult from(ReadShareGroupOffsetsStateResponseData data) {
     return new Builder()
         .setTopicsData(data.results().stream()
-            .map(readOffsetsStateResult -> new TopicData(readOffsetsStateResult.topicId(),
+            .map(readOffsetsStateResult -> new TopicData<>(readOffsetsStateResult.topicId(),
                 readOffsetsStateResult.partitions().stream()
-                    .map(partitionResult -> new PartitionData(partitionResult.partition(), partitionResult.stateEpoch(), partitionResult.startOffset(), partitionResult.errorCode(), null))
+                    .map(partitionResult -> PartitionFactory.newPartitionStateErrorData(partitionResult.partition(), partitionResult.stateEpoch(), partitionResult.startOffset(), partitionResult.errorCode()))
                     .collect(Collectors.toList())))
             .collect(Collectors.toList()))
         .build();
   }
 
   public static class Builder {
-    private List<TopicData> topicsData;
+    private List<TopicData<PartitionStateErrorData>> topicsData;
 
-    public Builder setTopicsData(List<TopicData> topicsData) {
+    public Builder setTopicsData(List<TopicData<PartitionStateErrorData>> topicsData) {
       this.topicsData = topicsData;
       return this;
     }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupStateParameters.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupStateParameters.java
@@ -19,6 +19,8 @@ package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.message.ReadShareGroupStateRequestData;
 
+import java.util.stream.Collectors;
+
 public class ReadShareGroupStateParameters implements PersisterParameters {
 
   private final GroupTopicPartitionData groupTopicPartitionData;
@@ -32,8 +34,22 @@ public class ReadShareGroupStateParameters implements PersisterParameters {
   }
 
   public static ReadShareGroupStateParameters from(ReadShareGroupStateRequestData data) {
+//    {
+//      groupId,
+//      topics[
+//          topicId,
+//          partitions [
+//              partitionId
+//          ]
+//      ]
+//    }
     return new Builder()
-        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topicId(), data.partition()))
+        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topics().stream()
+            .map(readStateData -> new TopicData(readStateData.topicId(),
+                readStateData.partitions().stream()
+                    .map(partitionData -> new PartitionData(partitionData.partition(), -1, -1, (short) 0, null))
+                    .collect(Collectors.toList())))
+            .collect(Collectors.toList())))
         .build();
   }
 

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupStateParameters.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupStateParameters.java
@@ -23,13 +23,13 @@ import java.util.stream.Collectors;
 
 public class ReadShareGroupStateParameters implements PersisterParameters {
 
-  private final GroupTopicPartitionData groupTopicPartitionData;
+  private final GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData;
 
-  private ReadShareGroupStateParameters(GroupTopicPartitionData groupTopicPartitionData) {
+  private ReadShareGroupStateParameters(GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData) {
     this.groupTopicPartitionData = groupTopicPartitionData;
   }
 
-  public GroupTopicPartitionData groupTopicPartitionData() {
+  public GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData() {
     return groupTopicPartitionData;
   }
 
@@ -44,19 +44,19 @@ public class ReadShareGroupStateParameters implements PersisterParameters {
 //      ]
 //    }
     return new Builder()
-        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topics().stream()
-            .map(readStateData -> new TopicData(readStateData.topicId(),
+        .setGroupTopicPartitionData(new GroupTopicPartitionData<>(data.groupId(), data.topics().stream()
+            .map(readStateData -> new TopicData<>(readStateData.topicId(),
                 readStateData.partitions().stream()
-                    .map(partitionData -> new PartitionData(partitionData.partition(), -1, -1, (short) 0, null))
+                    .map(partitionData -> PartitionFactory.newPartitionIdData(partitionData.partition()))
                     .collect(Collectors.toList())))
             .collect(Collectors.toList())))
         .build();
   }
 
   public static class Builder {
-    private GroupTopicPartitionData groupTopicPartitionData;
+    private GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData;
 
-    public Builder setGroupTopicPartitionData(GroupTopicPartitionData groupTopicPartitionData) {
+    public Builder setGroupTopicPartitionData(GroupTopicPartitionData<PartitionIdData> groupTopicPartitionData) {
       this.groupTopicPartitionData = groupTopicPartitionData;
       return this;
     }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupStateResult.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupStateResult.java
@@ -23,22 +23,22 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ReadShareGroupStateResult implements PersisterResult {
-  private final List<TopicData> topicsData;
+  private final List<TopicData<PartitionAllData>> topicsData;
 
-  private ReadShareGroupStateResult(List<TopicData> topicsData) {
+  private ReadShareGroupStateResult(List<TopicData<PartitionAllData>> topicsData) {
     this.topicsData = topicsData;
   }
 
-  public List<TopicData> topicsData() {
+  public List<TopicData<PartitionAllData>> topicsData() {
     return topicsData;
   }
 
   public static ReadShareGroupStateResult from(ReadShareGroupStateResponseData data) {
     return new Builder()
         .setTopicsData(data.results().stream()
-            .map(topicData -> new TopicData(topicData.topicId(),
+            .map(topicData -> new TopicData<>(topicData.topicId(),
                 topicData.partitions().stream()
-                    .map(partitionResult -> new PartitionData(partitionResult.partition(), partitionResult.stateEpoch(), partitionResult.startOffset(), partitionResult.errorCode(), partitionResult.stateBatches().stream()
+                    .map(partitionResult -> PartitionFactory.newPartitionAllData(partitionResult.partition(), partitionResult.stateEpoch(), partitionResult.startOffset(), partitionResult.errorCode(), partitionResult.stateBatches().stream()
                         .map(PersisterStateBatch::from)
                         .collect(Collectors.toList())))
                     .collect(Collectors.toList())))
@@ -48,9 +48,9 @@ public class ReadShareGroupStateResult implements PersisterResult {
 
   public static class Builder {
 
-    private List<TopicData> topicsData;
+    private List<TopicData<PartitionAllData>> topicsData;
 
-    public Builder setTopicsData(List<TopicData> topicsData) {
+    public Builder setTopicsData(List<TopicData<PartitionAllData>> topicsData) {
       this.topicsData = topicsData;
       return this;
     }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupStateResult.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/ReadShareGroupStateResult.java
@@ -23,74 +23,40 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ReadShareGroupStateResult implements PersisterResult {
-  private final short errorCode;
-  private final int stateEpoch;
-  private final long startOffset;
-  private final List<PersisterStateBatch> stateBatches;
+  private final List<TopicData> topicsData;
 
-  private ReadShareGroupStateResult(short errorCode, int stateEpoch, long startOffset, List<PersisterStateBatch> stateBatches) {
-    this.errorCode = errorCode;
-    this.stateEpoch = stateEpoch;
-    this.startOffset = startOffset;
-    this.stateBatches = stateBatches;
+  private ReadShareGroupStateResult(List<TopicData> topicsData) {
+    this.topicsData = topicsData;
   }
 
-  public short errorCode() {
-    return errorCode;
-  }
-
-  public int stateEpoch() {
-    return stateEpoch;
-  }
-
-  public long startOffset() {
-    return startOffset;
-  }
-
-  public List<PersisterStateBatch> stateBatches() {
-    return stateBatches;
+  public List<TopicData> topicsData() {
+    return topicsData;
   }
 
   public static ReadShareGroupStateResult from(ReadShareGroupStateResponseData data) {
     return new Builder()
-        .setErrorCode(data.errorCode())
-        .setStateEpoch(data.stateEpoch())
-        .setStartOffset(data.startOffset())
-        .setStateBatches(data.stateBatches().stream()
-            .map(PersisterStateBatch::from)
+        .setTopicsData(data.results().stream()
+            .map(topicData -> new TopicData(topicData.topicId(),
+                topicData.partitions().stream()
+                    .map(partitionResult -> new PartitionData(partitionResult.partition(), partitionResult.stateEpoch(), partitionResult.startOffset(), partitionResult.errorCode(), partitionResult.stateBatches().stream()
+                        .map(PersisterStateBatch::from)
+                        .collect(Collectors.toList())))
+                    .collect(Collectors.toList())))
             .collect(Collectors.toList()))
         .build();
   }
 
   public static class Builder {
 
-    private short errorCode;
-    private int stateEpoch;
-    private long startOffset;
-    private List<PersisterStateBatch> stateBatches;
+    private List<TopicData> topicsData;
 
-    public Builder setErrorCode(short errorCode) {
-      this.errorCode = errorCode;
-      return this;
-    }
-
-    public Builder setStateEpoch(int stateEpoch) {
-      this.stateEpoch = stateEpoch;
-      return this;
-    }
-
-    public Builder setStartOffset(long startOffset) {
-      this.startOffset = startOffset;
-      return this;
-    }
-
-    public Builder setStateBatches(List<PersisterStateBatch> stateBatches) {
-      this.stateBatches = stateBatches;
+    public Builder setTopicsData(List<TopicData> topicsData) {
+      this.topicsData = topicsData;
       return this;
     }
 
     public ReadShareGroupStateResult build() {
-      return new ReadShareGroupStateResult(errorCode, stateEpoch, startOffset, stateBatches);
+      return new ReadShareGroupStateResult(topicsData);
     }
   }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/TopicData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/TopicData.java
@@ -1,0 +1,37 @@
+package org.apache.kafka.server.group.share;
+
+import org.apache.kafka.common.Uuid;
+
+import java.util.List;
+import java.util.Objects;
+
+public class TopicData {
+  private final Uuid topicId;
+  private final List<PartitionData> partitions;
+
+  public TopicData(Uuid topicId, List<PartitionData> partitions) {
+    this.topicId = topicId;
+    this.partitions = partitions;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TopicData topicData = (TopicData) o;
+    return Objects.equals(topicId, topicData.topicId) && Objects.equals(partitions, topicData.partitions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(topicId, partitions);
+  }
+
+  public Uuid topicId() {
+    return topicId;
+  }
+
+  public List<PartitionData> partitions() {
+    return partitions;
+  }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/TopicData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/TopicData.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.Uuid;

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/WriteShareGroupStateParameters.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/WriteShareGroupStateParameters.java
@@ -18,27 +18,26 @@
 package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.message.WriteShareGroupStateRequestData;
-import org.apache.kafka.common.protocol.Errors;
 
 import java.util.stream.Collectors;
 
 public class WriteShareGroupStateParameters implements PersisterParameters {
-  private final GroupTopicPartitionData groupTopicPartitionData;
+  private final GroupTopicPartitionData<PartitionStateBatchData> groupTopicPartitionData;
 
-  private WriteShareGroupStateParameters(GroupTopicPartitionData groupTopicPartitionData) {
+  private WriteShareGroupStateParameters(GroupTopicPartitionData<PartitionStateBatchData> groupTopicPartitionData) {
     this.groupTopicPartitionData = groupTopicPartitionData;
   }
 
-  public GroupTopicPartitionData groupTopicPartitionData() {
+  public GroupTopicPartitionData<PartitionStateBatchData> groupTopicPartitionData() {
     return groupTopicPartitionData;
   }
 
   public static WriteShareGroupStateParameters from(WriteShareGroupStateRequestData data) {
     return new Builder()
-        .setGroupTopicPartitionData(new GroupTopicPartitionData(data.groupId(), data.topics().stream()
-            .map(writeStateData -> new TopicData(writeStateData.topicId(),
+        .setGroupTopicPartitionData(new GroupTopicPartitionData<>(data.groupId(), data.topics().stream()
+            .map(writeStateData -> new TopicData<>(writeStateData.topicId(),
                 writeStateData.partitions().stream()
-                    .map(partitionData -> new PartitionData(partitionData.partition(), partitionData.stateEpoch(), partitionData.startOffset(), Errors.NONE.code(),
+                    .map(partitionData -> PartitionFactory.newPartitionStateBatchData(partitionData.partition(), partitionData.stateEpoch(), partitionData.startOffset(),
                         partitionData.stateBatches().stream()
                             .map(PersisterStateBatch::from)
                             .collect(Collectors.toList())))
@@ -48,9 +47,9 @@ public class WriteShareGroupStateParameters implements PersisterParameters {
   }
 
   public static class Builder {
-    private GroupTopicPartitionData groupTopicPartitionData;
+    private GroupTopicPartitionData<PartitionStateBatchData> groupTopicPartitionData;
 
-    public Builder setGroupTopicPartitionData(GroupTopicPartitionData groupTopicPartitionData) {
+    public Builder setGroupTopicPartitionData(GroupTopicPartitionData<PartitionStateBatchData> groupTopicPartitionData) {
       this.groupTopicPartitionData = groupTopicPartitionData;
       return this;
     }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/WriteShareGroupStateResult.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/WriteShareGroupStateResult.java
@@ -19,33 +19,41 @@ package org.apache.kafka.server.group.share;
 
 import org.apache.kafka.common.message.WriteShareGroupStateResponseData;
 
-public class WriteShareGroupStateResult implements PersisterResult {
-  private final short errorCode;
+import java.util.List;
+import java.util.stream.Collectors;
 
-  private WriteShareGroupStateResult(short errorCode) {
-    this.errorCode = errorCode;
+public class WriteShareGroupStateResult implements PersisterResult {
+  private final List<TopicData> topicsData;
+
+  private WriteShareGroupStateResult(List<TopicData> topicsData) {
+    this.topicsData = topicsData;
   }
 
-  public short errorCode() {
-    return errorCode;
+  public List<TopicData> topicsData() {
+    return topicsData;
   }
 
   public static WriteShareGroupStateResult from(WriteShareGroupStateResponseData data) {
     return new Builder()
-        .setErrorCode(data.errorCode())
+        .setTopicsData(data.results().stream()
+            .map(writeStateResult -> new TopicData(writeStateResult.topicId(),
+                writeStateResult.partitions().stream()
+                    .map(partitionResult -> new PartitionData(partitionResult.partition(), -1, -1, partitionResult.errorCode(), null))
+                    .collect(Collectors.toList())))
+            .collect(Collectors.toList()))
         .build();
   }
 
   public static class Builder {
-    private short errorCode;
+    private List<TopicData> topicsData;
 
-    public Builder setErrorCode(short errorCode) {
-      this.errorCode = errorCode;
+    public Builder setTopicsData(List<TopicData> topicsData) {
+      this.topicsData = topicsData;
       return this;
     }
 
     public WriteShareGroupStateResult build() {
-      return new WriteShareGroupStateResult(errorCode);
+      return new WriteShareGroupStateResult(topicsData);
     }
   }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/WriteShareGroupStateResult.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/WriteShareGroupStateResult.java
@@ -23,31 +23,31 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class WriteShareGroupStateResult implements PersisterResult {
-  private final List<TopicData> topicsData;
+  private final List<TopicData<PartitionErrorData>> topicsData;
 
-  private WriteShareGroupStateResult(List<TopicData> topicsData) {
+  private WriteShareGroupStateResult(List<TopicData<PartitionErrorData>> topicsData) {
     this.topicsData = topicsData;
   }
 
-  public List<TopicData> topicsData() {
+  public List<TopicData<PartitionErrorData>> topicsData() {
     return topicsData;
   }
 
   public static WriteShareGroupStateResult from(WriteShareGroupStateResponseData data) {
     return new Builder()
         .setTopicsData(data.results().stream()
-            .map(writeStateResult -> new TopicData(writeStateResult.topicId(),
+            .map(writeStateResult -> new TopicData<>(writeStateResult.topicId(),
                 writeStateResult.partitions().stream()
-                    .map(partitionResult -> new PartitionData(partitionResult.partition(), -1, -1, partitionResult.errorCode(), null))
+                    .map(partitionResult -> PartitionFactory.newPartitionErrorData(partitionResult.partition(), partitionResult.errorCode()))
                     .collect(Collectors.toList())))
             .collect(Collectors.toList()))
         .build();
   }
 
   public static class Builder {
-    private List<TopicData> topicsData;
+    private List<TopicData<PartitionErrorData>> topicsData;
 
-    public Builder setTopicsData(List<TopicData> topicsData) {
+    public Builder setTopicsData(List<TopicData<PartitionErrorData>> topicsData) {
       this.topicsData = topicsData;
       return this;
     }


### PR DESCRIPTION
### What
- Modified RPC schemas for share coordinator as per discussions with david arthur. KIP already updated.
- Modified Param and Result POJO classes to reflect above. 
- Added `TopicData` to encapsulate `topicId`, `List<ParitionData>`.
- Added `PartitionData` to encapsulate partition info as well as `StateBatches`.