### PR TITLE
AKCORE-147: Changed tests in KafkaApisTest.scala to support share groups related configs in the broker

### DIFF
--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4355,6 +4355,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.ZERO_UUID
 
@@ -4385,7 +4386,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
     val response = verifyNoThrottling[ShareFetchResponse](request)
     val responseData = response.data()
@@ -4406,6 +4412,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.randomUuid()
 
@@ -4444,7 +4451,12 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
     var responseData = response.data()
@@ -4480,7 +4492,6 @@ class KafkaApisTest extends Logging {
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
     kafkaApis.handleShareFetchRequest(request)
     response = verifyNoThrottling[ShareFetchResponse](request)
     responseData = response.data()
@@ -4501,6 +4512,7 @@ class KafkaApisTest extends Logging {
   def testHandleShareFetchRequestInvalidRequestOnInitialEpoch() : Unit = {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.ZERO_UUID
 
@@ -4530,7 +4542,12 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
     var responseData = response.data()
@@ -4564,7 +4581,6 @@ class KafkaApisTest extends Logging {
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
     kafkaApis.handleShareFetchRequest(request)
     response = verifyNoThrottling[ShareFetchResponse](request)
     responseData = response.data()
@@ -4586,6 +4602,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.ZERO_UUID
 
@@ -4616,7 +4633,12 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
     var responseData = response.data()
@@ -4652,7 +4674,6 @@ class KafkaApisTest extends Logging {
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
     kafkaApis.handleShareFetchRequest(request)
     response = verifyNoThrottling[ShareFetchResponse](request)
     responseData = response.data()
@@ -4665,6 +4686,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.ZERO_UUID
 
@@ -4695,7 +4717,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
     val response = verifyNoThrottling[ShareFetchResponse](request)
     val responseData = response.data()
@@ -4717,6 +4744,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.ZERO_UUID
 
@@ -4748,7 +4776,12 @@ class KafkaApisTest extends Logging {
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
     var responseData = response.data()
@@ -4780,7 +4813,6 @@ class KafkaApisTest extends Logging {
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
     kafkaApis.handleShareFetchRequest(request)
     response = verifyNoThrottling[ShareFetchResponse](request)
     responseData = response.data()
@@ -4802,7 +4834,6 @@ class KafkaApisTest extends Logging {
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
     kafkaApis.handleShareFetchRequest(request)
     response = verifyNoThrottling[ShareFetchResponse](request)
     responseData = response.data()
@@ -4815,6 +4846,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId: Uuid = Uuid.ZERO_UUID
 
@@ -4846,7 +4878,12 @@ class KafkaApisTest extends Logging {
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
     var responseData = response.data()
@@ -4875,7 +4912,6 @@ class KafkaApisTest extends Logging {
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
     kafkaApis.handleShareFetchRequest(request)
     response = verifyNoThrottling[ShareFetchResponse](request)
     responseData = response.data()
@@ -4912,6 +4948,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId: Uuid = Uuid.randomUuid()
 
@@ -4960,7 +4997,12 @@ class KafkaApisTest extends Logging {
     var request = buildRequest(shareFetchRequest)
 
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
     var responseData = response.data()
@@ -5073,6 +5115,7 @@ class KafkaApisTest extends Logging {
     val topicName4 = "foo4"
     val topicId4 = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName1, 2, topicId = topicId1)
     addTopicToMetadataCache(topicName2, 2, topicId = topicId2)
     addTopicToMetadataCache(topicName3, 1, topicId = topicId3)
@@ -5154,7 +5197,12 @@ class KafkaApisTest extends Logging {
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
     var responseData = response.data()
@@ -5239,7 +5287,6 @@ class KafkaApisTest extends Logging {
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
     kafkaApis.handleShareFetchRequest(request)
     response = verifyNoThrottling[ShareFetchResponse](request)
     responseData = response.data()
@@ -5284,7 +5331,6 @@ class KafkaApisTest extends Logging {
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
     kafkaApis.handleShareFetchRequest(request)
     response = verifyNoThrottling[ShareFetchResponse](request)
     responseData = response.data()
@@ -5401,7 +5447,6 @@ class KafkaApisTest extends Logging {
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
     kafkaApis.handleShareFetchRequest(request)
     response = verifyNoThrottling[ShareFetchResponse](request)
     responseData = response.data()
@@ -5418,6 +5463,7 @@ class KafkaApisTest extends Logging {
     val topicId1 = Uuid.randomUuid()
     val topicId2 = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName1, 1, topicId = topicId1)
     addTopicToMetadataCache(topicName2, 2, topicId = topicId2)
 
@@ -5522,7 +5568,12 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     val shareFetchResponse : ShareFetchResponse = kafkaApis.handleFetchFromShareFetchRequest(
       request,
       erroneousAndValidPartitionData,
@@ -5592,6 +5643,7 @@ class KafkaApisTest extends Logging {
     val topicId1 = Uuid.randomUuid()
     val topicId2 = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName1, 1, topicId = topicId1)
     addTopicToMetadataCache(topicName2, 2, topicId = topicId2)
 
@@ -5694,7 +5746,12 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     val shareFetchResponse : ShareFetchResponse = kafkaApis.handleFetchFromShareFetchRequest(
       request,
       erroneousAndValidPartitionData,
@@ -5750,13 +5807,13 @@ class KafkaApisTest extends Logging {
     )
   }
 
-
   @Test
   def testHandleShareFetchFromShareFetchRequestFetchMessagesReturnError() : Unit = {
     val shareSessionEpoch = 0
     val topicName1 = "foo1"
     val topicId1 = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName1, 1, topicId = topicId1)
 
     val memberId: Uuid = Uuid.ZERO_UUID
@@ -5818,8 +5875,12 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(
-      overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"),
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true,
       sharePartitionManager = sharePartitionManagerMock
     )
 
@@ -5850,6 +5911,7 @@ class KafkaApisTest extends Logging {
     val topicId1 = Uuid.randomUuid()
     val topicId2 = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName1, 1, topicId = topicId1)
     addTopicToMetadataCache(topicName2, 2, topicId = topicId2)
 
@@ -5952,7 +6014,12 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     val shareFetchResponse : ShareFetchResponse = kafkaApis.handleFetchFromShareFetchRequest(
       request,
       erroneousAndValidPartitionData,
@@ -6024,6 +6091,7 @@ class KafkaApisTest extends Logging {
     val topicId2 = Uuid.randomUuid()
     val topicId3 = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName1, 1, topicId = topicId1)
     addTopicToMetadataCache(topicName2, 2, topicId = topicId2)
     // topicName3 is not in the metadataCache
@@ -6145,7 +6213,12 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     val shareFetchResponse : ShareFetchResponse = kafkaApis.handleFetchFromShareFetchRequest(
       request,
       erroneousAndValidPartitionData,
@@ -6242,6 +6315,7 @@ class KafkaApisTest extends Logging {
     val tp2 = new TopicIdPartition(topicId2, new TopicPartition(topicName2, 0))
     val tp3 = new TopicIdPartition(topicId2, new TopicPartition(topicName2, 1))
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName1, 2, topicId = topicId1)
     addTopicToMetadataCache(topicName2, 1, topicId = topicId2)
     val memberId: Uuid = Uuid.ZERO_UUID
@@ -6321,7 +6395,12 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
 
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"),
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true,
       sharePartitionManager = sharePartitionManagerMock)
     val ackResult = kafkaApis.handleAcknowledgements(
       request,
@@ -6360,6 +6439,7 @@ class KafkaApisTest extends Logging {
     val tp4 = new TopicIdPartition(topicId3, new TopicPartition(topicName3, 0))
     val tp5 = new TopicIdPartition(topicId4, new TopicPartition(topicName4, 0))
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName1, 1, topicId = topicId1)
     addTopicToMetadataCache(topicName2, 2, topicId = topicId2)
     addTopicToMetadataCache(topicName3, 1, topicId = topicId3)
@@ -6467,7 +6547,12 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
 
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"),
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true,
       sharePartitionManager = sharePartitionManagerMock)
     val ackResult = kafkaApis.handleAcknowledgements(
       request,
@@ -6506,6 +6591,7 @@ class KafkaApisTest extends Logging {
     val tp2 = new TopicIdPartition(topicId_2, new TopicPartition(topicName_2, 0))
     val tp3 = new TopicIdPartition(topicId_2, new TopicPartition(topicName_2, 1))
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName_1, 1, topicId = topicId_1)
     addTopicToMetadataCache(topicName_2, 2, topicId = topicId_2)
 
@@ -6581,7 +6667,12 @@ class KafkaApisTest extends Logging {
     ).asJava))
 
     val shareFetchRequest = buildRequest(new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion))
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true", KafkaConfig.ShareGroupEnableProp -> "true"),
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true,
       sharePartitionManager = sharePartitionManagerMock)
 
     val shareAcknowledgeResponse = kafkaApis.handleAcknowledgements(
@@ -9769,6 +9860,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.randomUuid()
 
@@ -9817,8 +9909,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
@@ -9842,6 +9938,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.randomUuid()
 
@@ -9890,8 +9987,12 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
@@ -9942,6 +10043,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.randomUuid()
 
@@ -9990,8 +10092,12 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
@@ -10041,6 +10147,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.ZERO_UUID
 
@@ -10089,8 +10196,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
@@ -10108,6 +10219,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val memberId : Uuid = Uuid.ZERO_UUID
 
@@ -10161,8 +10273,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true"),
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true,
       authorizer = Option(authorizer))
     kafkaApis.handleShareFetchRequest(request)
 
@@ -10181,6 +10297,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val groupId : String = "group"
     val memberId : Uuid = Uuid.ZERO_UUID
@@ -10230,8 +10347,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
@@ -10249,6 +10370,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val groupId : String = "group"
     val memberId : Uuid = Uuid.ZERO_UUID
@@ -10298,8 +10420,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
@@ -10320,6 +10446,7 @@ class KafkaApisTest extends Logging {
     val topicId1 = Uuid.randomUuid()
     val topicId2 = Uuid.randomUuid()
     val topicId3 = Uuid.randomUuid()
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName1, 1, topicId = topicId1)
     addTopicToMetadataCache(topicName2, 1, topicId = topicId2)
     addTopicToMetadataCache(topicName3, 1, topicId = topicId3)
@@ -10369,8 +10496,12 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
 
     var fetchResponse = verifyNoThrottling[ShareFetchResponse](request)
@@ -10529,6 +10660,7 @@ class KafkaApisTest extends Logging {
     val topicName = "foo"
     val topicId = Uuid.randomUuid()
     val partitionIndex = 0
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicName, 1, topicId = topicId)
     val groupId : String = "group"
     val memberId : Uuid = Uuid.ZERO_UUID
@@ -10578,8 +10710,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     kafkaApis.handleShareFetchRequest(request)
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
@@ -10605,6 +10741,7 @@ class KafkaApisTest extends Logging {
     val partitionIndex = 0
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(topicName, partitionIndex))
     val topicPartition = topicIdPartition.topicPartition
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache(topicPartition.topic, numPartitions = 1, numBrokers = 3, topicId)
     val memberId : Uuid = Uuid.ZERO_UUID
 
@@ -10666,8 +10803,12 @@ class KafkaApisTest extends Logging {
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
     val request = buildRequest(shareAcknowledgeRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true"),
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true,
       sharePartitionManager = sharePartitionManagerMock)
     kafkaApis.handleShareAcknowledgeRequest(request)
     val response = verifyNoThrottling[ShareAcknowledgeResponse](request)
@@ -10730,6 +10871,7 @@ class KafkaApisTest extends Logging {
   def testGetAcknowledgeBatchesFromShareFetchRequest() : Unit = {
     val topicId1 = Uuid.randomUuid()
     val topicId2 = Uuid.randomUuid()
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     val shareFetchRequestData = new ShareFetchRequestData().
       setGroupId("group").
       setMemberId(Uuid.randomUuid().toString).
@@ -10784,7 +10926,12 @@ class KafkaApisTest extends Logging {
     topicNames.put(topicId2, "foo2")
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
 
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     val acknowledgeBatches = kafkaApis.getAcknowledgeBatchesFromShareFetchRequest(shareFetchRequest, topicNames, erroneous)
 
     assertEquals(3, acknowledgeBatches.size)
@@ -10802,6 +10949,7 @@ class KafkaApisTest extends Logging {
   def testGetAcknowledgeBatchesFromShareFetchRequestError() : Unit = {
     val topicId1 = Uuid.randomUuid()
     val topicId2 = Uuid.randomUuid()
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     val shareFetchRequestData = new ShareFetchRequestData().
       setGroupId("group").
       setMemberId(Uuid.randomUuid().toString).
@@ -10827,7 +10975,12 @@ class KafkaApisTest extends Logging {
     topicNames.put(topicId2, "foo2")
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
 
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     val acknowledgeBatches = kafkaApis.getAcknowledgeBatchesFromShareFetchRequest(shareFetchRequest, topicNames, erroneous)
 
     assertEquals(0, acknowledgeBatches.size)
@@ -10840,6 +10993,7 @@ class KafkaApisTest extends Logging {
     val topicId1 = Uuid.randomUuid()
     val topicId2 = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     val shareAcknowledgeRequestData = new ShareAcknowledgeRequestData().
       setGroupId("group").
       setMemberId(Uuid.randomUuid().toString).
@@ -10889,7 +11043,12 @@ class KafkaApisTest extends Logging {
     topicNames.put(topicId2, "foo2")
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
 
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     val acknowledgeBatches = kafkaApis.getAcknowledgeBatchesFromShareAcknowledgeRequest(shareAcknowledgeRequest, topicNames, erroneous)
 
     assertEquals(3, acknowledgeBatches.size)
@@ -10908,6 +11067,7 @@ class KafkaApisTest extends Logging {
     val topicId1 = Uuid.randomUuid()
     val topicId2 = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     val shareAcknowledgeRequestData = new ShareAcknowledgeRequestData().
       setGroupId("group").
       setMemberId(Uuid.randomUuid().toString).
@@ -10933,7 +11093,12 @@ class KafkaApisTest extends Logging {
     topicNames.put(topicId2, "foo2")
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
 
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     val acknowledgeBatches = kafkaApis.getAcknowledgeBatchesFromShareAcknowledgeRequest(shareAcknowledgeRequest, topicNames, erroneous)
 
     assertEquals(0, acknowledgeBatches.size)
@@ -10948,6 +11113,7 @@ class KafkaApisTest extends Logging {
     val topicId2 = Uuid.randomUuid()
     val memberId = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache("foo1", 1, topicId = topicId1)
     addTopicToMetadataCache("foo2", 2, topicId = topicId2)
 
@@ -11022,7 +11188,12 @@ class KafkaApisTest extends Logging {
           .setErrorCode(Errors.NONE.code())
     ).asJava))
 
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"),
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true,
       sharePartitionManager = sharePartitionManagerMock)
     val ackResult = kafkaApis.handleAcknowledgements(
       request,
@@ -11054,6 +11225,7 @@ class KafkaApisTest extends Logging {
     val topicId2 = Uuid.randomUuid()
     val memberId = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache("foo1", 1, topicId = topicId1)
     addTopicToMetadataCache("foo2", 2, topicId = topicId2)
 
@@ -11125,7 +11297,12 @@ class KafkaApisTest extends Logging {
             .setErrorCode(Errors.NONE.code())
       ).asJava))
 
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"),
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true,
       sharePartitionManager = sharePartitionManagerMock)
     val ackResult = kafkaApis.handleAcknowledgements(
       request,
@@ -11157,6 +11334,7 @@ class KafkaApisTest extends Logging {
     val topicId2 = Uuid.randomUuid()
     val memberId = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     addTopicToMetadataCache("foo1", 1, topicId = topicId1)
     addTopicToMetadataCache("foo2", 2, topicId = topicId2)
 
@@ -11236,7 +11414,12 @@ class KafkaApisTest extends Logging {
             .setErrorCode(Errors.NONE.code())
       ).asJava))
 
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"),
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true,
       sharePartitionManager = sharePartitionManagerMock)
     val ackResult = kafkaApis.handleAcknowledgements(
       request,
@@ -11268,6 +11451,7 @@ class KafkaApisTest extends Logging {
     val topicId2 = Uuid.randomUuid()
     val memberId = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     // Topic with id topicId1 is not present in Metadata Cache
     addTopicToMetadataCache("foo2", 2, topicId = topicId2)
 
@@ -11347,7 +11531,12 @@ class KafkaApisTest extends Logging {
             .setErrorCode(Errors.NONE.code())
       ).asJava))
 
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"),
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true,
       sharePartitionManager = sharePartitionManagerMock)
     val ackResult = kafkaApis.handleAcknowledgements(
       request,
@@ -11379,6 +11568,7 @@ class KafkaApisTest extends Logging {
     val topicId1 = Uuid.randomUuid()
     val topicId2 = Uuid.randomUuid()
 
+    metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     val responseAcknowledgeData: mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData] = mutable.Map()
     responseAcknowledgeData += (new TopicIdPartition(topicId1, new TopicPartition("foo", 0)) ->
       new ShareAcknowledgeResponseData.PartitionData().setPartitionIndex(0).setErrorCode(Errors.NONE.code()))
@@ -11443,7 +11633,12 @@ class KafkaApisTest extends Logging {
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
     val request = buildRequest(shareAcknowledgeRequest)
-    kafkaApis = createKafkaApis(overrideProperties = Map(KafkaConfig.ShareGroupEnableProp -> "true"))
+    kafkaApis = createKafkaApis(overrideProperties = Map(
+      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
+      KafkaConfig.ShareGroupEnableProp -> "true",
+      KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
+      KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
+      raftSupport = true)
     val response = kafkaApis.AcknowledgeResponseCallback(responseAcknowledgeData, request, topicNames)
     val responseData = response.data()
     val topicResponses = responseData.responses()

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4387,8 +4387,6 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -4452,8 +4450,6 @@ class KafkaApisTest extends Logging {
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -4543,8 +4539,6 @@ class KafkaApisTest extends Logging {
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -4634,8 +4628,6 @@ class KafkaApisTest extends Logging {
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -4718,8 +4710,6 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -4777,8 +4767,6 @@ class KafkaApisTest extends Logging {
     var request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -4879,8 +4867,6 @@ class KafkaApisTest extends Logging {
     var request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -4998,8 +4984,6 @@ class KafkaApisTest extends Logging {
 
     // First fetch request is to establish the share session with the broker
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -5198,8 +5182,6 @@ class KafkaApisTest extends Logging {
     var request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -5569,8 +5551,6 @@ class KafkaApisTest extends Logging {
     val request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -5747,8 +5727,6 @@ class KafkaApisTest extends Logging {
     val request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -5876,8 +5854,6 @@ class KafkaApisTest extends Logging {
     val request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true,
@@ -6015,8 +5991,6 @@ class KafkaApisTest extends Logging {
     val request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -6214,8 +6188,6 @@ class KafkaApisTest extends Logging {
     val request = buildRequest(shareFetchRequest)
     // First fetch request is to establish the share session with the broker
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -6396,8 +6368,6 @@ class KafkaApisTest extends Logging {
     val request = buildRequest(shareFetchRequest)
 
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true,
@@ -6548,8 +6518,6 @@ class KafkaApisTest extends Logging {
     val request = buildRequest(shareFetchRequest)
 
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true,
@@ -6668,8 +6636,6 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = buildRequest(new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion))
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true,
@@ -9910,8 +9876,6 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -9988,8 +9952,6 @@ class KafkaApisTest extends Logging {
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -10093,8 +10055,6 @@ class KafkaApisTest extends Logging {
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -10197,8 +10157,6 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -10274,8 +10232,6 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true,
@@ -10348,8 +10304,6 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -10421,8 +10375,6 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -10497,8 +10449,6 @@ class KafkaApisTest extends Logging {
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -10711,8 +10661,6 @@ class KafkaApisTest extends Logging {
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -10804,8 +10752,6 @@ class KafkaApisTest extends Logging {
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
     val request = buildRequest(shareAcknowledgeRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true,
@@ -10927,8 +10873,6 @@ class KafkaApisTest extends Logging {
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
 
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -10976,8 +10920,6 @@ class KafkaApisTest extends Logging {
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
 
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -11044,8 +10986,6 @@ class KafkaApisTest extends Logging {
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
 
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -11094,8 +11034,6 @@ class KafkaApisTest extends Logging {
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
 
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)
@@ -11189,8 +11127,6 @@ class KafkaApisTest extends Logging {
     ).asJava))
 
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true,
@@ -11298,8 +11234,6 @@ class KafkaApisTest extends Logging {
       ).asJava))
 
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true,
@@ -11415,8 +11349,6 @@ class KafkaApisTest extends Logging {
       ).asJava))
 
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true,
@@ -11532,8 +11464,6 @@ class KafkaApisTest extends Logging {
       ).asJava))
 
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true,
@@ -11634,8 +11564,6 @@ class KafkaApisTest extends Logging {
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
     val request = buildRequest(shareAcknowledgeRequest)
     kafkaApis = createKafkaApis(overrideProperties = Map(
-      KafkaConfig.NewGroupCoordinatorEnableProp -> "true",
-      KafkaConfig.ShareGroupEnableProp -> "true",
       KafkaConfig.GroupCoordinatorRebalanceProtocolsProp -> "classic,consumer,share",
       KafkaConfig.UnstableApiVersionsEnableProp -> "true"),
       raftSupport = true)


### PR DESCRIPTION
The tests in KafkaApisTest.scala were not passing share group related configs to the broker. Also, the tests were written for zk based cluster. Required changes have been made in this PR

Reference: [AKCORE-147](https://confluentinc.atlassian.net/jira/software/c/projects/AKCORE/issues/AKCORE-147?jql=project%20%3D%20%22AKCORE%22%20ORDER%20BY%20created%20DESC)

[AKCORE-147]: https://confluentinc.atlassian.net/browse/AKCORE-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ