### PR TITLE
AKCORE-129: Permit fetching when some records are AVAILABLE, even when maxInFlightMessage limit is exceeded

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -238,6 +238,22 @@ public class SharePartition {
         initialize();
     }
 
+    long startOffset() {
+        long startOffset;
+        lock.readLock().lock();
+        startOffset = this.startOffset;
+        lock.readLock().unlock();
+        return startOffset;
+    }
+
+    long endOffset() {
+        long endOffset;
+        lock.readLock().lock();
+        endOffset = this.endOffset;
+        lock.readLock().unlock();
+        return endOffset;
+    }
+
     /**
      * The next fetch offset is used to determine the next offset that should be fetched from the leader.
      * The offset should be the next offset after the last fetched batch but there could be batches/
@@ -1182,16 +1198,6 @@ public class SharePartition {
     // Visible for testing.
     Timer timer() {
         return timer;
-    }
-
-    // Visible for testing
-    long startOffset() {
-        return this.startOffset;
-    }
-
-    // Visible for testing
-    long endOffset() {
-        return this.endOffset;
     }
 
     // Visible for testing.

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -163,16 +163,16 @@ public class SharePartitionManager implements AutoCloseable {
                     // 2. If condition 1 is not true, then that means we will be fetching new records which haven't been cached before.
                     //    In this case it is necessary to check if the partition limit for in flight messages has been reached.
                     if (sharePartition.nextFetchOffset() != (sharePartition.endOffset() + 1) || sharePartition.canAcquireMore()) {
-                    topicPartitionData.put(
-                        topicIdPartition,
-                        new FetchRequest.PartitionData(
-                                topicIdPartition.topicId(),
-                                sharePartition.nextFetchOffset(),
-                                0,
-                                partitionMaxBytes,
-                                Optional.empty()
-                        )
-                    );
+                        topicPartitionData.put(
+                            topicIdPartition,
+                            new FetchRequest.PartitionData(
+                                    topicIdPartition.topicId(),
+                                    sharePartition.nextFetchOffset(),
+                                    0,
+                                    partitionMaxBytes,
+                                    Optional.empty()
+                            )
+                        );
                     } else {
                         sharePartition.releaseFetchLock();
                         log.info("Record lock partition limit exceeded for SharePartition with key {}, " +

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -157,13 +157,18 @@ public class SharePartitionManager implements AutoCloseable {
                 // Add the share partition to the list of partitions to be fetched only if we can
                 // acquire the fetch lock on it.
                 if (sharePartition.maybeAcquireFetchLock()) {
-                    if (sharePartition.canAcquireMore()) {
-                        topicPartitionData.put(topicIdPartition, new FetchRequest.PartitionData(
-                                topicIdPartition.topicId(),
-                                sharePartition.nextFetchOffset(),
-                                0,
-                                partitionMaxBytes,
-                                Optional.empty()));
+                    // Fetching over a topic should be able to proceed if any one of the following 2 conditions are met:
+                    // 1. The fetch is to happen somewhere in between the record states cached in the share partition.
+                    //    This is because in this case we don't need to check for the partition limit for in flight messages
+                    // 2. If condition 1 is not true, then that means we will be fetching new records which haven't been cached before.
+                    //    In this case it is necessary to check if the partition limit for in flight messages has been reached.
+                    if (sharePartition.nextFetchOffset() != sharePartition.endOffset() || sharePartition.canAcquireMore()) {
+                    topicPartitionData.put(topicIdPartition, new FetchRequest.PartitionData(
+                            topicIdPartition.topicId(),
+                            sharePartition.nextFetchOffset(),
+                            0,
+                            partitionMaxBytes,
+                            Optional.empty()));
                     } else {
                         sharePartition.releaseFetchLock();
                         log.info("Record lock partition limit exceeded for SharePartition with key {}, " +

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -162,13 +162,17 @@ public class SharePartitionManager implements AutoCloseable {
                     //    This is because in this case we don't need to check for the partition limit for in flight messages
                     // 2. If condition 1 is not true, then that means we will be fetching new records which haven't been cached before.
                     //    In this case it is necessary to check if the partition limit for in flight messages has been reached.
-                    if (sharePartition.nextFetchOffset() != sharePartition.endOffset() || sharePartition.canAcquireMore()) {
-                    topicPartitionData.put(topicIdPartition, new FetchRequest.PartitionData(
-                            topicIdPartition.topicId(),
-                            sharePartition.nextFetchOffset(),
-                            0,
-                            partitionMaxBytes,
-                            Optional.empty()));
+                    if (sharePartition.nextFetchOffset() != (sharePartition.endOffset() + 1) || sharePartition.canAcquireMore()) {
+                    topicPartitionData.put(
+                        topicIdPartition,
+                        new FetchRequest.PartitionData(
+                                topicIdPartition.topicId(),
+                                sharePartition.nextFetchOffset(),
+                                0,
+                                partitionMaxBytes,
+                                Optional.empty()
+                        )
+                    );
                     } else {
                         sharePartition.releaseFetchLock();
                         log.info("Record lock partition limit exceeded for SharePartition with key {}, " +


### PR DESCRIPTION
This PR contains a minor bug fix

Rference: [AKCORE-129](https://confluentinc.atlassian.net/jira/software/c/projects/AKCORE/boards/2050/backlog?customFilter=4089&selectedIssue=AKCORE-129)

[AKCORE-129]: https://confluentinc.atlassian.net/browse/AKCORE-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ