### PR TITLE
AKCORE 66: Ensuring the partition limit of acquired records is not exceeded

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -43,8 +43,8 @@
     <suppress checks="ClassFanOutComplexity" files="RemoteLogManagerTest.java"/>
     <suppress checks="CyclomaticComplexity" files="(SharePartition).java"/>
     <suppress checks="MethodLength"
-              files="(KafkaClusterTestKit|SharePartition).java"/>
-    <suppress checks="JavaNCSS" files="(SharePartition).java"/>
+              files="(KafkaClusterTestKit|SharePartition|SharePartitionTest).java"/>
+    <suppress checks="JavaNCSS" files="(SharePartition|SharePartitionTest).java"/>
     <suppress checks="ClassDataAbstractionCoupling"
               files="(SharePartitionManagerTest).java"/>
 

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -1123,14 +1123,6 @@ public class SharePartition {
             this.inFlightState = new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask);
         }
 
-        InFlightBatch(long baseOffset, long lastOffset, InFlightState inFlightState, Set<Long> gapOffsets, NavigableMap<Long, InFlightState> offsetState) {
-            this.baseOffset = baseOffset;
-            this.lastOffset = lastOffset;
-            this.inFlightState = inFlightState;
-            this.gapOffsets = gapOffsets;
-            this.offsetState = offsetState;
-        }
-
         // Visible for testing.
         long baseOffset() {
             return baseOffset;

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -151,18 +151,19 @@ public class SharePartitionManager implements AutoCloseable {
                 int partitionMaxBytes = shareFetchPartitionData.partitionMaxBytes.getOrDefault(topicIdPartition, 0);
                 // Add the share partition to the list of partitions to be fetched only if we can
                 // acquire the fetch lock on it.
-                if (sharePartition.canAcquireMore()) {
-                    if (sharePartition.maybeAcquireFetchLock()) {
+                if (sharePartition.maybeAcquireFetchLock()) {
+                    if (sharePartition.canAcquireMore()) {
                         topicPartitionData.put(topicIdPartition, new FetchRequest.PartitionData(
                                 topicIdPartition.topicId(),
                                 sharePartition.nextFetchOffset(),
                                 0,
                                 partitionMaxBytes,
                                 Optional.empty()));
+                    } else {
+                        sharePartition.releaseFetchLock();
+                        log.trace("record lock partition limit exceeded for SharePartition with key {}, " +
+                                "cannot acquire more records", sharePartitionKey);
                     }
-                } else {
-                    log.trace("record lock partition limit exceeded for SharePartition with key {}, " +
-                            "cannot acquire more records", sharePartitionKey);
                 }
             });
 

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -161,7 +161,7 @@ public class SharePartitionManager implements AutoCloseable {
                                 Optional.empty()));
                     } else {
                         sharePartition.releaseFetchLock();
-                        log.trace("record lock partition limit exceeded for SharePartition with key {}, " +
+                        log.info("Record lock partition limit exceeded for SharePartition with key {}, " +
                                 "cannot acquire more records", sharePartitionKey);
                     }
                 }

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -141,7 +141,9 @@ public class SharePartitionManager implements AutoCloseable {
             assert shareFetchPartitionData != null;
             shareFetchPartitionData.topicIdPartitions.forEach(topicIdPartition -> {
                 SharePartitionKey sharePartitionKey = sharePartitionKey(
-                        shareFetchPartitionData.groupId, topicIdPartition);
+                        shareFetchPartitionData.groupId,
+                        topicIdPartition
+                );
                 // TODO: Fetch inflight and delivery count from config.
                 SharePartition sharePartition = partitionCacheMap.computeIfAbsent(sharePartitionKey,
                     k -> new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, 100, maxDeliveryCount,

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -393,7 +393,13 @@ class BrokerServer(
 
       val shareFetchSessionCache : ShareSessionCache = new ShareSessionCache(config.shareGroupMaxGroups * config.shareGroupMaxSize,
         KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS)
-      val sharePartitionManager = new SharePartitionManager(replicaManager, Time.SYSTEM, shareFetchSessionCache, config.shareGroupRecordLockDurationMs)
+      val sharePartitionManager = new SharePartitionManager(
+        replicaManager,
+        Time.SYSTEM,
+        shareFetchSessionCache,
+        config.shareGroupRecordLockDurationMs,
+        config.shareGroupRecordLockPartitionLimit
+      )
 
       // Create the request processor objects.
       val raftSupport = RaftSupport(forwardingManager, metadataCache)

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -401,7 +401,7 @@ class BrokerServer(
         shareFetchSessionCache,
         config.shareGroupRecordLockDurationMs,
         config.shareGroupDeliveryCountLimit,
-        config.shareGroupRecordLockPartitionLimit
+        config.shareGroupPartitionMaxRecordLocks
       )
 
       // Create the request processor objects.

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -254,7 +254,7 @@ object KafkaConfig {
 
   /** Share Group Configurations **/
   val ShareGroupEnableProp = "group.share.enable"
-  val ShareGroupRecordLockPartitionLimitProp = "group.share.record.lock.partition.limit"
+  val ShareGroupPartitionMaxRecordLocksProp = "group.share.partition.max.record.locks"
   val ShareGroupDeliveryCountLimitProp = "group.share.delivery.count.limit"
   val ShareGroupMaxGroupsProp = "group.share.max.groups"
   val ShareGroupMaxSizeProp = "group.share.max.size"
@@ -695,7 +695,7 @@ object KafkaConfig {
 
   /** Share Group Configurations */
   val ShareGroupEnableDoc = "Enable share groups on the broker."
-  val ShareGroupRecordLockPartitionLimitDoc = "Share-group record lock limit per share-partition."
+  val ShareGroupPartitionMaxRecordLocksDoc = "Share-group record lock limit per share-partition."
   val ShareGroupDeliveryCountLimitDoc = "The maximum number of delivery attempts for a record delivered to a share group."
   val ShareGroupMaxGroupsDoc = "The maximum number of share groups."
   val ShareGroupMaxSizeDoc = "The maximum number of consumers that a single share group can accommodate."
@@ -1079,7 +1079,7 @@ object KafkaConfig {
 
       /** Share Group Configurations **/
       .define(ShareGroupEnableProp, BOOLEAN, Defaults.SHARE_GROUP_ENABLE, null, MEDIUM, ShareGroupEnableDoc)
-      .define(ShareGroupRecordLockPartitionLimitProp, SHORT, Defaults.SHARE_GROUP_RECORD_LOCK_PARTITION_LIMIT, between(100, 10000), MEDIUM, ShareGroupRecordLockPartitionLimitDoc)
+      .define(ShareGroupPartitionMaxRecordLocksProp, INT, Defaults.SHARE_GROUP_PARTITION_MAX_RECORD_LOCKS, between(100, 10000), MEDIUM, ShareGroupPartitionMaxRecordLocksDoc)
       .define(ShareGroupDeliveryCountLimitProp, INT, Defaults.SHARE_GROUP_DELIVERY_COUNT_LIMIT, between(2, 10), MEDIUM, ShareGroupDeliveryCountLimitDoc)
       .define(ShareGroupMaxGroupsProp, SHORT, Defaults.SHARE_GROUP_MAX_GROUPS, between(1, 100), MEDIUM, ShareGroupMaxGroupsDoc)
       .define(ShareGroupMaxSizeProp, SHORT, Defaults.SHARE_GROUP_MAX_SIZE, between(10, 1000), MEDIUM, ShareGroupMaxSizeDoc)
@@ -1748,7 +1748,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
 
   /** Share Group Configurations **/
   val isShareGroupEnabled = getBoolean(KafkaConfig.ShareGroupEnableProp)
-  val shareGroupRecordLockPartitionLimit = getShort(KafkaConfig.ShareGroupRecordLockPartitionLimitProp)
+  val shareGroupPartitionMaxRecordLocks = getInt(KafkaConfig.ShareGroupPartitionMaxRecordLocksProp)
   val shareGroupDeliveryCountLimit = getInt(KafkaConfig.ShareGroupDeliveryCountLimitProp)
   val shareGroupMaxGroups = getShort(KafkaConfig.ShareGroupMaxGroupsProp)
   val shareGroupMaxSize = getShort(KafkaConfig.ShareGroupMaxSizeProp)

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -95,7 +95,7 @@ public class SharePartitionManagerTest {
 
     private static final int PARTITION_MAX_BYTES = 40000;
     static final int RECORD_LOCK_DURATION_MS = 30000;
-    private static final short RECORD_LOCK_PARTITION_LIMIT = 200;
+    private static final short MAX_IN_FLIGHT_MESSAGES = 200;
     static final int MAX_DELIVERY_COUNT = 5;
     private static Timer mockTimer;
 
@@ -141,7 +141,7 @@ public class SharePartitionManagerTest {
                 new SharePartitionManager.ShareSessionCache(10, 1000),
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         ShareFetchMetadata newReqMetadata = new ShareFetchMetadata(Uuid.ZERO_UUID, -1);
@@ -267,7 +267,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
@@ -417,7 +417,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid fooId = Uuid.randomUuid();
@@ -519,7 +519,7 @@ public class SharePartitionManagerTest {
                 new SharePartitionManager.ShareSessionCache(10, 1000),
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid fooId = Uuid.randomUuid();
@@ -592,7 +592,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid fooId = Uuid.randomUuid();
@@ -691,7 +691,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         Uuid fooId = Uuid.randomUuid();
         Uuid barId = Uuid.randomUuid();
@@ -739,7 +739,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         Uuid fooId = Uuid.randomUuid();
         Uuid barId = Uuid.randomUuid();
@@ -801,7 +801,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         String groupId = "grp";
         Uuid memberId = Uuid.randomUuid();
@@ -846,7 +846,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         String groupId = "grp";
         Uuid memberId = Uuid.randomUuid();
@@ -897,7 +897,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
@@ -1012,7 +1012,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
@@ -1137,7 +1137,7 @@ public class SharePartitionManagerTest {
                 partitionCacheMap,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         acknowledgeTopics.put(tp1, Arrays.asList(
                 new SharePartition.AcknowledgementBatch(12, 20, new ArrayList<>(), AcknowledgeType.ACCEPT),
@@ -1195,7 +1195,7 @@ public class SharePartitionManagerTest {
                 partitionCacheMap,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         acknowledgeTopics.put(tp1, Arrays.asList(
@@ -1254,7 +1254,7 @@ public class SharePartitionManagerTest {
                 partitionCacheMap,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         acknowledgeTopics.put(tp1, Arrays.asList(
@@ -1300,7 +1300,7 @@ public class SharePartitionManagerTest {
                 new SharePartitionManager.ShareSessionCache(10, 1000),
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         acknowledgeTopics.put(tp, Arrays.asList(
                 new SharePartition.AcknowledgementBatch(78, 90, new ArrayList<>(), AcknowledgeType.RELEASE),
@@ -1346,7 +1346,7 @@ public class SharePartitionManagerTest {
                 new SharePartitionManager.ShareSessionCache(10, 1000),
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         doAnswer(invocation -> {
@@ -1380,10 +1380,10 @@ public class SharePartitionManagerTest {
 
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp0),
-            k -> new SharePartition(groupId, tp0, 100, 5, RECORD_LOCK_PARTITION_LIMIT,
+            k -> new SharePartition(groupId, tp0, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
                     RECORD_LOCK_DURATION_MS, mockTimer, new MockTime()));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp1),
-            k -> new SharePartition(groupId, tp1, 100, 5, RECORD_LOCK_PARTITION_LIMIT,
+            k -> new SharePartition(groupId, tp1, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
                     RECORD_LOCK_DURATION_MS, mockTimer, new MockTime()));
 
         SharePartitionManager sharePartitionManager = new SharePartitionManager(
@@ -1393,7 +1393,7 @@ public class SharePartitionManagerTest {
                 partitionCacheMap,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
@@ -1454,10 +1454,10 @@ public class SharePartitionManagerTest {
 
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp0),
-            k -> new SharePartition(groupId, tp0, 100, 5, RECORD_LOCK_PARTITION_LIMIT,
+            k -> new SharePartition(groupId, tp0, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
                     RECORD_LOCK_DURATION_MS, mockTimer, new MockTime()));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp1),
-            k -> new SharePartition(groupId, tp1, 100, 5, RECORD_LOCK_PARTITION_LIMIT,
+            k -> new SharePartition(groupId, tp1, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
                     RECORD_LOCK_DURATION_MS, mockTimer, new MockTime()));
 
         SharePartitionManager sharePartitionManager = new SharePartitionManager(
@@ -1467,7 +1467,7 @@ public class SharePartitionManagerTest {
                 partitionCacheMap,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
@@ -1523,16 +1523,16 @@ public class SharePartitionManagerTest {
 
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp0),
-                k -> new SharePartition(groupId, tp0, 100, 5, RECORD_LOCK_PARTITION_LIMIT,
+                k -> new SharePartition(groupId, tp0, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
                         RECORD_LOCK_DURATION_MS, mockTimer, time));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp1),
-                k -> new SharePartition(groupId, tp1, 100, 5,  RECORD_LOCK_PARTITION_LIMIT,
+                k -> new SharePartition(groupId, tp1, MAX_DELIVERY_COUNT,  MAX_IN_FLIGHT_MESSAGES,
                         RECORD_LOCK_DURATION_MS, mockTimer, time));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp2),
-                k -> new SharePartition(groupId, tp2, 100, 5, RECORD_LOCK_PARTITION_LIMIT,
+                k -> new SharePartition(groupId, tp2, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
                         RECORD_LOCK_DURATION_MS, mockTimer, time));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp3),
-                k -> new SharePartition(groupId, tp3, 100, 5, RECORD_LOCK_PARTITION_LIMIT,
+                k -> new SharePartition(groupId, tp3, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
                         RECORD_LOCK_DURATION_MS, mockTimer, time));
 
         SharePartitionManager sharePartitionManager = new SharePartitionManager(
@@ -1542,7 +1542,7 @@ public class SharePartitionManagerTest {
                 partitionCacheMap,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         SharePartition sp0 = Mockito.mock(SharePartition.class);
@@ -1624,7 +1624,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         assertThrows(ShareSessionNotFoundException.class, () -> sharePartitionManager.cachedTopicIdPartitionsInShareSession("grp", Uuid.randomUuid()));
@@ -1639,7 +1639,7 @@ public class SharePartitionManagerTest {
                 cache,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
@@ -1780,7 +1780,7 @@ public class SharePartitionManagerTest {
                 partitionCacheMap,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.releaseAcquiredRecords(groupId, memberId, Arrays.asList(tp1, tp2, tp3));
@@ -1817,7 +1817,7 @@ public class SharePartitionManagerTest {
                 partitionCacheMap,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.releaseAcquiredRecords("grp-2", memberId, Collections.singletonList(tp1));
@@ -1852,7 +1852,7 @@ public class SharePartitionManagerTest {
                 partitionCacheMap,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
@@ -1891,7 +1891,7 @@ public class SharePartitionManagerTest {
                 partitionCacheMap,
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
@@ -1909,7 +1909,7 @@ public class SharePartitionManagerTest {
                 new HashMap<>(),
                 RECORD_LOCK_DURATION_MS,
                 MAX_DELIVERY_COUNT,
-                RECORD_LOCK_PARTITION_LIMIT
+                MAX_IN_FLIGHT_MESSAGES
         );
 
         List<Integer> mockList = new ArrayList<>();

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -92,6 +92,7 @@ public class SharePartitionManagerTest {
 
     private static final int PARTITION_MAX_BYTES = 40000;
     static final int RECORD_LOCK_DURATION_MS = 30000;
+    private static final short RECORD_LOCK_PARTITION_LIMIT = 200;
     static final Timer TIMER = new SystemTimerReaper("sharePartitionTestReaper",
             new SystemTimer("sharePartitionTestTimer"));
 
@@ -120,8 +121,13 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testNewContextReturnsFinalContext() {
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000), RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
 
         ShareFetchMetadata newReqMetadata = new ShareFetchMetadata(Uuid.ZERO_UUID, -1);
         ShareFetchContext shareFetchContext = sharePartitionManager.newContext("grp", new HashMap<>(), new ArrayList<>(), newReqMetadata);
@@ -240,8 +246,13 @@ public class SharePartitionManagerTest {
     public void testShareFetchRequests() {
         Time time = new MockTime();
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                time, cache, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                time,
+                cache,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
         Uuid tpId1 = Uuid.randomUuid();
@@ -384,8 +395,13 @@ public class SharePartitionManagerTest {
     public void testShareSessionExpiration() {
         Time time = new MockTime();
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(2, 1000);
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                time, cache, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                time,
+                cache,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid fooId = Uuid.randomUuid();
         topicNames.put(fooId, "foo");
@@ -480,8 +496,13 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testSubsequentShareSession() {
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000), RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid fooId = Uuid.randomUuid();
         Uuid barId = Uuid.randomUuid();
@@ -547,8 +568,13 @@ public class SharePartitionManagerTest {
     @Test
     public void testZeroSizeShareSession() {
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), cache, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                cache,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid fooId = Uuid.randomUuid();
         topicNames.put(fooId, "foo");
@@ -640,8 +666,13 @@ public class SharePartitionManagerTest {
     public void testToForgetPartitions() {
         String groupId = "grp";
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), cache, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                cache,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         Uuid fooId = Uuid.randomUuid();
         Uuid barId = Uuid.randomUuid();
         TopicIdPartition foo = new TopicIdPartition(fooId, new TopicPartition("foo", 0));
@@ -682,8 +713,13 @@ public class SharePartitionManagerTest {
     public void testShareSessionUpdateTopicIdsBrokerSide() {
         String groupId = "grp";
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), cache, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                cache,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         Uuid fooId = Uuid.randomUuid();
         Uuid barId = Uuid.randomUuid();
         TopicIdPartition foo = new TopicIdPartition(fooId, new TopicPartition("foo", 0));
@@ -738,8 +774,13 @@ public class SharePartitionManagerTest {
     public void testAcknowledgeShareSessionCacheUpdate() {
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
         Time time = new MockTime();
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                time, cache, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                time,
+                cache,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         String groupId = "grp";
         Uuid memberId = Uuid.randomUuid();
         // Manually create a share session in cache
@@ -791,8 +832,13 @@ public class SharePartitionManagerTest {
     public void testGetErroneousAndValidTopicIdPartitions() {
         Time time = new MockTime();
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                time, cache, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                time,
+                cache,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
         Uuid tpId1 = Uuid.randomUuid();
@@ -900,8 +946,13 @@ public class SharePartitionManagerTest {
     public void testShareFetchContextResponseSize() {
         Time time = new MockTime();
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                time, cache, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                time,
+                cache,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
         Uuid tpId1 = Uuid.randomUuid();
@@ -1018,8 +1069,14 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
         Map<TopicIdPartition, List<SharePartition.AcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(replicaManager,
-                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000), partitionCacheMap, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                replicaManager,
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                partitionCacheMap,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         acknowledgeTopics.put(tp1, Arrays.asList(
                 new SharePartition.AcknowledgementBatch(12, 20, new ArrayList<>(), AcknowledgeType.ACCEPT),
                 new SharePartition.AcknowledgementBatch(24, 56, new ArrayList<>(), AcknowledgeType.ACCEPT)
@@ -1069,8 +1126,14 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
         Map<TopicIdPartition, List<SharePartition.AcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(replicaManager,
-                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000), partitionCacheMap, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                replicaManager,
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                partitionCacheMap,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
 
         acknowledgeTopics.put(tp1, Arrays.asList(
                 new SharePartition.AcknowledgementBatch(12, 20, new ArrayList<>(), AcknowledgeType.ACCEPT),
@@ -1121,8 +1184,14 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
         Map<TopicIdPartition, List<SharePartition.AcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(replicaManager,
-                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000), partitionCacheMap, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                replicaManager,
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                partitionCacheMap,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
 
         acknowledgeTopics.put(tp1, Arrays.asList(
                 new SharePartition.AcknowledgementBatch(12, 20, new ArrayList<>(), AcknowledgeType.ACCEPT),
@@ -1161,8 +1230,13 @@ public class SharePartitionManagerTest {
         ));
         Map<TopicIdPartition, List<SharePartition.AcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(replicaManager,
-                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000), RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                replicaManager,
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         acknowledgeTopics.put(tp, Arrays.asList(
                 new SharePartition.AcknowledgementBatch(78, 90, new ArrayList<>(), AcknowledgeType.RELEASE),
                 new SharePartition.AcknowledgementBatch(94, 99, new ArrayList<>(), AcknowledgeType.RELEASE)
@@ -1201,8 +1275,13 @@ public class SharePartitionManagerTest {
         partitionMaxBytes.put(tp6, PARTITION_MAX_BYTES);
 
         ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(replicaManager, new MockTime(),
-                new SharePartitionManager.ShareSessionCache(10, 1000), RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                replicaManager,
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
 
         doAnswer(invocation -> {
             sharePartitionManager.releaseFetchQueueAndPartitionsLock(groupId, partitionMaxBytes.keySet());
@@ -1235,13 +1314,20 @@ public class SharePartitionManagerTest {
 
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp0),
-            k -> new SharePartition(groupId, tp0, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, new MockTime()));
+            k -> new SharePartition(groupId, tp0, 100, 5,
+                    RECORD_LOCK_PARTITION_LIMIT, RECORD_LOCK_DURATION_MS, TIMER, new MockTime()));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp1),
-            k -> new SharePartition(groupId, tp1, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, new MockTime()));
+            k -> new SharePartition(groupId, tp1, 100, 5,
+                    RECORD_LOCK_PARTITION_LIMIT, RECORD_LOCK_DURATION_MS, TIMER, new MockTime()));
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-            new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000),
-            partitionCacheMap, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                partitionCacheMap,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
 
         CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
         SharePartitionManager.ShareFetchPartitionData shareFetchPartitionData = new SharePartitionManager.ShareFetchPartitionData(
@@ -1301,13 +1387,20 @@ public class SharePartitionManagerTest {
 
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp0),
-            k -> new SharePartition(groupId, tp0, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, new MockTime()));
+            k -> new SharePartition(groupId, tp0, 100, 5,
+                    RECORD_LOCK_PARTITION_LIMIT, RECORD_LOCK_DURATION_MS, TIMER, new MockTime()));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp1),
-            k -> new SharePartition(groupId, tp1, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, new MockTime()));
+            k -> new SharePartition(groupId, tp1, 100, 5,
+                    RECORD_LOCK_PARTITION_LIMIT, RECORD_LOCK_DURATION_MS, TIMER, new MockTime()));
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-            new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000),
-            partitionCacheMap, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                partitionCacheMap,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
 
         CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
         SharePartitionManager.ShareFetchPartitionData shareFetchPartitionData = new SharePartitionManager.ShareFetchPartitionData(
@@ -1362,16 +1455,26 @@ public class SharePartitionManagerTest {
 
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp0),
-                k -> new SharePartition(groupId, tp0, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, time));
+                k -> new SharePartition(groupId, tp0, 100, 5,
+                        RECORD_LOCK_PARTITION_LIMIT, RECORD_LOCK_DURATION_MS, TIMER, time));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp1),
-                k -> new SharePartition(groupId, tp1, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, time));
+                k -> new SharePartition(groupId, tp1, 100, 5,
+                        RECORD_LOCK_PARTITION_LIMIT, RECORD_LOCK_DURATION_MS, TIMER, time));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp2),
-                k -> new SharePartition(groupId, tp2, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, time));
+                k -> new SharePartition(groupId, tp2, 100, 5,
+                        RECORD_LOCK_PARTITION_LIMIT, RECORD_LOCK_DURATION_MS, TIMER, time));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp3),
-                k -> new SharePartition(groupId, tp3, 100, 5, RECORD_LOCK_DURATION_MS, TIMER, time));
+                k -> new SharePartition(groupId, tp3, 100, 5,
+                        RECORD_LOCK_PARTITION_LIMIT, RECORD_LOCK_DURATION_MS, TIMER, time));
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(replicaManager, time,
-                new SharePartitionManager.ShareSessionCache(10, 1000), partitionCacheMap, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                replicaManager,
+                time,
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                partitionCacheMap,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
 
         SharePartition sp0 = Mockito.mock(SharePartition.class);
         SharePartition sp1 = Mockito.mock(SharePartition.class);
@@ -1446,8 +1549,13 @@ public class SharePartitionManagerTest {
     @Test
     public void testCachedTopicPartitionsForInvalidShareSession() {
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), cache, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                cache,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
 
         assertThrows(ShareSessionNotFoundException.class, () -> sharePartitionManager.cachedTopicIdPartitionsInShareSession("grp", Uuid.randomUuid()));
     }
@@ -1455,8 +1563,13 @@ public class SharePartitionManagerTest {
     @Test
     public void testCachedTopicPartitionsForValidShareSessions() {
         SharePartitionManager.ShareSessionCache cache = new SharePartitionManager.ShareSessionCache(10, 1000);
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), cache, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                cache,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         Map<Uuid, String> topicNames = new HashMap<>();
         Uuid tpId0 = Uuid.randomUuid();
         Uuid tpId1 = Uuid.randomUuid();
@@ -1589,8 +1702,14 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000), partitionCacheMap, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                partitionCacheMap,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.releaseAcquiredRecords(groupId, memberId, Arrays.asList(tp1, tp2, tp3));
         Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData> result = resultFuture.join();
@@ -1619,8 +1738,14 @@ public class SharePartitionManagerTest {
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new HashMap<>();
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000), partitionCacheMap, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                partitionCacheMap,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.releaseAcquiredRecords("grp-2", memberId, Collections.singletonList(tp1));
         Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData> result = resultFuture.join();
@@ -1647,8 +1772,14 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000), partitionCacheMap, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                partitionCacheMap,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
 
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.releaseAcquiredRecords(groupId, memberId, Arrays.asList(tp1, tp2));
@@ -1679,8 +1810,14 @@ public class SharePartitionManagerTest {
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
         partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp2), sp2);
 
-        SharePartitionManager sharePartitionManager = new SharePartitionManager(Mockito.mock(ReplicaManager.class),
-                new MockTime(), new SharePartitionManager.ShareSessionCache(10, 1000), partitionCacheMap, RECORD_LOCK_DURATION_MS);
+        SharePartitionManager sharePartitionManager = new SharePartitionManager(
+                Mockito.mock(ReplicaManager.class),
+                new MockTime(),
+                new SharePartitionManager.ShareSessionCache(10, 1000),
+                partitionCacheMap,
+                RECORD_LOCK_DURATION_MS,
+                RECORD_LOCK_PARTITION_LIMIT
+        );
 
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.releaseAcquiredRecords(groupId, memberId, Collections.emptyList());

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -72,7 +72,7 @@ public class SharePartitionTest {
     private static Timer mockTimer;
     private static final Time MOCK_TIME = new MockTime();
     private static final int ACQUISITION_LOCK_TIMEOUT_MS = 100;
-    private static final short RECORD_LOCK_PARTITION_LIMIT = 200;
+    private static final short MAX_IN_FLIGHT_MESSAGES = 200;
 
     @BeforeEach
     public void setUp() {
@@ -86,11 +86,11 @@ public class SharePartitionTest {
     }
 
     private SharePartition mockSharePartition() {
-        return mockSharePartition(RECORD_LOCK_DURATION_MS, RECORD_LOCK_PARTITION_LIMIT);
+        return mockSharePartition(RECORD_LOCK_DURATION_MS, MAX_IN_FLIGHT_MESSAGES);
     }
 
     private SharePartition mockSharePartition(int acquisitionLockTimeoutMs) {
-        return mockSharePartition(acquisitionLockTimeoutMs, RECORD_LOCK_PARTITION_LIMIT);
+        return mockSharePartition(acquisitionLockTimeoutMs, MAX_IN_FLIGHT_MESSAGES);
     }
 
     private SharePartition mockSharePartition(short recordLockPartitionLimit) {
@@ -98,7 +98,7 @@ public class SharePartitionTest {
     }
 
     private SharePartition mockSharePartition(int acquisitionLockTimeoutMs, short recordLockPartitionLimit) {
-        return new SharePartition(GROUP_ID, TOPIC_ID_PARTITION, 100, 5,
+        return new SharePartition(GROUP_ID, TOPIC_ID_PARTITION, MAX_DELIVERY_COUNT,
                 recordLockPartitionLimit, acquisitionLockTimeoutMs, mockTimer, MOCK_TIME);
     }
 
@@ -1291,9 +1291,8 @@ public class SharePartitionTest {
         SharePartition sharePartition = new SharePartition(
                 GROUP_ID,
                 TOPIC_ID_PARTITION,
-                100,
                 maxDeliveryCount,
-                RECORD_LOCK_PARTITION_LIMIT,
+                MAX_IN_FLIGHT_MESSAGES,
                 RECORD_LOCK_DURATION_MS,
                 mockTimer,
                 MOCK_TIME
@@ -1346,8 +1345,8 @@ public class SharePartitionTest {
         int maxDeliveryCount = 2;
         SharePartition sharePartition = new SharePartition(
                 GROUP_ID, TOPIC_ID_PARTITION,
-                100, maxDeliveryCount,
-                RECORD_LOCK_PARTITION_LIMIT,
+                maxDeliveryCount,
+                MAX_IN_FLIGHT_MESSAGES,
                 RECORD_LOCK_DURATION_MS,
                 mockTimer,
                 MOCK_TIME
@@ -1473,9 +1472,8 @@ public class SharePartitionTest {
         SharePartition sharePartition = new SharePartition(
                 GROUP_ID,
                 TOPIC_ID_PARTITION,
-                100,
                 maxDeliveryCount,
-                RECORD_LOCK_PARTITION_LIMIT,
+                MAX_IN_FLIGHT_MESSAGES,
                 RECORD_LOCK_DURATION_MS,
                 mockTimer,
                 MOCK_TIME
@@ -1564,9 +1562,8 @@ public class SharePartitionTest {
         SharePartition sharePartition = new SharePartition(
                 GROUP_ID,
                 TOPIC_ID_PARTITION,
-                100,
                 maxDeliveryCount,
-                RECORD_LOCK_PARTITION_LIMIT,
+                MAX_IN_FLIGHT_MESSAGES,
                 RECORD_LOCK_DURATION_MS,
                 mockTimer,
                 MOCK_TIME
@@ -1625,9 +1622,8 @@ public class SharePartitionTest {
         SharePartition sharePartition = new SharePartition(
                 GROUP_ID,
                 TOPIC_ID_PARTITION,
-                100,
                 maxDeliveryCount,
-                RECORD_LOCK_PARTITION_LIMIT,
+                MAX_IN_FLIGHT_MESSAGES,
                 RECORD_LOCK_DURATION_MS,
                 mockTimer,
                 MOCK_TIME

--- a/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
@@ -59,6 +59,7 @@ abstract class AbstractShareConsumerTest extends BaseRequestTest {
     properties.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, groupMaxSessionTimeoutMs.toString)
     properties.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "10")
     properties.setProperty(KafkaConfig.ShareGroupRecordLockDurationMsProp, "10000")
+    properties.setProperty(KafkaConfig.ShareGroupRecordLockPartitionLimitProp, "10000")
   }
 
   @BeforeEach

--- a/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractShareConsumerTest.scala
@@ -59,7 +59,7 @@ abstract class AbstractShareConsumerTest extends BaseRequestTest {
     properties.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, groupMaxSessionTimeoutMs.toString)
     properties.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "10")
     properties.setProperty(KafkaConfig.ShareGroupRecordLockDurationMsProp, "10000")
-    properties.setProperty(KafkaConfig.ShareGroupRecordLockPartitionLimitProp, "10000")
+    properties.setProperty(KafkaConfig.ShareGroupPartitionMaxRecordLocksProp, "10000")
   }
 
   @BeforeEach

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -132,7 +132,7 @@ class KafkaApisTest extends Logging {
     clientControllerQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, None)
   private val fetchManager: FetchManager = mock(classOf[FetchManager])
   val sharePartitionManager : SharePartitionManager =
-    new SharePartitionManager(replicaManager,new SystemTime(),  new ShareSessionCache(1000, 100), 30000)
+    new SharePartitionManager(replicaManager, new SystemTime(),  new ShareSessionCache(1000, 100), 30000, 200)
   private val clientMetricsManager: ClientMetricsManager = mock(classOf[ClientMetricsManager])
   private val brokerTopicStats = new BrokerTopicStats
   private val clusterId = "clusterId"

--- a/server/src/main/java/org/apache/kafka/server/config/Defaults.java
+++ b/server/src/main/java/org/apache/kafka/server/config/Defaults.java
@@ -154,7 +154,7 @@ public class Defaults {
 
     /** Share Group Configs **/
     public static final boolean SHARE_GROUP_ENABLE = false;
-    public static final short SHARE_GROUP_RECORD_LOCK_PARTITION_LIMIT = 200;
+    public static final int SHARE_GROUP_PARTITION_MAX_RECORD_LOCKS = 200;
     public static final int SHARE_GROUP_DELIVERY_COUNT_LIMIT = 5;
     public static final short SHARE_GROUP_MAX_GROUPS = 10;
     public static final short SHARE_GROUP_MAX_SIZE = 200;


### PR DESCRIPTION
This PR contains the addition of shareGroupRecordLockPartitionLimit in KafkaConfig.scala. Share Partition now uses this config to put a limit on the number of records that can be there in the cachedState at any time.

Reference : [AKCORE-66](https://confluentinc.atlassian.net/jira/software/c/projects/AKCORE/issues/AKCORE-66?filter=myopenissues&jql=project%20%3D%20%22AKCORE%22%20AND%20assignee%20IN%20%28currentUser%28%29%29%20AND%20statusCategory%20in%20%28%22To%20Do%22%2C%20%22In%20Progress%22%29%20ORDER%20BY%20created%20DESC)

[AKCORE-66]: https://confluentinc.atlassian.net/browse/AKCORE-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ