### PR TITLE
AKCORE-133: Added NoOpShareStatePersister as a noop persister.

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/group/share/NoOpShareStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/NoOpShareStatePersister.java
@@ -17,10 +17,15 @@
 
 package org.apache.kafka.server.group.share;
 
+import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 public class NoOpShareStatePersister implements Persister {
 
@@ -30,31 +35,55 @@ public class NoOpShareStatePersister implements Persister {
   @Override
   public CompletableFuture<InitializeShareGroupStateResult> initializeState(InitializeShareGroupStateParameters request) {
     banner("initializeState");
-    return CompletableFuture.completedFuture(null);
+    GroupTopicPartitionData<PartitionStateData> reqData = request.groupTopicPartitionData();
+    List<TopicData<PartitionErrorData>> resultArgs = new ArrayList<>();
+    for (TopicData<PartitionStateData> topicData : reqData.topicsData()) {
+      resultArgs.add(new TopicData<>(topicData.topicId(), topicData.partitions().stream()
+          .map(partStateData -> PartitionFactory.newPartitionErrorData(partStateData.partition(), Errors.NONE.code()))
+          .collect(Collectors.toList())));
+    }
+    return CompletableFuture.completedFuture(new InitializeShareGroupStateResult.Builder().setTopicsData(resultArgs).build());
   }
 
   @Override
   public CompletableFuture<ReadShareGroupStateResult> readState(ReadShareGroupStateParameters request) {
     banner("readState");
-    return CompletableFuture.completedFuture(null);
+    // return empty list
+    return CompletableFuture.completedFuture(new ReadShareGroupStateResult.Builder().setTopicsData(Collections.emptyList()).build());
   }
 
   @Override
   public CompletableFuture<WriteShareGroupStateResult> writeState(WriteShareGroupStateParameters request) {
     banner("writeState");
-    return CompletableFuture.completedFuture(null);
+    GroupTopicPartitionData<PartitionStateBatchData> reqData = request.groupTopicPartitionData();
+    List<TopicData<PartitionErrorData>> resultArgs = new ArrayList<>();
+    for (TopicData<PartitionStateBatchData> topicData : reqData.topicsData()) {
+      resultArgs.add(new TopicData<>(topicData.topicId(), topicData.partitions().stream()
+          .map(batch -> PartitionFactory.newPartitionErrorData(batch.partition(), Errors.NONE.code()))
+          .collect(Collectors.toList())));
+    }
+    return CompletableFuture.completedFuture(new WriteShareGroupStateResult.Builder().setTopicsData(resultArgs).build());
   }
 
   @Override
   public CompletableFuture<DeleteShareGroupStateResult> deleteState(DeleteShareGroupStateParameters request) {
     banner("deleteState");
-    return CompletableFuture.completedFuture(null);
+    GroupTopicPartitionData<PartitionIdData> reqData = request.groupTopicPartitionData();
+    List<TopicData<PartitionErrorData>> resultArgs = new ArrayList<>();
+    for (TopicData<PartitionIdData> topicData : reqData.topicsData()) {
+      resultArgs.add(new TopicData<>(topicData.topicId(), topicData.partitions().stream()
+          .map(batch -> PartitionFactory.newPartitionErrorData(batch.partition(), Errors.NONE.code()))
+          .collect(Collectors.toList())));
+    }
+    return CompletableFuture.completedFuture(new DeleteShareGroupStateResult.Builder().setTopicsData(resultArgs).build());
   }
 
   @Override
   public CompletableFuture<ReadShareGroupOffsetsStateResult> readOffsets(ReadShareGroupOffsetsStateParameters request) {
     banner("readOffsets");
-    return CompletableFuture.completedFuture(null);
+    List<TopicData<PartitionStateErrorData>> resultArgs = new ArrayList<>();
+    // empty list
+    return CompletableFuture.completedFuture(new ReadShareGroupOffsetsStateResult.Builder().setTopicsData(Collections.emptyList()).build());
   }
 
   private static void banner(String method) {

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/NoOpShareStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/NoOpShareStatePersister.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.group.share;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+
+public class NoOpShareStatePersister implements Persister {
+
+  private static final Logger log = LoggerFactory.getLogger(NoOpShareStatePersister.class);
+
+
+  @Override
+  public CompletableFuture<InitializeShareGroupStateResult> initializeState(InitializeShareGroupStateParameters request) {
+    banner("initializeState");
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<ReadShareGroupStateResult> readState(ReadShareGroupStateParameters request) {
+    banner("readState");
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<WriteShareGroupStateResult> writeState(WriteShareGroupStateParameters request) {
+    banner("writeState");
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<DeleteShareGroupStateResult> deleteState(DeleteShareGroupStateParameters request) {
+    banner("deleteState");
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<ReadShareGroupOffsetsStateResult> readOffsets(ReadShareGroupOffsetsStateParameters request) {
+    banner("readOffsets");
+    return CompletableFuture.completedFuture(null);
+  }
+
+  private static void banner(String method) {
+    log.info(method + " called on NoOpShareStatePersister. " +
+        "Nothing would be read from or persisted to topic. " +
+        "If this was unintended, please use some other implementations of Persister interface.");
+  }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionFactory.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionFactory.java
@@ -22,16 +22,21 @@ import org.apache.kafka.common.protocol.Errors;
 import java.util.List;
 
 public class PartitionFactory {
+
+  public static final int DEFAULT_STATE_EPOCH = 0;
+  public static final int DEFAULT_START_OFFSET = 0;
+  public static final short DEFAULT_ERROR_CODE = Errors.NONE.code();
+
   public static PartitionIdData newPartitionIdData(int partition) {
-    return new PartitionData(partition, -1, -1, Errors.NONE.code(), null);
+    return new PartitionData(partition, DEFAULT_STATE_EPOCH, DEFAULT_START_OFFSET, DEFAULT_ERROR_CODE, null);
   }
 
   public static PartitionStateData newPartitionStateData(int partition, int stateEpoch, long startOffset) {
-    return new PartitionData(partition, stateEpoch, startOffset, Errors.NONE.code(), null);
+    return new PartitionData(partition, stateEpoch, startOffset, DEFAULT_ERROR_CODE, null);
   }
 
   public static PartitionErrorData newPartitionErrorData(int partition, short errorCode) {
-    return new PartitionData(partition, -1, -1, errorCode, null);
+    return new PartitionData(partition, DEFAULT_STATE_EPOCH, DEFAULT_START_OFFSET, errorCode, null);
   }
 
   public static PartitionStateErrorData newPartitionStateErrorData(int partition, int stateEpoch, long startOffset, short errorCode) {
@@ -39,7 +44,7 @@ public class PartitionFactory {
   }
 
   public static PartitionStateBatchData newPartitionStateBatchData(int partition, int stateEpoch, long startOffset, List<PersisterStateBatch> stateBatches) {
-    return new PartitionData(partition, stateEpoch, startOffset, Errors.NONE.code(), stateBatches);
+    return new PartitionData(partition, stateEpoch, startOffset, DEFAULT_ERROR_CODE, stateBatches);
   }
 
   public static PartitionAllData newPartitionAllData(int partition, int stateEpoch, long startOffset, short errorCode, List<PersisterStateBatch> stateBatches) {


### PR DESCRIPTION
### What
- Added a NoOp impl of the `Persister` interface. The `NoOpShareStatePersister` simply returns a completed future with empty lists for read operations and success error codes for other mutation operations. It logs the NoOp operation as well.

### Why
- We want to use this impl to reduce feature dependency at development time and keep this impl as the default later on (if user chooses to not have any persistence but still use share groups).

### Testing
- Clean build.