### PR TITLE
AKCORE-68: Update share consumer following new consumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -288,7 +288,8 @@ public class RequestManagers implements Closeable {
                         subscriptions,
                         metadata,
                         clientTelemetryReporter,
-                        backgroundEventHandler);
+                        time,
+                        metrics);
                 ShareHeartbeatRequestManager shareHeartbeatRequestManager = new ShareHeartbeatRequestManager(
                         logContext,
                         time,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerTestBuilder.java
@@ -161,7 +161,8 @@ public class ShareConsumerTestBuilder implements Closeable {
                 subscriptions,
                 metadata,
                 Optional.empty(),
-                backgroundEventHandler));
+                time,
+                metrics));
 
         CoordinatorRequestManager coordinator = spy(new CoordinatorRequestManager(
                 time,


### PR DESCRIPTION
Since the KafkaShareConsumer was originally created following on from the AsyncKafkaConsumer, there have been considerable improvements as KIP-848 approaches preview status. This PR makes the equivalent changes to the KafkaShareConsumer.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
