### PR TITLE
AKCORE-110: Support reject and release in console share consumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManager.java
@@ -73,7 +73,7 @@ public class ShareFetchRequestManager implements RequestManager, MemberStateList
                              final FetchConfig fetchConfig,
                              final ShareFetchBuffer shareFetchBuffer,
                              final FetchMetricsManager metricsManager) {
-        this.log = logContext.logger(AbstractFetch.class);
+        this.log = logContext.logger(ShareFetchRequestManager.class);
         this.logContext = logContext;
         this.groupId = groupId;
         this.metadata = metadata;
@@ -295,9 +295,7 @@ public class ShareFetchRequestManager implements RequestManager, MemberStateList
 
     private Map<TopicIdPartition, List<ShareFetchRequestData.AcknowledgementBatch>> acknowledgementBatches(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
         Map<TopicIdPartition, List<ShareFetchRequestData.AcknowledgementBatch>> acknowledgementBatches = new HashMap<>();
-        acknowledgementsMap.forEach((partition, acknowledgements) -> {
-            acknowledgementBatches.put(partition, acknowledgements.getAcknowledgmentBatches());
-        });
+        acknowledgementsMap.forEach((partition, acknowledgements) -> acknowledgementBatches.put(partition, acknowledgements.getAcknowledgmentBatches()));
         return acknowledgementBatches;
     }
 
@@ -334,9 +332,7 @@ public class ShareFetchRequestManager implements RequestManager, MemberStateList
 
     @Override
     public void onMemberEpochUpdated(Optional<Integer> memberEpochOpt, Optional<String> memberIdOpt) {
-        if (memberIdOpt.isPresent()) {
-            memberId = Uuid.fromString(memberIdOpt.get());
-        }
+        memberIdOpt.ifPresent(s -> memberId = Uuid.fromString(s));
     }
 
     @FunctionalInterface

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.tools.consumer;
 
+import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.ShareConsumer;
@@ -28,7 +29,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.PrintStream;
 import java.time.Duration;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -60,7 +60,7 @@ public class ConsoleShareConsumerTest {
         });
 
         ConsoleShareConsumer.ConsumerWrapper consumer = new ConsoleShareConsumer.ConsumerWrapper(
-                Optional.of(topic),
+                topic,
                 mockConsumer,
                 timeoutMs
         );
@@ -77,7 +77,7 @@ public class ConsoleShareConsumerTest {
         int messageLimit = 10;
         when(consumer.receive()).thenReturn(record);
 
-        ConsoleShareConsumer.process(messageLimit, formatter, consumer, System.out, true);
+        ConsoleShareConsumer.process(messageLimit, formatter, consumer, System.out, true, AcknowledgeType.ACCEPT);
 
         verify(consumer, times(messageLimit)).receive();
         verify(formatter, times(messageLimit)).writeTo(any(), any());
@@ -97,7 +97,7 @@ public class ConsoleShareConsumerTest {
         //Simulate an error on System.out after the first record has been printed
         when(printStream.checkError()).thenReturn(true);
 
-        ConsoleShareConsumer.process(-1, formatter, consumer, printStream, true);
+        ConsoleShareConsumer.process(-1, formatter, consumer, printStream, true, AcknowledgeType.ACCEPT);
 
         verify(formatter).writeTo(any(), eq(printStream));
         verify(consumer).receive();


### PR DESCRIPTION
Added --reject and --release options to kafka-console-share-consumer.sh tool. Also fixed a few bugs and warnings.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
