### PR TITLE
Integrate share persister API for write share group state

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -226,8 +226,17 @@ public class SharePartition {
      * The state epoch is used to track the version of the state of the share partition.
      */
     private int stateEpoch;
+    /**
+     * the retry backoff is used to determine the backoff time between retries for write share group state to persister.
+     */
     private final ExponentialBackoff retryBackoff;
+    /**
+     * The max retries is used to determine the maximum number of retries for write share group state to persister.
+     */
     private final int maxRetries;
+    /**
+     * The attempts is used to track the number of retry attempts for write share group state to persister.
+     */
     private int attempts;
 
     SharePartition(String groupId, TopicIdPartition topicIdPartition, int maxInFlightMessages, int maxDeliveryCount,
@@ -1218,7 +1227,7 @@ public class SharePartition {
                     .setGroupId(this.groupId)
                     .setTopicsData(Collections.singletonList(new TopicData<>(topicIdPartition.topicId(),
                         Collections.singletonList(PartitionFactory.newPartitionStateBatchData(
-                            topicIdPartition.partition(), stateEpoch, startOffset, stateBatches))))
+                            topicIdPartition.partition(), ++stateEpoch, startOffset, stateBatches))))
                     ).build()).build()).get();
 
             if (response == null || response.topicsData() == null || response.topicsData().size() != 1) {

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -1209,7 +1209,7 @@ public class SharePartition {
                     .setGroupId(this.groupId)
                     .setTopicsData(Collections.singletonList(new TopicData<>(topicIdPartition.topicId(),
                         Collections.singletonList(PartitionFactory.newPartitionStateBatchData(
-                            topicIdPartition.partition(), ++stateEpoch, startOffset, stateBatches))))
+                            topicIdPartition.partition(), stateEpoch, startOffset, stateBatches))))
                     ).build()).build()).get();
 
             if (response == null || response.topicsData() == null || response.topicsData().size() != 1) {

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -20,18 +20,25 @@ import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.errors.InvalidRecordStateException;
 import org.apache.kafka.common.errors.InvalidRequestException;
+import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.message.ShareFetchResponseData.AcquiredRecords;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.group.share.GroupTopicPartitionData;
 import org.apache.kafka.server.group.share.PartitionAllData;
+import org.apache.kafka.server.group.share.PartitionErrorData;
 import org.apache.kafka.server.group.share.PartitionFactory;
 import org.apache.kafka.server.group.share.PartitionIdData;
+import org.apache.kafka.server.group.share.PartitionStateBatchData;
 import org.apache.kafka.server.group.share.Persister;
 import org.apache.kafka.server.group.share.PersisterStateBatch;
 import org.apache.kafka.server.group.share.ReadShareGroupStateParameters;
 import org.apache.kafka.server.group.share.ReadShareGroupStateResult;
 import org.apache.kafka.server.group.share.TopicData;
+import org.apache.kafka.server.group.share.WriteShareGroupStateParameters;
+import org.apache.kafka.server.group.share.WriteShareGroupStateResult;
 import org.apache.kafka.server.util.timer.Timer;
 import org.apache.kafka.server.util.timer.TimerTask;
 import org.apache.kafka.storage.internals.log.FetchPartitionData;
@@ -219,6 +226,9 @@ public class SharePartition {
      * The state epoch is used to track the version of the state of the share partition.
      */
     private int stateEpoch;
+    private final ExponentialBackoff retryBackoff;
+    private final int maxRetries;
+    private int attempts;
 
     SharePartition(String groupId, TopicIdPartition topicIdPartition, int maxInFlightMessages, int maxDeliveryCount,
                    int recordLockDurationMs, Timer timer, Time time, Persister persister) {
@@ -236,6 +246,10 @@ public class SharePartition {
         this.persister = persister;
         // Initialize the partition.
         initialize();
+        // TODO: Initialize the retry backoff and max retries with configs coming from BrokerServer.
+        this.retryBackoff = new ExponentialBackoff(100L, 2, 1000L, 0.2);
+        this.maxRetries = 10;
+        this.attempts = 0;
     }
 
     /**
@@ -455,6 +469,7 @@ public class SharePartition {
         Throwable throwable = null;
         lock.writeLock().lock();
         List<InFlightState> updatedStates = new ArrayList<>();
+        List<PersisterStateBatch> stateBatches = new ArrayList<>();
         try {
             long localNextFetchOffset = nextFetchOffset;
             // Avoided using enhanced for loop as need to check if the last batch have offsets
@@ -596,6 +611,8 @@ public class SharePartition {
                             // This should not change the nextFetchOffset because the record is not available for acquisition
                             // Successfully updated the state of the offset.
                             updatedStates.add(updateResult);
+                            stateBatches.add(new PersisterStateBatch(offsetState.getKey(), offsetState.getKey(),
+                                    updateResult.state.id, (short) updateResult.deliveryCount));
                             if (updateNextFetchOffset && updateResult.state != RecordState.ARCHIVED) {
                                 localNextFetchOffset = Math.min(offsetState.getKey(), localNextFetchOffset);
                             }
@@ -639,6 +656,8 @@ public class SharePartition {
 
                     // Successfully updated the state of the batch.
                     updatedStates.add(updateResult);
+                    stateBatches.add(new PersisterStateBatch(inFlightBatch.firstOffset, inFlightBatch.lastOffset,
+                            updateResult.state.id, (short) updateResult.deliveryCount));
                     if (updateNextFetchOffset && updateResult.state != RecordState.ARCHIVED) {
                         localNextFetchOffset = Math.min(inFlightBatch.firstOffset, localNextFetchOffset);
                     }
@@ -649,7 +668,7 @@ public class SharePartition {
                 }
             }
 
-            if (throwable != null) {
+            if (throwable != null || !isWriteShareGroupStateSuccessful(stateBatches)) {
                 // the log should be DEBUG to avoid flooding of logs for a faulty client
                 log.debug("Acknowledgement batch request failed for share partition, rollback any changed state"
                     + " for the share partition: {}-{}", groupId, topicIdPartition);
@@ -873,10 +892,10 @@ public class SharePartition {
             } else {
                 endOffset = partitionData.startOffset();
             }
-      } catch (InterruptedException | ExecutionException e) {
-          log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, e);
-          throw new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition), e);
-      }
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, e);
+            throw new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition), e);
+        }
     }
 
     private void maybeUpdateCachedStateAndOffsets() {
@@ -1172,6 +1191,73 @@ public class SharePartition {
         } finally {
             lock.writeLock().unlock();
         }
+    }
+
+
+    // Visible for testing
+     boolean isWriteShareGroupStateSuccessful(List<PersisterStateBatch> stateBatches) {
+        boolean isWriteSuccessful = false;
+        try {
+            // Persister class can be null during active development and shall be driven by temporary config.
+            if (persister == null)
+                return true;
+            WriteShareGroupStateResult response = persister.writeState(new WriteShareGroupStateParameters.Builder()
+                .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
+                    .setGroupId(this.groupId)
+                    .setTopicsData(Collections.singletonList(new TopicData<>(topicIdPartition.topicId(),
+                        Collections.singletonList(PartitionFactory.newPartitionStateBatchData(
+                            topicIdPartition.partition(), stateEpoch, startOffset, stateBatches))))
+                    ).build()).build()).get();
+
+            if (response == null || response.topicsData() == null || response.topicsData().size() != 1) {
+                log.error("Failed to write the share group state for share partition: {}-{}. Invalid state found: {}",
+                        groupId, topicIdPartition, response);
+                throw new IllegalStateException(String.format("Failed to write the share group state for share partition %s-%s",
+                        groupId, topicIdPartition));
+            }
+
+            TopicData<PartitionErrorData> state = response.topicsData().get(0);
+            if (state.topicId() != topicIdPartition.topicId() || state.partitions().size() != 1
+                    || state.partitions().get(0).partition() != topicIdPartition.partition()) {
+                log.error("Failed to write the share group state for share partition: {}-{}. Invalid topic partition response: {}",
+                        groupId, topicIdPartition, response);
+                throw new IllegalStateException(String.format("Failed to write the share group state for share partition %s-%s",
+                        groupId, topicIdPartition));
+            }
+
+            PartitionErrorData partitionData = state.partitions().get(0);
+            if (partitionData.errorCode() != Errors.NONE.code()) {
+                log.debug("Failed to write the share group state for share partition: {}-{}. Error code: {}",
+                        groupId, topicIdPartition, partitionData.errorCode());
+                Exception exception = Errors.forCode(partitionData.errorCode()).exception();
+                if (exception instanceof RetriableException) {
+                    if (attempts < maxRetries) {
+                        log.debug("Retrying to write the share group state for share partition, {}-{}, attempt: {}", groupId, topicIdPartition,
+                                ++attempts);
+                        time.sleep(retryBackoff.backoff(attempts));
+                        return isWriteShareGroupStateSuccessful(stateBatches);
+                    } else {
+                        log.error("Failed to write the share group state for share partition: {}-{} after reaching max retries: {} for exception",
+                                groupId, topicIdPartition, attempts, exception);
+                    }
+                } else {
+                    log.error("Failed to write the share group state for share partition: {}-{} due to non-retryable exception",
+                            groupId, topicIdPartition, exception);
+                }
+                return isWriteSuccessful;
+            }
+            isWriteSuccessful = true;
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Failed to write the share group state for share partition: {}-{}", groupId, topicIdPartition, e);
+            throw new IllegalStateException(String.format("Failed to write the share group state for share partition %s-%s",
+                    groupId, topicIdPartition), e);
+        }
+        return isWriteSuccessful;
+    }
+
+    // Visible for testing.
+    int attempts() {
+        return attempts;
     }
 
     // Visible for testing. Should only be used for testing purposes.

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -3644,7 +3644,6 @@ public class SharePartitionTest {
 
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(null));
         assertThrows(IllegalStateException.class, () -> sharePartition.isWriteShareGroupStateSuccessful(stateBatches));
-        assertEquals(1, sharePartition.stateEpoch());
     }
 
     @Test
@@ -3660,7 +3659,6 @@ public class SharePartitionTest {
         Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(null);
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
         assertThrows(IllegalStateException.class, () -> sharePartition.isWriteShareGroupStateSuccessful(stateBatches));
-        assertEquals(1, sharePartition.stateEpoch());
     }
 
     @Test
@@ -3712,7 +3710,6 @@ public class SharePartitionTest {
                         PartitionFactory.newPartitionErrorData(1, Errors.NONE.code())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
         assertThrows(IllegalStateException.class, () -> sharePartition.isWriteShareGroupStateSuccessful(stateBatches));
-        assertEquals(6, sharePartition.stateEpoch());
     }
 
     @Test
@@ -3726,7 +3723,6 @@ public class SharePartitionTest {
                 new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(FutureUtils.failedFuture(new RuntimeException("Write exception")));
         assertThrows(IllegalStateException.class, () -> sharePartition.isWriteShareGroupStateSuccessful(stateBatches));
-        assertEquals(1, sharePartition.stateEpoch());
     }
 
     @Test
@@ -3744,7 +3740,6 @@ public class SharePartitionTest {
                         PartitionFactory.newPartitionErrorData(0, Errors.NONE.code())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
         assertTrue(sharePartition.isWriteShareGroupStateSuccessful(stateBatches));
-        assertEquals(1, sharePartition.stateEpoch());
     }
 
     @Test
@@ -3762,7 +3757,6 @@ public class SharePartitionTest {
                         PartitionFactory.newPartitionErrorData(0, Errors.NOT_COORDINATOR.code())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
         assertFalse(sharePartition.isWriteShareGroupStateSuccessful(stateBatches));
-        assertEquals(1, sharePartition.stateEpoch());
     }
 
     @Test
@@ -3797,8 +3791,6 @@ public class SharePartitionTest {
         // Due to failure in writeShareGroupState, the cached state should not be updated.
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(5L).batchState());
-
-        assertEquals(1, sharePartition.stateEpoch());
     }
 
     @Test
@@ -3838,8 +3830,6 @@ public class SharePartitionTest {
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(5L).offsetState().get(8L).state());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(5L).offsetState().get(9L).state());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(5L).offsetState().get(10L).state());
-
-        assertEquals(1, sharePartition.stateEpoch());
     }
 
     @Test
@@ -3872,8 +3862,6 @@ public class SharePartitionTest {
         // Due to failure in writeShareGroupState, the cached state should not be updated.
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(5L).batchState());
-
-        assertEquals(1, sharePartition.stateEpoch());
     }
 
     @Test
@@ -3932,8 +3920,6 @@ public class SharePartitionTest {
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(5L).offsetState().get(8L).state());
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(5L).offsetState().get(9L).state());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(5L).offsetState().get(10L).state());
-
-        assertEquals(2, sharePartition.stateEpoch());
     }
 
     @Test
@@ -3970,8 +3956,6 @@ public class SharePartitionTest {
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
         assertEquals(0, sharePartition.timer().size());
         assertNull(sharePartition.cachedState().get(5L).acquisitionLockTimeoutTask());
-
-        assertEquals(1, sharePartition.stateEpoch());
     }
 
     @Test

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -3748,7 +3748,7 @@ public class SharePartitionTest {
     }
 
     @Test
-    public void testWriteShareGroupStateFailureAfterRetryableErrors() {
+    public void testWriteShareGroupStateFailure() {
         Persister persister = Mockito.mock(Persister.class);
         mockPersisterReadStateMethod(persister);
         SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
@@ -3762,67 +3762,6 @@ public class SharePartitionTest {
                         PartitionFactory.newPartitionErrorData(0, Errors.NOT_COORDINATOR.code())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
         assertFalse(sharePartition.isWriteShareGroupStateSuccessful(stateBatches));
-        assertEquals(10, sharePartition.attempts());
-        assertEquals(11, sharePartition.stateEpoch());
-    }
-
-    @Test
-    public void testWriteShareGroupStateSuccessfulAfterRetries() {
-        Persister persister = Mockito.mock(Persister.class);
-        mockPersisterReadStateMethod(persister);
-        SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
-        short retryableErrorCode = Errors.NOT_COORDINATOR.code();
-
-        List<PersisterStateBatch> stateBatches = Arrays.asList(
-                new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
-                new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3));
-        WriteShareGroupStateResult writeShareGroupStateResult1 = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult1.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
-                        PartitionFactory.newPartitionErrorData(0, retryableErrorCode)))));
-
-        WriteShareGroupStateResult writeShareGroupStateResult2 = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult2.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
-                        PartitionFactory.newPartitionErrorData(0, retryableErrorCode)))));
-
-        WriteShareGroupStateResult writeShareGroupStateResult3 = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult3.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
-                        PartitionFactory.newPartitionErrorData(0, retryableErrorCode)))));
-
-        WriteShareGroupStateResult writeShareGroupStateResult4 = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult4.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
-                        PartitionFactory.newPartitionErrorData(0, Errors.NONE.code())))));
-
-        Mockito.when(persister.writeState(Mockito.any())).thenReturn(
-                CompletableFuture.completedFuture(writeShareGroupStateResult1),
-                CompletableFuture.completedFuture(writeShareGroupStateResult2),
-                CompletableFuture.completedFuture(writeShareGroupStateResult3),
-                CompletableFuture.completedFuture(writeShareGroupStateResult4));
-
-        assertTrue(sharePartition.isWriteShareGroupStateSuccessful(stateBatches));
-        assertEquals(3, sharePartition.attempts());
-        assertEquals(4, sharePartition.stateEpoch());
-    }
-
-    @Test
-    public void testWriteShareGroupStateFailureAfterNonRetryableError() {
-        Persister persister = Mockito.mock(Persister.class);
-        mockPersisterReadStateMethod(persister);
-        SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
-
-        List<PersisterStateBatch> stateBatches = Arrays.asList(
-                new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
-                new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3));
-        WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
-                        PartitionFactory.newPartitionErrorData(0, Errors.GROUP_ID_NOT_FOUND.code())))));
-        Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
-        assertFalse(sharePartition.isWriteShareGroupStateSuccessful(stateBatches));
-        assertEquals(0, sharePartition.attempts());
         assertEquals(1, sharePartition.stateEpoch());
     }
 


### PR DESCRIPTION
### About
1. Implemented the call from share partition leader to share group persister for writing updated share group state -
            a. The functionality uses exponential backoff mechanism for retries.
            b. `stateEpoch` is incremented on every attempt to write share group state to persister (on retries as well).
2. Integrated the functionality mentioned in point 1 to `acknowledge()`, `releaseAcquiredRecords()` and `acquisitionLockTimeout()` features - 
            a. In case of failure to write share group state to persister, we provide a `log.error` message and rollback any state transistion that happens during `acknowledge()` and `releaseAcquiredRecords()`

### TODOs
1. `exponentialBackoff` object initialization in `SharePartition` currently uses hardcoded configs I found in `CommonClientConfigs`, not sure if we should be having configs for it coming from `BrokerServer`?
2. In case of failure to write share group state on `acquisitionLockTimeout()`, how should we handle it?