### PR TITLE
AKCORE-103: Added check to disallow calls from callback to ShareConsumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AcknowledgementCommitCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AcknowledgementCommitCallbackHandler.java
@@ -29,8 +29,13 @@ public class AcknowledgementCommitCallbackHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(AcknowledgementCommitCallbackHandler.class);
     private final AcknowledgementCommitCallback acknowledgementCommitCallback;
+    private boolean enteredCallback = false;
     AcknowledgementCommitCallbackHandler(AcknowledgementCommitCallback acknowledgementCommitCallback) {
         this.acknowledgementCommitCallback = acknowledgementCommitCallback;
+    }
+
+    public boolean hasEnteredCallback() {
+        return enteredCallback;
     }
 
     void onComplete(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
@@ -42,9 +47,12 @@ public class AcknowledgementCommitCallbackHandler {
             Set<Long> offsets = acknowledgements.getAcknowledgementsTypeMap().keySet();
             Set<Long> offsetsCopy = Collections.unmodifiableSet(offsets);
             try {
+                enteredCallback = true;
                 acknowledgementCommitCallback.onComplete(Collections.singletonMap(partition, offsetsCopy), exception);
             } catch (Throwable e) {
                 LOG.error("Exception thrown by acknowledgement commit callback", e);
+            } finally {
+                enteredCallback = false;
             }
         });
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -694,6 +694,10 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
                     "currentThread(name: " + thread.getName() + ", id: " + threadId + ")" +
                     " otherThread(id: " + currentThread.get() + ")"
             );
+        if (acknowledgementCommitCallbackHandler != null && acknowledgementCommitCallbackHandler.hasEnteredCallback()) {
+            throw new ConcurrentModificationException("KafkaShareConsumer methods are not accessible from user-defined" +
+                    "acknowledgement commit callback");
+        }
         refCount.incrementAndGet();
     }
 

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -949,10 +949,11 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         // The acknowledgment commit callback will try to call a method of KafkaShareConsumer
         testCallToShareConsumerMethods = true;
         ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(2000));
+        // The second poll sends the acknowledgments implicitly.
         shareConsumer.poll(Duration.ofMillis(2000));
-        // Till now acknowledgement commit callback has not been called, so exception thrown yet.
+        // Till now acknowledgement commit callback has not been called, so no exception thrown yet.
         assertFalse(isConcurrentAccessExceptionThrown);
-        // On 3rd poll, the acknowledgement commit callback will be called
+        // On 3rd poll, the acknowledgement commit callback will be called.
         shareConsumer.poll(Duration.ofMillis(2000));
         // Now the exception will be thrown as the callback tried to call a method of KafkaShareConsumer.
         assertTrue(isConcurrentAccessExceptionThrown);


### PR DESCRIPTION
*What*
Added a check to prevent re-entry to methods of KafkaShareConsumer from user defined acknowledgement commit callback.