### PR TITLE
AKCORE-105: Use ShareAcknowledge to close share session

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchRequestManager.java
@@ -25,9 +25,9 @@ import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.internals.IdempotentCloser;
-import org.apache.kafka.common.message.ShareFetchRequestData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ShareAcknowledgeRequest;
 import org.apache.kafka.common.requests.ShareFetchRequest;
 import org.apache.kafka.common.requests.ShareFetchResponse;
 import org.apache.kafka.common.utils.BufferSupplier;
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 /**
  * {@code ShareFetchRequestManager} is responsible for generating {@link ShareFetchRequest} that
  * represent the {@link SubscriptionState#fetchablePartitions(Predicate)} based on the share group
- * consumer's assignment.
+ * consumer's assignment. It also uses {@link ShareAcknowledgeRequest} to close the share session.
  */
 public class ShareFetchRequestManager implements RequestManager, MemberStateListener {
 
@@ -87,47 +87,14 @@ public class ShareFetchRequestManager implements RequestManager, MemberStateList
 
     @Override
     public PollResult poll(long currentTimeMs) {
-        return pollInternal(prepareShareFetchRequests(),
-                this::handleShareFetchSuccess,
-                this::handleShareFetchFailure);
-    }
+        // Update metrics in case there was an assignment change
+        metricsManager.maybeUpdateAssignment(subscriptions);
 
-    @Override
-    public PollResult pollOnClose() {
-        return pollInternal(prepareShareFetchCloseRequests(),
-                this::handleShareFetchCloseSuccess,
-                this::handleShareFetchCloseFailure);
-    }
-
-    private PollResult pollInternal(Map<Node, ShareSessionHandler.ShareFetchRequestData> shareFetchRequests,
-                                    ResponseHandler<ClientResponse> successHandler,
-                                    ResponseHandler<Throwable> failureHandler) {
         if (memberId == null) {
             return PollResult.EMPTY;
         }
 
-        List<UnsentRequest> requests = shareFetchRequests.entrySet().stream().map(entry -> {
-            final Node target = entry.getKey();
-            final ShareSessionHandler.ShareFetchRequestData data = entry.getValue();
-            final ShareFetchRequest.Builder request = createShareFetchRequest(target, data);
-            final BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, error) -> {
-                if (error != null) {
-                    failureHandler.accept(target, data, error);
-                } else {
-                    successHandler.accept(target, data, clientResponse);
-                }
-            };
-            return new UnsentRequest(request, Optional.of(target)).whenComplete(responseHandler);
-        }).collect(Collectors.toList());
-
-        return new PollResult(requests);
-    }
-
-    private Map<Node, ShareSessionHandler.ShareFetchRequestData> prepareShareFetchRequests() {
-        // Update metrics in case there was an assignment change
-        metricsManager.maybeUpdateAssignment(subscriptions);
-
-        Map<Node, ShareSessionHandler.Builder> requestBuilderMap = new HashMap<>();
+        Map<Node, ShareSessionHandler> handlerMap = new HashMap<>();
         Map<String, Uuid> topicIds = metadata.topicIds();
 
         for (TopicPartition partition : partitionsToFetch()) {
@@ -151,29 +118,99 @@ public class ShareFetchRequestManager implements RequestManager, MemberStateList
                 log.trace("Skipping fetch for partition {} because previous fetch request to {} has not been processed", partition, node);
             } else {
                 // if there is a leader and no in-flight requests, issue a new fetch
-                ShareSessionHandler.Builder builder = requestBuilderMap.computeIfAbsent(node, k -> {
-                    ShareSessionHandler shareSessionHandler =
-                            sessionHandlers.computeIfAbsent(node.id(), n -> new ShareSessionHandler(logContext, n, memberId));
-                    return shareSessionHandler.newBuilder();
-                });
+                ShareSessionHandler handler = handlerMap.computeIfAbsent(node, k -> sessionHandlers.computeIfAbsent(node.id(), n -> new ShareSessionHandler(logContext, n, memberId)));
 
                 TopicIdPartition tip = new TopicIdPartition(topicId, partition);
-                builder.add(tip, shareFetchBuffer.getAcknowledgementsToSend(tip));
+                handler.addPartitionToFetch(tip, shareFetchBuffer.getAcknowledgementsToSend(tip));
 
                 log.debug("Added fetch request for partition {} to node {}", partition, node);
             }
         }
 
-        Map<Node, ShareSessionHandler.ShareFetchRequestData> requests = new LinkedHashMap<>();
-        for (Map.Entry<Node, ShareSessionHandler.Builder> entry : requestBuilderMap.entrySet()) {
-            requests.put(entry.getKey(), entry.getValue().build());
+        Map<Node, ShareFetchRequest.Builder> builderMap = new LinkedHashMap<>();
+        for (Map.Entry<Node, ShareSessionHandler> entry : handlerMap.entrySet()) {
+            builderMap.put(entry.getKey(), entry.getValue().newShareFetchBuilder(groupId, fetchConfig));
         }
 
-        return requests;
+        List<UnsentRequest> requests = builderMap.entrySet().stream().map(entry -> {
+            Node target = entry.getKey();
+            ShareFetchRequest.Builder request = entry.getValue();
+
+            nodesWithPendingRequests.add(target.id());
+
+            BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, error) -> {
+                if (error != null) {
+                    handleShareFetchFailure(target, error);
+                } else {
+                    handleShareFetchSuccess(target, clientResponse);
+                }
+            };
+            return new UnsentRequest(request, Optional.of(target)).whenComplete(responseHandler);
+        }).collect(Collectors.toList());
+
+        return new PollResult(requests);
+    }
+
+    @Override
+    public PollResult pollOnClose() {
+        // Update metrics in case there was an assignment change
+        metricsManager.maybeUpdateAssignment(subscriptions);
+
+        if (memberId == null) {
+            return PollResult.EMPTY;
+        }
+
+        final Cluster cluster = metadata.fetch();
+
+        Map<Node, ShareSessionHandler> handlerMap = new HashMap<>();
+
+        sessionHandlers.forEach((nodeId, sessionHandler) -> {
+            sessionHandler.notifyClose();
+            Node node = cluster.nodeById(nodeId);
+            if (node != null) {
+                handlerMap.put(node, sessionHandler);
+
+                for (TopicIdPartition tip : sessionHandler.sessionPartitions()) {
+                    Acknowledgements acknowledgements = shareFetchBuffer.getAcknowledgementsToSend(tip);
+                    if (acknowledgements != null) {
+                        sessionHandler.addPartitionToFetch(tip, acknowledgements);
+
+                        log.debug("Added closing acknowledge request for partition {} to node {}", tip.topicPartition(), node);
+                    }
+                }
+            }
+        });
+
+        Map<Node, ShareAcknowledgeRequest.Builder> builderMap = new LinkedHashMap<>();
+        for (Map.Entry<Node, ShareSessionHandler> entry : handlerMap.entrySet()) {
+            Node target = entry.getKey();
+            ShareSessionHandler handler = entry.getValue();
+            ShareAcknowledgeRequest.Builder builder = handler.newShareAcknowledgeBuilder(groupId, fetchConfig);
+            if (builder != null) {
+                builderMap.put(target, builder);
+            }
+        }
+
+        List<UnsentRequest> requests = builderMap.entrySet().stream().map(entry -> {
+            Node target = entry.getKey();
+            ShareAcknowledgeRequest.Builder request = entry.getValue();
+
+            nodesWithPendingRequests.add(target.id());
+
+            BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, error) -> {
+                if (error != null) {
+                    handleShareAcknowledgeCloseFailure(target, error);
+                } else {
+                    handleShareAcknowledgeCloseSuccess(target, clientResponse);
+                }
+            };
+            return new UnsentRequest(request, Optional.of(target)).whenComplete(responseHandler);
+        }).collect(Collectors.toList());
+
+        return new PollResult(requests);
     }
 
     private void handleShareFetchSuccess(Node fetchTarget,
-                                         ShareSessionHandler.ShareFetchRequestData data,
                                          ClientResponse resp) {
         try {
             final ShareFetchResponse response = (ShareFetchResponse) resp.responseBody();
@@ -229,7 +266,6 @@ public class ShareFetchRequestManager implements RequestManager, MemberStateList
     }
 
     private void handleShareFetchFailure(Node fetchTarget,
-                                         ShareSessionHandler.ShareFetchRequestData data,
                                          Throwable error) {
         try {
             data.sessionPartitions().values().forEach(tip -> {
@@ -246,40 +282,8 @@ public class ShareFetchRequestManager implements RequestManager, MemberStateList
         }
     }
 
-    private Map<Node, ShareSessionHandler.ShareFetchRequestData> prepareShareFetchCloseRequests() {
-        final Cluster cluster = metadata.fetch();
-
-        Map<Node, ShareSessionHandler.Builder> requestBuilderMap = new HashMap<>();
-
-        sessionHandlers.forEach((nodeId, sessionHandler) -> {
-            sessionHandler.notifyClose();
-            Node node = cluster.nodeById(nodeId);
-            if (node != null) {
-                ShareSessionHandler.Builder builder = sessionHandler.newBuilder();
-                requestBuilderMap.put(node, builder);
-
-                for (TopicIdPartition tip : sessionHandler.sessionPartitions()) {
-                    Acknowledgements acknowledgements = shareFetchBuffer.getAcknowledgementsToSend(tip);
-                    if (acknowledgements != null) {
-                        builder.add(tip, acknowledgements);
-
-                        log.debug("Added closing fetch request for partition {} to node {}", tip.topicPartition(), node);
-                    }
-                }
-            }
-        });
-
-        Map<Node, ShareSessionHandler.ShareFetchRequestData> requests = new LinkedHashMap<>();
-        for (Map.Entry<Node, ShareSessionHandler.Builder> entry : requestBuilderMap.entrySet()) {
-            requests.put(entry.getKey(), entry.getValue().build());
-        }
-
-        return requests;
-    }
-
-    private void handleShareFetchCloseSuccess(Node fetchTarget,
-                                              ShareSessionHandler.ShareFetchRequestData data,
-                                              ClientResponse resp) {
+    private void handleShareAcknowledgeCloseSuccess(Node fetchTarget,
+                                                    ClientResponse resp) {
         try {
             metricsManager.recordLatency(resp.requestLatencyMs());
         } finally {
@@ -289,29 +293,11 @@ public class ShareFetchRequestManager implements RequestManager, MemberStateList
         }
     }
 
-    private void handleShareFetchCloseFailure(Node fetchTarget,
-                                              ShareSessionHandler.ShareFetchRequestData data,
-                                              Throwable error) {
+    private void handleShareAcknowledgeCloseFailure(Node fetchTarget,
+                                                    Throwable error) {
         log.debug("Removing pending request for node {} - failed", fetchTarget);
         nodesWithPendingRequests.remove(fetchTarget.id());
         sessionHandlers.remove(fetchTarget.id());
-    }
-
-    private Map<TopicIdPartition, List<ShareFetchRequestData.AcknowledgementBatch>> acknowledgementBatches(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
-        Map<TopicIdPartition, List<ShareFetchRequestData.AcknowledgementBatch>> acknowledgementBatches = new HashMap<>();
-        acknowledgementsMap.forEach((partition, acknowledgements) -> acknowledgementBatches.put(partition, acknowledgements.getAcknowledgmentBatches()));
-        return acknowledgementBatches;
-    }
-
-    private ShareFetchRequest.Builder createShareFetchRequest(Node fetchTarget, ShareSessionHandler.ShareFetchRequestData requestData) {
-        final ShareFetchRequest.Builder request = ShareFetchRequest.Builder
-                .forConsumer(groupId, requestData.metadata(),
-                        fetchConfig.maxWaitMs, fetchConfig.minBytes, fetchConfig.maxBytes, fetchConfig.fetchSize,
-                        requestData.toSend(), acknowledgementBatches(requestData.acknowledgements()));
-
-        nodesWithPendingRequests.add(fetchTarget.id());
-
-        return request;
     }
 
     private List<TopicPartition> partitionsToFetch() {
@@ -337,10 +323,5 @@ public class ShareFetchRequestManager implements RequestManager, MemberStateList
     @Override
     public void onMemberEpochUpdated(Optional<Integer> memberEpochOpt, Optional<String> memberIdOpt) {
         memberIdOpt.ifPresent(s -> memberId = Uuid.fromString(s));
-    }
-
-    @FunctionalInterface
-    public interface ResponseHandler<T> {
-        void accept(Node fetchTarget, ShareSessionHandler.ShareFetchRequestData data, T response);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
@@ -20,9 +20,13 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ShareAcknowledgeRequestData;
+import org.apache.kafka.common.message.ShareFetchRequestData;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ShareAcknowledgeRequest;
 import org.apache.kafka.common.requests.ShareAcknowledgeResponse;
 import org.apache.kafka.common.requests.ShareFetchMetadata;
+import org.apache.kafka.common.requests.ShareFetchRequest;
 import org.apache.kafka.common.requests.ShareFetchResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
@@ -31,6 +35,7 @@ import org.slf4j.Logger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -45,7 +50,7 @@ import java.util.Map.Entry;
  * without explicitly enumerating all the partitions in the request and response.
  *
  * <p>ShareSessionHandler tracks the partitions which are in the session. It also determines
- * which partitions need to be included in each ShareFetch request.
+ * which partitions need to be included in each ShareFetch/ShareAcknowledge request.
  */
 public class ShareSessionHandler {
     private final Logger log;
@@ -53,7 +58,7 @@ public class ShareSessionHandler {
     private final Uuid memberId;
 
     /**
-     * The metadata for the next ShareFetchRequest.
+     * The metadata for the next ShareFetchRequest/ShareAcknowledgeRequest.
      */
     private ShareFetchMetadata nextMetadata;
 
@@ -62,127 +67,59 @@ public class ShareSessionHandler {
      */
     private LinkedHashMap<TopicPartition, TopicIdPartition> sessionPartitions;
 
+    /*
+     * The partitions to be included in the next ShareFetch request.
+     */
+    private LinkedHashMap<TopicPartition, TopicIdPartition> nextPartitions;
+
+    /*
+     * The acknowledgements to be included in the next ShareFetch/ShareAcknowledge request.
+     */
+    private LinkedHashMap<TopicIdPartition, Acknowledgements> nextAcknowledgements;
+
     public ShareSessionHandler(LogContext logContext, int node, Uuid memberId) {
         this.log = logContext.logger(ShareSessionHandler.class);
         this.node = node;
         this.memberId = memberId;
         this.nextMetadata = ShareFetchMetadata.initialEpoch(memberId);
         this.sessionPartitions = new LinkedHashMap<>();
+        this.nextPartitions = new LinkedHashMap<>();
+        this.nextAcknowledgements = new LinkedHashMap<>();
+    }
+
+    Map<TopicPartition, TopicIdPartition> sessionPartitionMap() {
+        return sessionPartitions;
     }
 
     public Collection<TopicIdPartition> sessionPartitions() {
         return Collections.unmodifiableCollection(sessionPartitions.values());
     }
 
-    public static class ShareFetchRequestData {
-
-        /**
-         * All the partitions which exist in the share session.
-         */
-        private final Map<TopicPartition, TopicIdPartition> sessionPartitions;
-
-        /**
-         * The partitions to send in the ShareFetch request.
-         */
-        private final List<TopicIdPartition> toSend;
-
-        /**
-         * The partitions to send in the ShareFetch "forget" list.
-         */
-        private final List<TopicIdPartition> toForget;
-
-        /**
-         * The partitions whose TopicIds have changed due to topic recreation.
-         */
-        private final List<TopicIdPartition> toReplace;
-
-        /**
-         * The metadata to use in this ShareFetch request.
-         */
-        private final ShareFetchMetadata metadata;
-
-        /**
-         * A map of the acknowledgements to send.
-         */
-        private final Map<TopicIdPartition, Acknowledgements> acknowledgements;
-
-        ShareFetchRequestData(Map<TopicPartition, TopicIdPartition> sessionPartitions,
-                              List<TopicIdPartition> toSend,
-                              List<TopicIdPartition> toForget,
-                              List<TopicIdPartition> toReplace,
-                              Map<TopicIdPartition, Acknowledgements> acknowledgements,
-                              ShareFetchMetadata metadata) {
-            this.toSend = toSend;
-            this.toForget = toForget;
-            this.toReplace = toReplace;
-            this.sessionPartitions = sessionPartitions;
-            this.metadata = metadata;
-            this.acknowledgements = acknowledgements;
-        }
-
-        public Map<TopicPartition, TopicIdPartition> sessionPartitions() {
-            return sessionPartitions;
-        }
-
-        public List<TopicIdPartition> toSend() {
-            return toSend;
-        }
-
-        public List<TopicIdPartition> toForget() {
-            return toForget;
-        }
-
-        public List<TopicIdPartition> toReplace() {
-            return toReplace;
-        }
-
-        public Map<TopicIdPartition, Acknowledgements> acknowledgements() {
-            return acknowledgements;
-        }
-
-        public ShareFetchMetadata metadata() {
-            return metadata;
+    public void addPartitionToFetch(TopicIdPartition topicIdPartition, Acknowledgements partitionAcknowledgements) {
+        nextPartitions.put(topicIdPartition.topicPartition(), topicIdPartition);
+        if (partitionAcknowledgements != null) {
+            nextAcknowledgements.put(topicIdPartition, partitionAcknowledgements);
         }
     }
 
-    public class Builder {
+    public ShareFetchRequest.Builder newShareFetchBuilder(String groupId, FetchConfig fetchConfig) {
+        List<TopicIdPartition> added = new ArrayList<>();
+        List<TopicIdPartition> removed = new ArrayList<>();
+        List<TopicIdPartition> replaced = new ArrayList<>();
 
-        private LinkedHashMap<TopicPartition, TopicIdPartition> nextPartitions;
-
-        private LinkedHashMap<TopicIdPartition, Acknowledgements> nextAcknowledgements;
-
-        Builder() {
-            this.nextPartitions = new LinkedHashMap<>();
-            this.nextAcknowledgements = new LinkedHashMap<>();
-        }
-
-        public void add(TopicIdPartition topicIdPartition, Acknowledgements partitionAcknowledgements) {
-            nextPartitions.put(topicIdPartition.topicPartition(), topicIdPartition);
-            if (partitionAcknowledgements != null) {
-                nextAcknowledgements.put(topicIdPartition, partitionAcknowledgements);
-            }
-        }
-
-        public ShareFetchRequestData build() {
-            if (nextMetadata.isNewSession()) {
-                sessionPartitions = nextPartitions;
-                nextPartitions = null;
-                nextAcknowledgements = null;
-                return new ShareFetchRequestData(sessionPartitions,
-                        Collections.unmodifiableList(new ArrayList<>(sessionPartitions.values())),
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.emptyMap(),
-                        nextMetadata);
+        if (nextMetadata.isNewSession()) {
+            // Add any new partitions to the session
+            for (Entry<TopicPartition, TopicIdPartition> entry : nextPartitions.entrySet()) {
+                TopicPartition topicPartition = entry.getKey();
+                TopicIdPartition topicIdPartition = entry.getValue();
+                sessionPartitions.put(topicPartition, topicIdPartition);
             }
 
-            List<TopicIdPartition> added = new ArrayList<>();
-            List<TopicIdPartition> removed = new ArrayList<>();
-            List<TopicIdPartition> replaced = new ArrayList<>();
-
-            // Iterate over the session partitions, tallying which were added to the builder
-            Iterator<Entry<TopicPartition, TopicIdPartition>> partitionIterator =
-                    sessionPartitions.entrySet().iterator();
+            // If it's a new session, all the partitions must be added to the request
+            added.addAll(sessionPartitions.values());
+        } else {
+            // Iterate over the session partitions, tallying which were added
+            Iterator<Entry<TopicPartition, TopicIdPartition>> partitionIterator = sessionPartitions.entrySet().iterator();
             while (partitionIterator.hasNext()) {
                 Entry<TopicPartition, TopicIdPartition> entry = partitionIterator.next();
                 TopicPartition topicPartition = entry.getKey();
@@ -209,34 +146,44 @@ public class ShareSessionHandler {
                 sessionPartitions.put(topicPartition, topicIdPartition);
                 added.add(topicIdPartition);
             }
-
-            if (log.isDebugEnabled()) {
-                log.debug("Build ShareFetch {} for node {}. Added {}, removed {}, replaced {} out of {}",
-                        nextMetadata, node,
-                        topicIdPartitionsToLogString(added),
-                        topicIdPartitionsToLogString(removed),
-                        topicIdPartitionsToLogString(replaced),
-                        topicIdPartitionsToLogString(sessionPartitions.values()));
-            }
-
-            Map<TopicPartition, TopicIdPartition> curSessionPartitions = Collections.unmodifiableMap(sessionPartitions);
-            List<TopicIdPartition> toSend = Collections.unmodifiableList(added);
-            List<TopicIdPartition> toForget = Collections.unmodifiableList(removed);
-            List<TopicIdPartition> toReplace = Collections.unmodifiableList(replaced);
-            Map<TopicIdPartition, Acknowledgements> curAcknowledgements = Collections.unmodifiableMap(nextAcknowledgements);
-            nextPartitions = null;
-            nextAcknowledgements = null;
-            return new ShareFetchRequestData(curSessionPartitions,
-                    toSend,
-                    toForget,
-                    toReplace,
-                    curAcknowledgements,
-                    nextMetadata);
         }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Build ShareFetch {} for node {}. Added {}, removed {}, replaced {} out of {}",
+                    nextMetadata, node,
+                    topicIdPartitionsToLogString(added),
+                    topicIdPartitionsToLogString(removed),
+                    topicIdPartitionsToLogString(replaced),
+                    topicIdPartitionsToLogString(sessionPartitions.values()));
+        }
+
+        // The replaced topic-partitions need to be removed, and their replacements are already added
+        removed.addAll(replaced);
+
+        Map<TopicIdPartition, List<ShareFetchRequestData.AcknowledgementBatch>> acknowledgementBatches = new HashMap<>();
+        nextAcknowledgements.forEach((partition, acknowledgements) -> acknowledgementBatches.put(partition, acknowledgements.getShareFetchBatches()));
+
+        nextPartitions = new LinkedHashMap<>();
+        nextAcknowledgements = new LinkedHashMap<>();
+
+        return ShareFetchRequest.Builder.forConsumer(
+                groupId, nextMetadata, fetchConfig.maxWaitMs,
+                fetchConfig.minBytes, fetchConfig.maxBytes, fetchConfig.fetchSize,
+                added, removed, acknowledgementBatches);
     }
 
-    Builder newBuilder() {
-        return new Builder();
+    public ShareAcknowledgeRequest.Builder newShareAcknowledgeBuilder(String groupId, FetchConfig fetchConfig) {
+        if (nextMetadata.isNewSession()) {
+            // A share session cannot be started with a ShareAcknowledge request
+            return null;
+        }
+
+        Map<TopicIdPartition, List<ShareAcknowledgeRequestData.AcknowledgementBatch>> acknowledgementBatches = new HashMap<>();
+        nextAcknowledgements.forEach((partition, acknowledgements) -> acknowledgementBatches.put(partition, acknowledgements.getShareAcknowledgeBatches()));
+
+        nextAcknowledgements = new LinkedHashMap<>();
+
+        return ShareAcknowledgeRequest.Builder.forConsumer(groupId, nextMetadata, acknowledgementBatches);
     }
 
     private String topicIdPartitionsToLogString(Collection<TopicIdPartition> partitions) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandler.java
@@ -268,7 +268,7 @@ public class ShareSessionHandler {
 
     /**
      * Handle an error sending the prepared request.
-     * When a network error occurs, we close any existing fetch session on our next request,
+     * When a network error occurs, we close any existing share session on our next request,
      * and try to create a new session.
      *
      * @param t     The exception.

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeRequest.java
@@ -83,6 +83,10 @@ public class ShareAcknowledgeRequest extends AbstractRequest {
             return new ShareAcknowledgeRequest.Builder(data, true);
         }
 
+        public ShareAcknowledgeRequestData data() {
+            return data;
+        }
+
         @Override
         public ShareAcknowledgeRequest build(short version) {
             return new ShareAcknowledgeRequest(data, version);

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeRequest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareAcknowledgeRequestData;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -23,6 +25,10 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ShareAcknowledgeRequest extends AbstractRequest {
 
@@ -37,6 +43,44 @@ public class ShareAcknowledgeRequest extends AbstractRequest {
         public Builder(ShareAcknowledgeRequestData data, boolean enableUnstableLastVersion) {
             super(ApiKeys.SHARE_ACKNOWLEDGE, enableUnstableLastVersion);
             this.data = data;
+        }
+
+        public static ShareAcknowledgeRequest.Builder forConsumer(String groupId, ShareFetchMetadata metadata,
+                                                                  Map<TopicIdPartition, List<ShareAcknowledgeRequestData.AcknowledgementBatch>> acknowledgementsMap) {
+            ShareAcknowledgeRequestData data = new ShareAcknowledgeRequestData();
+            data.setGroupId(groupId);
+            if (metadata != null) {
+                data.setMemberId(metadata.memberId().toString());
+                data.setShareSessionEpoch(metadata.epoch());
+            }
+
+            // Build a map of topics to acknowledge keyed by topic ID, and within each a map of partitions keyed by index
+            Map<Uuid, Map<Integer, ShareAcknowledgeRequestData.AcknowledgePartition>> ackMap = new HashMap<>();
+
+            for (Map.Entry<TopicIdPartition, List<ShareAcknowledgeRequestData.AcknowledgementBatch>> acknowledgeEntry : acknowledgementsMap.entrySet()) {
+                TopicIdPartition tip = acknowledgeEntry.getKey();
+                Map<Integer, ShareAcknowledgeRequestData.AcknowledgePartition> partMap = ackMap.computeIfAbsent(tip.topicId(), k -> new HashMap<>());
+                ShareAcknowledgeRequestData.AcknowledgePartition ackPartition = partMap.get(tip.partition());
+                if (ackPartition == null) {
+                    ackPartition = new ShareAcknowledgeRequestData.AcknowledgePartition()
+                            .setPartitionIndex(tip.partition());
+                    partMap.put(tip.partition(), ackPartition);
+                }
+                ackPartition.setAcknowledgementBatches(acknowledgeEntry.getValue());
+            }
+
+            // Finally, build up the data to fetch
+            data.setTopics(new ArrayList<>());
+            ackMap.forEach((topicId, partMap) -> {
+                ShareAcknowledgeRequestData.AcknowledgeTopic ackTopic = new ShareAcknowledgeRequestData.AcknowledgeTopic()
+                        .setTopicId(topicId)
+                        .setPartitions(new ArrayList<>());
+                data.topics().add(ackTopic);
+
+                partMap.forEach((index, ackPartition) -> ackTopic.partitions().add(ackPartition));
+            });
+
+            return new ShareAcknowledgeRequest.Builder(data, true);
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.message.ShareFetchRequestData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -51,7 +50,7 @@ public class ShareFetchRequest extends AbstractRequest {
 
         public static Builder forConsumer(String groupId, ShareFetchMetadata metadata,
                                           int maxWait, int minBytes, int maxBytes, int fetchSize,
-                                          List<TopicIdPartition> send,
+                                          List<TopicIdPartition> send, List<TopicIdPartition> forget,
                                           Map<TopicIdPartition, List<ShareFetchRequestData.AcknowledgementBatch>> acknowledgementsMap) {
             ShareFetchRequestData data = new ShareFetchRequestData();
             data.setGroupId(groupId);
@@ -98,16 +97,34 @@ public class ShareFetchRequest extends AbstractRequest {
                 fetchPartition.setAcknowledgementBatches(acknowledgeEntry.getValue());
             }
 
-            // Finally, build up the data to fetch
-            data.setTopics(new ArrayList<>());
-            fetchMap.forEach((topicId, partMap) -> {
-                ShareFetchRequestData.FetchTopic fetchTopic = new ShareFetchRequestData.FetchTopic()
-                        .setTopicId(topicId)
-                        .setPartitions(new ArrayList<>());
-                data.topics().add(fetchTopic);
+            // Build up the data to fetch
+            if (!fetchMap.isEmpty()) {
+                data.setTopics(new ArrayList<>());
+                fetchMap.forEach((topicId, partMap) -> {
+                    ShareFetchRequestData.FetchTopic fetchTopic = new ShareFetchRequestData.FetchTopic()
+                            .setTopicId(topicId)
+                            .setPartitions(new ArrayList<>());
+                    partMap.forEach((index, fetchPartition) -> fetchTopic.partitions().add(fetchPartition));
+                    data.topics().add(fetchTopic);
+                });
+            }
 
-                partMap.forEach((index, fetchPartition) -> fetchTopic.partitions().add(fetchPartition));
-            });
+            // And finally, forget the topic-partitions that are no longer in the session
+            if (!forget.isEmpty()) {
+                Map<Uuid, List<Integer>> forgetMap = new HashMap<>();
+                for (TopicIdPartition tip : forget) {
+                    List<Integer> partList = forgetMap.computeIfAbsent(tip.topicId(), k -> new ArrayList<>());
+                    partList.add(tip.partition());
+                }
+                data.setForgottenTopicsData(new ArrayList<>());
+                forgetMap.forEach((topicId, partList) -> {
+                    ShareFetchRequestData.ForgottenTopic forgetTopic = new ShareFetchRequestData.ForgottenTopic()
+                            .setTopicId(topicId)
+                            .setPartitions(new ArrayList<>());
+                    partList.forEach(index -> forgetTopic.partitions().add(index));
+                    data.forgottenTopicsData().add(forgetTopic);
+                });
+            }
 
             return new Builder(data, true);
         }
@@ -141,20 +158,6 @@ public class ShareFetchRequest extends AbstractRequest {
     public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         Errors error = Errors.forException(e);
         return new ShareFetchResponse(new ShareFetchResponseData()
-                .setThrottleTimeMs(throttleTimeMs)
-                .setErrorCode(error.code()));
-    }
-
-    public AbstractResponse getEmptyResponse(int throttleTimeMs) {
-        return new ShareFetchResponse(new ShareFetchResponseData()
-                .setThrottleTimeMs(throttleTimeMs)
-                .setErrorCode(Errors.NONE.code())
-                .setResponses(new ArrayList<>()));
-    }
-
-    public AbstractResponse getErrorAcknowledgeResponse(int throttleTimeMs, Throwable e) {
-        Errors error = Errors.forException(e);
-        return new ShareAcknowledgeResponse(new ShareAcknowledgeResponseData()
                 .setThrottleTimeMs(throttleTimeMs)
                 .setErrorCode(error.code()));
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchRequest.java
@@ -129,6 +129,10 @@ public class ShareFetchRequest extends AbstractRequest {
             return new Builder(data, true);
         }
 
+        public ShareFetchRequestData data() {
+            return data;
+        }
+
         @Override
         public ShareFetchRequest build(short version) {
             return new ShareFetchRequest(data, version);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerTest.java
@@ -394,9 +394,9 @@ public class KafkaShareConsumerTest {
 
         AtomicBoolean heartbeatReceived = prepareShareGroupHeartbeatResponse(client, coordinator, memberId, 2, Errors.NONE);
 
-        // heartbeat interval is 2 seconds
-        time.sleep(heartbeatIntervalMs);
-        Thread.sleep(heartbeatIntervalMs);
+        // heartbeat interval is 1 second
+        time.sleep(heartbeatIntervalMs + 500);
+        Thread.sleep(heartbeatIntervalMs + 500);
 
         assertTrue(heartbeatReceived.get());
     }
@@ -425,8 +425,8 @@ public class KafkaShareConsumerTest {
         client.prepareResponseFrom(shareFetchResponse(tp0, 5L, 0), node);
         AtomicBoolean heartbeatReceived = prepareShareGroupHeartbeatResponse(client, coordinator, memberId, 2, Errors.NONE);
 
-        time.sleep(heartbeatIntervalMs);
-        Thread.sleep(heartbeatIntervalMs);
+        time.sleep(heartbeatIntervalMs + 500);
+        Thread.sleep(heartbeatIntervalMs + 500);
 
         consumer.poll(Duration.ZERO);
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AcknowledgementsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AcknowledgementsTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.AcknowledgeType;
+import org.apache.kafka.common.message.ShareAcknowledgeRequestData;
 import org.apache.kafka.common.message.ShareFetchRequestData;
 import org.junit.jupiter.api.Test;
 
@@ -32,15 +33,18 @@ public class AcknowledgementsTest {
 
     @Test
     public void testEmptyBatch() {
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertTrue(ackList.isEmpty());
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertTrue(ackList2.isEmpty());
     }
 
     @Test
     public void testSingleBatchSingleRecord() {
         acks.add(0L, AcknowledgeType.ACCEPT);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(0L, ackList.get(0).lastOffset());
@@ -48,6 +52,15 @@ public class AcknowledgementsTest {
         assertTrue(ackList.get(0).gapOffsets().isEmpty());
         assertEquals(1, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(1, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(0L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
+        assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
     }
 
     @Test
@@ -58,7 +71,7 @@ public class AcknowledgementsTest {
         acks.add(3L, AcknowledgeType.ACCEPT);
         acks.add(4L, AcknowledgeType.ACCEPT);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(4L, ackList.get(0).lastOffset());
@@ -66,6 +79,15 @@ public class AcknowledgementsTest {
         assertTrue(ackList.get(0).gapOffsets().isEmpty());
         assertNotEquals(0, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(1, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(4L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
+        assertNotEquals(0, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
     }
 
     @Test
@@ -76,7 +98,7 @@ public class AcknowledgementsTest {
         acks.add(3L, AcknowledgeType.RELEASE);
         acks.add(4L, AcknowledgeType.RELEASE);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(2, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(2L, ackList.get(0).lastOffset());
@@ -93,6 +115,24 @@ public class AcknowledgementsTest {
         assertEquals(2, ackList.get(1).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(1));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(2, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(2L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
+        assertEquals(3, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(2));
+        assertEquals(3L, ackList2.get(1).firstOffset());
+        assertEquals(4L, ackList2.get(1).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeType());
+        assertTrue(ackList2.get(1).gapOffsets().isEmpty());
+        assertEquals(2, ackList2.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(1));
     }
 
     @Test
@@ -103,7 +143,7 @@ public class AcknowledgementsTest {
         acks.add(3L, AcknowledgeType.RELEASE);
         acks.add(4L, AcknowledgeType.RELEASE);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(2, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(0L, ackList.get(0).lastOffset());
@@ -120,6 +160,24 @@ public class AcknowledgementsTest {
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(1));
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(2));
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(3));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(2, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(0L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
+        assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
+        assertEquals(1L, ackList2.get(1).firstOffset());
+        assertEquals(4L, ackList2.get(1).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeType());
+        assertTrue(ackList2.get(1).gapOffsets().isEmpty());
+        assertEquals(4, ackList2.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(2));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(3));
     }
 
     @Test
@@ -130,7 +188,7 @@ public class AcknowledgementsTest {
         acks.add(3L, AcknowledgeType.ACCEPT);
         acks.add(4L, AcknowledgeType.RELEASE);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(2, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(3L, ackList.get(0).lastOffset());
@@ -147,13 +205,31 @@ public class AcknowledgementsTest {
         assertTrue(ackList.get(1).gapOffsets().isEmpty());
         assertEquals(1, ackList.get(1).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(2, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(3L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
+        assertEquals(4, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(2));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(3));
+        assertEquals(4L, ackList2.get(1).firstOffset());
+        assertEquals(4L, ackList2.get(1).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeType());
+        assertTrue(ackList2.get(1).gapOffsets().isEmpty());
+        assertEquals(1, ackList2.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(0));
     }
 
     @Test
     public void testSingleBatchSingleGap() {
         acks.addGap(0L);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(0L, ackList.get(0).lastOffset());
@@ -161,6 +237,15 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList.get(0).gapOffsets().size());
         assertEquals(1, ackList.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(1, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(0L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertEquals(1, ackList2.get(0).gapOffsets().size());
+        assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(0));
     }
 
     @Test
@@ -168,7 +253,7 @@ public class AcknowledgementsTest {
         acks.addGap(0L);
         acks.addGap(1L);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(1L, ackList.get(0).lastOffset());
@@ -177,6 +262,16 @@ public class AcknowledgementsTest {
         assertEquals(2, ackList.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(1));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(1, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(1L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertEquals(2, ackList2.get(0).gapOffsets().size());
+        assertEquals(2, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(0));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(1));
     }
 
     @Test
@@ -184,7 +279,7 @@ public class AcknowledgementsTest {
         acks.addGap(0L);
         acks.add(1L, AcknowledgeType.ACCEPT);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(1L, ackList.get(0).lastOffset());
@@ -193,6 +288,16 @@ public class AcknowledgementsTest {
         assertEquals(2, ackList.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(1));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(1, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(1L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertEquals(1, ackList2.get(0).gapOffsets().size());
+        assertEquals(2, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(1));
     }
 
     @Test
@@ -200,7 +305,7 @@ public class AcknowledgementsTest {
         acks.add(0L, AcknowledgeType.ACCEPT);
         acks.addGap(1L);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(1L, ackList.get(0).lastOffset());
@@ -209,6 +314,16 @@ public class AcknowledgementsTest {
         assertEquals(2, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(1));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(1, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(1L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertEquals(1, ackList2.get(0).gapOffsets().size());
+        assertEquals(2, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(1));
     }
 
     @Test
@@ -219,7 +334,7 @@ public class AcknowledgementsTest {
         acks.add(3L, AcknowledgeType.ACCEPT);
         acks.add(4L, AcknowledgeType.ACCEPT);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(2, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(2L, ackList.get(0).lastOffset());
@@ -236,6 +351,24 @@ public class AcknowledgementsTest {
         assertEquals(2, ackList.get(1).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeTypes().get(0));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeTypes().get(1));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(2, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(2L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeType());
+        assertEquals(2, ackList2.get(0).gapOffsets().size());
+        assertEquals(3, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(0));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(1));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(2));
+        assertEquals(3L, ackList2.get(1).firstOffset());
+        assertEquals(4L, ackList2.get(1).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(1).acknowledgeType());
+        assertTrue(ackList2.get(1).gapOffsets().isEmpty());
+        assertEquals(2, ackList2.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(1).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(1).acknowledgeTypes().get(1));
     }
 
     @Test
@@ -246,7 +379,7 @@ public class AcknowledgementsTest {
         acks.add(3L, AcknowledgeType.RELEASE);
         acks.addGap(4L);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(2, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(0L, ackList.get(0).lastOffset());
@@ -263,6 +396,24 @@ public class AcknowledgementsTest {
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(1).acknowledgeTypes().get(1));
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(2));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(1).acknowledgeTypes().get(3));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(2, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(0L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
+        assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
+        assertEquals(1L, ackList2.get(1).firstOffset());
+        assertEquals(4L, ackList2.get(1).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeType());
+        assertEquals(2, ackList2.get(1).gapOffsets().size());
+        assertEquals(4, ackList2.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(0));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(1).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(2));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(1).acknowledgeTypes().get(3));
     }
 
     @Test
@@ -273,7 +424,7 @@ public class AcknowledgementsTest {
         acks.add(4L, AcknowledgeType.REJECT);
         acks.add(6L, AcknowledgeType.REJECT);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(4, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(0L, ackList.get(0).lastOffset());
@@ -300,6 +451,34 @@ public class AcknowledgementsTest {
         assertTrue(ackList.get(3).gapOffsets().isEmpty());
         assertEquals(1, ackList.get(3).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.REJECT.id, ackList.get(3).acknowledgeTypes().get(0));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(4, ackList2.size());
+        assertEquals(0L, ackList2.get(0).firstOffset());
+        assertEquals(0L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
+        assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
+        assertEquals(1L, ackList2.get(1).firstOffset());
+        assertEquals(1L, ackList2.get(1).lastOffset());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeType());
+        assertTrue(ackList2.get(1).gapOffsets().isEmpty());
+        assertEquals(1, ackList2.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(0));
+        assertEquals(3L, ackList2.get(2).firstOffset());
+        assertEquals(4L, ackList2.get(2).lastOffset());
+        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(2).acknowledgeType());
+        assertTrue(ackList2.get(2).gapOffsets().isEmpty());
+        assertEquals(2, ackList2.get(2).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(2).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(2).acknowledgeTypes().get(1));
+        assertEquals(6L, ackList2.get(3).firstOffset());
+        assertEquals(6L, ackList2.get(3).lastOffset());
+        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(3).acknowledgeType());
+        assertTrue(ackList2.get(3).gapOffsets().isEmpty());
+        assertEquals(1, ackList2.get(3).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(3).acknowledgeTypes().get(0));
     }
 
 
@@ -308,7 +487,7 @@ public class AcknowledgementsTest {
         acks.addGap(2L);
         acks.addGap(4L);
 
-        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getAcknowledgmentBatches();
+        List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(2, ackList.size());
         assertEquals(2L, ackList.get(0).firstOffset());
         assertEquals(2L, ackList.get(0).lastOffset());
@@ -322,5 +501,20 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList.get(1).gapOffsets().size());
         assertEquals(1, ackList.get(1).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(1).acknowledgeTypes().get(0));
+
+        List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
+        assertEquals(2, ackList2.size());
+        assertEquals(2L, ackList2.get(0).firstOffset());
+        assertEquals(2L, ackList2.get(0).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
+        assertEquals(1, ackList2.get(0).gapOffsets().size());
+        assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(0));
+        assertEquals(4L, ackList2.get(1).firstOffset());
+        assertEquals(4L, ackList2.get(1).lastOffset());
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(1).acknowledgeType());
+        assertEquals(1, ackList2.get(1).gapOffsets().size());
+        assertEquals(1, ackList2.get(1).acknowledgeTypes().size());
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(1).acknowledgeTypes().get(0));
     }
 }

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -52,11 +52,9 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -243,7 +241,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(2000));
         assertEquals(1, records.count());
         // Now in the second poll, we implicitly acknowledge the record received in the first poll.
-        // We get back the acknowledgment error code after the second poll.
+        // We get back the acknowledgement error code after the second poll.
         // The acknowledgement commit callback is invoked in close.
         shareConsumer.poll(Duration.ofMillis(2000));
         shareConsumer.close();
@@ -288,9 +286,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
 
         @Override
         public void onComplete(Map<TopicIdPartition, Set<Long>> offsetsMap, Exception exception) {
-            offsetsMap.forEach((partition, offsets) -> offsets.forEach(offset -> {
-                partitionExceptionMap.put(partition.topicPartition(), exception);
-            }));
+            offsetsMap.forEach((partition, offsets) -> offsets.forEach(offset -> partitionExceptionMap.put(partition.topicPartition(), exception)));
         }
     }
 
@@ -591,7 +587,6 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
-    @Disabled
     public void testMultipleConsumersInGroupSequentialConsumption(String quorum) {
         ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp().topic(), tp().partition(), null, "key".getBytes(), "value".getBytes());
         KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
@@ -667,6 +662,8 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
                 totalMessagesConsumed.addAndGet(records.count());
                 retries++;
             }
+            // One final poll to complete acknowledgement of the records (will be commit once we have that)
+            shareConsumer.poll(Duration.ofMillis(2000));
         } catch (Exception e) {
             fail("Consumer " + consumerNumber + " failed with exception: " + e);
         } finally {
@@ -678,7 +675,6 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
-    @Disabled
     public void testMultipleConsumersInGroupConcurrentConsumption(String quorum) {
         AtomicInteger totalMessagesConsumed = new AtomicInteger(0);
 
@@ -720,10 +716,8 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
     }
 
     // This test is disabled because it is not stable and fails intermittently.
-    @Disabled
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
-    @Disabled
     public void testMultipleConsumersInMultipleGroupsConcurrentConsumption(String quorum) {
         AtomicInteger totalMessagesConsumedGroup1 = new AtomicInteger(0);
         AtomicInteger totalMessagesConsumedGroup2 = new AtomicInteger(0);
@@ -866,29 +860,12 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
-    @Disabled
     public void testMultipleConsumersInGroupFailureConcurrentConsumption(String quorum) {
         AtomicInteger totalMessagesConsumed = new AtomicInteger(0);
 
         int consumerCount = 5;
         int producerCount = 5;
         int messagesPerProducer = 2000;
-
-        Random random = new Random();
-        // Generates a random number between 1 and consumerCount, this represents the random number of consumers that will be simulated to fail
-        int totalConsumerFailures = random.nextInt(consumerCount - 1) + 1;
-        System.out.println("number of failing consumers : " + totalConsumerFailures);
-        Set<Integer> failedConsumers = new HashSet<>();
-
-        while (failedConsumers.size() < totalConsumerFailures) {
-            int randomNumber = random.nextInt(consumerCount) + 1; // Generates a random number between 1 and 5
-            failedConsumers.add(randomNumber);
-        }
-
-        System.out.println("Failing consumers are :-");
-        for (Integer consumer : failedConsumers) {
-            System.out.println(consumer);
-        }
 
         ExecutorService consumerExecutorService = Executors.newFixedThreadPool(consumerCount);
         ExecutorService producerExecutorService = Executors.newFixedThreadPool(producerCount);
@@ -903,19 +880,17 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         ConcurrentLinkedQueue<CompletableFuture<Integer>> futuresSuccess = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<CompletableFuture<Integer>> futuresFail = new ConcurrentLinkedQueue<>();
 
+        consumerExecutorService.submit(() -> {
+            // The "failing" consumer polls but immediately closes, which releases the records for the other consumers
+            CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumed, producerCount * messagesPerProducer, "group1", 0, 0);
+            futuresFail.add(future);
+        });
         for (int i = 0; i < consumerCount; i++) {
             final int consumerNumber = i + 1;
-            if (failedConsumers.contains(consumerNumber)) {
-                consumerExecutorService.submit(() -> {
-                    CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumed, producerCount * messagesPerProducer, "group1", consumerNumber, 1);
-                    futuresFail.add(future);
-                });
-            } else {
-                consumerExecutorService.submit(() -> {
-                    CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumed, producerCount * messagesPerProducer, "group1", consumerNumber, 25);
-                    futuresSuccess.add(future);
-                });
-            }
+            consumerExecutorService.submit(() -> {
+                CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumed, producerCount * messagesPerProducer, "group1", consumerNumber, 25);
+                futuresSuccess.add(future);
+            });
         }
         producerExecutorService.shutdown();
         consumerExecutorService.shutdown();
@@ -1067,7 +1042,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
     }
 
     /**
-     * Test to verify that the acknowledgement commit callback can throw an exception and it is propagated
+     * Test to verify that the acknowledgement commit callback can throw an exception, and it is propagated
      * to the caller of poll().
      */
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
@@ -1100,7 +1075,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
     }
 
     /**
-     * Test to verify that calling Thread.interrupt before KafkaShareConsumer.poll(Duration)
+     * Test to verify that calling Thread.interrupt() before KafkaShareConsumer.poll(Duration)
      * causes it to throw InterruptException
      */
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
@@ -1194,6 +1169,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
     @Disabled
+    // This test is under development and disabled while it is still flaky
     public void testSubscriptionAndPollFollowedByTopicDeletion(String quorum) {
         String topic1 = "bar";
         String topic2 = "baz";

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -591,6 +591,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
+    @Disabled
     public void testMultipleConsumersInGroupSequentialConsumption(String quorum) {
         ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp().topic(), tp().partition(), null, "key".getBytes(), "value".getBytes());
         KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
@@ -611,12 +612,15 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         int consumer1MessageCount = 0;
         int consumer2MessageCount = 0;
 
-        while (true) {
+        int maxRetries = 10;
+        int retries = 0;
+        while (retries < maxRetries) {
             ConsumerRecords<byte[], byte[]> records1 = shareConsumer1.poll(Duration.ofMillis(2000));
             consumer1MessageCount += records1.count();
             ConsumerRecords<byte[], byte[]> records2 = shareConsumer2.poll(Duration.ofMillis(2000));
             consumer2MessageCount += records2.count();
             if (records1.count() + records2.count() == 0) break;
+            retries++;
         }
 
         assertEquals(totalMessages, consumer1MessageCount + consumer2MessageCount);
@@ -719,6 +723,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
     @Disabled
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
+    @Disabled
     public void testMultipleConsumersInMultipleGroupsConcurrentConsumption(String quorum) {
         AtomicInteger totalMessagesConsumedGroup1 = new AtomicInteger(0);
         AtomicInteger totalMessagesConsumedGroup2 = new AtomicInteger(0);
@@ -840,9 +845,12 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         // because the consumer is closed, which makes the broker release the records fetched.
         ConsumerRecords<byte[], byte[]> records1 = shareConsumer1.poll(Duration.ofMillis(2000));
         consumer1MessageCount += records1.count();
+        int consumer1MessageCountA = records1.count();
         records1 = shareConsumer1.poll(Duration.ofMillis(2000));
         consumer1MessageCount += records1.count();
-        shareConsumer1.poll(Duration.ofMillis(2000));
+        int consumer1MessageCountB = records1.count();
+        records1 = shareConsumer1.poll(Duration.ofMillis(2000));
+        int consumer1MessageCountC = records1.count();
         shareConsumer1.close();
 
         int maxRetries = 10;
@@ -858,7 +866,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
-    @Disabled // This test remains disabled until the broker releases records automatically when a share session is closed
+    @Disabled
     public void testMultipleConsumersInGroupFailureConcurrentConsumption(String quorum) {
         AtomicInteger totalMessagesConsumed = new AtomicInteger(0);
 
@@ -867,8 +875,9 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         int messagesPerProducer = 2000;
 
         Random random = new Random();
-        int totalConsumerFailures = random.nextInt(consumerCount - 1) + 1; // Generates a random number between 1 and consumerCount, this represents the random number of consumers that will be simulated to fail
-            System.out.println("number of failing consumers : " + totalConsumerFailures);
+        // Generates a random number between 1 and consumerCount, this represents the random number of consumers that will be simulated to fail
+        int totalConsumerFailures = random.nextInt(consumerCount - 1) + 1;
+        System.out.println("number of failing consumers : " + totalConsumerFailures);
         Set<Integer> failedConsumers = new HashSet<>();
 
         while (failedConsumers.size() < totalConsumerFailures) {


### PR DESCRIPTION
Use the ShareAcknowledge RPC to close the share session. This has recently been added to the broker so the original intent of KIP-932 can now be implemented.

This PR contains significant refactoring of the share session handling and fetching, with additional testing.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
