### PR TITLE
AKCORE-93: MINOR: Refactor consumerGroupMetadataRefreshIntervalMs to groupMetadataRefreshIntervalMs

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -167,7 +167,7 @@ public class GroupMetadataManager {
         private PartitionAssignor shareGroupAssignor = null;
         private int consumerGroupMaxSize = Integer.MAX_VALUE;
         private int consumerGroupHeartbeatIntervalMs = 5000;
-        private int consumerGroupMetadataRefreshIntervalMs = Integer.MAX_VALUE;
+        private int groupMetadataRefreshIntervalMs = Integer.MAX_VALUE;
         private MetadataImage metadataImage = null;
         private int consumerGroupSessionTimeoutMs = 45000;
         private int classicGroupMaxSize = Integer.MAX_VALUE;
@@ -224,8 +224,8 @@ public class GroupMetadataManager {
             return this;
         }
 
-        Builder withConsumerGroupMetadataRefreshIntervalMs(int consumerGroupMetadataRefreshIntervalMs) {
-            this.consumerGroupMetadataRefreshIntervalMs = consumerGroupMetadataRefreshIntervalMs;
+        Builder withGroupMetadataRefreshIntervalMs(int groupMetadataRefreshIntervalMs) {
+            this.groupMetadataRefreshIntervalMs = groupMetadataRefreshIntervalMs;
             return this;
         }
 
@@ -301,7 +301,7 @@ public class GroupMetadataManager {
                 consumerGroupMaxSize,
                 consumerGroupSessionTimeoutMs,
                 consumerGroupHeartbeatIntervalMs,
-                consumerGroupMetadataRefreshIntervalMs,
+                groupMetadataRefreshIntervalMs,
                 classicGroupMaxSize,
                 classicGroupInitialRebalanceDelayMs,
                 classicGroupNewMemberJoinTimeoutMs,
@@ -386,7 +386,7 @@ public class GroupMetadataManager {
     /**
      * The metadata refresh interval.
      */
-    private final int consumerGroupMetadataRefreshIntervalMs;
+    private final int groupMetadataRefreshIntervalMs;
 
     /**
      * The metadata image.
@@ -449,7 +449,7 @@ public class GroupMetadataManager {
         int consumerGroupMaxSize,
         int consumerGroupSessionTimeoutMs,
         int consumerGroupHeartbeatIntervalMs,
-        int consumerGroupMetadataRefreshIntervalMs,
+        int groupMetadataRefreshIntervalMs,
         int classicGroupMaxSize,
         int classicGroupInitialRebalanceDelayMs,
         int classicGroupNewMemberJoinTimeoutMs,
@@ -473,7 +473,7 @@ public class GroupMetadataManager {
         this.consumerGroupMaxSize = consumerGroupMaxSize;
         this.consumerGroupSessionTimeoutMs = consumerGroupSessionTimeoutMs;
         this.consumerGroupHeartbeatIntervalMs = consumerGroupHeartbeatIntervalMs;
-        this.consumerGroupMetadataRefreshIntervalMs = consumerGroupMetadataRefreshIntervalMs;
+        this.groupMetadataRefreshIntervalMs = groupMetadataRefreshIntervalMs;
         this.classicGroupMaxSize = classicGroupMaxSize;
         this.classicGroupInitialRebalanceDelayMs = classicGroupInitialRebalanceDelayMs;
         this.classicGroupNewMemberJoinTimeoutMs = classicGroupNewMemberJoinTimeoutMs;
@@ -1406,7 +1406,7 @@ public class GroupMetadataManager {
                 metrics.record(CONSUMER_GROUP_REBALANCES_SENSOR_NAME);
             }
 
-            group.setMetadataRefreshDeadline(currentTimeMs + consumerGroupMetadataRefreshIntervalMs, groupEpoch);
+            group.setMetadataRefreshDeadline(currentTimeMs + groupMetadataRefreshIntervalMs, groupEpoch);
         }
 
         // 2. Update the target assignment if the group epoch is larger than the target assignment epoch or a static member
@@ -1636,7 +1636,7 @@ public class GroupMetadataManager {
                 log.info("[GroupId {}] Bumped group epoch to {}.", groupId, groupEpoch);
             }
 
-            group.setMetadataRefreshDeadline(currentTimeMs + consumerGroupMetadataRefreshIntervalMs, groupEpoch);
+            group.setMetadataRefreshDeadline(currentTimeMs + groupMetadataRefreshIntervalMs, groupEpoch);
         }
 
         // 2. Update the target assignment if the group epoch is larger than the target assignment epoch.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -2359,7 +2359,7 @@ public class GroupMetadataManagerTest {
         MockPartitionAssignor assignor = new MockPartitionAssignor("range");
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withAssignors(Collections.singletonList(assignor))
-            .withConsumerGroupMetadataRefreshIntervalMs(5 * 60 * 1000)
+            .withGroupMetadataRefreshIntervalMs(5 * 60 * 1000)
             .withMetadataImage(new MetadataImageBuilder()
                 .addTopic(fooTopicId, fooTopicName, 6)
                 .addRacks()
@@ -2470,7 +2470,7 @@ public class GroupMetadataManagerTest {
         MockPartitionAssignor assignor = new MockPartitionAssignor("range");
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withAssignors(Collections.singletonList(assignor))
-            .withConsumerGroupMetadataRefreshIntervalMs(5 * 60 * 1000)
+            .withGroupMetadataRefreshIntervalMs(5 * 60 * 1000)
             .withMetadataImage(new MetadataImageBuilder()
                 .addTopic(fooTopicId, fooTopicName, 6)
                 .addRacks()

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -354,7 +354,7 @@ public class GroupMetadataManagerTestContext {
         private PartitionAssignor shareGroupAssignor = new MockPartitionAssignor("share");
         final private List<ConsumerGroupBuilder> consumerGroupBuilders = new ArrayList<>();
         private int consumerGroupMaxSize = Integer.MAX_VALUE;
-        private int consumerGroupMetadataRefreshIntervalMs = Integer.MAX_VALUE;
+        private int groupMetadataRefreshIntervalMs = Integer.MAX_VALUE;
         private int classicGroupMaxSize = Integer.MAX_VALUE;
         private int classicGroupInitialRebalanceDelayMs = 3000;
         final private int classicGroupNewMemberJoinTimeoutMs = 5 * 60 * 1000;
@@ -387,8 +387,8 @@ public class GroupMetadataManagerTestContext {
             return this;
         }
 
-        public Builder withConsumerGroupMetadataRefreshIntervalMs(int consumerGroupMetadataRefreshIntervalMs) {
-            this.consumerGroupMetadataRefreshIntervalMs = consumerGroupMetadataRefreshIntervalMs;
+        public Builder withGroupMetadataRefreshIntervalMs(int groupMetadataRefreshIntervalMs) {
+            this.groupMetadataRefreshIntervalMs = groupMetadataRefreshIntervalMs;
             return this;
         }
 
@@ -432,7 +432,7 @@ public class GroupMetadataManagerTestContext {
                     .withConsumerGroupMaxSize(consumerGroupMaxSize)
                     .withConsumerGroupAssignors(consumerGroupAssignors)
                     .withShareGroupAssignor(shareGroupAssignor)
-                    .withConsumerGroupMetadataRefreshIntervalMs(consumerGroupMetadataRefreshIntervalMs)
+                    .withGroupMetadataRefreshIntervalMs(groupMetadataRefreshIntervalMs)
                     .withClassicGroupMaxSize(classicGroupMaxSize)
                     .withClassicGroupMinSessionTimeoutMs(classicGroupMinSessionTimeoutMs)
                     .withClassicGroupMaxSessionTimeoutMs(classicGroupMaxSessionTimeoutMs)


### PR DESCRIPTION
### About
MINOR: Refactor `consumerGroupMetadataRefreshIntervalMs` to `groupMetadataRefreshIntervalMs` to have it common between consumer and share groups