### PR TITLE
Make pipeline only trigger on branches in the kafkaMuckrakeVersionMap

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -16,6 +16,26 @@ name: kafka
 semaphore:
   enable: true
   pipeline_enable: false
+  triggers:
+  - branches
+  - pull_requests
+  branches:
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
+  - 2.8
+  - 3.0
+  - 3.1
+  - 3.2
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
+  - trunk
+  - master
 git:
   enable: true
 lang: java


### PR DESCRIPTION
changes pipeline triggers to only the branches in kafkaMuckrakeVersionMap
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
