### PR TITLE
AKCORE-123: Add temporary config for supporting share persister in share partition

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -45,7 +45,7 @@
     <suppress checks="MethodLength|JavaNCSS|NPath"
               files="(KafkaClusterTestKit|SharePartition|SharePartitionTest).java"/>
     <suppress checks="JavaNCSS" files="(SharePartition|SharePartitionTest).java"/>
-    <suppress checks="ClassDataAbstractionCoupling"
+    <suppress checks="ClassDataAbstractionCoupling|ClassFanOutComplexity"
               files="(SharePartitionManagerTest).java"/>
 
     <!-- server tests -->

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -16,9 +16,11 @@
  */
 package kafka.server;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.ShareSessionNotFoundException;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
@@ -30,6 +32,8 @@ import org.apache.kafka.common.requests.ShareFetchRequest;
 import org.apache.kafka.common.requests.ShareFetchResponse;
 import org.apache.kafka.common.utils.ImplicitLinkedHashCollection;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.group.share.Persister;
 import org.apache.kafka.server.util.timer.SystemTimer;
 import org.apache.kafka.server.util.timer.SystemTimerReaper;
 import org.apache.kafka.server.util.timer.Timer;
@@ -77,6 +81,7 @@ public class SharePartitionManager implements AutoCloseable {
     private final Timer timer;
     private final int maxInFlightMessages;
     private final int maxDeliveryCount;
+    private final String shareGroupPersisterClassName;
 
     public SharePartitionManager(
             ReplicaManager replicaManager,
@@ -84,14 +89,15 @@ public class SharePartitionManager implements AutoCloseable {
             ShareSessionCache cache,
             int recordLockDurationMs,
             int maxDeliveryCount,
-            int maxInFlightMessages
+            int maxInFlightMessages,
+            String shareGroupPersisterClassName
     ) {
-        this(replicaManager, time, cache, new ConcurrentHashMap<>(), recordLockDurationMs, maxDeliveryCount, maxInFlightMessages);
+        this(replicaManager, time, cache, new ConcurrentHashMap<>(), recordLockDurationMs, maxDeliveryCount, maxInFlightMessages, shareGroupPersisterClassName);
     }
 
     // Visible for testing
     SharePartitionManager(ReplicaManager replicaManager, Time time, ShareSessionCache cache, Map<SharePartitionKey, SharePartition> partitionCacheMap,
-                          int recordLockDurationMs, int maxDeliveryCount, int maxInFlightMessages) {
+                          int recordLockDurationMs, int maxDeliveryCount, int maxInFlightMessages, String shareGroupPersisterClassName) {
         this.replicaManager = replicaManager;
         this.time = time;
         this.cache = cache;
@@ -103,6 +109,7 @@ public class SharePartitionManager implements AutoCloseable {
                 new SystemTimer("share-group-lock-timeout"));
         this.maxDeliveryCount = maxDeliveryCount;
         this.maxInFlightMessages = maxInFlightMessages;
+        this.shareGroupPersisterClassName = shareGroupPersisterClassName;
     }
 
     // TODO: Move some part in share session context and change method signature to accept share
@@ -146,8 +153,7 @@ public class SharePartitionManager implements AutoCloseable {
                 );
                 // TODO: Fetch inflight and delivery count from config.
                 SharePartition sharePartition = partitionCacheMap.computeIfAbsent(sharePartitionKey,
-                    k -> new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, maxDeliveryCount,
-                            maxInFlightMessages, recordLockDurationMs, timer, time, null));
+                    k -> sharePartition(shareFetchPartitionData, topicIdPartition));
                 int partitionMaxBytes = shareFetchPartitionData.partitionMaxBytes.getOrDefault(topicIdPartition, 0);
                 // Add the share partition to the list of partitions to be fetched only if we can
                 // acquire the fetch lock on it.
@@ -255,6 +261,18 @@ public class SharePartitionManager implements AutoCloseable {
             futures.forEach((topicIdPartition, future) -> processedResult.put(topicIdPartition, future.join()));
             return processedResult;
         });
+    }
+
+    // Visible for testing.
+    SharePartition sharePartition(ShareFetchPartitionData shareFetchPartitionData, TopicIdPartition topicIdPartition) {
+        try {
+            return new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, 100, maxDeliveryCount,
+                    recordLockDurationMs, timer, time, Utils.newInstance(shareGroupPersisterClassName, Persister.class));
+        } catch (ClassNotFoundException e) {
+            throw new ConfigException("Could not instantiate class share partition " + e.getMessage());
+        } catch (RuntimeException e) {
+            throw new KafkaException("Could not instantiate class share partition " + e.getMessage());
+        }
     }
 
     // Visible for testing.

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -151,7 +151,6 @@ public class SharePartitionManager implements AutoCloseable {
                         shareFetchPartitionData.groupId,
                         topicIdPartition
                 );
-                // TODO: Fetch inflight and delivery count from config.
                 SharePartition sharePartition = partitionCacheMap.computeIfAbsent(sharePartitionKey,
                     k -> sharePartition(shareFetchPartitionData, topicIdPartition));
                 int partitionMaxBytes = shareFetchPartitionData.partitionMaxBytes.getOrDefault(topicIdPartition, 0);
@@ -269,7 +268,7 @@ public class SharePartitionManager implements AutoCloseable {
             Persister persister = null;
             if (!shareGroupPersisterClassName.isEmpty())
                 persister = Utils.newInstance(shareGroupPersisterClassName, Persister.class);
-            return new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, 100, maxDeliveryCount,
+            return new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, maxInFlightMessages, maxDeliveryCount,
                     recordLockDurationMs, timer, time, persister);
         } catch (ClassNotFoundException e) {
             throw new ConfigException("Could not instantiate class share partition " + e.getMessage());

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -266,8 +266,11 @@ public class SharePartitionManager implements AutoCloseable {
     // Visible for testing.
     SharePartition sharePartition(ShareFetchPartitionData shareFetchPartitionData, TopicIdPartition topicIdPartition) {
         try {
+            Persister persister = null;
+            if (!shareGroupPersisterClassName.isEmpty())
+                persister = Utils.newInstance(shareGroupPersisterClassName, Persister.class);
             return new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, 100, maxDeliveryCount,
-                    recordLockDurationMs, timer, time, Utils.newInstance(shareGroupPersisterClassName, Persister.class));
+                    recordLockDurationMs, timer, time, persister);
         } catch (ClassNotFoundException e) {
             throw new ConfigException("Could not instantiate class share partition " + e.getMessage());
         } catch (RuntimeException e) {

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -401,7 +401,8 @@ class BrokerServer(
         shareFetchSessionCache,
         config.shareGroupRecordLockDurationMs,
         config.shareGroupDeliveryCountLimit,
-        config.shareGroupPartitionMaxRecordLocks
+        config.shareGroupPartitionMaxRecordLocks,
+        config.ShareGroupPersisterClassName
       )
 
       // Create the request processor objects.

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -402,7 +402,7 @@ class BrokerServer(
         config.shareGroupRecordLockDurationMs,
         config.shareGroupDeliveryCountLimit,
         config.shareGroupPartitionMaxRecordLocks,
-        config.ShareGroupPersisterClassName
+        config.shareGroupPersisterClassName
       )
 
       // Create the request processor objects.

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1771,7 +1771,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   val shareGroupMaxHeartbeatIntervalMs = getInt(KafkaConfig.ShareGroupMaxHeartbeatIntervalMsProp)
   val shareGroupRecordLockDurationMs = getInt(KafkaConfig.ShareGroupRecordLockDurationMsProp)
   val shareGroupMaxRecordLockDurationMs = getInt(KafkaConfig.ShareGroupMaxRecordLockDurationMsProp)
-  val ShareGroupPersisterClassName = getString(KafkaConfig.ShareGroupPersisterClassNameProp)
+  val shareGroupPersisterClassName = getString(KafkaConfig.ShareGroupPersisterClassNameProp)
 
   /** ********* Offset management configuration ***********/
   val offsetMetadataMaxSize = getInt(KafkaConfig.OffsetMetadataMaxSizeProp)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -268,6 +268,7 @@ object KafkaConfig {
   val ShareGroupMinRecordLockDurationMsProp = "group.share.min.record.lock.duration.ms"
   val ShareGroupMaxRecordLockDurationMsProp = "group.share.max.record.lock.duration.ms"
   val ShareGroupAssignorsProp = "group.share.assignors"
+  val ShareGroupPersisterClassNameProp = "group.share.persister.class.name"
 
   /** ********* Offset management configuration ***********/
   val OffsetMetadataMaxSizeProp = "offset.metadata.max.bytes"
@@ -711,6 +712,8 @@ object KafkaConfig {
   val ShareGroupMinRecordLockDurationMsDoc = "The record acquisition lock minimum duration in milliseconds for share groups."
   val ShareGroupMaxRecordLockDurationMsDoc = "The record acquisition lock maximum duration in milliseconds for share groups."
   val ShareGroupAssignorsDoc = "The server-side assignors as a list of full class names. The first one in the list is considered as the default assignor to be used in the case where the share group does not specify an assignor."
+  val ShareGroupPersisterClassNameDoc = "The class name of share persister for share group. The class should implement " +
+    "the <code>org.apache.kafka.server.group.share.Persister</code> interface."
 
   /** ********* Offset management configuration ***********/
   val OffsetMetadataMaxSizeDoc = "The maximum size for a metadata entry associated with an offset commit."
@@ -1098,6 +1101,7 @@ object KafkaConfig {
       .define(ShareGroupMaxGroupsProp, SHORT, Defaults.SHARE_GROUP_MAX_GROUPS, between(1, 100), MEDIUM, ShareGroupMaxGroupsDoc)
       .define(ShareGroupMaxSizeProp, SHORT, Defaults.SHARE_GROUP_MAX_SIZE, between(10, 1000), MEDIUM, ShareGroupMaxSizeDoc)
       .define(ShareGroupAssignorsProp, LIST, Defaults.SHARE_GROUP_ASSIGNORS, null, MEDIUM, ShareGroupAssignorsDoc)
+      .defineInternal(ShareGroupPersisterClassNameProp, STRING, Defaults.SHARE_GROUP_PERSISTER_CLASS_NAME, new ConfigDef.NonNullValidator(), MEDIUM, ShareGroupPersisterClassNameDoc)
 
       /** ********* Offset management configuration ***********/
       .define(OffsetMetadataMaxSizeProp, INT, Defaults.OFFSET_METADATA_MAX_SIZE, HIGH, OffsetMetadataMaxSizeDoc)
@@ -1767,6 +1771,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   val shareGroupMaxHeartbeatIntervalMs = getInt(KafkaConfig.ShareGroupMaxHeartbeatIntervalMsProp)
   val shareGroupRecordLockDurationMs = getInt(KafkaConfig.ShareGroupRecordLockDurationMsProp)
   val shareGroupMaxRecordLockDurationMs = getInt(KafkaConfig.ShareGroupMaxRecordLockDurationMsProp)
+  val ShareGroupPersisterClassName = getString(KafkaConfig.ShareGroupPersisterClassNameProp)
 
   /** ********* Offset management configuration ***********/
   val offsetMetadataMaxSize = getInt(KafkaConfig.OffsetMetadataMaxSizeProp)

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -144,7 +144,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testNewContextReturnsFinalContext() {
-        SharePartitionManager sharePartitionManager = sharePartitionManager();
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder().build();
 
         ShareFetchMetadata newReqMetadata = new ShareFetchMetadata(Uuid.ZERO_UUID, -1);
         ShareFetchContext shareFetchContext = sharePartitionManager.newContext("grp", new HashMap<>(), new ArrayList<>(), newReqMetadata);
@@ -263,7 +263,8 @@ public class SharePartitionManagerTest {
     public void testShareFetchRequests() {
         Time time = new MockTime();
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache, time);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).withTime(time).build();
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
         Uuid tpId1 = Uuid.randomUuid();
@@ -406,7 +407,8 @@ public class SharePartitionManagerTest {
     public void testShareSessionExpiration() {
         Time time = new MockTime();
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(2, 1000);
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache, time);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).withTime(time).build();
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid fooId = Uuid.randomUuid();
         topicNames.put(fooId, "foo");
@@ -501,7 +503,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testSubsequentShareSession() {
-        SharePartitionManager sharePartitionManager = sharePartitionManager();
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder().build();
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid fooId = Uuid.randomUuid();
         Uuid barId = Uuid.randomUuid();
@@ -567,7 +569,8 @@ public class SharePartitionManagerTest {
     @Test
     public void testZeroSizeShareSession() {
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).build();
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid fooId = Uuid.randomUuid();
         topicNames.put(fooId, "foo");
@@ -659,7 +662,8 @@ public class SharePartitionManagerTest {
     public void testToForgetPartitions() {
         String groupId = "grp";
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).build();
         Uuid fooId = Uuid.randomUuid();
         Uuid barId = Uuid.randomUuid();
         TopicIdPartition foo = new TopicIdPartition(fooId, new TopicPartition("foo", 0));
@@ -700,7 +704,8 @@ public class SharePartitionManagerTest {
     public void testShareSessionUpdateTopicIdsBrokerSide() {
         String groupId = "grp";
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).build();
         Uuid fooId = Uuid.randomUuid();
         Uuid barId = Uuid.randomUuid();
         TopicIdPartition foo = new TopicIdPartition(fooId, new TopicPartition("foo", 0));
@@ -755,7 +760,8 @@ public class SharePartitionManagerTest {
     public void testAcknowledgeShareSessionCacheUpdate() {
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
         Time time = new MockTime();
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache, time);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).withTime(time).build();
         String groupId = "grp";
         Uuid memberId = Uuid.randomUuid();
         // Manually create a share session in cache
@@ -793,7 +799,8 @@ public class SharePartitionManagerTest {
     public void testAcknowledgeShareSessionCacheUpdateForPiggybackedAcknowledgement() {
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
         Time time = new MockTime();
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache, time);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).withTime(time).build();
         String groupId = "grp";
         Uuid memberId = Uuid.randomUuid();
         boolean isAcknowledgementPiggybackedOnFetch = true;
@@ -837,7 +844,8 @@ public class SharePartitionManagerTest {
     public void testGetErroneousAndValidTopicIdPartitions() {
         Time time = new MockTime();
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache, time);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).withTime(time).build();
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
         Uuid tpId1 = Uuid.randomUuid();
@@ -945,7 +953,8 @@ public class SharePartitionManagerTest {
     public void testShareFetchContextResponseSize() {
         Time time = new MockTime();
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache, time);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).withTime(time).build();
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
         Uuid tpId1 = Uuid.randomUuid();
@@ -1061,7 +1070,8 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
         Map<TopicIdPartition, List<SharePartition.AcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager(partitionCacheMap);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).build();
         acknowledgeTopics.put(tp1, Arrays.asList(
                 new SharePartition.AcknowledgementBatch(12, 20, new ArrayList<>(), AcknowledgeType.ACCEPT),
                 new SharePartition.AcknowledgementBatch(24, 56, new ArrayList<>(), AcknowledgeType.ACCEPT)
@@ -1110,7 +1120,8 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
         Map<TopicIdPartition, List<SharePartition.AcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager(partitionCacheMap);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).build();
 
         acknowledgeTopics.put(tp1, Arrays.asList(
                 new SharePartition.AcknowledgementBatch(12, 20, new ArrayList<>(), AcknowledgeType.ACCEPT),
@@ -1160,7 +1171,8 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
         Map<TopicIdPartition, List<SharePartition.AcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager(partitionCacheMap);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).build();
 
         acknowledgeTopics.put(tp1, Arrays.asList(
                 new SharePartition.AcknowledgementBatch(12, 20, new ArrayList<>(), AcknowledgeType.ACCEPT),
@@ -1198,7 +1210,7 @@ public class SharePartitionManagerTest {
         ));
         Map<TopicIdPartition, List<SharePartition.AcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager();
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder().build();
         acknowledgeTopics.put(tp, Arrays.asList(
                 new SharePartition.AcknowledgementBatch(78, 90, new ArrayList<>(), AcknowledgeType.RELEASE),
                 new SharePartition.AcknowledgementBatch(94, 99, new ArrayList<>(), AcknowledgeType.RELEASE)
@@ -1237,7 +1249,8 @@ public class SharePartitionManagerTest {
         partitionMaxBytes.put(tp6, PARTITION_MAX_BYTES);
 
         ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
-        SharePartitionManager sharePartitionManager = sharePartitionManager(replicaManager);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withReplicaManager(replicaManager).build();
 
         doAnswer(invocation -> {
             sharePartitionManager.releaseFetchQueueAndPartitionsLock(groupId, partitionMaxBytes.keySet());
@@ -1278,7 +1291,8 @@ public class SharePartitionManagerTest {
             k -> new SharePartition(groupId, tp1, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
                     RECORD_LOCK_DURATION_MS, mockTimer, new MockTime(), null));
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager(partitionCacheMap);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).build();
 
         CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
         SharePartitionManager.ShareFetchPartitionData shareFetchPartitionData = new SharePartitionManager.ShareFetchPartitionData(
@@ -1344,7 +1358,8 @@ public class SharePartitionManagerTest {
             k -> new SharePartition(groupId, tp1, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
                     RECORD_LOCK_DURATION_MS, mockTimer, new MockTime(), null));
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager(partitionCacheMap);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).build();
 
         CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
         SharePartitionManager.ShareFetchPartitionData shareFetchPartitionData = new SharePartitionManager.ShareFetchPartitionData(
@@ -1411,7 +1426,8 @@ public class SharePartitionManagerTest {
                 k -> new SharePartition(groupId, tp3, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
                         RECORD_LOCK_DURATION_MS, mockTimer, time, null));
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager(partitionCacheMap, time, replicaManager);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).withTime(time).withReplicaManager(replicaManager).build();
 
         SharePartition sp0 = Mockito.mock(SharePartition.class);
         SharePartition sp1 = Mockito.mock(SharePartition.class);
@@ -1486,7 +1502,8 @@ public class SharePartitionManagerTest {
     @Test
     public void testCachedTopicPartitionsForInvalidShareSession() {
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).build();
 
         assertThrows(ShareSessionNotFoundException.class, () -> sharePartitionManager.cachedTopicIdPartitionsInShareSession("grp", Uuid.randomUuid()));
     }
@@ -1494,7 +1511,8 @@ public class SharePartitionManagerTest {
     @Test
     public void testCachedTopicPartitionsForValidShareSessions() {
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = sharePartitionManager(cache);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache).build();
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
         Uuid tpId1 = Uuid.randomUuid();
@@ -1627,7 +1645,8 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager(partitionCacheMap);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).build();
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.releaseAcquiredRecords(groupId, memberId, Arrays.asList(tp1, tp2, tp3));
         Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData> result = resultFuture.join();
@@ -1656,7 +1675,8 @@ public class SharePartitionManagerTest {
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new HashMap<>();
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager(partitionCacheMap);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).build();
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.releaseAcquiredRecords("grp-2", memberId, Collections.singletonList(tp1));
         Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData> result = resultFuture.join();
@@ -1683,7 +1703,8 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager(partitionCacheMap);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).build();
 
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.releaseAcquiredRecords(groupId, memberId, Arrays.asList(tp1, tp2));
@@ -1714,7 +1735,8 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager(partitionCacheMap);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).build();
 
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.releaseAcquiredRecords(groupId, memberId, Collections.emptyList());
@@ -1724,7 +1746,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testCloseSharePartitionManager() throws Exception {
-        SharePartitionManager sharePartitionManager = sharePartitionManager();
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder().build();
 
         List<Integer> mockList = new ArrayList<>();
         sharePartitionManager.timer().add(createTimerTask(mockList));
@@ -1762,7 +1784,7 @@ public class SharePartitionManagerTest {
                 "grp", Uuid.randomUuid().toString(), Arrays.asList(tp0, tp1), new CompletableFuture<>(),
                 partitionMaxBytes);
 
-        SharePartitionManager sharePartitionManager = sharePartitionManager();
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder().build();
 
         mockUtils.when(() -> Utils.newInstance(ArgumentMatchers.anyString(), ArgumentMatchers.any())).thenThrow(new
                 RuntimeException("Persister object creation failed"));
@@ -1773,33 +1795,37 @@ public class SharePartitionManagerTest {
         assertThrows(ConfigException.class, () -> sharePartitionManager.sharePartition(shareFetchPartitionData, tp0));
     }
 
-    private SharePartitionManager sharePartitionManager() {
-        return sharePartitionManager(new SharePartitionManager.ShareSessionCache(10, 1000), new MockTime(), Mockito.mock(ReplicaManager.class));
-    }
+    private static class SharePartitionManagerBuilder {
+        private ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+        private Time time = new MockTime();
+        private SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
+        private Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new HashMap<>();
 
-    private SharePartitionManager sharePartitionManager(ReplicaManager replicaManager) {
-        return sharePartitionManager(new SharePartitionManager.ShareSessionCache(10, 1000), new MockTime(), replicaManager);
-    }
+        private SharePartitionManagerBuilder withReplicaManager(ReplicaManager replicaManager) {
+            this.replicaManager = replicaManager;
+            return this;
+        }
 
-    private SharePartitionManager sharePartitionManager(SharePartitionManager.ShareSessionCache cache) {
-        return sharePartitionManager(cache, new MockTime(), Mockito.mock(ReplicaManager.class));
-    }
+        private SharePartitionManagerBuilder withTime(Time time) {
+            this.time = time;
+            return this;
+        }
 
-    private SharePartitionManager sharePartitionManager(SharePartitionManager.ShareSessionCache cache, Time time) {
-        return sharePartitionManager(cache, time, Mockito.mock(ReplicaManager.class));
-    }
+        private SharePartitionManagerBuilder withCache(SharePartitionManager.ShareSessionCache cache) {
+            this.cache = cache;
+            return this;
+        }
 
-    private SharePartitionManager sharePartitionManager(SharePartitionManager.ShareSessionCache cache, Time time, ReplicaManager replicaManager) {
-        return new SharePartitionManager(replicaManager, time, cache, RECORD_LOCK_DURATION_MS, MAX_IN_FLIGHT_MESSAGES, MAX_DELIVERY_COUNT, SHARE_GROUP_PERSISTER_CLASS_NAME);
-    }
+        private SharePartitionManagerBuilder withPartitionCacheMap(Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap) {
+            this.partitionCacheMap = partitionCacheMap;
+            return this;
+        }
 
-    private SharePartitionManager sharePartitionManager(Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap) {
-        return sharePartitionManager(partitionCacheMap, new MockTime(), Mockito.mock(ReplicaManager.class));
-    }
-
-    private SharePartitionManager sharePartitionManager(Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap, Time time, ReplicaManager replicaManager) {
-        return new SharePartitionManager(replicaManager, time,
-                new SharePartitionManager.ShareSessionCache(10, 1000), partitionCacheMap,
-                RECORD_LOCK_DURATION_MS, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES, SHARE_GROUP_PERSISTER_CLASS_NAME);
+        public static SharePartitionManagerBuilder builder() {
+            return new SharePartitionManagerBuilder();
+        }
+        public SharePartitionManager build() {
+            return new SharePartitionManager(replicaManager, time, cache, partitionCacheMap, RECORD_LOCK_DURATION_MS, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES, SHARE_GROUP_PERSISTER_CLASS_NAME);
+        }
     }
 }

--- a/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
@@ -60,7 +60,6 @@ abstract class AbstractShareConsumerTest extends BaseRequestTest {
     properties.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "10")
     properties.setProperty(KafkaConfig.ShareGroupRecordLockDurationMsProp, "10000")
     properties.setProperty(KafkaConfig.ShareGroupPartitionMaxRecordLocksProp, "10000")
-    properties.setProperty(KafkaConfig.ShareGroupPersisterClassNameProp, "org.apache.kafka.server.group.share.DefaultStatePersister")
   }
 
   @BeforeEach

--- a/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
@@ -60,6 +60,7 @@ abstract class AbstractShareConsumerTest extends BaseRequestTest {
     properties.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "10")
     properties.setProperty(KafkaConfig.ShareGroupRecordLockDurationMsProp, "10000")
     properties.setProperty(KafkaConfig.ShareGroupPartitionMaxRecordLocksProp, "10000")
+    properties.setProperty(KafkaConfig.ShareGroupPersisterClassNameProp, "org.apache.kafka.server.group.share.DefaultStatePersister")
   }
 
   @BeforeEach

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -132,7 +132,7 @@ class KafkaApisTest extends Logging {
     clientControllerQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, None)
   private val fetchManager: FetchManager = mock(classOf[FetchManager])
   val sharePartitionManager : SharePartitionManager =
-    new SharePartitionManager(replicaManager, new SystemTime(),  new ShareSessionCache(1000, 100), 30000, 5, 200)
+    new SharePartitionManager(replicaManager, new SystemTime(),  new ShareSessionCache(1000, 100), 30000, 5, 200, "MockShareGroupPersisterClassPath")
   private val clientMetricsManager: ClientMetricsManager = mock(classOf[ClientMetricsManager])
   private val brokerTopicStats = new BrokerTopicStats
   private val clusterId = "clusterId"

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -132,7 +132,7 @@ class KafkaApisTest extends Logging {
     clientControllerQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, None)
   private val fetchManager: FetchManager = mock(classOf[FetchManager])
   val sharePartitionManager : SharePartitionManager =
-    new SharePartitionManager(replicaManager, new SystemTime(),  new ShareSessionCache(1000, 100), 30000, 5, 200, "MockShareGroupPersisterClassPath")
+    new SharePartitionManager(replicaManager, new SystemTime(),  new ShareSessionCache(1000, 100), 30000, 5, 200, "")
   private val clientMetricsManager: ClientMetricsManager = mock(classOf[ClientMetricsManager])
   private val brokerTopicStats = new BrokerTopicStats
   private val clusterId = "clusterId"

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1048,6 +1048,7 @@ class KafkaConfigTest {
         case KafkaConfig.ShareGroupHeartbeatIntervalMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
         case KafkaConfig.ShareGroupMinHeartbeatIntervalMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
         case KafkaConfig.ShareGroupMaxHeartbeatIntervalMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
+        case KafkaConfig.ShareGroupPersisterClassNameProp => //ignore string
 
         case _ => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1")
       }
@@ -1893,5 +1894,16 @@ class KafkaConfigTest {
     props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, String.valueOf(true))
     props.put(KafkaConfig.LogDirsProp, "/tmp/a")
     assertDoesNotThrow(() => KafkaConfig.fromProps(props))
+  }
+
+  @Test
+  def testInvalidShareGroupPersisterClassName(): Unit = {
+    val props = new Properties()
+    props.putAll(kraftProps())
+    val configs = new util.HashMap[Object, Object](props)
+    configs.put(KafkaConfig.ShareGroupPersisterClassNameProp, null)
+    val ce = assertThrows(classOf[ConfigException], () => KafkaConfig.apply(configs))
+    assertTrue(ce.getMessage.contains(KafkaConfig.ShareGroupPersisterClassNameProp))
+
   }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1049,6 +1049,7 @@ class KafkaConfigTest {
         case KafkaConfig.ShareGroupMinHeartbeatIntervalMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
         case KafkaConfig.ShareGroupMaxHeartbeatIntervalMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
         case KafkaConfig.ShareGroupPersisterClassNameProp => //ignore string
+        case KafkaConfig.ShareGroupAssignorsProp => //ignore string
 
         case _ => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1")
       }

--- a/server/src/main/java/org/apache/kafka/server/config/Defaults.java
+++ b/server/src/main/java/org/apache/kafka/server/config/Defaults.java
@@ -171,6 +171,7 @@ public class Defaults {
     public static final List<String> SHARE_GROUP_ASSIGNORS = Arrays.asList(
         SimpleAssignor.class.getName()
     );
+    public static final String SHARE_GROUP_PERSISTER_CLASS_NAME = "";
 
     /** ********* Offset management configuration *********/
     public static final int OFFSET_METADATA_MAX_SIZE = OffsetConfig.DEFAULT_MAX_METADATA_SIZE;


### PR DESCRIPTION
### About
1. Added temporary internal broker config `group.share.persister.class.name` to determine the implemented class name of `Persister.java`
2. Refactored `SharePartitionManagerTest`
3. Fixed flaky test `testAcknowledgeShareSessionCacheUpdate` in `SharePartitionManagerTest`.
