### PR TITLE
MINOR: Integrated NoOpPersister with share partition leader

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -856,15 +856,6 @@ public class SharePartition {
     private void initialize() {
         // Initialize the partition.
         log.debug("Initializing share partition: {}-{}", groupId, topicIdPartition);
-        // Persister class can be null during active development and shall be driven by temporary config.
-        if (persister == null) {
-            // Set the default states so that the partition can be used without the persister.
-            startOffset = 0;
-            endOffset = 0;
-            nextFetchOffset = 0;
-            stateEpoch = 0;
-            return;
-        }
 
         // Initialize the partition by issuing an initialize RPC call to persister.
         ReadShareGroupStateResult response = null;
@@ -1235,9 +1226,6 @@ public class SharePartition {
     // Visible for testing
      boolean isWriteShareGroupStateSuccessful(List<PersisterStateBatch> stateBatches) {
         try {
-            // Persister class can be null during active development and shall be driven by temporary config.
-            if (persister == null)
-                return true;
             WriteShareGroupStateResult response = persister.writeState(new WriteShareGroupStateParameters.Builder()
                 .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
                     .setGroupId(this.groupId)

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -275,7 +275,7 @@ public class SharePartitionManager implements AutoCloseable {
     // Visible for testing.
     SharePartition sharePartition(ShareFetchPartitionData shareFetchPartitionData, TopicIdPartition topicIdPartition) {
         try {
-            Persister persister = new NoOpShareStatePersister();
+            Persister persister = NoOpShareStatePersister.getInstance();
             if (!shareGroupPersisterClassName.isEmpty())
                 persister = Utils.newInstance(shareGroupPersisterClassName, Persister.class);
             return new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, maxInFlightMessages, maxDeliveryCount,

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.requests.ShareFetchResponse;
 import org.apache.kafka.common.utils.ImplicitLinkedHashCollection;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.group.share.NoOpShareStatePersister;
 import org.apache.kafka.server.group.share.Persister;
 import org.apache.kafka.server.util.timer.SystemTimer;
 import org.apache.kafka.server.util.timer.SystemTimerReaper;
@@ -274,7 +275,7 @@ public class SharePartitionManager implements AutoCloseable {
     // Visible for testing.
     SharePartition sharePartition(ShareFetchPartitionData shareFetchPartitionData, TopicIdPartition topicIdPartition) {
         try {
-            Persister persister = null;
+            Persister persister = new NoOpShareStatePersister();
             if (!shareGroupPersisterClassName.isEmpty())
                 persister = Utils.newInstance(shareGroupPersisterClassName, Persister.class);
             return new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, maxInFlightMessages, maxDeliveryCount,

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -111,7 +111,7 @@ public class SharePartitionManagerTest {
     private static Timer mockTimer;
     private static final String SHARE_GROUP_PERSISTER_CLASS_NAME = "MockShareGroupPersisterClassPath";
     private static MockedStatic<Utils> mockUtils;
-    private static Persister persister = new NoOpShareStatePersister();
+    private static Persister persister = NoOpShareStatePersister.getInstance();
 
     @BeforeEach
     public void setUp() {

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -42,6 +42,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.group.share.NoOpShareStatePersister;
 import org.apache.kafka.server.group.share.PartitionFactory;
 import org.apache.kafka.server.group.share.Persister;
 import org.apache.kafka.server.group.share.PersisterStateBatch;
@@ -110,6 +111,7 @@ public class SharePartitionManagerTest {
     private static Timer mockTimer;
     private static final String SHARE_GROUP_PERSISTER_CLASS_NAME = "MockShareGroupPersisterClassPath";
     private static MockedStatic<Utils> mockUtils;
+    private static Persister persister = new NoOpShareStatePersister();
 
     @BeforeEach
     public void setUp() {
@@ -1263,7 +1265,7 @@ public class SharePartitionManagerTest {
             return null;
         }).when(replicaManager).fetchMessages(any(), any(), any(ReplicaQuota.class), any());
 
-        mockUtils.when(() -> Utils.newInstance(ArgumentMatchers.anyString(), ArgumentMatchers.any())).thenReturn(null);
+        mockUtils.when(() -> Utils.newInstance(ArgumentMatchers.anyString(), ArgumentMatchers.any())).thenReturn(persister);
 
         sharePartitionManager.fetchMessages(groupId, memberId1.toString(), fetchParams, Arrays.asList(tp0, tp1, tp2, tp3), partitionMaxBytes);
         Mockito.verify(replicaManager, times(1)).fetchMessages(
@@ -1292,10 +1294,10 @@ public class SharePartitionManagerTest {
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp0),
             k -> new SharePartition(groupId, tp0, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
-                    RECORD_LOCK_DURATION_MS, mockTimer, new MockTime(), null));
+                    RECORD_LOCK_DURATION_MS, mockTimer, new MockTime(), persister));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp1),
             k -> new SharePartition(groupId, tp1, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
-                    RECORD_LOCK_DURATION_MS, mockTimer, new MockTime(), null));
+                    RECORD_LOCK_DURATION_MS, mockTimer, new MockTime(), persister));
 
         SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
                 .withPartitionCacheMap(partitionCacheMap).build();
@@ -1359,10 +1361,10 @@ public class SharePartitionManagerTest {
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp0),
             k -> new SharePartition(groupId, tp0, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
-                    RECORD_LOCK_DURATION_MS, mockTimer, new MockTime(), null));
+                    RECORD_LOCK_DURATION_MS, mockTimer, new MockTime(), persister));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp1),
             k -> new SharePartition(groupId, tp1, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
-                    RECORD_LOCK_DURATION_MS, mockTimer, new MockTime(), null));
+                    RECORD_LOCK_DURATION_MS, mockTimer, new MockTime(), persister));
 
         SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
                 .withPartitionCacheMap(partitionCacheMap).build();
@@ -1421,16 +1423,16 @@ public class SharePartitionManagerTest {
         Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp0),
                 k -> new SharePartition(groupId, tp0, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
-                        RECORD_LOCK_DURATION_MS, mockTimer, time, null));
+                        RECORD_LOCK_DURATION_MS, mockTimer, time, persister));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp1),
                 k -> new SharePartition(groupId, tp1, MAX_DELIVERY_COUNT,  MAX_IN_FLIGHT_MESSAGES,
-                        RECORD_LOCK_DURATION_MS, mockTimer, time, null));
+                        RECORD_LOCK_DURATION_MS, mockTimer, time, persister));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp2),
                 k -> new SharePartition(groupId, tp2, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
-                        RECORD_LOCK_DURATION_MS, mockTimer, time, null));
+                        RECORD_LOCK_DURATION_MS, mockTimer, time, persister));
         partitionCacheMap.computeIfAbsent(new SharePartitionManager.SharePartitionKey(groupId, tp3),
                 k -> new SharePartition(groupId, tp3, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES,
-                        RECORD_LOCK_DURATION_MS, mockTimer, time, null));
+                        RECORD_LOCK_DURATION_MS, mockTimer, time, persister));
 
         SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
                 .withPartitionCacheMap(partitionCacheMap).withTime(time).withReplicaManager(replicaManager).build();

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.group.share.NoOpShareStatePersister;
 import org.apache.kafka.server.group.share.PartitionFactory;
 import org.apache.kafka.server.group.share.Persister;
 import org.apache.kafka.server.group.share.PersisterStateBatch;
@@ -230,7 +231,7 @@ public class SharePartitionTest {
     }
 
     @Test
-    public void testInitializeWithNullPersister() {
+    public void testInitializeWithNoOpShareStatePersister() {
         SharePartition sharePartition = SharePartitionBuilder.builder().build();
 
         assertTrue(sharePartition.cachedState().isEmpty());
@@ -4168,6 +4169,17 @@ public class SharePartitionTest {
     }
 
     @Test
+    public void testWriteShareGroupStateWithNoOpShareStatePersister() {
+        SharePartition sharePartition = SharePartitionBuilder.builder().build();
+
+        List<PersisterStateBatch> stateBatches = Arrays.asList(
+                new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
+                new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3));
+
+        assertTrue(sharePartition.isWriteShareGroupStateSuccessful(stateBatches));
+    }
+
+    @Test
     public void testAcknowledgeBatchWithWriteShareGroupStateFailure() {
         Persister persister = Mockito.mock(Persister.class);
         mockPersisterReadStateMethod(persister);
@@ -4535,7 +4547,7 @@ public class SharePartitionTest {
         private int acquisitionLockTimeoutMs = RECORD_LOCK_DURATION_MS;
         private int maxDeliveryCount = MAX_DELIVERY_COUNT;
         private int maxInflightMessages = MAX_IN_FLIGHT_MESSAGES;
-        private Persister persister = null;
+        private Persister persister = new NoOpShareStatePersister();
 
         private SharePartitionBuilder withAcquisitionLockTimeoutMs(int acquisitionLockTimeoutMs) {
             this.acquisitionLockTimeoutMs = acquisitionLockTimeoutMs;

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -4547,7 +4547,7 @@ public class SharePartitionTest {
         private int acquisitionLockTimeoutMs = RECORD_LOCK_DURATION_MS;
         private int maxDeliveryCount = MAX_DELIVERY_COUNT;
         private int maxInflightMessages = MAX_IN_FLIGHT_MESSAGES;
-        private Persister persister = new NoOpShareStatePersister();
+        private Persister persister = NoOpShareStatePersister.getInstance();
 
         private SharePartitionBuilder withAcquisitionLockTimeoutMs(int acquisitionLockTimeoutMs) {
             this.acquisitionLockTimeoutMs = acquisitionLockTimeoutMs;

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/NoOpShareStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/NoOpShareStatePersister.java
@@ -26,10 +26,23 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+/**
+ * A no-op singleton implementation of {@link Persister} interface.
+ */
 public class NoOpShareStatePersister implements Persister {
 
   private static final Logger log = LoggerFactory.getLogger(NoOpShareStatePersister.class);
+  private static Persister instance = null;
 
+  private NoOpShareStatePersister() {
+  }
+
+  public static synchronized Persister getInstance() {
+    if (instance == null) {
+      instance = new NoOpShareStatePersister();
+    }
+    return instance;
+  }
 
   @Override
   public CompletableFuture<InitializeShareGroupStateResult> initializeState(InitializeShareGroupStateParameters request) {

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/NoOpShareStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/NoOpShareStatePersister.java
@@ -32,12 +32,12 @@ import java.util.stream.Collectors;
 public class NoOpShareStatePersister implements Persister {
 
   private static final Logger log = LoggerFactory.getLogger(NoOpShareStatePersister.class);
-  private static Persister instance = null;
+  private static volatile Persister instance = null;
 
   private NoOpShareStatePersister() {
   }
 
-  public static synchronized Persister getInstance() {
+  public static Persister getInstance() {
     if (instance == null) {
       instance = new NoOpShareStatePersister();
     }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/NoOpShareStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/NoOpShareStatePersister.java
@@ -39,7 +39,11 @@ public class NoOpShareStatePersister implements Persister {
 
   public static Persister getInstance() {
     if (instance == null) {
-      instance = new NoOpShareStatePersister();
+      synchronized (NoOpShareStatePersister.class) {
+        if (instance == null) {
+          instance = new NoOpShareStatePersister();
+        }
+      }
     }
     return instance;
   }


### PR DESCRIPTION
### About
Share Partition Leaders needs to use NoOpPersister instead of keeping persister object as `null`