### PR TITLE
AKCORE-138: Integrated logic for handling maxDeliveryCount and moving SPSO with releaseAcquisitionLockOnTimeout in Share Partition

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -1463,20 +1463,8 @@ public class SharePartition {
         }
 
         private InFlightState startStateTransition(RecordState newState, boolean incrementDeliveryCount, int maxDeliveryCount) {
-            try {
-                rollbackState = new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask);
-                if (newState == RecordState.AVAILABLE && deliveryCount >= maxDeliveryCount) {
-                    newState = RecordState.ARCHIVED;
-                }
-                state = state.validateTransition(newState);
-                if (incrementDeliveryCount && newState != RecordState.ARCHIVED) {
-                    deliveryCount++;
-                }
-                return this;
-            } catch (IllegalStateException e) {
-                log.info("Failed to start state transition of the records", e);
-                return null;
-            }
+            rollbackState = new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask);
+            return tryUpdateState(newState, incrementDeliveryCount, maxDeliveryCount);
         }
 
         private void completeStateTransition(boolean commit) {

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -1188,6 +1188,7 @@ public class SharePartition {
                     }
                 }
                 nextFetchOffset = localNextFetchOffset;
+                
                 // Update the cached state and start and end offsets after releasing the acquisition lock on timeout.
                 maybeUpdateCachedStateAndOffsets();
             }


### PR DESCRIPTION
This PR contains the logic for handling the cases where delivery count of records exceed max delivery count config when releaseAcquisitionLockOnTimeout is called in share partition. In case the cache needs to be cleared of initial batches because the state is ARCHIVED, that is also handled here.

Reference: [AKCORE-138](https://confluentinc.atlassian.net/jira/software/c/projects/AKCORE/boards/2050/backlog?selectedIssue=AKCORE-138)

[AKCORE-138]: https://confluentinc.atlassian.net/browse/AKCORE-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ