### PR TITLE
AKCORE-127: Enable share group using rebalance protocol config

### DIFF
--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -77,8 +77,7 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
     }
 
     if (isShareGroupEnabled()) {
-      cfgs.foreach(_.setProperty(KafkaConfig.ShareGroupEnableProp, "true"))
-      cfgs.foreach(_.setProperty(KafkaConfig.GroupCoordinatorRebalanceProtocolsProp, "classic,consumer"))
+      cfgs.foreach(_.setProperty(KafkaConfig.GroupCoordinatorRebalanceProtocolsProp, "classic,consumer,share"))
       cfgs.foreach(_.setProperty(KafkaConfig.UnstableApiVersionsEnableProp, "true"))
     }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1864,7 +1864,7 @@ class KafkaConfigTest {
     val props = new Properties()
     props.putAll(kraftProps())
 
-    // Only classic and consumer are supported.
+    // Only classic, consumer and share are supported.
     props.put(KafkaConfig.GroupCoordinatorRebalanceProtocolsProp, "foo")
     assertThrows(classOf[ConfigException], () => KafkaConfig.fromProps(props))
 
@@ -1874,9 +1874,19 @@ class KafkaConfigTest {
 
     // This is OK.
     props.put(KafkaConfig.GroupCoordinatorRebalanceProtocolsProp, "classic,consumer")
-    val config = KafkaConfig.fromProps(props)
+    var config = KafkaConfig.fromProps(props)
     assertEquals(Set(GroupType.CLASSIC, GroupType.CONSUMER), config.groupCoordinatorRebalanceProtocols)
     assertTrue(config.isNewGroupCoordinatorEnabled)
+
+    // This is OK.
+    props.put(KafkaConfig.GroupCoordinatorRebalanceProtocolsProp, "classic,consumer,share")
+    config = KafkaConfig.fromProps(props)
+    assertEquals(Set(GroupType.CLASSIC, GroupType.CONSUMER, GroupType.SHARE), config.groupCoordinatorRebalanceProtocols)
+    assertTrue(config.isShareGroupEnabled)
+
+    // If you set share, you must also set consumer.
+    props.put(KafkaConfig.GroupCoordinatorRebalanceProtocolsProp, "classic,share")
+    assertThrows(classOf[ConfigException], () => KafkaConfig.fromProps(props))
   }
 
   @Test


### PR DESCRIPTION
Use the "share" rebalance protocol as the proper way to enable share groups.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
