### PR TITLE
AKCORE-129-2: Bugfix for the issue where partition maxInFlightMessages limit was getting exceeded with multiple consumers

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -384,8 +384,7 @@ public class SharePartition {
                 log.trace("No cached data exists for the share partition for requested fetch batch: {}-{}",
                     groupId, topicIdPartition);
                 return CompletableFuture.completedFuture(Collections.singletonList(
-                            acquireNewBatchRecords(memberId, firstBatch.baseOffset(), lastBatch.lastOffset(),
-                            lastBatch.nextOffset())));
+                            acquireNewBatchRecords(memberId, firstBatch.baseOffset(), lastBatch.lastOffset())));
             }
 
             log.trace("Overlap exists with in-flight records. Acquire the records if available for"
@@ -455,7 +454,7 @@ public class SharePartition {
             if (subMap.lastEntry().getValue().lastOffset < lastBatch.lastOffset()) {
                 log.trace("There exists another batch which needs to be acquired as well");
                 result.add(acquireNewBatchRecords(memberId, subMap.lastEntry().getValue().lastOffset() + 1,
-                    lastBatch.lastOffset(), lastBatch.nextOffset()));
+                    lastBatch.lastOffset()));
             }
             return CompletableFuture.completedFuture(result);
         } finally {
@@ -1014,7 +1013,7 @@ public class SharePartition {
         }
     }
 
-    private AcquiredRecords acquireNewBatchRecords(String memberId, long firstOffset, long lastOffset, long nextOffset) {
+    private AcquiredRecords acquireNewBatchRecords(String memberId, long firstOffset, long lastOffset) {
         lock.writeLock().lock();
         try {
             // Schedule acquisition lock timeout for the batch.
@@ -1032,7 +1031,7 @@ public class SharePartition {
                 startOffset = firstOffset;
             }
             endOffset = lastOffset;
-            nextFetchOffset = nextOffset;
+            findNextFetchOffset.set(true);
             return new AcquiredRecords()
                 .setFirstOffset(firstOffset)
                 .setLastOffset(lastOffset)

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -4041,6 +4041,76 @@ public class SharePartitionTest {
     }
 
     @Test
+    void testNextFetchOffsetWorksCorrectlyWithMultipleConsumers() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().withMaxInflightMessages(100).build();
+        MemoryRecords records1 = memoryRecords(3, 0);
+        MemoryRecords records2 = memoryRecords(2, 3);
+
+        String memberId1 = "member-1";
+        String memberId2 = "member-2";
+
+        CompletableFuture<List<AcquiredRecords>> result = sharePartition.acquire(
+                memberId1,
+                new FetchPartitionData(Errors.NONE, 20, 0, records1,
+                        Optional.empty(), OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        assertFalse(result.isCompletedExceptionally());
+        assertEquals(1, result.join().size());
+        assertEquals(1, sharePartition.cachedState().size());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).batchState());
+        assertEquals(memberId1, sharePartition.cachedState().get(0L).batchMemberId());
+        assertEquals(3, sharePartition.nextFetchOffset());
+
+        CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
+                memberId1,
+                Collections.singletonList(new AcknowledgementBatch(0, 2, null, AcknowledgeType.RELEASE)));
+        assertFalse(ackResult.isCompletedExceptionally());
+        assertFalse(ackResult.join().isPresent());
+
+        assertEquals(1, sharePartition.cachedState().size());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
+        assertEquals(0, sharePartition.nextFetchOffset());
+
+        result = sharePartition.acquire(
+                memberId2,
+                new FetchPartitionData(Errors.NONE, 20, 0, records2,
+                        Optional.empty(), OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        assertFalse(result.isCompletedExceptionally());
+        assertEquals(1, result.join().size());
+        assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(3L).batchState());
+        assertEquals(memberId2, sharePartition.cachedState().get(3L).batchMemberId());
+        assertEquals(0, sharePartition.nextFetchOffset());
+
+        result = sharePartition.acquire(
+                memberId1,
+                new FetchPartitionData(Errors.NONE, 20, 0, records1,
+                        Optional.empty(), OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        assertFalse(result.isCompletedExceptionally());
+        assertEquals(1, result.join().size());
+        assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).batchState());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(3L).batchState());
+        assertEquals(memberId1, sharePartition.cachedState().get(0L).batchMemberId());
+        assertEquals(memberId2, sharePartition.cachedState().get(3L).batchMemberId());
+        assertEquals(5, sharePartition.nextFetchOffset());
+
+        ackResult = sharePartition.acknowledge(
+                memberId2,
+                Collections.singletonList(new AcknowledgementBatch(3, 4, null, AcknowledgeType.RELEASE)));
+        assertFalse(ackResult.isCompletedExceptionally());
+        assertFalse(ackResult.join().isPresent());
+
+        assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).batchState());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(3L).batchState());
+        assertEquals(3, sharePartition.nextFetchOffset());
+    }
+
+    @Test
     public void testWriteShareGroupStateWithNullResponse() {
         Persister persister = Mockito.mock(Persister.class);
         mockPersisterReadStateMethod(persister);


### PR DESCRIPTION
With the previous code, when there were multiple consumers consuming from a single topic partition with a huge number of records, maxInFlightMessages limit was getting exceeded. This was because next fetch offset handling was a bit off. When a new batch of records are being acquired, there could be a possibility that some records prior to this batch have been released. So instead of strictly setting nextFetchOffset to the next offset of the last offset of the new batch acquired, the nextFetchOffset should be computed again

Reference: [AKCORE-129](https://confluentinc.atlassian.net/jira/software/c/projects/AKCORE/issues/AKCORE-129?jql=project%20%3D%20%22AKCORE%22%20ORDER%20BY%20created%20DESC)