### PR TITLE
AKCORE-96: Fix flaky integration test testMultipleConsumersWithDifferentGroupIds

### DIFF
--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -450,31 +450,45 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         producer.send(record);
         producer.send(record);
         producer.send(record);
-        ConsumerRecords<byte[], byte[]> records1 = shareConsumer1.poll(Duration.ofMillis(5000));
-        ConsumerRecords<byte[], byte[]> records2 = shareConsumer2.poll(Duration.ofMillis(5000));
+        ConsumerRecords<byte[], byte[]> records1;
+        ConsumerRecords<byte[], byte[]> records2;
         // Both the consumers should read all the messages, because they are part of different share groups (both have different group IDs)
-        assertEquals(3, records1.count());
-        assertEquals(3, records2.count());
-
-        producer.send(record);
-        producer.send(record);
-        records1 = shareConsumer1.poll(Duration.ofMillis(5000));
-        assertEquals(2, records1.count());
-
-        producer.send(record);
-        producer.send(record);
-        producer.send(record);
-        int shareConsumer1records = 0, shareConsumer2records = 0;
-        while (shareConsumer1records < 3) {
+        int shareConsumer1Records = 0, shareConsumer2Records = 0;
+        while (shareConsumer1Records < 3) {
             records1 = shareConsumer1.poll(Duration.ofMillis(2000));
-            shareConsumer1records += records1.count();
+            shareConsumer1Records += records1.count();
         }
-        while (shareConsumer2records < 5) {
+        while (shareConsumer2Records < 3) {
             records2 = shareConsumer2.poll(Duration.ofMillis(2000));
-            shareConsumer2records += records2.count();
+            shareConsumer2Records += records2.count();
         }
-        assertEquals(3, shareConsumer1records);
-        assertEquals(5, shareConsumer2records);
+        assertEquals(3, shareConsumer1Records);
+        assertEquals(3, shareConsumer2Records);
+
+        producer.send(record);
+        producer.send(record);
+        shareConsumer1Records = 0;
+        while (shareConsumer1Records < 2) {
+            records1 = shareConsumer1.poll(Duration.ofMillis(2000));
+            shareConsumer1Records += records1.count();
+        }
+        assertEquals(2, shareConsumer1Records);
+
+        producer.send(record);
+        producer.send(record);
+        producer.send(record);
+        shareConsumer1Records = 0;
+        shareConsumer2Records = 0;
+        while (shareConsumer1Records < 3) {
+            records1 = shareConsumer1.poll(Duration.ofMillis(2000));
+            shareConsumer1Records += records1.count();
+        }
+        while (shareConsumer2Records < 5) {
+            records2 = shareConsumer2.poll(Duration.ofMillis(2000));
+            shareConsumer2Records += records2.count();
+        }
+        assertEquals(3, shareConsumer1Records);
+        assertEquals(5, shareConsumer2Records);
 
         shareConsumer1.close();
         shareConsumer2.close();

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -464,10 +464,17 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         producer.send(record);
         producer.send(record);
         producer.send(record);
-        records1 = shareConsumer1.poll(Duration.ofMillis(5000));
-        records2 = shareConsumer2.poll(Duration.ofMillis(5000));
-        assertEquals(3, records1.count());
-        assertEquals(5, records2.count());
+        int shareConsumer1records = 0, shareConsumer2records = 0;
+        while(shareConsumer1records < 3) {
+            records1 = shareConsumer1.poll(Duration.ofMillis(2000));
+            shareConsumer1records += records1.count();
+        }
+        while(shareConsumer2records < 5) {
+            records2 = shareConsumer2.poll(Duration.ofMillis(2000));
+            shareConsumer2records += records2.count();
+        }
+        assertEquals(3, shareConsumer1records);
+        assertEquals(5, shareConsumer2records);
 
         shareConsumer1.close();
         shareConsumer2.close();

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -465,11 +465,11 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         producer.send(record);
         producer.send(record);
         int shareConsumer1records = 0, shareConsumer2records = 0;
-        while(shareConsumer1records < 3) {
+        while (shareConsumer1records < 3) {
             records1 = shareConsumer1.poll(Duration.ofMillis(2000));
             shareConsumer1records += records1.count();
         }
-        while(shareConsumer2records < 5) {
+        while (shareConsumer2records < 5) {
             records2 = shareConsumer2.poll(Duration.ofMillis(2000));
             shareConsumer2records += records2.count();
         }

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -18,6 +18,7 @@ package kafka.test.api;
 
 import kafka.api.AbstractShareConsumerTest;
 import kafka.api.BaseConsumerTest;
+import kafka.utils.TestUtils;
 import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -56,6 +57,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -450,45 +452,35 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         producer.send(record);
         producer.send(record);
         producer.send(record);
-        ConsumerRecords<byte[], byte[]> records1;
-        ConsumerRecords<byte[], byte[]> records2;
         // Both the consumers should read all the messages, because they are part of different share groups (both have different group IDs)
-        int shareConsumer1Records = 0, shareConsumer2Records = 0;
-        while (shareConsumer1Records < 3) {
-            records1 = shareConsumer1.poll(Duration.ofMillis(2000));
-            shareConsumer1Records += records1.count();
-        }
-        while (shareConsumer2Records < 3) {
-            records2 = shareConsumer2.poll(Duration.ofMillis(2000));
-            shareConsumer2Records += records2.count();
-        }
-        assertEquals(3, shareConsumer1Records);
-        assertEquals(3, shareConsumer2Records);
+        AtomicInteger shareConsumer1Records = new AtomicInteger();
+        AtomicInteger shareConsumer2Records = new AtomicInteger();
+        TestUtils.waitUntilTrue(() -> {
+            int records1 = shareConsumer1Records.addAndGet(shareConsumer1.poll(Duration.ofMillis(2000)).count());
+            int records2 = shareConsumer2Records.addAndGet(shareConsumer2.poll(Duration.ofMillis(2000)).count());
+            return records1 == 3 && records2 == 3;
+        }, () -> "Failed to consume records for both consumers", DEFAULT_MAX_WAIT_MS, 100L);
 
         producer.send(record);
         producer.send(record);
-        shareConsumer1Records = 0;
-        while (shareConsumer1Records < 2) {
-            records1 = shareConsumer1.poll(Duration.ofMillis(2000));
-            shareConsumer1Records += records1.count();
-        }
-        assertEquals(2, shareConsumer1Records);
+
+        shareConsumer1Records.set(0);
+        TestUtils.waitUntilTrue(() -> {
+            int records1 = shareConsumer1Records.addAndGet(shareConsumer1.poll(Duration.ofMillis(2000)).count());
+            return records1 == 2;
+        }, () -> "Failed to consume records for share consumer 1", DEFAULT_MAX_WAIT_MS, 100L);
 
         producer.send(record);
         producer.send(record);
         producer.send(record);
-        shareConsumer1Records = 0;
-        shareConsumer2Records = 0;
-        while (shareConsumer1Records < 3) {
-            records1 = shareConsumer1.poll(Duration.ofMillis(2000));
-            shareConsumer1Records += records1.count();
-        }
-        while (shareConsumer2Records < 5) {
-            records2 = shareConsumer2.poll(Duration.ofMillis(2000));
-            shareConsumer2Records += records2.count();
-        }
-        assertEquals(3, shareConsumer1Records);
-        assertEquals(5, shareConsumer2Records);
+
+        shareConsumer1Records.set(0);
+        shareConsumer2Records.set(0);
+        TestUtils.waitUntilTrue(() -> {
+            int records1 = shareConsumer1Records.addAndGet(shareConsumer1.poll(Duration.ofMillis(2000)).count());
+            int records2 = shareConsumer2Records.addAndGet(shareConsumer2.poll(Duration.ofMillis(2000)).count());
+            return records1 == 3 && records2 == 5;
+        }, () -> "Failed to consume records for both consumers for the last batch", DEFAULT_MAX_WAIT_MS, 100L);
 
         shareConsumer1.close();
         shareConsumer2.close();


### PR DESCRIPTION
### About
Fixed flaky integration test testMultipleConsumersWithDifferentGroupIds. The cause of flakiness was that the test was unable to do the complete fetch of all 'n' records as expected in the test in 1 `poll()` itself.