### PR TITLE
AKCORE-115: Fix synchronization on share session cache

### DIFF
--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -1081,18 +1081,20 @@ public class SharePartitionManager {
          * @param now      The current time in milliseconds.
          */
         public void touch(ShareSession session, long now) {
-            synchronized (session) {
-                // Update the lastUsed map.
-                lastUsed.remove(session.lastUsedKey());
-                session.lastUsedMs = now;
-                lastUsed.put(session.lastUsedKey(), session);
+            synchronized (this) {
+                synchronized (session) {
+                    // Update the lastUsed map.
+                    lastUsed.remove(session.lastUsedKey());
+                    session.lastUsedMs = now;
+                    lastUsed.put(session.lastUsedKey(), session);
 
-                int oldSize = session.cachedSize;
-                if (oldSize != -1) {
-                    numPartitions = numPartitions - oldSize;
+                    int oldSize = session.cachedSize;
+                    if (oldSize != -1) {
+                        numPartitions = numPartitions - oldSize;
+                    }
+                    session.cachedSize = session.size();
+                    numPartitions = numPartitions + session.cachedSize;
                 }
-                session.cachedSize = session.size();
-                numPartitions = numPartitions + session.cachedSize;
             }
         }
 


### PR DESCRIPTION
Incorrect synchronization caused an NPE in SharePartitionManager.ShareSessionCache.touch. This method doesn't synchronize when accessing the last-used tree.

Here's the offending stack trace:
```
java.lang.NullPointerException: Cannot assign field "color" because "this.root" is null
	at java.base/java.util.TreeMap.fixAfterInsertion(TreeMap.java:2614)
	at java.base/java.util.TreeMap.addEntry(TreeMap.java:770)
	at java.base/java.util.TreeMap.put(TreeMap.java:828)
	at java.base/java.util.TreeMap.put(TreeMap.java:534)
	at kafka.server.SharePartitionManager$ShareSessionCache.touch(SharePartitionManager.java:1088)
	at kafka.server.SharePartitionManager.acknowledgeShareSessionCacheUpdate(SharePartitionManager.java:306)
	at kafka.server.KafkaApis.handleShareFetchRequest(KafkaApis.scala:1564)
	at kafka.server.KafkaApis.handle(KafkaApis.scala:195)
	at kafka.server.KafkaRequestHandler.run(KafkaRequestHandler.scala:160)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
