### PR TITLE
AKCORE-106: Expose metrics for share consumer and tests

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -118,10 +118,10 @@
 
     <!-- Clients tests -->
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(Sender|Fetcher|FetchRequestManager|OffsetFetcher|KafkaConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
+              files="(Sender|Fetcher|FetchRequestManager|OffsetFetcher|KafkaConsumer|KafkaShareConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
-              files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|FetchRequestManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
+              files="(ConsumerCoordinator|KafkaConsumer|KafkaShareConsumer|RequestResponse|Fetcher|FetchRequestManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="MockAdminClient.java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetch.java
@@ -152,9 +152,7 @@ public class ShareCompletedFetch {
 
         if (cachedRecordException != null) {
             inFlightBatch.addAcknowledgement(lastRecord.offset(), AcknowledgeType.RELEASE);
-            inFlightBatch.setException(
-                    new KafkaException("Received exception when fetching the next record from " + partition +
-                            ". The record has been released.", cachedRecordException));
+            inFlightBatch.setException(cachedRecordException);
             cachedRecordException = null;
             return inFlightBatch;
         }
@@ -207,6 +205,7 @@ public class ShareCompletedFetch {
                 inFlightBatch.setException(se);
             } else {
                 cachedRecordException = se;
+                inFlightBatch.setHasCachedException(true);
             }
         } catch (CorruptRecordException e) {
             if (inFlightBatch.isEmpty()) {
@@ -215,6 +214,7 @@ public class ShareCompletedFetch {
                 inFlightBatch.setException(e);
             } else {
                 cachedBatchException = e;
+                inFlightBatch.setHasCachedException(true);
             }
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerDelegate.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ShareConsumer;
+import org.apache.kafka.clients.consumer.internals.metrics.KafkaConsumerMetrics;
+import org.apache.kafka.common.metrics.Metrics;
+
+/**
+ * This extension interface provides a handful of methods to expose internals of the {@link ShareConsumer} for
+ * various tests.
+ *
+ * <p/>
+ *
+ * <em>Note</em>: this is for internal use only and is not intended for use by end users. Internal users should
+ * not attempt to determine the underlying implementation to avoid coding to an unstable interface. Rather, it is
+ * the {@link ShareConsumer} API contract that should serve as the caller's interface.
+ */
+public interface ShareConsumerDelegate<K, V> extends ShareConsumer<K, V> {
+
+    String clientId();
+
+    Metrics metricsRegistry();
+
+    KafkaConsumerMetrics kafkaConsumerMetrics();
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerDelegateCreator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerDelegateCreator.java
@@ -16,11 +16,14 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaShareConsumer;
 import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
 
 /**
  * {@code ShareConsumerDelegateCreator} implements a quasi-factory pattern to allow the caller to remain unaware of the
@@ -34,11 +37,41 @@ import org.apache.kafka.common.serialization.Deserializer;
  * the {@link ShareConsumer} API contract that should serve as the caller's interface.
  */
 public class ShareConsumerDelegateCreator {
-    public <K, V> ShareConsumer<K, V> create(ConsumerConfig config,
-                                             Deserializer<K> keyDeserializer,
-                                             Deserializer<V> valueDeserializer) {
+    public <K, V> ShareConsumerDelegate<K, V> create(final ConsumerConfig config,
+                                                     final Deserializer<K> keyDeserializer,
+                                                     final Deserializer<V> valueDeserializer) {
         try {
             return new ShareConsumerImpl<>(config, keyDeserializer, valueDeserializer);
+        } catch (KafkaException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new KafkaException("Failed to construct Kafka share consumer", t);
+        }
+    }
+
+    public <K, V> ShareConsumerDelegate<K, V> create(final LogContext logContext,
+                                                     final String clientId,
+                                                     final String groupId,
+                                                     final ConsumerConfig config,
+                                                     final Deserializer<K> keyDeserializer,
+                                                     final Deserializer<V> valueDeserializer,
+                                                     final Time time,
+                                                     final KafkaClient client,
+                                                     final SubscriptionState subscriptions,
+                                                     final ConsumerMetadata metadata) {
+        try {
+            return new ShareConsumerImpl<>(
+                    logContext,
+                    clientId,
+                    groupId,
+                    config,
+                    keyDeserializer,
+                    valueDeserializer,
+                    time,
+                    client,
+                    subscriptions,
+                    metadata
+            );
         } catch (KafkaException e) {
             throw e;
         } catch (Throwable t) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -98,8 +99,8 @@ import static org.apache.kafka.common.utils.Utils.swallow;
  * {@link ApplicationEvent application events} so that the network I/O can be processed in a dedicated
  * {@link ConsumerNetworkThread network thread}.
  */
-@SuppressWarnings("ClassFanOutComplexity")
-public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
+@SuppressWarnings({"ClassFanOutComplexity", "ClassDataAbstractionCoupling"})
+public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
 
     private static final long NO_CURRENT_THREAD = -1L;
 
@@ -186,7 +187,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
         IMPLICIT
     }
 
-    private AcknowledgementMode acknowledgementMode;
+    private AcknowledgementMode acknowledgementMode = AcknowledgementMode.UNKNOWN;
 
     /**
      * A thread-safe {@link ShareFetchBuffer fetch buffer} for the results that are populated in the
@@ -242,7 +243,6 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
             maybeThrowInvalidGroupIdException();
             LogContext logContext = createLogContext(clientId, groupId);
             this.log = logContext.logger(getClass());
-            this.acknowledgementMode = AcknowledgementMode.UNKNOWN;
 
             log.debug("Initializing the Kafka share consumer");
             this.time = time;
@@ -334,6 +334,89 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
             // Now propagate the exception
             throw new KafkaException("Failed to construct Kafka share consumer", t);
         }
+    }
+
+    // Visible for testing
+    ShareConsumerImpl(final LogContext logContext,
+                      final String clientId,
+                      final String groupId,
+                      final ConsumerConfig config,
+                      final Deserializer<K> keyDeserializer,
+                      final Deserializer<V> valueDeserializer,
+                      final Time time,
+                      final KafkaClient client,
+                      final SubscriptionState subscriptions,
+                      final ConsumerMetadata metadata) {
+        this.clientId = clientId;
+        this.groupId = groupId;
+        this.log = logContext.logger(getClass());
+        this.time = time;
+        this.metrics = new Metrics(time);
+        this.clientTelemetryReporter = Optional.empty();
+        this.deserializers = new Deserializers<>(config, keyDeserializer, valueDeserializer);
+        this.subscriptions = subscriptions;
+        this.metadata = metadata;
+        this.fetchBuffer = new ShareFetchBuffer(logContext);
+
+        ConsumerMetrics metricsRegistry = new ConsumerMetrics(CONSUMER_METRIC_GROUP_PREFIX);
+        FetchMetricsManager fetchMetricsManager = new FetchMetricsManager(metrics, metricsRegistry.fetcherMetrics);
+        this.fetchCollector = new ShareFetchCollector<>(
+                logContext,
+                metadata,
+                subscriptions,
+                new FetchConfig(config),
+                deserializers);
+        this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, CONSUMER_METRIC_GROUP_PREFIX);
+
+        final BlockingQueue<ApplicationEvent> applicationEventQueue = new LinkedBlockingQueue<>();
+        final BlockingQueue<BackgroundEvent> backgroundEventQueue = new LinkedBlockingQueue<>();
+        final BackgroundEventHandler backgroundEventHandler = new BackgroundEventHandler(
+                logContext,
+                backgroundEventQueue
+        );
+
+        final Supplier<NetworkClientDelegate> networkClientDelegateSupplier =
+                () -> new NetworkClientDelegate(time, config, logContext, client);
+
+        GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(
+                config,
+                GroupRebalanceConfig.ProtocolType.SHARE);
+        final Supplier<RequestManagers> requestManagersSupplier = RequestManagers.supplier(
+                time,
+                logContext,
+                backgroundEventHandler,
+                metadata,
+                subscriptions,
+                fetchBuffer,
+                config,
+                groupRebalanceConfig,
+                networkClientDelegateSupplier,
+                fetchMetricsManager,
+                clientTelemetryReporter,
+                metrics
+        );
+
+        final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier = ApplicationEventProcessor.supplier(
+                logContext,
+                metadata,
+                applicationEventQueue,
+                requestManagersSupplier
+        );
+
+        this.applicationEventHandler = new ApplicationEventHandler(
+                logContext,
+                time,
+                applicationEventQueue,
+                applicationEventProcessorSupplier,
+                networkClientDelegateSupplier,
+                requestManagersSupplier);
+
+        this.backgroundEventProcessor = new BackgroundEventProcessor(
+                logContext,
+                backgroundEventQueue);
+
+        config.logUnused();
+        AppInfoParser.registerAppInfo(CONSUMER_JMX_PREFIX, clientId, metrics, time.milliseconds());
     }
 
     // auxiliary interface for testing
@@ -452,6 +535,8 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
 
                 backgroundEventProcessor.process();
 
+                metadata.maybeThrowAnyException();
+
                 // Make sure the network thread can tell the application is actively polling
                 applicationEventHandler.add(new PollEvent(timer.currentTimeMs()));
 
@@ -487,6 +572,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
             fetchBuffer.awaitNotEmpty(pollTimer);
         } catch (InterruptException e) {
             log.trace("Timeout during fetch", e);
+            throw e;
         } finally {
             timer.update(pollTimer.currentTimeMs());
         }
@@ -624,9 +710,6 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
         clientTelemetryReporter.ifPresent(reporter -> reporter.initiateClose(timeout.toMillis()));
         closeTimer.update();
 
-        // Send any outstanding acknowledgements and release any acquired records
-        maybeSendAcknowledgementsOnClose();
-
         // Prepare shutting down the network thread
         prepareShutdown(closeTimer, firstException);
         closeTimer.update();
@@ -653,12 +736,15 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
 
     /**
      * Prior to closing the network thread, we need to make sure the following operations happen in the right sequence:
-     * 1. commit pending acknowledgements and close any share sessions (AKCORE-109 will implement this)
+     * 1. commit pending acknowledgements and close any share sessions
      * 2. send leave group
      */
     void prepareShutdown(final Timer timer, final AtomicReference<Throwable> firstException) {
         completeQuietly(
-            () -> applicationEventHandler.addAndGet(new ShareLeaveOnCloseApplicationEvent(timer), timer),
+            () -> {
+                maybeSendAcknowledgementsOnClose();
+                applicationEventHandler.addAndGet(new ShareLeaveOnCloseApplicationEvent(timer), timer);
+            },
             "Failed to send leaveGroup heartbeat with a timeout(ms)=" + timer.timeoutMs(), firstException);
     }
 
@@ -730,9 +816,11 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
      * interested.
      */
     private void handleCompletedAcknowledgements() {
-        Map<TopicIdPartition, Acknowledgements> completedAcknowledgements = fetchBuffer.getCompletedAcknowledgements();
-        if (!completedAcknowledgements.isEmpty() && acknowledgementCommitCallbackHandler != null) {
-            acknowledgementCommitCallbackHandler.onComplete(completedAcknowledgements);
+        if (fetchBuffer != null) {
+            Map<TopicIdPartition, Acknowledgements> completedAcknowledgements = fetchBuffer.getCompletedAcknowledgements();
+            if (!completedAcknowledgements.isEmpty() && acknowledgementCommitCallbackHandler != null) {
+                acknowledgementCommitCallbackHandler.onComplete(completedAcknowledgements);
+            }
         }
     }
 
@@ -859,5 +947,20 @@ public class ShareConsumerImpl<K, V> implements ShareConsumer<K, V> {
         } catch (Exception e) {
             firstException.compareAndSet(null, e);
         }
+    }
+
+    @Override
+    public String clientId() {
+        return clientId;
+    }
+
+    @Override
+    public Metrics metricsRegistry() {
+        return metrics;
+    }
+
+    @Override
+    public KafkaConsumerMetrics kafkaConsumerMetrics() {
+        return kafkaConsumerMetrics;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchBuffer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchBuffer.java
@@ -230,13 +230,15 @@ public class ShareFetchBuffer implements AutoCloseable {
     void awaitNotEmpty(Timer timer) {
         lock.lock();
         try {
-
             while (completedFetches.isEmpty() && !wokenUp.compareAndSet(true, false)) {
                 // Update the timer before we head into the loop in case it took a while to get the lock.
                 timer.update();
 
-                if (timer.isExpired())
+                if (timer.isExpired()) {
+                    if (Thread.interrupted())
+                        throw new InterruptException("Thread interrupted.");
                     break;
+                }
 
                 if (!notEmptyCondition.await(timer.remainingMs(), TimeUnit.MILLISECONDS)) {
                     break;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollector.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollector.java
@@ -113,6 +113,8 @@ public class ShareFetchCollector<K, V> {
 
                     if (batch.getException() != null) {
                         throw batch.getException();
+                    } else if (batch.hasCachedException()) {
+                        break;
                     }
                 }
             }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManager.java
@@ -124,6 +124,9 @@ public class ShareFetchRequestManager implements RequestManager, MemberStateList
     }
 
     private Map<Node, ShareSessionHandler.ShareFetchRequestData> prepareShareFetchRequests() {
+        // Update metrics in case there was an assignment change
+        metricsManager.maybeUpdateAssignment(subscriptions);
+
         Map<Node, ShareSessionHandler.Builder> requestBuilderMap = new HashMap<>();
         Map<String, Uuid> topicIds = metadata.topicIds();
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
@@ -30,6 +30,7 @@ public class ShareInFlightBatch<K, V> {
     private final Acknowledgements acknowledgements;
     private final List<ConsumerRecord<K, V>> inFlightRecords;
     private KafkaException exception;
+    private boolean hasCachedException = false;
 
     public ShareInFlightBatch(TopicIdPartition partition) {
         this.partition = partition;
@@ -90,5 +91,13 @@ public class ShareInFlightBatch<K, V> {
 
     public KafkaException getException() {
         return exception;
+    }
+
+    public void setHasCachedException(boolean hasCachedException) {
+        this.hasCachedException = hasCachedException;
+    }
+
+    public boolean hasCachedException() {
+        return hasCachedException;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerTest.java
@@ -1,0 +1,1044 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+import org.apache.kafka.clients.ClientRequest;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
+import org.apache.kafka.clients.consumer.internals.SubscriptionState;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.errors.RecordDeserializationException;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.message.ShareFetchResponseData;
+import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.network.Selectable;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.RequestTestUtils;
+import org.apache.kafka.common.requests.ShareFetchResponse;
+import org.apache.kafka.common.requests.ShareGroupHeartbeatResponse;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.telemetry.internals.ClientTelemetryReporter;
+import org.apache.kafka.common.telemetry.internals.ClientTelemetrySender;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.test.MockMetricsReporter;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.internal.stubbing.answers.CallsRealMethods;
+
+import java.lang.management.ManagementFactory;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Queue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import static org.apache.kafka.common.utils.Utils.propsToMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Note to future authors in this class. If you close the consumer, close with Duration.ZERO to reduce the duration of
+ * the test.
+ */
+public class KafkaShareConsumerTest {
+
+    private final String topic = "test";
+    private final Uuid topicId = Uuid.randomUuid();
+    private final TopicPartition tp0 = new TopicPartition(topic, 0);
+
+    private final String topic2 = "test2";
+    private final Uuid topicId2 = Uuid.randomUuid();
+    private final TopicPartition t2p0 = new TopicPartition(topic2, 0);
+
+    private final String topic3 = "test3";
+    private final Uuid topicId3 = Uuid.randomUuid();
+
+    private final int sessionTimeoutMs = 10000;
+    private final int heartbeatIntervalMs = 1000;
+
+    private final String groupId = "mock-group";
+    private final Map<String, Uuid> topicIds = Stream.of(
+                    new AbstractMap.SimpleEntry<>(topic, topicId),
+                    new AbstractMap.SimpleEntry<>(topic2, topicId2),
+                    new AbstractMap.SimpleEntry<>(topic3, topicId3))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    private final Time time = new MockTime();
+    private final SubscriptionState subscription = new SubscriptionState(new LogContext(), OffsetResetStrategy.EARLIEST);
+
+    private KafkaShareConsumer<?, ?> consumer;
+
+    @AfterEach
+    public void cleanup() {
+        if (consumer != null) {
+            consumer.close(Duration.ZERO);
+        }
+    }
+
+    @Test
+    public void testMetricsReporterAutoGeneratedClientId() {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.setProperty(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
+        consumer = newShareConsumer(props, new StringDeserializer(), new StringDeserializer());
+
+        assertEquals(3, consumer.metricsRegistry().reporters().size());
+
+        MockMetricsReporter mockMetricsReporter = (MockMetricsReporter) consumer.metricsRegistry().reporters().stream()
+                .filter(reporter -> reporter instanceof MockMetricsReporter).findFirst().get();
+        assertEquals(consumer.clientId(), mockMetricsReporter.clientId);
+    }
+
+    @Test
+    public void testExplicitlyOnlyEnableJmxReporter() {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.setProperty(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG, "org.apache.kafka.common.metrics.JmxReporter");
+        props.setProperty(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG, "false");
+        consumer = newShareConsumer(props, new StringDeserializer(), new StringDeserializer());
+        assertEquals(1, consumer.metricsRegistry().reporters().size());
+        assertInstanceOf(JmxReporter.class, consumer.metricsRegistry().reporters().get(0));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testPollReturnsRecords() {
+        consumer = setUpConsumerWithRecordsToPoll(tp0, 5);
+
+        ConsumerRecords<String, String> records = (ConsumerRecords<String, String>) consumer.poll(Duration.ofMillis(2000L));
+
+        assertEquals(records.count(), 5);
+        assertEquals(records.partitions(), Collections.singleton(tp0));
+        assertEquals(records.records(tp0).size(), 5);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSecondPollWithDeserializationErrorThrowsRecordDeserializationException() {
+        int invalidRecordNumber = 4;
+        int invalidRecordOffset = 3;
+        StringDeserializer deserializer = mockErrorDeserializer(invalidRecordNumber);
+
+        consumer = setUpConsumerWithRecordsToPoll(tp0, 5, deserializer);
+        ConsumerRecords<String, String> records = (ConsumerRecords<String, String>) consumer.poll(Duration.ofMillis(2000L));
+
+        assertEquals(invalidRecordNumber - 1, records.count());
+        assertEquals(Collections.singleton(tp0), records.partitions());
+        assertEquals(invalidRecordNumber - 1, records.records(tp0).size());
+        long lastOffset = records.records(tp0).get(records.records(tp0).size() - 1).offset();
+        assertEquals(invalidRecordNumber - 2, lastOffset);
+
+        RecordDeserializationException rde = assertThrows(RecordDeserializationException.class, () -> consumer.poll(Duration.ZERO));
+        assertEquals(invalidRecordOffset, rde.offset());
+        assertEquals(tp0, rde.topicPartition());
+    }
+
+    /* A mock deserializer which throws a SerializationException on the Nth record's value deserialization */
+    private StringDeserializer mockErrorDeserializer(int recordNumber) {
+        int recordIndex = recordNumber - 1;
+        return new StringDeserializer() {
+            int i = 0;
+            @Override
+            public String deserialize(String topic, byte[] data) {
+                if (i == recordIndex) {
+                    throw new SerializationException();
+                } else {
+                    i++;
+                    return super.deserialize(topic, data);
+                }
+            }
+
+            @Override
+            public String deserialize(String topic, Headers headers, ByteBuffer data) {
+                if (i == recordIndex) {
+                    throw new SerializationException();
+                } else {
+                    i++;
+                    return super.deserialize(topic, headers, data);
+                }
+            }
+        };
+    }
+
+    private KafkaShareConsumer<?, ?> setUpConsumerWithRecordsToPoll(TopicPartition tp,
+                                                                    int recordCount) {
+        return setUpConsumerWithRecordsToPoll(tp, recordCount, new StringDeserializer());
+    }
+
+    private KafkaShareConsumer<?, ?> setUpConsumerWithRecordsToPoll(TopicPartition tp,
+                                                                    int recordCount,
+                                                                    Deserializer<String> deserializer) {
+        Cluster cluster = TestUtils.singletonCluster(tp.topic(), 1);
+        Node node = cluster.nodes().get(0);
+
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+        initMetadata(client, Collections.singletonMap(topic, 1));
+        Uuid memberId = Uuid.randomUuid();
+        joinGroupAndGetInitialAssignment(client, node, memberId, 1, Collections.singletonList(tp), null);
+        client.prepareResponseFrom(shareFetchResponse(tp, 0L, recordCount), node);
+
+        consumer = newShareConsumer(time, client, subscription, metadata, groupId, Optional.of(deserializer));
+        consumer.subscribe(Collections.singleton(topic));
+        return consumer;
+    }
+
+    @Test
+    public void testConstructorClose() {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "testConstructorClose");
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "invalid-23-8409-adsfsdj");
+        props.setProperty(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+
+        final int oldInitCount = MockMetricsReporter.INIT_COUNT.get();
+        final int oldCloseCount = MockMetricsReporter.CLOSE_COUNT.get();
+        try {
+            newShareConsumer(props, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+            fail("should have caught an exception and returned");
+        } catch (KafkaException e) {
+            assertEquals(oldInitCount + 1, MockMetricsReporter.INIT_COUNT.get());
+            assertEquals(oldCloseCount + 1, MockMetricsReporter.CLOSE_COUNT.get());
+            assertEquals("Failed to construct Kafka share consumer", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testOsDefaultSocketBufferSizes() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        config.put(ConsumerConfig.SEND_BUFFER_CONFIG, Selectable.USE_DEFAULT_BUFFER_SIZE);
+        config.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, Selectable.USE_DEFAULT_BUFFER_SIZE);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        consumer = newShareConsumer(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+    }
+
+    @Test
+    public void testInvalidSocketSendBufferSize() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        config.put(ConsumerConfig.SEND_BUFFER_CONFIG, -2);
+        assertThrows(KafkaException.class,
+                () -> newShareConsumer(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()));
+    }
+
+    @Test
+    public void testInvalidSocketReceiveBufferSize() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        config.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, -2);
+        assertThrows(KafkaException.class,
+                () -> newShareConsumer(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()));
+    }
+
+    @Test
+    public void testSubscription() {
+        consumer = newShareConsumer(groupId);
+
+        consumer.subscribe(Collections.singletonList(topic));
+        assertEquals(Collections.singleton(topic), consumer.subscription());
+
+        consumer.subscribe(Collections.emptyList());
+        assertTrue(consumer.subscription().isEmpty());
+
+        consumer.unsubscribe();
+        assertTrue(consumer.subscription().isEmpty());
+    }
+
+    @Test
+    public void testSubscriptionOnNullTopicCollection() {
+        consumer = newShareConsumer(groupId);
+        assertThrows(IllegalArgumentException.class, () -> consumer.subscribe(null));
+    }
+
+    @Test
+    public void testSubscriptionOnNullTopic() {
+        consumer = newShareConsumer(groupId);
+        assertThrows(IllegalArgumentException.class, () -> consumer.subscribe(Collections.singletonList(null)));
+    }
+
+    @Test
+    public void testSubscriptionOnEmptyTopic() {
+        consumer = newShareConsumer(groupId);
+        String emptyTopic = "  ";
+        assertThrows(IllegalArgumentException.class, () -> consumer.subscribe(Collections.singletonList(emptyTopic)));
+    }
+
+    @Test
+    public void testConsumerJmxPrefix() throws  Exception {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        config.put(ConsumerConfig.SEND_BUFFER_CONFIG, Selectable.USE_DEFAULT_BUFFER_SIZE);
+        config.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, Selectable.USE_DEFAULT_BUFFER_SIZE);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        config.put(ConsumerConfig.CLIENT_ID_CONFIG, "client-1");
+        consumer = newShareConsumer(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        MetricName testMetricName = consumer.metricsRegistry().metricName("test-metric",
+                "grp1", "test metric");
+        consumer.metricsRegistry().addMetric(testMetricName, new Avg());
+        assertNotNull(server.getObjectInstance(new ObjectName("kafka.consumer:type=grp1,client-id=client-1")));
+    }
+
+    private KafkaShareConsumer<byte[], byte[]> newShareConsumer(String groupId) {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "my.consumer");
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.setProperty(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        return newShareConsumer(props, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+    }
+
+    private <K, V> KafkaShareConsumer<K, V> newShareConsumer(Properties props) {
+        return newShareConsumer(props, null, null);
+    }
+
+    private <K, V> KafkaShareConsumer<K, V> newShareConsumer(Map<String, Object> configs,
+                                                             Deserializer<K> keyDeserializer,
+                                                             Deserializer<V> valueDeserializer) {
+        return new KafkaShareConsumer<>(
+                new ConsumerConfig(ConsumerConfig.appendDeserializerToConfig(configs, keyDeserializer, valueDeserializer)),
+                keyDeserializer, valueDeserializer);
+    }
+
+    private <K, V> KafkaShareConsumer<K, V> newShareConsumer(Properties props,
+                                                             Deserializer<K> keyDeserializer,
+                                                             Deserializer<V> valueDeserializer) {
+        return newShareConsumer(propsToMap(props), keyDeserializer, valueDeserializer);
+    }
+
+    @Test
+    public void testHeartbeatSent() throws Exception {
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+
+        initMetadata(client, Collections.singletonMap(topic, 1));
+        Node node = metadata.fetch().nodes().get(0);
+
+        Uuid memberId = Uuid.randomUuid();
+        Node coordinator = joinGroupAndGetInitialAssignment(client, node, memberId, 1, Collections.singletonList(tp0), null);
+
+        consumer = newShareConsumer(time, client, subscription, metadata);
+        consumer.subscribe(Collections.singleton(topic));
+
+        // initial share fetch
+        client.prepareResponseFrom(shareFetchResponse(tp0, 0L, 0), node);
+
+        AtomicBoolean heartbeatReceived = prepareShareGroupHeartbeatResponse(client, coordinator, memberId, 2, Errors.NONE);
+
+        // heartbeat interval is 2 seconds
+        time.sleep(heartbeatIntervalMs);
+        Thread.sleep(heartbeatIntervalMs);
+
+        assertTrue(heartbeatReceived.get());
+    }
+
+    @Test
+    public void testHeartbeatSentWhenFetchedDataReady() throws Exception {
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+
+        initMetadata(client, Collections.singletonMap(topic, 1));
+        Node node = metadata.fetch().nodes().get(0);
+
+        Uuid memberId = Uuid.randomUuid();
+        Node coordinator = joinGroupAndGetInitialAssignment(client, node, memberId, 1, Collections.singletonList(tp0), null);
+
+        consumer = newShareConsumer(time, client, subscription, metadata);
+        consumer.subscribe(Collections.singleton(topic));
+
+        client.prepareResponseFrom(shareFetchResponse(Collections.singletonList(tp0), Errors.NONE, Errors.NONE), node);
+        consumer.poll(Duration.ZERO);
+
+        // respond to the outstanding fetch so that we have data available on the next poll
+        client.prepareResponseFrom(shareFetchResponse(tp0, 0L, 5), node);
+        client.poll(0, time.milliseconds());
+
+        client.prepareResponseFrom(shareFetchResponse(tp0, 5L, 0), node);
+        AtomicBoolean heartbeatReceived = prepareShareGroupHeartbeatResponse(client, coordinator, memberId, 2, Errors.NONE);
+
+        time.sleep(heartbeatIntervalMs);
+        Thread.sleep(heartbeatIntervalMs);
+
+        consumer.poll(Duration.ZERO);
+
+        assertTrue(heartbeatReceived.get());
+    }
+
+    @Test
+    public void testPollTimesOutDuringMetadataUpdate() {
+        final ConsumerMetadata metadata = createMetadata(subscription);
+        final MockClient client = new MockClient(time, metadata);
+
+        initMetadata(client, Collections.singletonMap(topic, 1));
+        Node node = metadata.fetch().nodes().get(0);
+
+        consumer = newShareConsumer(time, client, subscription, metadata);
+        consumer.subscribe(Collections.singleton(topic));
+
+        client.prepareResponseFrom(FindCoordinatorResponse.prepareResponse(Errors.NONE, groupId, node), node);
+        Node coordinator = new Node(Integer.MAX_VALUE - node.id(), node.host(), node.port());
+        Uuid memberId = Uuid.randomUuid();
+        client.prepareResponseFrom(shareGroupHeartbeatResponse(memberId, 0, Errors.NONE), coordinator);
+
+        consumer.poll(Duration.ZERO);
+
+        final Queue<ClientRequest> requests = client.requests();
+        assertEquals(0, requests.stream().filter(request -> request.apiKey().equals(ApiKeys.SHARE_FETCH)).count());
+    }
+
+    private void initMetadata(MockClient mockClient, Map<String, Integer> partitionCounts) {
+        Map<String, Uuid> metadataIds = new HashMap<>();
+        for (String name : partitionCounts.keySet()) {
+            metadataIds.put(name, topicIds.get(name));
+        }
+        MetadataResponse initialMetadata = RequestTestUtils.metadataUpdateWithIds(1, partitionCounts, metadataIds);
+
+        mockClient.updateMetadata(initialMetadata);
+    }
+
+    @Test
+    public void testWakeupWithFetchDataAvailable() throws Exception {
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+
+        initMetadata(client, Collections.singletonMap(topic, 1));
+        Node node = metadata.fetch().nodes().get(0);
+
+        Uuid memberId = Uuid.randomUuid();
+        joinGroupAndGetInitialAssignment(client, node, memberId, 1, Collections.singletonList(tp0), null);
+
+        consumer = newShareConsumer(time, client, subscription, metadata);
+        consumer.subscribe(Collections.singleton(topic));
+
+        consumer.poll(Duration.ZERO);
+
+        // respond to the outstanding fetch so that we have data available on the next poll
+        client.prepareResponseFrom(shareFetchResponse(tp0, 0L, 5), node);
+        client.poll(0, time.milliseconds());
+
+        consumer.wakeup();
+
+        assertThrows(WakeupException.class, () -> consumer.poll(Duration.ofMillis(2000L)));
+
+        // the next poll should return the completed fetch
+        @SuppressWarnings("unchecked")
+        ConsumerRecords<String, String> records = (ConsumerRecords<String, String>) consumer.poll(Duration.ZERO);
+        assertEquals(5, records.count());
+        // Increment time asynchronously to clear timeouts in closing the consumer
+        final ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
+        exec.scheduleAtFixedRate(() -> time.sleep(sessionTimeoutMs), 0L, 10L, TimeUnit.MILLISECONDS);
+        consumer.close();
+        exec.shutdownNow();
+        exec.awaitTermination(5L, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPollThrowsInterruptExceptionIfInterrupted() {
+        final ConsumerMetadata metadata = createMetadata(subscription);
+        final MockClient client = new MockClient(time, metadata);
+
+        initMetadata(client, Collections.singletonMap(topic, 1));
+        Node node = metadata.fetch().nodes().get(0);
+
+        consumer = newShareConsumer(time, client, subscription, metadata);
+        consumer.subscribe(Collections.singleton(topic));
+        Uuid memberId = Uuid.randomUuid();
+        joinGroupAndGetInitialAssignment(client, node, memberId, 1, Collections.singletonList(tp0), null);
+
+        consumer.poll(Duration.ZERO);
+
+        // interrupt the thread and call poll
+        try {
+            Thread.currentThread().interrupt();
+            assertThrows(InterruptException.class, () -> consumer.poll(Duration.ZERO));
+        } finally {
+            // clear interrupted state again since this thread may be reused by JUnit
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void testFetchResponseWithUnexpectedPartitionIsIgnored() {
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+
+        initMetadata(client, Collections.singletonMap(topic, 1));
+        Node node = metadata.fetch().nodes().get(0);
+
+        consumer = newShareConsumer(time, client, subscription, metadata);
+        consumer.subscribe(Collections.singletonList(topic));
+
+        Uuid memberId = Uuid.randomUuid();
+        joinGroupAndGetInitialAssignment(client, node, memberId, 1, Collections.singletonList(tp0), null);
+
+        Map<TopicPartition, ShareFetchInfo> fetches1 = new HashMap<>();
+        fetches1.put(tp0, new ShareFetchInfo(0, 40000, 1));
+        fetches1.put(t2p0, new ShareFetchInfo(0, 40000, 10)); // not assigned and not fetched
+        client.prepareResponseFrom(shareFetchResponse(fetches1), node);
+
+        @SuppressWarnings("unchecked")
+        ConsumerRecords<String, String> records = (ConsumerRecords<String, String>) consumer.poll(Duration.ZERO);
+        assertEquals(0, records.count());
+    }
+
+    @Test
+    public void testPollWithNoSubscription() {
+        consumer = newShareConsumer(groupId);
+        assertThrows(IllegalStateException.class, () -> consumer.poll(Duration.ofMillis(2000L)));
+    }
+
+    @Test
+    public void testPollWithEmptySubscription() {
+        consumer = newShareConsumer(groupId);
+        consumer.subscribe(Collections.emptyList());
+        assertThrows(IllegalStateException.class, () -> consumer.poll(Duration.ofMillis(2000L)));
+    }
+
+    @Test
+    public void testCloseShouldBeIdempotent() {
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = spy(new MockClient(time, metadata));
+        initMetadata(client, Collections.singletonMap(topic, 1));
+
+        consumer = newShareConsumer(time, client, subscription, metadata);
+
+        consumer.close(Duration.ZERO);
+        consumer.close(Duration.ZERO);
+
+        // verify that the call is idempotent by checking that the network client is only closed once.
+        verify(client).close();
+    }
+
+    @Test
+    public void testMetricConfigRecordingLevelInfo() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        KafkaShareConsumer<byte[], byte[]> consumer = newShareConsumer(props, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+        assertEquals(Sensor.RecordingLevel.INFO, consumer.metricsRegistry().config().recordLevel());
+        consumer.close(Duration.ZERO);
+
+        props.put(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG, "DEBUG");
+        KafkaShareConsumer<byte[], byte[]> consumer2 = newShareConsumer(props, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+        assertEquals(Sensor.RecordingLevel.DEBUG, consumer2.metricsRegistry().config().recordLevel());
+        consumer2.close(Duration.ZERO);
+    }
+
+    @Test
+    public void testPollAuthenticationFailure() {
+        final KafkaShareConsumer<String, String> consumer = consumerWithPendingAuthenticationError();
+        consumer.subscribe(Collections.singleton(topic));
+        assertThrows(AuthenticationException.class, () -> consumer.poll(Duration.ofMillis(2000L)));
+    }
+
+    private KafkaShareConsumer<String, String> consumerWithPendingAuthenticationError(final Time time) {
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+
+        initMetadata(client, Collections.singletonMap(topic, 1));
+        Node node = metadata.fetch().nodes().get(0);
+
+        client.createPendingAuthenticationError(node, 0);
+        return newShareConsumer(time, client, subscription, metadata);
+    }
+
+    private KafkaShareConsumer<String, String> consumerWithPendingAuthenticationError() {
+        return consumerWithPendingAuthenticationError(new MockTime());
+    }
+
+    private ConsumerMetadata createMetadata(SubscriptionState subscription) {
+        return new ConsumerMetadata(0, 0, Long.MAX_VALUE, false, false,
+                subscription, new LogContext(), new ClusterResourceListeners());
+    }
+
+    private ShareGroupHeartbeatResponse shareGroupHeartbeatResponse(Uuid memberId, int memberEpoch, List<ShareGroupHeartbeatResponseData.TopicPartitions> topicPartitions, Errors error) {
+        return new ShareGroupHeartbeatResponse(
+                new ShareGroupHeartbeatResponseData()
+                        .setErrorCode(error.code())
+                        .setMemberId(memberId.toString())
+                        .setMemberEpoch(memberEpoch)
+                        .setHeartbeatIntervalMs(30000)
+                        .setAssignment(
+                                new ShareGroupHeartbeatResponseData.Assignment()
+                                        .setTopicPartitions(topicPartitions)));
+    }
+
+    private ShareGroupHeartbeatResponse shareGroupHeartbeatResponse(Uuid memberId, int memberEpoch, Errors error) {
+        return new ShareGroupHeartbeatResponse(
+                new ShareGroupHeartbeatResponseData()
+                        .setMemberId(memberId.toString())
+                        .setMemberEpoch(memberEpoch)
+                        .setHeartbeatIntervalMs(30000)
+                        .setErrorCode(error.code()));
+    }
+
+    private Node joinGroupAndGetInitialAssignment(MockClient client, Node node, Uuid memberId, int memberEpoch, List<TopicPartition> partitions, Node coordinator) {
+        if (coordinator == null) {
+            // lookup coordinator
+            client.prepareResponseFrom(FindCoordinatorResponse.prepareResponse(Errors.NONE, groupId, node), node);
+            coordinator = new Node(Integer.MAX_VALUE - node.id(), node.host(), node.port());
+        }
+
+        // share group heartbeat
+        Map<Uuid, ShareGroupHeartbeatResponseData.TopicPartitions> uuidTopicPartitionsMap = new HashMap<>();
+        for (TopicPartition partition : partitions) {
+            TopicIdPartition tip = new TopicIdPartition(topicIds.get(partition.topic()), partition);
+            ShareGroupHeartbeatResponseData.TopicPartitions responseTopicData =
+                    uuidTopicPartitionsMap.computeIfAbsent(tip.topicId(),
+                            topicId -> new ShareGroupHeartbeatResponseData.TopicPartitions().setTopicId(topicId));
+            responseTopicData.partitions().add(tip.partition());
+        }
+        List<ShareGroupHeartbeatResponseData.TopicPartitions> topicPartitionsList = new ArrayList<>(uuidTopicPartitionsMap.values());
+        client.prepareResponseFrom(shareGroupHeartbeatResponse(memberId, memberEpoch, topicPartitionsList, Errors.NONE), coordinator);
+
+        return coordinator;
+    }
+
+    private AtomicBoolean prepareShareGroupHeartbeatResponse(MockClient client, Node coordinator, Uuid memberId, int memberEpoch, Errors error) {
+        final AtomicBoolean heartbeatReceived = new AtomicBoolean(false);
+        client.prepareResponseFrom(body -> {
+            heartbeatReceived.set(true);
+            return true;
+        }, new ShareGroupHeartbeatResponse(new ShareGroupHeartbeatResponseData()
+                .setMemberId(memberId.toString())
+                .setMemberEpoch(memberEpoch)
+                .setHeartbeatIntervalMs(30000)
+                .setErrorCode(error.code())), coordinator);
+        return heartbeatReceived;
+    }
+
+    private ShareFetchResponse shareFetchResponse(Map<TopicPartition, ShareFetchInfo> fetches) {
+        LinkedHashMap<TopicIdPartition, ShareFetchResponseData.PartitionData> tpResponses = new LinkedHashMap<>();
+        for (Map.Entry<TopicPartition, ShareFetchInfo> fetchEntry : fetches.entrySet()) {
+            TopicPartition tp = fetchEntry.getKey();
+            TopicIdPartition tip = new TopicIdPartition(topicIds.get(tp.topic()), tp);
+            long firstOffset = fetchEntry.getValue().firstOffset;
+            int count = fetchEntry.getValue().count;
+            MemoryRecords records;
+            if (count == 0) {
+                records = MemoryRecords.EMPTY;
+            } else {
+                try (MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
+                        TimestampType.CREATE_TIME, firstOffset)) {
+                    for (int i = 0; i < count; i++)
+                        builder.append(0L, ("key-" + i).getBytes(), ("value-" + i).getBytes());
+                    records = builder.build();
+                }
+            }
+            tpResponses.put(tip,
+                    new ShareFetchResponseData.PartitionData()
+                            .setPartitionIndex(tip.partition())
+                            .setRecords(records)
+                            .setAcquiredRecords(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
+                                    .setBaseOffset(firstOffset)
+                                    .setLastOffset(firstOffset + count - 1)
+                                    .setDeliveryCount((short) 1))));
+        }
+        return ShareFetchResponse.of(Errors.NONE, 0, tpResponses, Collections.emptyList());
+    }
+
+    private ShareFetchResponse shareFetchResponse(TopicPartition tp, long firstOffset, int count) {
+        ShareFetchInfo info = new ShareFetchInfo(firstOffset, 40000, count);
+        return shareFetchResponse(Collections.singletonMap(tp, info));
+    }
+
+    private ShareFetchResponse shareFetchResponse(List<TopicPartition> partitions, Errors error, Errors acknowledgeError) {
+        LinkedHashMap<TopicIdPartition, ShareFetchResponseData.PartitionData> tpResponses = new LinkedHashMap<>();
+        for (TopicPartition tp : partitions) {
+            TopicIdPartition tip = new TopicIdPartition(topicIds.get(tp.topic()), tp);
+            final MemoryRecords records = MemoryRecords.EMPTY;
+            tpResponses.put(tip,
+                    new ShareFetchResponseData.PartitionData()
+                            .setPartitionIndex(tip.partition())
+                            .setRecords(records)
+                            .setErrorCode(error.code())
+                            .setAcknowledgeErrorCode(acknowledgeError.code()));
+        }
+        return ShareFetchResponse.of(Errors.NONE, 0, tpResponses, Collections.emptyList());
+    }
+
+    private KafkaShareConsumer<String, String> newShareConsumer(Time time,
+                                                                KafkaClient client,
+                                                                SubscriptionState subscription,
+                                                                ConsumerMetadata metadata) {
+        return newShareConsumer(
+                time,
+                client,
+                subscription,
+                metadata,
+                groupId,
+                Optional.of(new StringDeserializer())
+        );
+    }
+
+    private KafkaShareConsumer<String, String> newShareConsumer(Time time,
+                                                                KafkaClient client,
+                                                                SubscriptionState subscriptions,
+                                                                ConsumerMetadata metadata,
+                                                                String groupId,
+                                                                Optional<Deserializer<String>> valueDeserializerOpt) {
+        String clientId = "mock-consumer";
+        Deserializer<String> keyDeserializer = new StringDeserializer();
+        Deserializer<String> valueDeserializer = valueDeserializerOpt.orElse(new StringDeserializer());
+        LogContext logContext = new LogContext();
+        ConsumerConfig config = newConsumerConfig(groupId, valueDeserializer);
+        return new KafkaShareConsumer<>(
+                logContext,
+                clientId,
+                groupId,
+                config,
+                keyDeserializer,
+                valueDeserializer,
+                time,
+                client,
+                subscriptions,
+                metadata
+        );
+    }
+
+    private ConsumerConfig newConsumerConfig(String groupId,
+                                             Deserializer<String> valueDeserializer) {
+        String clientId = "mock-consumer";
+        long retryBackoffMs = 100;
+        long retryBackoffMaxMs = 1000;
+        int minBytes = 1;
+        int maxBytes = Integer.MAX_VALUE;
+        int maxWaitMs = 500;
+        int fetchSize = 1024 * 1024;
+        int maxPollRecords = Integer.MAX_VALUE;
+        boolean checkCrcs = true;
+        int rebalanceTimeoutMs = 60000;
+        int defaultApiTimeoutMs = 60000;
+        int requestTimeoutMs = defaultApiTimeoutMs / 2;
+
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ConsumerConfig.CHECK_CRCS_CONFIG, checkCrcs);
+        configs.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
+        configs.put(ConsumerConfig.CLIENT_RACK_CONFIG, CommonClientConfigs.DEFAULT_CLIENT_RACK);
+        configs.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, defaultApiTimeoutMs);
+        configs.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, maxBytes);
+        configs.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, maxWaitMs);
+        configs.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, minBytes);
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configs.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, fetchSize);
+        configs.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, rebalanceTimeoutMs);
+        configs.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
+        configs.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
+        configs.put(ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG, retryBackoffMaxMs);
+        configs.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, retryBackoffMs);
+        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getClass());
+
+        return new ConsumerConfig(configs);
+    }
+
+    private static class ShareFetchInfo {
+        long firstOffset;
+        int partitionMaxBytes;
+        int count;
+
+        ShareFetchInfo(long firstOffset, int partitionMaxBytes, int count) {
+            this.firstOffset = firstOffset;
+            this.partitionMaxBytes = partitionMaxBytes;
+            this.count = count;
+        }
+    }
+
+    @Test
+    public void testSubscriptionOnInvalidTopic() {
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+
+        initMetadata(client, Collections.singletonMap(topic, 1));
+        Cluster cluster = metadata.fetch();
+
+        String invalidTopicName = "topic abc";  // Invalid topic name due to space
+
+        List<MetadataResponse.TopicMetadata> topicMetadata = new ArrayList<>();
+        topicMetadata.add(new MetadataResponse.TopicMetadata(Errors.INVALID_TOPIC_EXCEPTION,
+                invalidTopicName, false, Collections.emptyList()));
+        MetadataResponse updateResponse = RequestTestUtils.metadataResponse(cluster.nodes(),
+                cluster.clusterResource().clusterId(),
+                cluster.controller().id(),
+                topicMetadata);
+        client.prepareMetadataUpdate(updateResponse);
+
+        KafkaShareConsumer<String, String> consumer = newShareConsumer(time, client, subscription, metadata);
+        consumer.subscribe(Collections.singleton(invalidTopicName));
+
+        assertThrows(InvalidTopicException.class, () -> consumer.poll(Duration.ZERO));
+    }
+
+    @Test
+    public void testPollTimeMetrics() {
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+        initMetadata(client, Collections.singletonMap(topic, 1));
+
+        KafkaShareConsumer<String, String> consumer = newShareConsumer(time, client, subscription, metadata);
+        consumer.subscribe(Collections.singletonList(topic));
+        // MetricName objects to check
+        Metrics metrics = consumer.metricsRegistry();
+        MetricName lastPollSecondsAgoName = metrics.metricName("last-poll-seconds-ago", "consumer-metrics");
+        MetricName timeBetweenPollAvgName = metrics.metricName("time-between-poll-avg", "consumer-metrics");
+        MetricName timeBetweenPollMaxName = metrics.metricName("time-between-poll-max", "consumer-metrics");
+        // Test default values
+        assertEquals(-1.0d, consumer.metrics().get(lastPollSecondsAgoName).metricValue());
+        assertEquals(Double.NaN, consumer.metrics().get(timeBetweenPollAvgName).metricValue());
+        assertEquals(Double.NaN, consumer.metrics().get(timeBetweenPollMaxName).metricValue());
+        // Call first poll
+        consumer.poll(Duration.ZERO);
+        assertEquals(0.0d, consumer.metrics().get(lastPollSecondsAgoName).metricValue());
+        assertEquals(0.0d, consumer.metrics().get(timeBetweenPollAvgName).metricValue());
+        assertEquals(0.0d, consumer.metrics().get(timeBetweenPollMaxName).metricValue());
+        // Advance time by 5,000 (total time = 5,000)
+        time.sleep(5 * 1000L);
+        assertEquals(5.0d, consumer.metrics().get(lastPollSecondsAgoName).metricValue());
+        // Call second poll
+        consumer.poll(Duration.ZERO);
+        assertEquals(2.5 * 1000d, consumer.metrics().get(timeBetweenPollAvgName).metricValue());
+        assertEquals(5 * 1000d, consumer.metrics().get(timeBetweenPollMaxName).metricValue());
+        // Advance time by 10,000 (total time = 15,000)
+        time.sleep(10 * 1000L);
+        assertEquals(10.0d, consumer.metrics().get(lastPollSecondsAgoName).metricValue());
+        // Call third poll
+        consumer.poll(Duration.ZERO);
+        assertEquals(5 * 1000d, consumer.metrics().get(timeBetweenPollAvgName).metricValue());
+        assertEquals(10 * 1000d, consumer.metrics().get(timeBetweenPollMaxName).metricValue());
+        // Advance time by 5,000 (total time = 20,000)
+        time.sleep(5 * 1000L);
+        assertEquals(5.0d, consumer.metrics().get(lastPollSecondsAgoName).metricValue());
+        // Call fourth poll
+        consumer.poll(Duration.ZERO);
+        assertEquals(5 * 1000d, consumer.metrics().get(timeBetweenPollAvgName).metricValue());
+        assertEquals(10 * 1000d, consumer.metrics().get(timeBetweenPollMaxName).metricValue());
+    }
+
+    @Test
+    public void testPollIdleRatio() {
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+        initMetadata(client, Collections.singletonMap(topic, 1));
+
+        KafkaShareConsumer<String, String> consumer = newShareConsumer(time, client, subscription, metadata);
+        // MetricName object to check
+        Metrics metrics = consumer.metricsRegistry();
+        MetricName pollIdleRatio = metrics.metricName("poll-idle-ratio-avg", "consumer-metrics");
+        // Test default value
+        assertEquals(Double.NaN, consumer.metrics().get(pollIdleRatio).metricValue());
+
+        // 1st poll
+        // Spend 50ms in poll so value = 1.0
+        consumer.kafkaConsumerMetrics().recordPollStart(time.milliseconds());
+        time.sleep(50);
+        consumer.kafkaConsumerMetrics().recordPollEnd(time.milliseconds());
+
+        assertEquals(1.0d, consumer.metrics().get(pollIdleRatio).metricValue());
+
+        // 2nd poll
+        // Spend 50m outside poll and 0ms in poll so value = 0.0
+        time.sleep(50);
+        consumer.kafkaConsumerMetrics().recordPollStart(time.milliseconds());
+        consumer.kafkaConsumerMetrics().recordPollEnd(time.milliseconds());
+
+        // Avg of first two data points
+        assertEquals((1.0d + 0.0d) / 2, consumer.metrics().get(pollIdleRatio).metricValue());
+
+        // 3rd poll
+        // Spend 25ms outside poll and 25ms in poll so value = 0.5
+        time.sleep(25);
+        consumer.kafkaConsumerMetrics().recordPollStart(time.milliseconds());
+        time.sleep(25);
+        consumer.kafkaConsumerMetrics().recordPollEnd(time.milliseconds());
+
+        // Avg of three data points
+        assertEquals((1.0d + 0.0d + 0.5d) / 3, consumer.metrics().get(pollIdleRatio).metricValue());
+    }
+
+    private static boolean consumerMetricPresent(KafkaShareConsumer<String, String> consumer, String name) {
+        MetricName metricName = new MetricName(name, "consumer-metrics", "", Collections.emptyMap());
+        return consumer.metricsRegistry().metrics().containsKey(metricName);
+    }
+
+    @Test
+    public void testClosingConsumerUnregistersConsumerMetrics() {
+        Time time = new MockTime(1L);
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+        initMetadata(client, Collections.singletonMap(topic, 1));
+        KafkaShareConsumer<String, String> consumer = newShareConsumer(time, client, subscription, metadata);
+        consumer.subscribe(Collections.singletonList(topic));
+        assertTrue(consumerMetricPresent(consumer, "last-poll-seconds-ago"));
+        assertTrue(consumerMetricPresent(consumer, "time-between-poll-avg"));
+        assertTrue(consumerMetricPresent(consumer, "time-between-poll-max"));
+        consumer.close();
+        assertFalse(consumerMetricPresent(consumer, "last-poll-seconds-ago"));
+        assertFalse(consumerMetricPresent(consumer, "time-between-poll-avg"));
+        assertFalse(consumerMetricPresent(consumer, "time-between-poll-max"));
+    }
+
+    private static final List<String> CLIENT_IDS = new ArrayList<>();
+    public static class DeserializerForClientId implements Deserializer<byte[]> {
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) {
+            CLIENT_IDS.add(configs.get(ConsumerConfig.CLIENT_ID_CONFIG).toString());
+        }
+
+        @Override
+        public byte[] deserialize(String topic, byte[] data) {
+            return data;
+        }
+    }
+
+    @Test
+    public void testConfigurableObjectsShouldSeeGeneratedClientId() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, DeserializerForClientId.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, DeserializerForClientId.class.getName());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+
+        consumer = newShareConsumer(props);
+        assertNotNull(consumer.clientId());
+        assertNotEquals(0, consumer.clientId().length());
+        assertEquals(2, CLIENT_IDS.size());
+        CLIENT_IDS.forEach(id -> assertEquals(id, consumer.clientId()));
+    }
+
+    @Test
+    public void testUnusedConfigs() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLS");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        ConsumerConfig config = new ConsumerConfig(ConsumerConfig.appendDeserializerToConfig(props, new StringDeserializer(), new StringDeserializer()));
+
+        assertTrue(config.unused().contains(SslConfigs.SSL_PROTOCOL_CONFIG));
+
+        consumer = new KafkaShareConsumer<>(config, null, null);
+        assertTrue(config.unused().contains(SslConfigs.SSL_PROTOCOL_CONFIG));
+    }
+
+    @Test
+    public void testClientInstanceId() {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+
+        ClientTelemetryReporter clientTelemetryReporter = mock(ClientTelemetryReporter.class);
+        clientTelemetryReporter.configure(any());
+
+        try (MockedStatic<CommonClientConfigs> mockedCommonClientConfigs = mockStatic(CommonClientConfigs.class, new CallsRealMethods())) {
+            mockedCommonClientConfigs.when(() -> CommonClientConfigs.telemetryReporter(anyString(), any())).thenReturn(Optional.of(clientTelemetryReporter));
+
+            ClientTelemetrySender clientTelemetrySender = mock(ClientTelemetrySender.class);
+            Uuid expectedUuid = Uuid.randomUuid();
+            when(clientTelemetryReporter.telemetrySender()).thenReturn(clientTelemetrySender);
+            when(clientTelemetrySender.clientInstanceId(any())).thenReturn(Optional.of(expectedUuid));
+
+            consumer = newShareConsumer(props, new StringDeserializer(), new StringDeserializer());
+            Uuid uuid = consumer.clientInstanceId(Duration.ofMillis(0));
+            assertEquals(expectedUuid, uuid);
+        }
+    }
+
+    @Test
+    public void testClientInstanceIdInvalidTimeout() {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+
+        consumer = newShareConsumer(props, new StringDeserializer(), new StringDeserializer());
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> consumer.clientInstanceId(Duration.ofMillis(-1)));
+        assertEquals("The timeout cannot be negative.", exception.getMessage());
+    }
+
+    @Test
+    public void testClientInstanceIdNoTelemetryReporterRegistered() {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.setProperty(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG, "false");
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+
+        consumer = newShareConsumer(props, new StringDeserializer(), new StringDeserializer());
+        Exception exception = assertThrows(IllegalStateException.class, () -> consumer.clientInstanceId(Duration.ofMillis(0)));
+        assertEquals("Telemetry is not enabled. Set config `enable.metrics.push` to `true`.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
This PR introduces methods to KafkaShareConsumer which can be used to validate that metrics are working properly. But then I added an integration test which does test some metrics, and also uses a mock client to validate requests and responses with the KafkaShareConsumer. So, this is the first step towards a decent amount of KIP-932 protocol testing of the client, as well as adding the proper metrics.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
