### PR TITLE
AKCORE-99: Corrected the exceptions from SharePartition.java.

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -449,16 +449,11 @@ public class SharePartition {
                 Map.Entry<Long, InFlightBatch> floorOffset = cachedState.floorEntry(batch.baseOffset);
                 if (floorOffset == null) {
                     log.debug("Batch record {} not found for share partition: {}-{}", batch, groupId, topicIdPartition);
-                    throwable = new InvalidRequestException("Batch record not found. The base offset is not found in the cache.");
+                    throwable = new InvalidRecordStateException("Batch record not found. The base offset is not found in the cache.");
                     break;
                 }
 
                 NavigableMap<Long, InFlightBatch> subMap = cachedState.subMap(floorOffset.getKey(), true, batch.lastOffset, true);
-                if (subMap.isEmpty()) {
-                    log.debug("Batch record {} not found for share partition: {}-{}", batch, groupId, topicIdPartition);
-                    throwable = new InvalidRequestException("Batch record not found. No records exists for the request batch.");
-                    break;
-                }
 
                 // Validate if the request batch has the last offset greater than the last offset of
                 // the last fetched cached batch, then there will be offsets in the request than cannot
@@ -1227,7 +1222,6 @@ public class SharePartition {
         private final AcknowledgeType acknowledgeType;
 
         public AcknowledgementBatch(long baseOffset, long lastOffset, List<Long> gapOffsets, AcknowledgeType acknowledgeType) {
-            assert baseOffset <= lastOffset;
             this.baseOffset = baseOffset;
             this.lastOffset = lastOffset;
             this.gapOffsets = gapOffsets;

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1206,6 +1206,11 @@ class KafkaApis(val requestChannel: RequestChannel,
         var prevEndOffset = -1L
         breakable {
           acknowledgeBatches.forEach(batch => {
+            if (batch.baseOffset() > batch.lastOffset()) {
+              erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
+              erroneousTopicIdPartitions :+ tp
+              break()
+            }
             if (batch.baseOffset() < prevEndOffset) {
               erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
               erroneousTopicIdPartitions :+ tp

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -428,7 +428,7 @@ public class SharePartitionTest {
             Collections.singletonList(new AcknowledgementBatch(0, 15, null, AcknowledgeType.REJECT)));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
-        assertEquals(InvalidRequestException.class, ackResult.join().get().getClass());
+        assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
 
         MemoryRecords records = memoryRecords(5, 5);
         CompletableFuture<List<AcquiredRecords>> result = sharePartition.acquire(


### PR DESCRIPTION
### About
Corrected/Removed the exceptions thrown from `SharePartition.java` during acknowledgement and added check for validity of acknowledgement batches in `KafkaApis`

Note - I have corrected the exceptions when owner of the batch/offset does not match the member during acknowledgment earlier in this [PR](https://github.com/confluentinc/kafka/pull/1174) 