### PR TITLE
AKCORE-117: Close Timer objects to avoid thread leak

### DIFF
--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -62,7 +62,7 @@ import scala.runtime.BoxedUnit;
 
 import org.slf4j.LoggerFactory;
 
-public class SharePartitionManager {
+public class SharePartitionManager implements AutoCloseable {
 
     private final static Logger log = LoggerFactory.getLogger(SharePartitionManager.class);
 
@@ -431,6 +431,16 @@ public class SharePartitionManager {
 
     String partitionsToLogString(Collection<TopicIdPartition> partitions) {
         return FetchSession.partitionsToLogString(partitions, log.isTraceEnabled());
+    }
+
+    // Visible for testing.
+    Timer timer() {
+        return timer;
+    }
+
+    @Override
+    public void close() throws Exception {
+        timer.close();
     }
 
     public static class ShareSession {

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -149,6 +149,8 @@ class BrokerServer(
 
   var clientMetricsManager: ClientMetricsManager = _
 
+  var sharePartitionManager: SharePartitionManager = _
+
   private def maybeChangeStatus(from: ProcessStatus, to: ProcessStatus): Boolean = {
     lock.lock()
     try {
@@ -393,13 +395,8 @@ class BrokerServer(
 
       val shareFetchSessionCache : ShareSessionCache = new ShareSessionCache(config.shareGroupMaxGroups * config.shareGroupMaxSize,
         KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS)
-      val sharePartitionManager = new SharePartitionManager(
-        replicaManager,
-        Time.SYSTEM,
-        shareFetchSessionCache,
-        config.shareGroupRecordLockDurationMs,
-        config.shareGroupDeliveryCountLimit
-      )
+      sharePartitionManager = new SharePartitionManager(replicaManager, Time.SYSTEM, shareFetchSessionCache,
+        config.shareGroupRecordLockDurationMs, config.shareGroupDeliveryCountLimit)
 
       // Create the request processor objects.
       val raftSupport = RaftSupport(forwardingManager, metadataCache)
@@ -717,6 +714,8 @@ class BrokerServer(
         CoreUtils.swallow(socketServer.shutdown(), this)
       if (brokerTopicStats != null)
         CoreUtils.swallow(brokerTopicStats.close(), this)
+      if (sharePartitionManager != null)
+        CoreUtils.swallow(sharePartitionManager.close(), this)
 
       isShuttingDown.set(false)
 


### PR DESCRIPTION
### About
Close `Timer` objects to avoid memory leak for both tests and actual code.