### PR TITLE
AKCORE-100: Client support for revised gap handling in RPCs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgeType.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgeType.java
@@ -22,7 +22,7 @@ import java.util.Locale;
 
 @InterfaceStability.Evolving
 public enum AcknowledgeType {
-    ACCEPT((byte) 0), RELEASE((byte) 1), REJECT((byte) 2);
+    ACCEPT((byte) 1), RELEASE((byte) 2), REJECT((byte) 3);
 
     public final byte id;
 
@@ -38,11 +38,11 @@ public enum AcknowledgeType {
 
     public static AcknowledgeType forId(byte id) {
         switch (id) {
-            case 0:
-                return ACCEPT;
             case 1:
-                return RELEASE;
+                return ACCEPT;
             case 2:
+                return RELEASE;
+            case 3:
                 return REJECT;
             default:
                 throw new IllegalArgumentException("Unknown acknowledge type id: " + id);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
@@ -31,6 +31,8 @@ import java.util.TreeMap;
  * topic-partition being delivered to a consumer in a share group.
  */
 public class Acknowledgements {
+    public static final byte ACKNOWLEDGE_TYPE_GAP = (byte) 0;
+
     // The acknowledgements keyed by offset. If the record is a gap, the AcknowledgeType will be null.
     private final Map<Long, AcknowledgeType> acknowledgements;
 
@@ -147,8 +149,8 @@ public class Acknowledgements {
     public List<ShareFetchRequestData.AcknowledgementBatch> getAcknowledgmentBatches() {
         List<ShareFetchRequestData.AcknowledgementBatch> batches = new ArrayList<>();
         if (acknowledgements.isEmpty()) return batches;
-        Iterator<Map.Entry<Long, AcknowledgeType>> iterator = acknowledgements.entrySet().iterator();
         ShareFetchRequestData.AcknowledgementBatch currentBatch = null;
+        Iterator<Map.Entry<Long, AcknowledgeType>> iterator = acknowledgements.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<Long, AcknowledgeType> entry = iterator.next();
             if (currentBatch == null) {
@@ -157,19 +159,23 @@ public class Acknowledgements {
                 currentBatch.setLastOffset(entry.getKey());
                 if (entry.getValue() != null) {
                     currentBatch.setAcknowledgeType(entry.getValue().id);
+                    currentBatch.acknowledgeTypes().add(entry.getValue().id);
                 } else {
                     // Put a marker value of -1 while this batch only has gaps
                     currentBatch.setAcknowledgeType((byte) -1);
                     currentBatch.gapOffsets().add(entry.getKey());
+                    currentBatch.acknowledgeTypes().add(ACKNOWLEDGE_TYPE_GAP);
                 }
             } else {
                 if (entry.getValue() != null) {
                     if (entry.getKey() == currentBatch.lastOffset() + 1) {
                         if (entry.getValue().id == currentBatch.acknowledgeType()) {
                             currentBatch.setLastOffset(entry.getKey());
+                            currentBatch.acknowledgeTypes().add(entry.getValue().id);
                         } else if (currentBatch.acknowledgeType() == (byte) -1) {
                             currentBatch.setAcknowledgeType(entry.getValue().id);
                             currentBatch.setLastOffset(entry.getKey());
+                            currentBatch.acknowledgeTypes().add(entry.getValue().id);
                         } else {
                             if (currentBatch.acknowledgeType() == -1) {
                                 // Even though this batch is just gaps, we mark it as ACCEPT.
@@ -181,6 +187,7 @@ public class Acknowledgements {
                             currentBatch.setBaseOffset(entry.getKey());
                             currentBatch.setLastOffset(entry.getKey());
                             currentBatch.setAcknowledgeType(entry.getValue().id);
+                            currentBatch.acknowledgeTypes().add(entry.getValue().id);
                         }
                     } else {
                         if (currentBatch.acknowledgeType() == -1) {
@@ -193,11 +200,13 @@ public class Acknowledgements {
                         currentBatch.setBaseOffset(entry.getKey());
                         currentBatch.setLastOffset(entry.getKey());
                         currentBatch.setAcknowledgeType(entry.getValue().id);
+                        currentBatch.acknowledgeTypes().add(entry.getValue().id);
                     }
                 } else {
                     if (entry.getKey() == currentBatch.lastOffset() + 1) {
                         currentBatch.setLastOffset(entry.getKey());
                         currentBatch.gapOffsets().add(entry.getKey());
+                        currentBatch.acknowledgeTypes().add(ACKNOWLEDGE_TYPE_GAP);
                     } else {
                         if (currentBatch.acknowledgeType() == -1) {
                             // Even though this batch is just gaps, we mark it as ACCEPT.
@@ -211,6 +220,7 @@ public class Acknowledgements {
                         // Put a marker value of -1 while this batch only has gaps
                         currentBatch.setAcknowledgeType((byte) -1);
                         currentBatch.gapOffsets().add(entry.getKey());
+                        currentBatch.acknowledgeTypes().add(ACKNOWLEDGE_TYPE_GAP);
                     }
                 }
             }

--- a/clients/src/main/resources/common/message/ShareAcknowledgeRequest.json
+++ b/clients/src/main/resources/common/message/ShareAcknowledgeRequest.json
@@ -48,9 +48,9 @@
           { "name": "AcknowledgeTypes", "type": "[]int8", "versions": "0+",
             "about": "Array of acknowledge types - 0:Gap,1:Accept,2:Release,3:Reject."},
           { "name": "GapOffsets", "type": "[]int64", "versions": "0+",
-            "about": "Array of offsets in this range which do not correspond to records."},
-          { "name": "AcknowledgeType", "type": "int8", "versions": "0+", "default": "0",
-            "about": "The type of acknowledgement - 0:Accept,1:Release,2:Reject."}
+            "about": "[TO BE REMOVED] Array of offsets in this range which do not correspond to records."},
+          { "name": "AcknowledgeType", "type": "int8", "versions": "0+", "default": "1",
+            "about": "[TO BE REMOVED] The type of acknowledgement - 1:Accept,2:Release,3:Reject."}
         ]}
       ]}
     ]}

--- a/clients/src/main/resources/common/message/ShareFetchRequest.json
+++ b/clients/src/main/resources/common/message/ShareFetchRequest.json
@@ -55,9 +55,9 @@
           { "name": "AcknowledgeTypes", "type": "[]int8", "versions": "0+",
             "about": "Array of acknowledge types - 0:Gap,1:Accept,2:Release,3:Reject."},
           { "name": "GapOffsets", "type": "[]int64", "versions": "0+",
-            "about": "Array of offsets in this range which do not correspond to records."},
-          { "name": "AcknowledgeType", "type": "int8", "versions": "0+", "default": "0",
-            "about": "The type of acknowledgement - 0:Accept,1:Release,2:Reject."}
+            "about": "[TO BE REMOVED] Array of offsets in this range which do not correspond to records."},
+          { "name": "AcknowledgeType", "type": "int8", "versions": "0+", "default": "1",
+            "about": "[TO BE REMOVED] The type of acknowledgement - 1:Accept,2:Release,3:Reject."}
         ]}
       ]}
     ]},

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AcknowledgementsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AcknowledgementsTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AcknowledgementsTest {
@@ -45,6 +46,8 @@ public class AcknowledgementsTest {
         assertEquals(0L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(1, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
     }
 
     @Test
@@ -61,6 +64,8 @@ public class AcknowledgementsTest {
         assertEquals(4L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertNotEquals(0, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
     }
 
     @Test
@@ -77,10 +82,17 @@ public class AcknowledgementsTest {
         assertEquals(2L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(3, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(2));
         assertEquals(3L, ackList.get(1).baseOffset());
         assertEquals(4L, ackList.get(1).lastOffset());
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
         assertTrue(ackList.get(1).gapOffsets().isEmpty());
+        assertEquals(2, ackList.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(1));
     }
 
     @Test
@@ -97,10 +109,17 @@ public class AcknowledgementsTest {
         assertEquals(0L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(1, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(1L, ackList.get(1).baseOffset());
         assertEquals(4L, ackList.get(1).lastOffset());
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
         assertTrue(ackList.get(1).gapOffsets().isEmpty());
+        assertEquals(4, ackList.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(2));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(3));
     }
 
     @Test
@@ -117,10 +136,17 @@ public class AcknowledgementsTest {
         assertEquals(3L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(4, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(2));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(3));
         assertEquals(4L, ackList.get(1).baseOffset());
         assertEquals(4L, ackList.get(1).lastOffset());
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
         assertTrue(ackList.get(1).gapOffsets().isEmpty());
+        assertEquals(1, ackList.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
     }
 
     @Test
@@ -133,6 +159,8 @@ public class AcknowledgementsTest {
         assertEquals(0L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertEquals(1, ackList.get(0).gapOffsets().size());
+        assertEquals(1, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
     }
 
     @Test
@@ -146,6 +174,9 @@ public class AcknowledgementsTest {
         assertEquals(1L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertEquals(2, ackList.get(0).gapOffsets().size());
+        assertEquals(2, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(1));
     }
 
     @Test
@@ -159,6 +190,9 @@ public class AcknowledgementsTest {
         assertEquals(1L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertEquals(1, ackList.get(0).gapOffsets().size());
+        assertEquals(2, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(1));
     }
 
     @Test
@@ -172,6 +206,9 @@ public class AcknowledgementsTest {
         assertEquals(1L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertEquals(1, ackList.get(0).gapOffsets().size());
+        assertEquals(2, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(1));
     }
 
     @Test
@@ -188,10 +225,17 @@ public class AcknowledgementsTest {
         assertEquals(2L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeType());
         assertEquals(2, ackList.get(0).gapOffsets().size());
+        assertEquals(3, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(0));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(1));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(2));
         assertEquals(3L, ackList.get(1).baseOffset());
         assertEquals(4L, ackList.get(1).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeType());
         assertTrue(ackList.get(1).gapOffsets().isEmpty());
+        assertEquals(2, ackList.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeTypes().get(1));
     }
 
     @Test
@@ -208,10 +252,17 @@ public class AcknowledgementsTest {
         assertEquals(0L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(1, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(1L, ackList.get(1).baseOffset());
         assertEquals(4L, ackList.get(1).lastOffset());
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
         assertEquals(2, ackList.get(1).gapOffsets().size());
+        assertEquals(4, ackList.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(1).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(2));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(1).acknowledgeTypes().get(3));
     }
 
     @Test
@@ -228,18 +279,27 @@ public class AcknowledgementsTest {
         assertEquals(0L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertTrue(ackList.get(0).gapOffsets().isEmpty());
+        assertEquals(1, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(1L, ackList.get(1).baseOffset());
         assertEquals(1L, ackList.get(1).lastOffset());
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
         assertTrue(ackList.get(1).gapOffsets().isEmpty());
+        assertEquals(1, ackList.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
         assertEquals(3L, ackList.get(2).baseOffset());
         assertEquals(4L, ackList.get(2).lastOffset());
         assertEquals(AcknowledgeType.REJECT.id, ackList.get(2).acknowledgeType());
         assertTrue(ackList.get(2).gapOffsets().isEmpty());
+        assertEquals(2, ackList.get(2).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.REJECT.id, ackList.get(2).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.REJECT.id, ackList.get(2).acknowledgeTypes().get(1));
         assertEquals(6L, ackList.get(3).baseOffset());
         assertEquals(6L, ackList.get(3).lastOffset());
         assertEquals(AcknowledgeType.REJECT.id, ackList.get(3).acknowledgeType());
         assertTrue(ackList.get(3).gapOffsets().isEmpty());
+        assertEquals(1, ackList.get(3).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.REJECT.id, ackList.get(3).acknowledgeTypes().get(0));
     }
 
 
@@ -254,9 +314,13 @@ public class AcknowledgementsTest {
         assertEquals(2L, ackList.get(0).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
         assertEquals(1, ackList.get(0).gapOffsets().size());
+        assertEquals(1, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(4L, ackList.get(1).baseOffset());
         assertEquals(4L, ackList.get(1).lastOffset());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeType());
         assertEquals(1, ackList.get(1).gapOffsets().size());
+        assertEquals(1, ackList.get(1).acknowledgeTypes().size());
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(1).acknowledgeTypes().get(0));
     }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4891,6 +4891,7 @@ class KafkaApisTest extends Logging {
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setBaseOffset(11)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
             ).asJava)
         ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -4903,6 +4904,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(21)
                   .setLastOffset(35)
+                  .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
               ).asJava),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
@@ -4911,6 +4913,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(54)
                   .setLastOffset(67)
+                  .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
               ).asJava)
           ).asJava)
       ).asJava)
@@ -5071,6 +5074,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(11)
                   .setLastOffset(20)
+                  .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -5083,6 +5087,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(21)
                   .setLastOffset(35)
+                  .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -5095,6 +5100,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(34)
                   .setLastOffset(54)
+                  .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -5107,6 +5113,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(23)
                   .setLastOffset(32)
+                  .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
               ).asJava)
           ).asJava)
       ).asJava)
@@ -5212,6 +5219,7 @@ class KafkaApisTest extends Logging {
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setBaseOffset(11)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -5286,6 +5294,7 @@ class KafkaApisTest extends Logging {
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setBaseOffset(11)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -5368,6 +5377,7 @@ class KafkaApisTest extends Logging {
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setBaseOffset(11)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -5426,6 +5436,7 @@ class KafkaApisTest extends Logging {
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setBaseOffset(11)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -5562,6 +5573,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(11)
                   .setLastOffset(20)
+                  .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -5574,6 +5586,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(21)
                   .setLastOffset(35)
+                  .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
               ).asJava),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
@@ -5585,6 +5598,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(10)
                   .setLastOffset(20)
+                  .setAcknowledgeTypes(util.Arrays.asList(1.toByte))
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -5597,6 +5611,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setBaseOffset(23)
                   .setLastOffset(32)
+                  .setAcknowledgeTypes(util.Arrays.asList(1.toByte,0.toByte,0.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte))
                   .setGapOffsets(util.Arrays.asList(1L, 2L))
               ).asJava)
           ).asJava)
@@ -8836,6 +8851,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setBaseOffset(10)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte,1.toByte,0.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte))
                 .setGapOffsets(List(12L.asInstanceOf[java.lang.Long]).asJava)
             ).asJava)
         ).asJava)
@@ -8880,6 +8896,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setBaseOffset(10)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte,1.toByte,0.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte))
                 .setGapOffsets(List(12L.asInstanceOf[java.lang.Long]).asJava)
             ).asJava)
         ).asJava)
@@ -8936,6 +8953,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setBaseOffset(10)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte,1.toByte,0.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte))
                 .setGapOffsets(List(12L.asInstanceOf[java.lang.Long]).asJava)
             ).asJava)
         ).asJava)
@@ -8990,6 +9008,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setBaseOffset(10)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte,1.toByte,0.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte))
                 .setGapOffsets(List(12L.asInstanceOf[java.lang.Long]).asJava)
             ).asJava)
         ).asJava)
@@ -9051,6 +9070,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setBaseOffset(10)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte,1.toByte,0.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte))
                 .setGapOffsets(List(12L.asInstanceOf[java.lang.Long]).asJava)
             ).asJava)
         ).asJava)
@@ -9100,8 +9120,9 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setBaseOffset(10)
                 .setLastOffset(20)
+                .setAcknowledgeTypes(util.Arrays.asList(4.toByte,4.toByte,0.toByte,4.toByte,4.toByte,4.toByte,4.toByte,4.toByte,4.toByte,4.toByte,4.toByte))
                 .setGapOffsets(List(12L.asInstanceOf[java.lang.Long]).asJava)
-                .setAcknowledgeType(3)
+                .setAcknowledgeType(4)
             ).asJava)
         ).asJava)
       ).asJava)


### PR DESCRIPTION
Add support for the revised gap handling in ShareFetch and ShareAcknowledge requests to the client. This does not optimise the encoding yet, but it does fill in both the new and the old way of encoding gaps. This enables the broker changes to be delivered safely.

Added unit tests for the new encoding, and also upgraded KafkaApisTest to handle the new encoding.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
