### PR TITLE
AKCORE-142: Update the cachedState when releaseAcquiredRecords is called in sharePartition

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -690,7 +690,7 @@ public class SharePartition {
                 });
 
                 nextFetchOffset = localNextFetchOffset;
-
+                // Update the cached state and start and end offsets after acknowledgements are completed
                 maybeUpdateCachedStateAndOffsets();
             }
         } finally {
@@ -829,6 +829,8 @@ public class SharePartition {
                     state.cancelAndClearAcquisitionLockTimeoutTask();
                 });
                 nextFetchOffset = localNextFetchOffset;
+                // Update the cached state and start and end offsets after releasing the acquired records
+                maybeUpdateCachedStateAndOffsets();
             }
         } finally {
             lock.writeLock().unlock();


### PR DESCRIPTION
When releaseAcquiredRecords is called in sharePartition, some acquired records are released in the cachedState. If these records have a deliveryCount >= maxDeliveryCount, then these records are moved to ARCHIVED state. If these ARCHIVED records are at the beginning of the cachedState, then the SPSO needs to be updated. Also, if the initial batches in the cachedState are either acknowledged (either ACCEPT or REJECT), then these batches need to be cleared off the cache.

Reference: [AKCORE-142](https://confluentinc.atlassian.net/jira/software/c/projects/AKCORE/boards/2050/backlog?selectedIssue=AKCORE-142)

[AKCORE-142]: https://confluentinc.atlassian.net/browse/AKCORE-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ