### PR TITLE
AKCORE-87: Handle array of acknowledgement types

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgeType.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgeType.java
@@ -22,6 +22,8 @@ import java.util.Locale;
 
 @InterfaceStability.Evolving
 public enum AcknowledgeType {
+    /** The record was identified as gap. */
+    GAP((byte) 0),
     /** The record was consumed successfully. */
     ACCEPT((byte) 1),
 
@@ -45,6 +47,8 @@ public enum AcknowledgeType {
 
     public static AcknowledgeType forId(byte id) {
         switch (id) {
+            case 0:
+                return GAP;
             case 1:
                 return ACCEPT;
             case 2:

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgeType.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgeType.java
@@ -22,8 +22,6 @@ import java.util.Locale;
 
 @InterfaceStability.Evolving
 public enum AcknowledgeType {
-    /** The record was identified as gap. */
-    GAP((byte) 0),
     /** The record was consumed successfully. */
     ACCEPT((byte) 1),
 
@@ -47,8 +45,6 @@ public enum AcknowledgeType {
 
     public static AcknowledgeType forId(byte id) {
         switch (id) {
-            case 0:
-                return GAP;
             case 1:
                 return ACCEPT;
             case 2:

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1462,7 +1462,7 @@ public class RequestResponseTest {
                                 .setAcknowledgementBatches(singletonList(new ShareAcknowledgeRequestData.AcknowledgementBatch()
                                         .setFirstOffset(0)
                                         .setLastOffset(0)
-                                        .setAcknowledgeType((byte) 0)))))));
+                                        .setAcknowledgeTypes(Collections.singletonList((byte) 0))))))));
         return new ShareAcknowledgeRequest.Builder(data).build(version);
     }
 

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -46,13 +46,12 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
@@ -353,7 +352,10 @@ public class SharePartition {
      *
      * @return A future which is completed when the records are acquired.
      */
-    public CompletableFuture<List<AcquiredRecords>> acquire(String memberId, FetchPartitionData fetchPartitionData) {
+    public CompletableFuture<List<AcquiredRecords>> acquire(
+        String memberId,
+        FetchPartitionData fetchPartitionData
+    ) {
         log.trace("Received acquire request for share partition: {}-{}", memberId, fetchPartitionData);
         RecordBatch lastBatch = fetchPartitionData.records.lastBatch().orElse(null);
         if (lastBatch == null) {
@@ -472,7 +474,10 @@ public class SharePartition {
      *
      * @return A future which is completed when the records are acknowledged.
      */
-    public CompletableFuture<Optional<Throwable>> acknowledge(String memberId, List<AcknowledgementBatch> acknowledgementBatch) {
+    public CompletableFuture<Optional<Throwable>> acknowledge(
+        String memberId,
+        List<AcknowledgementBatch> acknowledgementBatch
+    ) {
         log.trace("Acknowledgement batch request for share partition: {}-{}", groupId, topicIdPartition);
 
         Throwable throwable = null;
@@ -485,76 +490,54 @@ public class SharePartition {
             for (int i = 0; i < acknowledgementBatch.size(); i++) {
                 AcknowledgementBatch batch = acknowledgementBatch.get(i);
 
-                RecordState recordState;
+                // Client can either send a single entry in acknowledgeTypes which represents the state
+                // of the complete batch or can send individual offsets state.
+                Map<Long, RecordState> recordStateMap;
                 try {
-                    recordState = fetchRecordState(batch.acknowledgeType);
+                    recordStateMap = fetchRecordStateMapForAcknowledgementBatch(batch);
                 } catch (IllegalArgumentException e) {
                     log.debug("Invalid acknowledge type: {} for share partition: {}-{}",
-                        batch.acknowledgeType, groupId, topicIdPartition);
-                    throwable = new InvalidRequestException("Invalid acknowledge type: " + batch.acknowledgeType);
+                        batch.acknowledgeTypes(), groupId, topicIdPartition);
+                    throwable = new InvalidRequestException("Invalid acknowledge type: " + batch.acknowledgeTypes());
                     break;
                 }
 
-                // Find the floor batch record for the request batch. The request batch could be
-                // for a subset of the batch i.e. cached batch of offset 10-14 and request batch
-                // of 12-13. Hence, floor entry is fetched to find the sub-map.
-                Map.Entry<Long, InFlightBatch> floorOffset = cachedState.floorEntry(batch.firstOffset);
-                if (floorOffset == null) {
-                    log.debug("Batch record {} not found for share partition: {}-{}", batch, groupId, topicIdPartition);
-                    throwable = new InvalidRecordStateException("Batch record not found. The base offset is not found in the cache.");
+                // Fetch the sub-map from the cached map for the batch to acknowledge. The sub-map can
+                // be a full match, subset or spans over multiple fetched batches.
+                NavigableMap<Long, InFlightBatch> subMap;
+                try {
+                    subMap = fetchSubMapForAcknowledgementBatch(batch, i == acknowledgementBatch.size() - 1);
+                } catch (InvalidRecordStateException | InvalidRequestException e) {
+                    throwable = e;
                     break;
                 }
 
-                NavigableMap<Long, InFlightBatch> subMap = cachedState.subMap(floorOffset.getKey(), true, batch.lastOffset, true);
-
-                // Validate if the request batch has the last offset greater than the last offset of
-                // the last fetched cached batch, then there will be offsets in the request than cannot
-                // be found in the fetched batches.
-                if (i == acknowledgementBatch.size() - 1 && batch.lastOffset > subMap.lastEntry().getValue().lastOffset) {
-                    log.debug("Request batch: {} has offsets which are not found for share partition: {}-{}", batch, groupId, topicIdPartition);
-                    throwable = new InvalidRequestException("Batch record not found. The last offset in request is past acquired records.");
-                    break;
-                }
-
-                // Add the gap offsets. There is no need to roll back the gap offsets for any
-                // in-flight batch if the acknowledgement request for any batch fails as once
-                // identified gap offset should remain the gap offset in future requests.
-                Set<Long> gapOffsetsSet = null;
-                if (batch.gapOffsets != null && !batch.gapOffsets.isEmpty()) {
-                    // Keep a set to easily check if the gap offset is part of the iterated in-flight
-                    // batch.
-                    gapOffsetsSet = new HashSet<>(batch.gapOffsets);
-                }
-
-                boolean isAckTypeRelease = batch.acknowledgeType == AcknowledgeType.RELEASE;
                 // The acknowledgement batch either is exact fetch equivalent batch (mostly), subset
                 // or spans over multiple fetched batches. The state can vary per offset itself from
-                // the fetched batch in case of subset.
+                // the fetched batch in case of subset or client sent individual offsets state.
                 for (Map.Entry<Long, InFlightBatch> entry : subMap.entrySet()) {
                     InFlightBatch inFlightBatch = entry.getValue();
 
-                    if (inFlightBatch.offsetState == null && inFlightBatch.batchMemberId().equals(EMPTY_MEMBER_ID)) {
-                        log.debug("The batch is not in the acquired state: {} for share partition: {}-{}",
-                                inFlightBatch, groupId, topicIdPartition);
-                        throwable = new InvalidRecordStateException("The batch cannot be acknowledged. The batch is not in the acquired state.");
-                        break;
+                    // Validate if the requested member id is the owner of the batch.
+                    if (inFlightBatch.offsetState == null) {
+                        throwable = validateAcknowledgementBatchMemberId(memberId, inFlightBatch).orElse(null);
+                        if (throwable != null) {
+                            break;
+                        }
                     }
 
-                    if (inFlightBatch.offsetState == null && !inFlightBatch.inFlightState.memberId().equals(memberId)) {
-                        log.debug("Member {} is not the owner of batch record {} for share partition: {}-{}",
-                            memberId, inFlightBatch, groupId, topicIdPartition);
-                        throwable = new InvalidRecordStateException("Member is not the owner of batch record");
-                        break;
-                    }
-
+                    // Determine if the in-flight batch is a full match from the request batch.
                     boolean fullMatch = inFlightBatch.firstOffset() >= batch.firstOffset
                         && inFlightBatch.lastOffset() <= batch.lastOffset;
+                    boolean isPerOffsetClientAck = batch.acknowledgeTypes().size() > 1;
 
-                    if (!fullMatch || inFlightBatch.offsetState != null) {
+                    // Maintain state per offset if the inflight batch is not a full match or the
+                    // offset state is managed or client sent individual offsets state.
+                    if (!fullMatch || inFlightBatch.offsetState != null || isPerOffsetClientAck) {
                         log.debug("Subset or offset tracked batch record found for acknowledgement,"
-                                + " batch: {} request offsets - first: {}, last: {} for the share"
-                                + " partition: {}-{}", inFlightBatch, batch.firstOffset, batch.lastOffset,
-                                groupId, topicIdPartition);
+                            + " batch: {}, request offsets - first: {}, last: {}, client per offset"
+                            + "state {} for the share partition: {}-{}", inFlightBatch, batch.firstOffset,
+                            batch.lastOffset, isPerOffsetClientAck, groupId, topicIdPartition);
                         if (inFlightBatch.offsetState == null) {
                             // Though the request is a subset of in-flight batch but the offset
                             // tracking has not been initialized yet which means that we could only
@@ -571,113 +554,19 @@ public class SharePartition {
                             // the offsets state in the in-flight batch.
                             inFlightBatch.maybeInitializeOffsetStateUpdate();
                         }
-                        for (Map.Entry<Long, InFlightState> offsetState : inFlightBatch.offsetState.entrySet()) {
 
-                            // For the first batch which might have offsets prior to the request base
-                            // offset i.e. cached batch of 10-14 offsets and request batch of 12-13.
-                            if (offsetState.getKey() < batch.firstOffset) {
-                                continue;
-                            }
-
-                            if (offsetState.getKey() > batch.lastOffset) {
-                                // No further offsets to process.
-                                break;
-                            }
-
-                            // Add the gap offsets.
-                            if (gapOffsetsSet != null && gapOffsetsSet.contains(offsetState.getKey())) {
-                                inFlightBatch.addGapOffsets(offsetState.getKey());
-                                // Force the state of the offset to Archived for the gap offset
-                                // irrespectively.
-                                offsetState.getValue().state = RecordState.ARCHIVED;
-                                offsetState.getValue().memberId = EMPTY_MEMBER_ID;
-                                // Cancel and clear the acquisition lock timeout task for the state since it is moved to ARCHIVED state.
-                                offsetState.getValue().cancelAndClearAcquisitionLockTimeoutTask();
-                                continue;
-                            }
-
-                            if (offsetState.getValue().state != RecordState.ACQUIRED) {
-                                log.debug("The offset is not acquired, offset: {} batch: {} for the share"
-                                        + " partition: {}-{}", offsetState.getKey(), inFlightBatch, groupId, topicIdPartition);
-                                throwable = new InvalidRecordStateException("The batch cannot be acknowledged. The offset is not acquired.");
-                                break;
-                            }
-
-                            // Check if member id is the owner of the offset.
-                            if (!offsetState.getValue().memberId.equals(memberId)) {
-                                log.debug("Member {} is not the owner of offset: {} in batch: {} for the share"
-                                        + " partition: {}-{}", memberId, offsetState.getKey(), inFlightBatch, groupId, topicIdPartition);
-                                throwable = new InvalidRecordStateException("Member is not the owner of offset");
-                                break;
-                            }
-
-                            InFlightState updateResult =  offsetState.getValue().startStateTransition(
-                                    recordState,
-                                    false,
-                                    this.maxDeliveryCount,
-                                    EMPTY_MEMBER_ID
-                            );
-                            if (updateResult == null) {
-                                log.debug("Unable to acknowledge records for the offset: {} in batch: {}"
-                                        + " for the share partition: {}-{}", offsetState.getKey(),
-                                    inFlightBatch, groupId, topicIdPartition);
-                                throwable = new InvalidRecordStateException("Unable to acknowledge records for the batch");
-                                break;
-                            }
-                            // Successfully updated the state of the offset.
-                            updatedStates.add(updateResult);
-                            stateBatches.add(new PersisterStateBatch(offsetState.getKey(), offsetState.getKey(),
-                                    updateResult.state.id, (short) updateResult.deliveryCount));
-                            // If the maxDeliveryCount limit has been exceeded, the record will be transitioned to ARCHIVED state.
-                            // This should not change the next fetch offset because the record is not available for acquisition
-                            if (isAckTypeRelease && updateResult.state != RecordState.ARCHIVED) {
-                                findNextFetchOffset.set(true);
-                            }
+                        throwable = acknowledgePerOffsetBatchRecords(memberId, batch, inFlightBatch,
+                            recordStateMap, updatedStates, stateBatches).orElse(null);
+                        if (throwable != null) {
+                            break;
                         }
-                        continue;
-                    }
-
-                    // The in-flight batch is a full match hence change the state of the complete.
-                    log.trace("Acknowledging complete batch record {} for the share partition: {}-{}",
-                        batch, groupId, topicIdPartition);
-                    if (inFlightBatch.batchState() != RecordState.ACQUIRED) {
-                        log.debug("The batch is not in the acquired state: {} for share partition: {}-{}",
-                            inFlightBatch, groupId, topicIdPartition);
-                        throwable = new InvalidRecordStateException("The batch cannot be acknowledged. The batch is not in the acquired state.");
-                        break;
-                    }
-
-                    InFlightState updateResult = inFlightBatch.startBatchStateTransition(
-                            recordState,
-                            false,
-                            this.maxDeliveryCount,
-                            EMPTY_MEMBER_ID
-                    );
-                    if (updateResult == null) {
-                        log.debug("Unable to acknowledge records for the batch: {} with state: {}"
-                            + " for the share partition: {}-{}", inFlightBatch, recordState, groupId, topicIdPartition);
-                        throwable = new InvalidRecordStateException("Unable to acknowledge records for the batch");
-                        break;
-                    }
-                    // If the maxDeliveryCount limit has been exceeded, the record will be transitioned to ARCHIVED state.
-                    // This should not change the nextFetchOffset because the record is not available for acquisition
-                    // Add the gap offsets.
-                    if (batch.gapOffsets != null && !batch.gapOffsets.isEmpty()) {
-                        for (Long gapOffset : batch.gapOffsets) {
-                            if (inFlightBatch.firstOffset() <= gapOffset && inFlightBatch.lastOffset() >= gapOffset) {
-                                inFlightBatch.addGapOffsets(gapOffset);
-                                // Just track the gap offset, no need to change the state of the offset
-                                // as the offset tracking is not maintained for the batch.
-                            }
+                    } else {
+                        // The in-flight batch is a full match hence change the state of the complete batch.
+                        throwable = acknowledgeCompleteBatch(batch, inFlightBatch,
+                            recordStateMap.get(batch.firstOffset), updatedStates, stateBatches).orElse(null);
+                        if (throwable != null) {
+                            break;
                         }
-                    }
-
-                    // Successfully updated the state of the batch.
-                    updatedStates.add(updateResult);
-                    stateBatches.add(new PersisterStateBatch(inFlightBatch.firstOffset, inFlightBatch.lastOffset,
-                            updateResult.state.id, (short) updateResult.deliveryCount));
-                    if (isAckTypeRelease && updateResult.state != RecordState.ARCHIVED) {
-                        findNextFetchOffset.set(true);
                     }
                 }
 
@@ -686,22 +575,9 @@ public class SharePartition {
                 }
             }
 
-            if (throwable != null || !isWriteShareGroupStateSuccessful(stateBatches)) {
-                // the log should be DEBUG to avoid flooding of logs for a faulty client
-                log.debug("Acknowledgement batch request failed for share partition, rollback any changed state"
-                    + " for the share partition: {}-{}", groupId, topicIdPartition);
-                updatedStates.forEach(state -> state.completeStateTransition(false));
-            } else {
-                log.trace("Acknowledgement batch request successful for share partition: {}-{}",
-                    groupId, topicIdPartition);
-                updatedStates.forEach(state -> {
-                    state.completeStateTransition(true);
-                    // Cancel the acquisition lock timeout task for the state since it is acknowledged successfully.
-                    state.cancelAndClearAcquisitionLockTimeoutTask();
-                });
-                // Update the cached state and start and end offsets after acknowledgements are completed
-                maybeUpdateCachedStateAndOffsets();
-            }
+            // If the acknowledgement is successful then persist state, complete the state transition
+            // and update the cached state for start offset. Else rollback the state transition.
+            rollbackOrProcessStateUpdates(throwable, updatedStates, stateBatches);
         } finally {
             lock.writeLock().unlock();
         }
@@ -792,11 +668,12 @@ public class SharePartition {
                 }
 
                 // Check if member id is the owner of the batch.
-                if (!inFlightBatch.inFlightState.memberId().equals(memberId) && !inFlightBatch.inFlightState.memberId.equals(EMPTY_MEMBER_ID)) {
-                    log.debug("Member {} is not the owner of batch record {} for share partition: {}-{}",
+                if (!inFlightBatch.batchMemberId().equals(memberId) && !inFlightBatch.batchMemberId().equals(EMPTY_MEMBER_ID)) {
+                    log.debug("Member {} is not the owner of batch record {} for share partition: {}-{}. Skipping batch.",
                             memberId, inFlightBatch, groupId, topicIdPartition);
                     continue;
                 }
+
                 // Change the state of complete batch since the same state exists for the entire inFlight batch
                 log.trace("Releasing acquired records for complete batch {} for the share partition: {}-{}",
                         inFlightBatch, groupId, topicIdPartition);
@@ -826,21 +703,9 @@ public class SharePartition {
                 }
             }
 
-            if (throwable != null || !isWriteShareGroupStateSuccessful(stateBatches)) {
-                log.debug("Release records from acquired state failed for share partition, rollback any changed state"
-                        + " for the share partition: {}-{}", groupId, topicIdPartition);
-                updatedStates.forEach(state -> state.completeStateTransition(false));
-            } else {
-                log.trace("Release records from acquired state successful for share partition: {}-{}",
-                        groupId, topicIdPartition);
-                updatedStates.forEach(state -> {
-                    state.completeStateTransition(true);
-                    // Cancel the acquisition lock timeout task for the state since it is released successfully.
-                    state.cancelAndClearAcquisitionLockTimeoutTask();
-                });
-                // Update the cached state and start and end offsets after releasing the acquired records
-                maybeUpdateCachedStateAndOffsets();
-            }
+            // If the acknowledgement is successful then persist state, complete the state transition
+            // and update the cached state for start offset. Else rollback the state transition.
+            rollbackOrProcessStateUpdates(throwable, updatedStates, stateBatches);
         } finally {
             lock.writeLock().unlock();
         }
@@ -906,6 +771,237 @@ public class SharePartition {
         } catch (InterruptedException | ExecutionException e) {
             log.error("Failed to initialize the share partition: {}-{}", groupId, topicIdPartition, e);
             throw new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition), e);
+        }
+    }
+
+    private Map<Long, RecordState> fetchRecordStateMapForAcknowledgementBatch(AcknowledgementBatch batch) {
+        // Client can either send a single entry in acknowledgeTypes which represents the state
+        // of the complete batch or can send individual offsets state. Construct a map with record state
+        // for each offset in the batch, if single acknowledge type is sent, the map will have only one entry.
+        Map<Long, RecordState> recordStateMap = new HashMap<>();
+        for (int index = 0; index < batch.acknowledgeTypes.size(); index++) {
+            recordStateMap.put(batch.firstOffset() + index,
+                fetchRecordState(batch.acknowledgeTypes().get(index)));
+        }
+        return recordStateMap;
+    }
+
+    private NavigableMap<Long, InFlightBatch> fetchSubMapForAcknowledgementBatch(
+        AcknowledgementBatch batch,
+        boolean isLastBatch
+    ) {
+        lock.writeLock().lock();
+        try {
+            // Find the floor batch record for the request batch. The request batch could be
+            // for a subset of the batch i.e. cached batch of offset 10-14 and request batch
+            // of 12-13. Hence, floor entry is fetched to find the sub-map.
+            Map.Entry<Long, InFlightBatch> floorOffset = cachedState.floorEntry(batch.firstOffset);
+            if (floorOffset == null) {
+                log.debug("Batch record {} not found for share partition: {}-{}", batch, groupId,
+                    topicIdPartition);
+                throw new InvalidRecordStateException(
+                    "Batch record not found. The base offset is not found in the cache.");
+            }
+
+            NavigableMap<Long, InFlightBatch> subMap = cachedState.subMap(floorOffset.getKey(), true, batch.lastOffset, true);
+            // Validate if the request batch has the first offset less than the last offset of the last
+            // fetched cached batch, then there will be offsets in the request that are already acquired.
+            if (subMap.lastEntry().getValue().lastOffset < batch.firstOffset) {
+                log.debug("Request batch: {} has offsets which are not found for share partition: {}-{}", batch, groupId, topicIdPartition);
+                throw new InvalidRequestException("Batch record not found. The first offset in request is past acquired records.");
+            }
+
+            // Validate if the request batch has the last offset greater than the last offset of
+            // the last fetched cached batch, then there will be offsets in the request than cannot
+            // be found in the fetched batches.
+            if (isLastBatch && batch.lastOffset > subMap.lastEntry().getValue().lastOffset) {
+                log.debug("Request batch: {} has offsets which are not found for share partition: {}-{}", batch, groupId, topicIdPartition);
+                throw new InvalidRequestException("Batch record not found. The last offset in request is past acquired records.");
+            }
+
+            return subMap;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private Optional<Throwable> validateAcknowledgementBatchMemberId(
+        String memberId,
+        InFlightBatch inFlightBatch
+    ) {
+        // EMPTY_MEMBER_ID is used to indicate that the batch is not in acquired state.
+        if (inFlightBatch.batchMemberId().equals(EMPTY_MEMBER_ID)) {
+            log.debug("The batch is not in the acquired state: {} for share partition: {}-{}",
+                inFlightBatch, groupId, topicIdPartition);
+            return Optional.of(new InvalidRecordStateException("The batch cannot be acknowledged. The batch is not in the acquired state."));
+        }
+
+        if (!inFlightBatch.batchMemberId().equals(memberId)) {
+            log.debug("Member {} is not the owner of batch record {} for share partition: {}-{}",
+                memberId, inFlightBatch, groupId, topicIdPartition);
+            return Optional.of(new InvalidRecordStateException("Member is not the owner of batch record"));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Throwable> acknowledgePerOffsetBatchRecords(
+        String memberId,
+        AcknowledgementBatch batch,
+        InFlightBatch inFlightBatch,
+        Map<Long, RecordState> recordStateMap,
+        List<InFlightState> updatedStates,
+        List<PersisterStateBatch> stateBatches
+    ) {
+        lock.writeLock().lock();
+        try {
+            // Fetch the first record state from the map to be used as default record state in case the
+            // offset record state is not provided by client.
+            RecordState recordStateDefault = recordStateMap.get(batch.firstOffset());
+            for (Map.Entry<Long, InFlightState> offsetState : inFlightBatch.offsetState.entrySet()) {
+
+                // For the first batch which might have offsets prior to the request base
+                // offset i.e. cached batch of 10-14 offsets and request batch of 12-13.
+                if (offsetState.getKey() < batch.firstOffset) {
+                    continue;
+                }
+
+                if (offsetState.getKey() > batch.lastOffset) {
+                    // No further offsets to process.
+                    break;
+                }
+
+                if (offsetState.getValue().state != RecordState.ACQUIRED) {
+                    log.debug("The offset is not acquired, offset: {} batch: {} for the share"
+                            + " partition: {}-{}", offsetState.getKey(), inFlightBatch, groupId,
+                        topicIdPartition);
+                    return Optional.of(new InvalidRecordStateException(
+                        "The batch cannot be acknowledged. The offset is not acquired."));
+                }
+
+                // Check if member id is the owner of the offset.
+                if (!offsetState.getValue().memberId.equals(memberId)) {
+                    log.debug("Member {} is not the owner of offset: {} in batch: {} for the share"
+                            + " partition: {}-{}", memberId, offsetState.getKey(), inFlightBatch,
+                        groupId, topicIdPartition);
+                    return Optional.of(
+                        new InvalidRecordStateException("Member is not the owner of offset"));
+                }
+
+                // Determine the record state for the offset. If the per offset record state is not provided
+                // by the client, then use the batch record state.
+                RecordState recordState =
+                    recordStateMap.size() > 1 ? recordStateMap.get(offsetState.getKey()) :
+                        recordStateDefault;
+                InFlightState updateResult = offsetState.getValue().startStateTransition(
+                    recordState,
+                    false,
+                    this.maxDeliveryCount,
+                    EMPTY_MEMBER_ID
+                );
+                if (updateResult == null) {
+                    log.debug("Unable to acknowledge records for the offset: {} in batch: {}"
+                            + " for the share partition: {}-{}", offsetState.getKey(),
+                        inFlightBatch, groupId, topicIdPartition);
+                    return Optional.of(new InvalidRecordStateException(
+                        "Unable to acknowledge records for the batch"));
+                }
+                // Successfully updated the state of the offset.
+                updatedStates.add(updateResult);
+                stateBatches.add(new PersisterStateBatch(offsetState.getKey(), offsetState.getKey(),
+                    updateResult.state.id, (short) updateResult.deliveryCount));
+                // If the maxDeliveryCount limit has been exceeded, the record will be transitioned to ARCHIVED state.
+                // This should not change the next fetch offset because the record is not available for acquisition
+                if (recordState == RecordState.AVAILABLE
+                    && updateResult.state != RecordState.ARCHIVED) {
+                    findNextFetchOffset.set(true);
+                }
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Throwable> acknowledgeCompleteBatch(
+        AcknowledgementBatch batch,
+        InFlightBatch inFlightBatch,
+        RecordState recordState,
+        List<InFlightState> updatedStates,
+        List<PersisterStateBatch> stateBatches
+    ) {
+        lock.writeLock().lock();
+        try {
+            // The in-flight batch is a full match hence change the state of the complete.
+            log.trace("Acknowledging complete batch record {} for the share partition: {}-{}",
+                batch, groupId, topicIdPartition);
+            if (inFlightBatch.batchState() != RecordState.ACQUIRED) {
+                log.debug("The batch is not in the acquired state: {} for share partition: {}-{}",
+                    inFlightBatch, groupId, topicIdPartition);
+                return Optional.of(new InvalidRecordStateException(
+                    "The batch cannot be acknowledged. The batch is not in the acquired state."));
+            }
+
+            // Change the state of complete batch since the same state exists for the entire inFlight batch.
+            // The member id is reset to EMPTY_MEMBER_ID irrespective of the acknowledge type as the batch is
+            // either released or moved to a state where member id existence is not important. The member id
+            // is only important when the batch is acquired.
+            InFlightState updateResult = inFlightBatch.startBatchStateTransition(
+                recordState,
+                false,
+                this.maxDeliveryCount,
+                EMPTY_MEMBER_ID
+            );
+            if (updateResult == null) {
+                log.debug("Unable to acknowledge records for the batch: {} with state: {}"
+                        + " for the share partition: {}-{}", inFlightBatch, recordState, groupId,
+                    topicIdPartition);
+                return Optional.of(
+                    new InvalidRecordStateException("Unable to acknowledge records for the batch"));
+            }
+
+            // Successfully updated the state of the batch.
+            updatedStates.add(updateResult);
+            stateBatches.add(
+                new PersisterStateBatch(inFlightBatch.firstOffset, inFlightBatch.lastOffset,
+                    updateResult.state.id, (short) updateResult.deliveryCount));
+
+            // If the maxDeliveryCount limit has been exceeded, the record will be transitioned to ARCHIVED state.
+            // This should not change the nextFetchOffset because the record is not available for acquisition
+            if (recordState == RecordState.AVAILABLE
+                && updateResult.state != RecordState.ARCHIVED) {
+                findNextFetchOffset.set(true);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+        return Optional.empty();
+    }
+
+    private void rollbackOrProcessStateUpdates(
+        Throwable throwable,
+        List<InFlightState> updatedStates,
+        List<PersisterStateBatch> stateBatches
+    ) {
+        lock.writeLock().lock();
+        try {
+            if (throwable != null || !isWriteShareGroupStateSuccessful(stateBatches)) {
+                // Log in DEBUG to avoid flooding of logs for a faulty client.
+                log.debug("Request failed for updating state, rollback any changed state"
+                    + " for the share partition: {}-{}", groupId, topicIdPartition);
+                updatedStates.forEach(state -> state.completeStateTransition(false));
+            } else {
+                log.trace("State change request successful for share partition: {}-{}",
+                    groupId, topicIdPartition);
+                updatedStates.forEach(state -> {
+                    state.completeStateTransition(true);
+                    // Cancel the acquisition lock timeout task for the state since it is released successfully.
+                    state.cancelAndClearAcquisitionLockTimeoutTask();
+                });
+                // Update the cached state and start and end offsets after releasing the acquired records
+                maybeUpdateCachedStateAndOffsets();
+            }
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -1001,7 +1097,11 @@ public class SharePartition {
         }
     }
 
-    private AcquiredRecords acquireNewBatchRecords(String memberId, long firstOffset, long lastOffset) {
+    private AcquiredRecords acquireNewBatchRecords(
+        String memberId,
+        long firstOffset,
+        long lastOffset
+    ) {
         lock.writeLock().lock();
         try {
             // Schedule acquisition lock timeout for the batch.
@@ -1028,8 +1128,13 @@ public class SharePartition {
         }
     }
 
-    private void acquireSubsetBatchRecords(String memberId, long requestFirstOffset, long requestLastOffset,
-        InFlightBatch inFlightBatch, List<AcquiredRecords> result) {
+    private void acquireSubsetBatchRecords(
+        String memberId,
+        long requestFirstOffset,
+        long requestLastOffset,
+        InFlightBatch inFlightBatch,
+        List<AcquiredRecords> result
+    ) {
         lock.writeLock().lock();
         try {
             for (Map.Entry<Long, InFlightState> offsetState : inFlightBatch.offsetState.entrySet()) {
@@ -1082,6 +1187,7 @@ public class SharePartition {
             case RELEASE:
                 return RecordState.AVAILABLE;
             case REJECT:
+            case GAP:
                 return RecordState.ARCHIVED;
             default:
                 throw new IllegalArgumentException("Invalid acknowledge type: " + acknowledgeType);
@@ -1290,9 +1396,7 @@ public class SharePartition {
         // determines the state of the complete batch else individual offset determines the state of
         // the respective records.
         private InFlightState inFlightState;
-        // Must be null for most of the records hence lazily-initialize. Should hold the gap offsets for
-        // the batch that are reported by the client.
-        private Set<Long> gapOffsets;
+
         // The subset of offsets within the batch that holds different record states within the parent
         // fetched batch. This is used to maintain the state of the records per offset, it is complex
         // to maintain the subset batch (InFlightBatch) within the parent batch itself as the nesting
@@ -1340,11 +1444,6 @@ public class SharePartition {
         }
 
         // Visible for testing.
-        Set<Long> gapOffsets() {
-            return gapOffsets;
-        }
-
-        // Visible for testing.
         NavigableMap<Long, InFlightState> offsetState() {
             return offsetState;
         }
@@ -1362,13 +1461,6 @@ public class SharePartition {
                 throw new IllegalStateException("The batch state update is not available as the offset state is maintained");
             }
             return inFlightState.startStateTransition(newState, incrementDeliveryCount, maxDeliveryCount, newMemberId);
-        }
-
-        private void addGapOffsets(Long gapOffset) {
-            if (this.gapOffsets == null) {
-                this.gapOffsets = new HashSet<>();
-            }
-            this.gapOffsets.add(gapOffset);
         }
 
         private void addOffsetState(long firstOffset, long lastOffset, RecordState state, boolean incrementDeliveryCount, int maxDeliveryCount,
@@ -1394,11 +1486,6 @@ public class SharePartition {
                 // from the first offset to the last offset. Mark the batch inflightState to null as
                 // the state of the records is maintained in the offset state map now.
                 for (long offset = this.firstOffset; offset <= this.lastOffset; offset++) {
-                    if (gapOffsets != null && gapOffsets.contains(offset)) {
-                        // Directly move the record to archived if gap offset is already known.
-                        offsetState.put(offset, new InFlightState(RecordState.ARCHIVED, 0, inFlightState.memberId));
-                        continue;
-                    }
                     if (inFlightState.acquisitionLockTimeoutTask != null) {
                         // The acquisition lock timeout task is already scheduled for the batch, hence we need to schedule
                         // the acquisition lock timeout task for the offset as well.
@@ -1439,7 +1526,6 @@ public class SharePartition {
                 " firstOffset=" + firstOffset +
                 ", lastOffset=" + lastOffset +
                 ", inFlightState=" + inFlightState +
-                ", gapOffsets=" + ((gapOffsets == null) ? "null" : gapOffsets) +
                 ", offsetState=" + ((offsetState == null) ? "null" : offsetState) +
                 ")";
         }
@@ -1582,14 +1668,12 @@ public class SharePartition {
 
         private final long firstOffset;
         private final long lastOffset;
-        private final List<Long> gapOffsets;
-        private final AcknowledgeType acknowledgeType;
+        private final List<AcknowledgeType> acknowledgeTypes;
 
-        public AcknowledgementBatch(long firstOffset, long lastOffset, List<Long> gapOffsets, AcknowledgeType acknowledgeType) {
+        public AcknowledgementBatch(long firstOffset, long lastOffset, List<AcknowledgeType> acknowledgeTypes) {
             this.firstOffset = firstOffset;
             this.lastOffset = lastOffset;
-            this.gapOffsets = gapOffsets;
-            this.acknowledgeType = Objects.requireNonNull(acknowledgeType);
+            this.acknowledgeTypes = acknowledgeTypes;
         }
 
         public long firstOffset() {
@@ -1600,12 +1684,8 @@ public class SharePartition {
             return lastOffset;
         }
 
-        public List<Long> gapOffsets() {
-            return gapOffsets;
-        }
-
-        public AcknowledgeType acknowledgeType() {
-            return acknowledgeType;
+        public List<AcknowledgeType> acknowledgeTypes() {
+            return acknowledgeTypes;
         }
 
         @Override
@@ -1613,8 +1693,7 @@ public class SharePartition {
             return "AcknowledgementBatch(" +
                 " firstOffset=" + firstOffset +
                 ", lastOffset=" + lastOffset +
-                ", gapOffsets=" + ((gapOffsets == null) ? "" : gapOffsets) +
-                ", acknowledgeType=" + acknowledgeType +
+                ", acknowledgeTypes=" + ((acknowledgeTypes == null) ? "" : acknowledgeTypes) +
                 ")";
         }
     }

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -994,10 +994,10 @@ public class SharePartition {
                     groupId, topicIdPartition);
                 updatedStates.forEach(state -> {
                     state.completeStateTransition(true);
-                    // Cancel the acquisition lock timeout task for the state since it is released successfully.
+                    // Cancel the acquisition lock timeout task for the state since it is acknowledged/released successfully.
                     state.cancelAndClearAcquisitionLockTimeoutTask();
                 });
-                // Update the cached state and start and end offsets after releasing the acquired records
+                // Update the cached state and start and end offsets after acknowledging/releasing the acquired records.
                 maybeUpdateCachedStateAndOffsets();
             }
         } finally {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -84,6 +84,7 @@ import java.time.Duration
 import java.util
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
+import java.util.stream.Collectors
 import java.util.{Collections, Optional, OptionalInt}
 import scala.annotation.nowarn
 import scala.collection.mutable.ArrayBuffer
@@ -1108,8 +1109,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                 acknowledgeBatches.add(new SharePartition.AcknowledgementBatch(
                   batch.firstOffset(),
                   batch.lastOffset(),
-                  batch.gapOffsets(),
-                  AcknowledgeType.forId(batch.acknowledgeType())
+                  batch.acknowledgeTypes().stream().map(AcknowledgeType.forId(_)).collect(Collectors.toList())
                 ))
               } catch {
                 case e : IllegalArgumentException =>
@@ -1170,18 +1170,14 @@ class KafkaApis(val requestChannel: RequestChannel,
               erroneousTopicIdPartitions.add(tp)
               break()
             }
-            var gapOffsetsValid = true
-            breakable {
-              batch.gapOffsets().forEach(gapOffset => {
-                if (gapOffset < batch.firstOffset() || gapOffset > batch.lastOffset()) {
-                  erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
-                  erroneousTopicIdPartitions.add(tp)
-                  gapOffsetsValid = false
-                  break()
-                }
-              })
+            if (batch.acknowledgeTypes() == null || batch.acknowledgeTypes().isEmpty) {
+              erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
+              erroneousTopicIdPartitions.add(tp)
+              break()
             }
-            if (!gapOffsetsValid) {
+            if (batch.acknowledgeTypes().size() > 1 && batch.lastOffset() - batch.firstOffset() != batch.acknowledgeTypes().size() - 1) {
+              erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
+              erroneousTopicIdPartitions.add(tp)
               break()
             }
             prevEndOffset = batch.lastOffset()
@@ -4617,8 +4613,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                 acknowledgeBatches.add(new SharePartition.AcknowledgementBatch(
                   batch.firstOffset(),
                   batch.lastOffset(),
-                  batch.gapOffsets(),
-                  AcknowledgeType.forId(batch.acknowledgeType())
+                  batch.acknowledgeTypes().stream().map(AcknowledgeType.forId(_)).collect(Collectors.toList())
                 ))
               } catch {
                 case e : IllegalArgumentException =>

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -30,7 +30,6 @@ import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.admin.AdminUtils
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry, EndpointType}
-import org.apache.kafka.clients.consumer.AcknowledgeType
 import org.apache.kafka.common.acl.AclOperation
 import org.apache.kafka.common.acl.AclOperation._
 import org.apache.kafka.common.config.ConfigResource
@@ -84,7 +83,6 @@ import java.time.Duration
 import java.util
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
-import java.util.stream.Collectors
 import java.util.{Collections, Optional, OptionalInt}
 import scala.annotation.nowarn
 import scala.collection.mutable.ArrayBuffer
@@ -1109,7 +1107,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                 acknowledgeBatches.add(new SharePartition.AcknowledgementBatch(
                   batch.firstOffset(),
                   batch.lastOffset(),
-                  batch.acknowledgeTypes().stream().map(AcknowledgeType.forId(_)).collect(Collectors.toList())
+                  batch.acknowledgeTypes()
                 ))
               } catch {
                 case e : IllegalArgumentException =>
@@ -1154,42 +1152,10 @@ class KafkaApis(val requestChannel: RequestChannel,
       acknowledgementDataFromRequest = getAcknowledgeBatchesFromShareAcknowledgeRequest(requestData.asInstanceOf[ShareAcknowledgeRequest], topicNames, erroneous)
     }
 
-    def validateAcknowledgementBatchesInFetchRequest() : Unit = {
-      val erroneousTopicIdPartitions: mutable.Set[TopicIdPartition] = mutable.Set.empty[TopicIdPartition]
-      acknowledgementDataFromRequest.foreach{ case (tp : TopicIdPartition, acknowledgeBatches : util.List[SharePartition.AcknowledgementBatch]) => {
-        var prevEndOffset = -1L
-        breakable {
-          acknowledgeBatches.forEach(batch => {
-            if (batch.firstOffset() > batch.lastOffset()) {
-              erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
-              erroneousTopicIdPartitions.add(tp)
-              break()
-            }
-            if (batch.firstOffset() < prevEndOffset) {
-              erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
-              erroneousTopicIdPartitions.add(tp)
-              break()
-            }
-            if (batch.acknowledgeTypes() == null || batch.acknowledgeTypes().isEmpty) {
-              erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
-              erroneousTopicIdPartitions.add(tp)
-              break()
-            }
-            if (batch.acknowledgeTypes().size() > 1 && batch.lastOffset() - batch.firstOffset() != batch.acknowledgeTypes().size() - 1) {
-              erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
-              erroneousTopicIdPartitions.add(tp)
-              break()
-            }
-            prevEndOffset = batch.lastOffset()
-          })
-        }
-      }}
-      erroneousTopicIdPartitions.foreach(tp => {
-        acknowledgementDataFromRequest.remove(tp)
-      })
-    }
-
-    validateAcknowledgementBatchesInFetchRequest()
+    val erroneousTopicIdPartitions = validateAcknowledgementBatches(acknowledgementDataFromRequest, erroneous)
+    erroneousTopicIdPartitions.foreach(tp => {
+      acknowledgementDataFromRequest.remove(tp)
+    })
 
     acknowledgementDataFromRequest.foreach{
       case (topicIdPartition : TopicIdPartition, acknowledgeBatches : util.List[SharePartition.AcknowledgementBatch]) =>
@@ -4613,7 +4579,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                 acknowledgeBatches.add(new SharePartition.AcknowledgementBatch(
                   batch.firstOffset(),
                   batch.lastOffset(),
-                  batch.acknowledgeTypes().stream().map(AcknowledgeType.forId(_)).collect(Collectors.toList())
+                  batch.acknowledgeTypes()
                 ))
               } catch {
                 case e : IllegalArgumentException =>
@@ -4630,6 +4596,47 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
     })
     acknowledgeBatchesMap
+  }
+
+  def validateAcknowledgementBatches(
+                                    acknowledgementDataFromRequest : mutable.Map[TopicIdPartition, util.List[SharePartition.AcknowledgementBatch]],
+                                    erroneous : mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]
+                                    ) : mutable.Set[TopicIdPartition] = {
+    val erroneousTopicIdPartitions: mutable.Set[TopicIdPartition] = mutable.Set.empty[TopicIdPartition]
+    acknowledgementDataFromRequest.foreach{ case (tp : TopicIdPartition, acknowledgeBatches : util.List[SharePartition.AcknowledgementBatch]) =>
+      var prevEndOffset = -1L
+      breakable {
+        acknowledgeBatches.forEach(batch => {
+          if (batch.firstOffset() > batch.lastOffset()) {
+            erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
+            erroneousTopicIdPartitions.add(tp)
+            break()
+          }
+          if (batch.firstOffset() < prevEndOffset) {
+            erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
+            erroneousTopicIdPartitions.add(tp)
+            break()
+          }
+          if (batch.acknowledgeTypes() == null || batch.acknowledgeTypes().isEmpty) {
+            erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
+            erroneousTopicIdPartitions.add(tp)
+            break()
+          }
+          if (batch.acknowledgeTypes().size() > 1 && batch.lastOffset() - batch.firstOffset() != batch.acknowledgeTypes().size() - 1) {
+            erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
+            erroneousTopicIdPartitions.add(tp)
+            break()
+          }
+          if (batch.acknowledgeTypes().stream().anyMatch(ackType => ackType < 0 || ackType > 3)) {
+            erroneous += tp -> ShareAcknowledgeResponse.partitionResponse(tp, Errors.INVALID_REQUEST)
+            erroneousTopicIdPartitions.add(tp)
+            break()
+          }
+          prevEndOffset = batch.lastOffset()
+        })
+      }
+    }
+    erroneousTopicIdPartitions
   }
 
   def handleShareAcknowledgeRequest(request: RequestChannel.Request): Unit = {

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -1080,16 +1080,16 @@ public class SharePartitionManagerTest {
         SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
                 .withPartitionCacheMap(partitionCacheMap).build();
         acknowledgeTopics.put(tp1, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(12, 20, new ArrayList<>(), AcknowledgeType.ACCEPT),
-                new SharePartition.AcknowledgementBatch(24, 56, new ArrayList<>(), AcknowledgeType.ACCEPT)
+                new SharePartition.AcknowledgementBatch(12, 20, Collections.singletonList(AcknowledgeType.ACCEPT)),
+                new SharePartition.AcknowledgementBatch(24, 56, Collections.singletonList(AcknowledgeType.ACCEPT))
         ));
         acknowledgeTopics.put(tp2, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(5, 17, new ArrayList<>(), AcknowledgeType.REJECT),
-                new SharePartition.AcknowledgementBatch(19, 26, new ArrayList<>(), AcknowledgeType.ACCEPT)
+                new SharePartition.AcknowledgementBatch(5, 17, Collections.singletonList(AcknowledgeType.REJECT)),
+                new SharePartition.AcknowledgementBatch(19, 26, Collections.singletonList(AcknowledgeType.ACCEPT))
         ));
         acknowledgeTopics.put(tp3, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(45, 60, new ArrayList<>(), AcknowledgeType.RELEASE),
-                new SharePartition.AcknowledgementBatch(67, 82, new ArrayList<>(), AcknowledgeType.RELEASE)
+                new SharePartition.AcknowledgementBatch(45, 60, Collections.singletonList(AcknowledgeType.RELEASE)),
+                new SharePartition.AcknowledgementBatch(67, 82, Collections.singletonList(AcknowledgeType.RELEASE))
         ));
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.acknowledge(memberId, groupId, acknowledgeTopics);
@@ -1131,16 +1131,16 @@ public class SharePartitionManagerTest {
                 .withPartitionCacheMap(partitionCacheMap).build();
 
         acknowledgeTopics.put(tp1, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(12, 20, new ArrayList<>(), AcknowledgeType.ACCEPT),
-                new SharePartition.AcknowledgementBatch(24, 56, new ArrayList<>(), AcknowledgeType.ACCEPT)
+                new SharePartition.AcknowledgementBatch(12, 20, Collections.singletonList(AcknowledgeType.ACCEPT)),
+                new SharePartition.AcknowledgementBatch(24, 56, Collections.singletonList(AcknowledgeType.ACCEPT))
         ));
         acknowledgeTopics.put(tp2, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(5, 17, new ArrayList<>(), AcknowledgeType.REJECT),
-                new SharePartition.AcknowledgementBatch(19, 26, new ArrayList<>(), AcknowledgeType.ACCEPT)
+                new SharePartition.AcknowledgementBatch(5, 17, Collections.singletonList(AcknowledgeType.REJECT)),
+                new SharePartition.AcknowledgementBatch(19, 26, Collections.singletonList(AcknowledgeType.ACCEPT))
         ));
         acknowledgeTopics.put(tp3, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(45, 60, new ArrayList<>(), AcknowledgeType.RELEASE),
-                new SharePartition.AcknowledgementBatch(67, 82, new ArrayList<>(), AcknowledgeType.RELEASE)
+                new SharePartition.AcknowledgementBatch(45, 60, Collections.singletonList(AcknowledgeType.RELEASE)),
+                new SharePartition.AcknowledgementBatch(67, 82, Collections.singletonList(AcknowledgeType.RELEASE))
         ));
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.acknowledge(memberId, groupId2, acknowledgeTopics);
@@ -1182,12 +1182,12 @@ public class SharePartitionManagerTest {
                 .withPartitionCacheMap(partitionCacheMap).build();
 
         acknowledgeTopics.put(tp1, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(12, 20, new ArrayList<>(), AcknowledgeType.ACCEPT),
-                new SharePartition.AcknowledgementBatch(24, 56, new ArrayList<>(), AcknowledgeType.ACCEPT)
+                new SharePartition.AcknowledgementBatch(12, 20, Collections.singletonList(AcknowledgeType.ACCEPT)),
+                new SharePartition.AcknowledgementBatch(24, 56, Collections.singletonList(AcknowledgeType.ACCEPT))
         ));
         acknowledgeTopics.put(tp2, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(5, 17, new ArrayList<>(), AcknowledgeType.REJECT),
-                new SharePartition.AcknowledgementBatch(19, 26, new ArrayList<>(), AcknowledgeType.ACCEPT)
+                new SharePartition.AcknowledgementBatch(5, 17, Collections.singletonList(AcknowledgeType.REJECT)),
+                new SharePartition.AcknowledgementBatch(19, 26, Collections.singletonList(AcknowledgeType.ACCEPT))
         ));
 
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
@@ -1219,8 +1219,8 @@ public class SharePartitionManagerTest {
 
         SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder().build();
         acknowledgeTopics.put(tp, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(78, 90, new ArrayList<>(), AcknowledgeType.RELEASE),
-                new SharePartition.AcknowledgementBatch(94, 99, new ArrayList<>(), AcknowledgeType.RELEASE)
+                new SharePartition.AcknowledgementBatch(78, 90, Collections.singletonList(AcknowledgeType.RELEASE)),
+                new SharePartition.AcknowledgementBatch(94, 99, Collections.singletonList(AcknowledgeType.RELEASE))
         ));
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.acknowledge(memberId, groupId, acknowledgeTopics);

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -16,7 +16,6 @@
  */
 package kafka.server;
 
-import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InvalidRecordStateException;
@@ -1080,16 +1079,16 @@ public class SharePartitionManagerTest {
         SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
                 .withPartitionCacheMap(partitionCacheMap).build();
         acknowledgeTopics.put(tp1, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(12, 20, Collections.singletonList(AcknowledgeType.ACCEPT)),
-                new SharePartition.AcknowledgementBatch(24, 56, Collections.singletonList(AcknowledgeType.ACCEPT))
+                new SharePartition.AcknowledgementBatch(12, 20, Collections.singletonList((byte) 1)),
+                new SharePartition.AcknowledgementBatch(24, 56, Collections.singletonList((byte) 1))
         ));
         acknowledgeTopics.put(tp2, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(5, 17, Collections.singletonList(AcknowledgeType.REJECT)),
-                new SharePartition.AcknowledgementBatch(19, 26, Collections.singletonList(AcknowledgeType.ACCEPT))
+                new SharePartition.AcknowledgementBatch(5, 17, Collections.singletonList((byte) 3)),
+                new SharePartition.AcknowledgementBatch(19, 26, Collections.singletonList((byte) 1))
         ));
         acknowledgeTopics.put(tp3, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(45, 60, Collections.singletonList(AcknowledgeType.RELEASE)),
-                new SharePartition.AcknowledgementBatch(67, 82, Collections.singletonList(AcknowledgeType.RELEASE))
+                new SharePartition.AcknowledgementBatch(45, 60, Collections.singletonList((byte) 2)),
+                new SharePartition.AcknowledgementBatch(67, 82, Collections.singletonList((byte) 2))
         ));
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.acknowledge(memberId, groupId, acknowledgeTopics);
@@ -1131,16 +1130,16 @@ public class SharePartitionManagerTest {
                 .withPartitionCacheMap(partitionCacheMap).build();
 
         acknowledgeTopics.put(tp1, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(12, 20, Collections.singletonList(AcknowledgeType.ACCEPT)),
-                new SharePartition.AcknowledgementBatch(24, 56, Collections.singletonList(AcknowledgeType.ACCEPT))
+                new SharePartition.AcknowledgementBatch(12, 20, Collections.singletonList((byte) 1)),
+                new SharePartition.AcknowledgementBatch(24, 56, Collections.singletonList((byte) 1))
         ));
         acknowledgeTopics.put(tp2, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(5, 17, Collections.singletonList(AcknowledgeType.REJECT)),
-                new SharePartition.AcknowledgementBatch(19, 26, Collections.singletonList(AcknowledgeType.ACCEPT))
+                new SharePartition.AcknowledgementBatch(5, 17, Collections.singletonList((byte) 3)),
+                new SharePartition.AcknowledgementBatch(19, 26, Collections.singletonList((byte) 1))
         ));
         acknowledgeTopics.put(tp3, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(45, 60, Collections.singletonList(AcknowledgeType.RELEASE)),
-                new SharePartition.AcknowledgementBatch(67, 82, Collections.singletonList(AcknowledgeType.RELEASE))
+                new SharePartition.AcknowledgementBatch(45, 60, Collections.singletonList((byte) 2)),
+                new SharePartition.AcknowledgementBatch(67, 82, Collections.singletonList((byte) 2))
         ));
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.acknowledge(memberId, groupId2, acknowledgeTopics);
@@ -1182,12 +1181,12 @@ public class SharePartitionManagerTest {
                 .withPartitionCacheMap(partitionCacheMap).build();
 
         acknowledgeTopics.put(tp1, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(12, 20, Collections.singletonList(AcknowledgeType.ACCEPT)),
-                new SharePartition.AcknowledgementBatch(24, 56, Collections.singletonList(AcknowledgeType.ACCEPT))
+                new SharePartition.AcknowledgementBatch(12, 20, Collections.singletonList((byte) 1)),
+                new SharePartition.AcknowledgementBatch(24, 56, Collections.singletonList((byte) 1))
         ));
         acknowledgeTopics.put(tp2, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(5, 17, Collections.singletonList(AcknowledgeType.REJECT)),
-                new SharePartition.AcknowledgementBatch(19, 26, Collections.singletonList(AcknowledgeType.ACCEPT))
+                new SharePartition.AcknowledgementBatch(5, 17, Collections.singletonList((byte) 3)),
+                new SharePartition.AcknowledgementBatch(19, 26, Collections.singletonList((byte) 1))
         ));
 
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
@@ -1219,8 +1218,8 @@ public class SharePartitionManagerTest {
 
         SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder().build();
         acknowledgeTopics.put(tp, Arrays.asList(
-                new SharePartition.AcknowledgementBatch(78, 90, Collections.singletonList(AcknowledgeType.RELEASE)),
-                new SharePartition.AcknowledgementBatch(94, 99, Collections.singletonList(AcknowledgeType.RELEASE))
+                new SharePartition.AcknowledgementBatch(78, 90, Collections.singletonList((byte) 2)),
+                new SharePartition.AcknowledgementBatch(94, 99, Collections.singletonList((byte) 2))
         ));
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.acknowledge(memberId, groupId, acknowledgeTopics);

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -55,7 +55,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -160,13 +159,11 @@ public class SharePartitionTest {
         assertEquals(10, sharePartition.cachedState().get(5L).lastOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
         assertEquals(2, sharePartition.cachedState().get(5L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(5L).gapOffsets());
         assertNull(sharePartition.cachedState().get(5L).offsetState());
 
         assertEquals(15, sharePartition.cachedState().get(11L).lastOffset());
         assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(11L).batchState());
         assertEquals(3, sharePartition.cachedState().get(11L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(11L).gapOffsets());
         assertNull(sharePartition.cachedState().get(11L).offsetState());
     }
 
@@ -292,7 +289,6 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.cachedState().get(0L).lastOffset());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).batchState());
         assertEquals(1, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
     }
 
@@ -315,7 +311,6 @@ public class SharePartitionTest {
         assertEquals(14, sharePartition.cachedState().get(10L).lastOffset());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(10L).batchState());
         assertEquals(1, sharePartition.cachedState().get(10L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(10L).gapOffsets());
         assertNull(sharePartition.cachedState().get(10L).offsetState());
     }
 
@@ -422,7 +417,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(1, 1, null, AcknowledgeType.ACCEPT)));
+            Collections.singletonList(new AcknowledgementBatch(1, 1, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -430,7 +425,6 @@ public class SharePartitionTest {
         assertEquals(2, sharePartition.cachedState().size());
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(1L).batchState());
         assertEquals(1, sharePartition.cachedState().get(1L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(1L).gapOffsets());
         assertNull(sharePartition.cachedState().get(1L).offsetState());
     }
 
@@ -448,7 +442,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(5, 14, null, AcknowledgeType.ACCEPT)));
+            Collections.singletonList(new AcknowledgementBatch(5, 14, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -484,19 +478,35 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(5, 18, Arrays.asList(15L, 16L, 17L), AcknowledgeType.RELEASE)));
+            Arrays.asList(
+                new AcknowledgementBatch(5, 6, Collections.singletonList(AcknowledgeType.RELEASE)),
+                new AcknowledgementBatch(10, 18, Arrays.asList(
+                    AcknowledgeType.RELEASE, AcknowledgeType.RELEASE, AcknowledgeType.RELEASE,
+                    AcknowledgeType.RELEASE, AcknowledgeType.RELEASE, AcknowledgeType.GAP,
+                    AcknowledgeType.GAP, AcknowledgeType.GAP, AcknowledgeType.ACCEPT
+                ))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
         assertEquals(5, sharePartition.nextFetchOffset());
         assertEquals(2, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
-        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
+        assertThrows(IllegalStateException.class, () -> sharePartition.cachedState().get(10L).batchState());
         assertNull(sharePartition.cachedState().get(5L).offsetState());
-        assertNull(sharePartition.cachedState().get(10L).offsetState());
-        assertNull(sharePartition.cachedState().get(5L).gapOffsets());
-        assertNotNull(sharePartition.cachedState().get(10L).gapOffsets());
-        assertEquals(new HashSet<>(Arrays.asList(15L, 16L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
+        assertNotNull(sharePartition.cachedState().get(10L).offsetState());
+
+        // Check cached state.
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(12L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(13L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(14L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(15L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(16L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(17L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(18L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
     }
 
     @Test
@@ -532,7 +542,15 @@ public class SharePartitionTest {
         // Acknowledging over subset of both batch with subset of gap offsets.
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(6, 18, Arrays.asList(12L, 13L, 15L, 17L, 19L), AcknowledgeType.ACCEPT)));
+            Collections.singletonList(new AcknowledgementBatch(6, 18, Arrays.asList(
+                // TODO: NOTE - untracked gap of 3 offsets from 7-9 has no effect on acknowledgment
+                //  irrespective of acknowledgement type provided. While acquiring, the log start
+                //  offset should be used to determine such gaps.
+                AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT,
+                AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT,
+                AcknowledgeType.GAP, AcknowledgeType.GAP, AcknowledgeType.ACCEPT,
+                AcknowledgeType.GAP, AcknowledgeType.ACCEPT, AcknowledgeType.GAP,
+                AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -560,11 +578,6 @@ public class SharePartitionTest {
         expectedOffsetStateMap.put(19L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
         expectedOffsetStateMap.put(20L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
         assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
-
-        assertNull(sharePartition.cachedState().get(5L).gapOffsets());
-        assertNotNull(sharePartition.cachedState().get(10L).gapOffsets());
-        // Gap offset 19 will be avoided as it's greater than the batch last offset.
-        assertEquals(new HashSet<>(Arrays.asList(12L, 13L, 15L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
     }
 
     @Test
@@ -573,7 +586,7 @@ public class SharePartitionTest {
         // Acknowledge a batch when cache is empty.
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(0, 15, null, AcknowledgeType.REJECT)));
+            Collections.singletonList(new AcknowledgementBatch(0, 15, Collections.singletonList(AcknowledgeType.REJECT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -591,7 +604,7 @@ public class SharePartitionTest {
 
         ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(20, 25, null, AcknowledgeType.REJECT)));
+            Collections.singletonList(new AcknowledgementBatch(20, 25, Collections.singletonList(AcknowledgeType.REJECT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRequestException.class, ackResult.join().get().getClass());
@@ -613,7 +626,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             "member-2",
-            Collections.singletonList(new AcknowledgementBatch(5, 9, null, AcknowledgeType.REJECT)));
+            Collections.singletonList(new AcknowledgementBatch(5, 9, Collections.singletonList(AcknowledgeType.REJECT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -635,14 +648,14 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(5, 9, null, AcknowledgeType.RELEASE)));
+            Collections.singletonList(new AcknowledgementBatch(5, 9, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
         // Acknowledge the same batch again but with ACCEPT type.
         ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(5, 9, null, AcknowledgeType.ACCEPT)));
+            Collections.singletonList(new AcknowledgementBatch(5, 9, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -657,14 +670,14 @@ public class SharePartitionTest {
 
         ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(6, 8, null, AcknowledgeType.REJECT)));
+            Collections.singletonList(new AcknowledgementBatch(6, 8, Collections.singletonList(AcknowledgeType.REJECT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
         // Re-acknowledge the subset batch with REJECT type.
         ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(6, 8, null, AcknowledgeType.REJECT)));
+            Collections.singletonList(new AcknowledgementBatch(6, 8, Collections.singletonList(AcknowledgeType.REJECT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -702,11 +715,11 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
             Arrays.asList(
-                new AcknowledgementBatch(5, 9, null, AcknowledgeType.RELEASE),
-                new AcknowledgementBatch(10, 14, null, AcknowledgeType.ACCEPT),
-                new AcknowledgementBatch(15, 19, null, AcknowledgeType.ACCEPT),
+                new AcknowledgementBatch(5, 9, Collections.singletonList(AcknowledgeType.RELEASE)),
+                new AcknowledgementBatch(10, 14, Collections.singletonList(AcknowledgeType.ACCEPT)),
+                new AcknowledgementBatch(15, 19, Collections.singletonList(AcknowledgeType.ACCEPT)),
                 // Add another batch which should fail the request.
-                new AcknowledgementBatch(15, 19, null, AcknowledgeType.ACCEPT)));
+                new AcknowledgementBatch(15, 19, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -750,11 +763,11 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
             Arrays.asList(
-                new AcknowledgementBatch(5, 9, null, AcknowledgeType.RELEASE),
-                new AcknowledgementBatch(10, 14, null, AcknowledgeType.ACCEPT),
-                new AcknowledgementBatch(15, 19, null, AcknowledgeType.ACCEPT),
+                new AcknowledgementBatch(5, 9, Collections.singletonList(AcknowledgeType.RELEASE)),
+                new AcknowledgementBatch(10, 14, Collections.singletonList(AcknowledgeType.ACCEPT)),
+                new AcknowledgementBatch(15, 19, Collections.singletonList(AcknowledgeType.ACCEPT)),
                 // Add another batch which should fail the request.
-                new AcknowledgementBatch(16, 19, null, AcknowledgeType.ACCEPT)));
+                new AcknowledgementBatch(16, 19, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -785,14 +798,13 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(12, 13, null, AcknowledgeType.RELEASE)));
+            Collections.singletonList(new AcknowledgementBatch(12, 13, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
         assertEquals(12, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
         assertThrows(IllegalStateException.class, () -> sharePartition.cachedState().get(10L).batchState());
-        assertNull(sharePartition.cachedState().get(10L).gapOffsets());
 
         Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
         expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
@@ -873,7 +885,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new AcknowledgementBatch(12, 30, null, AcknowledgeType.RELEASE)));
+            Collections.singletonList(new AcknowledgementBatch(12, 30, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -993,7 +1005,6 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
         assertEquals(1, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
     }
 
@@ -1026,10 +1037,7 @@ public class SharePartitionTest {
         MemoryRecords records0 = memoryRecords(5, 0);
         MemoryRecords records1 = memoryRecords(2, 5);
         // Untracked gap of 3 offsets from 7-9.
-        MemoryRecordsBuilder recordsBuilder = memoryRecordsBuilder(5, 10);
-        // Gap from 15-17 offsets.
-        recordsBuilder.appendWithOffset(18, 0L, TestUtils.randomString(10).getBytes(), TestUtils.randomString(10).getBytes());
-        MemoryRecords records2 = recordsBuilder.build();
+        MemoryRecords records2 = memoryRecords(9, 10);
 
         CompletableFuture<List<AcquiredRecords>> result = sharePartition.acquire(
                 MEMBER_ID,
@@ -1057,7 +1065,11 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(5, 18, Arrays.asList(15L, 16L, 17L), AcknowledgeType.ACCEPT)));
+                Collections.singletonList(
+                    // TODO: NOTE - untracked gap of 3 offsets from 7-9 has no effect on acknowledgment
+                    //  irrespective of acknowledgement type provided. While acquiring, the log start
+                    //  offset should be used to determine such gaps.
+                    new AcknowledgementBatch(5, 18, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -1067,9 +1079,6 @@ public class SharePartitionTest {
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(10L).batchState());
         assertNull(sharePartition.cachedState().get(5L).offsetState());
         assertNull(sharePartition.cachedState().get(10L).offsetState());
-        assertNull(sharePartition.cachedState().get(5L).gapOffsets());
-        assertNotNull(sharePartition.cachedState().get(10L).gapOffsets());
-        assertEquals(new HashSet<>(Arrays.asList(15L, 16L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
 
         CompletableFuture<Optional<Throwable>> releaseResult = sharePartition.releaseAcquiredRecords(MEMBER_ID);
         assertFalse(releaseResult.isCompletedExceptionally());
@@ -1080,9 +1089,6 @@ public class SharePartitionTest {
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(10L).batchState());
         assertNull(sharePartition.cachedState().get(5L).offsetState());
         assertNull(sharePartition.cachedState().get(10L).offsetState());
-        assertNull(sharePartition.cachedState().get(5L).gapOffsets());
-        assertNotNull(sharePartition.cachedState().get(10L).gapOffsets());
-        assertEquals(new HashSet<>(Arrays.asList(15L, 16L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
     }
 
     @Test
@@ -1118,7 +1124,15 @@ public class SharePartitionTest {
         // Acknowledging over subset of both batch with subset of gap offsets.
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(6, 18, Arrays.asList(12L, 13L, 15L, 17L, 19L), AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(6, 18, Arrays.asList(
+                    // TODO: NOTE - untracked gap of 3 offsets from 7-9 has no effect on acknowledgment
+                    //  irrespective of acknowledgement type provided. While acquiring, the log start
+                    //  offset should be used to determine such gaps.
+                    AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT,
+                    AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT,
+                    AcknowledgeType.GAP, AcknowledgeType.GAP, AcknowledgeType.ACCEPT,
+                    AcknowledgeType.GAP, AcknowledgeType.ACCEPT, AcknowledgeType.GAP,
+                    AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(21, sharePartition.nextFetchOffset());
@@ -1182,7 +1196,10 @@ public class SharePartitionTest {
         // Acknowledging over subset of second batch with subset of gap offsets.
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(10, 18, Arrays.asList(12L, 13L, 15L, 17L, 19L), AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(10, 18, Arrays.asList(
+                    AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.GAP, AcknowledgeType.GAP,
+                    AcknowledgeType.ACCEPT, AcknowledgeType.GAP, AcknowledgeType.ACCEPT, AcknowledgeType.GAP,
+                    AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(21, sharePartition.nextFetchOffset());
@@ -1267,7 +1284,10 @@ public class SharePartitionTest {
         // Acknowledging over subset of second batch with subset of gap offsets.
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(10, 18, Arrays.asList(12L, 13L, 15L, 17L, 19L), AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(10, 18, Arrays.asList(
+                    AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.GAP, AcknowledgeType.GAP,
+                    AcknowledgeType.ACCEPT, AcknowledgeType.GAP, AcknowledgeType.ACCEPT, AcknowledgeType.GAP,
+                    AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(21, sharePartition.nextFetchOffset());
@@ -1298,7 +1318,7 @@ public class SharePartitionTest {
         // Ack subset of records by "member-2".
         ackResult = sharePartition.acknowledge(
                 "member-2",
-                Collections.singletonList(new AcknowledgementBatch(5, 5, null, AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(5, 5, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(19, sharePartition.nextFetchOffset());
@@ -1357,14 +1377,14 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(5, 6, null, AcknowledgeType.RELEASE)));
+                Collections.singletonList(new AcknowledgementBatch(5, 6, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(5, sharePartition.nextFetchOffset());
 
         ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(8, 9, null, AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(8, 9, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -1396,7 +1416,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(5, 14, null, AcknowledgeType.RELEASE)));
+                Collections.singletonList(new AcknowledgementBatch(5, 14, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -1404,7 +1424,6 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
         assertEquals(1, sharePartition.cachedState().get(5L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(5L).gapOffsets());
         assertNull(sharePartition.cachedState().get(5L).offsetState());
 
         result = sharePartition.acquire(
@@ -1416,7 +1435,7 @@ public class SharePartitionTest {
 
         ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(5, 14, null, AcknowledgeType.RELEASE)));
+                Collections.singletonList(new AcknowledgementBatch(5, 14, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -1460,9 +1479,9 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
                 new ArrayList<>(Arrays.asList(
-                        new AcknowledgementBatch(10, 12, null, AcknowledgeType.ACCEPT),
-                        new AcknowledgementBatch(13, 16, null, AcknowledgeType.RELEASE),
-                        new AcknowledgementBatch(17, 19, null, AcknowledgeType.ACCEPT)
+                        new AcknowledgementBatch(10, 12, Collections.singletonList(AcknowledgeType.ACCEPT)),
+                        new AcknowledgementBatch(13, 16, Collections.singletonList(AcknowledgeType.RELEASE)),
+                        new AcknowledgementBatch(17, 19, Collections.singletonList(AcknowledgeType.ACCEPT))
                 )));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
@@ -1534,7 +1553,7 @@ public class SharePartitionTest {
         ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
                 Collections.singletonList(
-                        new AcknowledgementBatch(13, 16, null, AcknowledgeType.RELEASE)
+                        new AcknowledgementBatch(13, 16, Collections.singletonList(AcknowledgeType.RELEASE))
                 ));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
@@ -1568,7 +1587,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
                 new ArrayList<>(Collections.singletonList(
-                        new AcknowledgementBatch(0, 1, null, AcknowledgeType.RELEASE)
+                        new AcknowledgementBatch(0, 1, Collections.singletonList(AcknowledgeType.RELEASE))
                 )));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
@@ -1608,7 +1627,7 @@ public class SharePartitionTest {
         ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
                 Collections.singletonList(
-                        new AcknowledgementBatch(0, 4, null, AcknowledgeType.RELEASE)
+                        new AcknowledgementBatch(0, 4, Collections.singletonList(AcknowledgeType.RELEASE))
                 ));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
@@ -1661,7 +1680,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
                 Collections.singletonList(
-                        new AcknowledgementBatch(10, 14, null, AcknowledgeType.RELEASE)
+                        new AcknowledgementBatch(10, 14, Collections.singletonList(AcknowledgeType.RELEASE))
                 ));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
@@ -1738,9 +1757,9 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
                 new ArrayList<>(Arrays.asList(
-                        new AcknowledgementBatch(13, 16, null, AcknowledgeType.RELEASE),
-                        new AcknowledgementBatch(17, 19, null, AcknowledgeType.REJECT),
-                        new AcknowledgementBatch(20, 24, null, AcknowledgeType.RELEASE)
+                        new AcknowledgementBatch(13, 16, Collections.singletonList(AcknowledgeType.RELEASE)),
+                        new AcknowledgementBatch(17, 19, Collections.singletonList(AcknowledgeType.REJECT)),
+                        new AcknowledgementBatch(20, 24, Collections.singletonList(AcknowledgeType.RELEASE))
                 )));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
@@ -1881,10 +1900,10 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
                 new ArrayList<>(Arrays.asList(
-                        new AcknowledgementBatch(10, 12, null, AcknowledgeType.ACCEPT),
-                        new AcknowledgementBatch(13, 16, null, AcknowledgeType.RELEASE),
-                        new AcknowledgementBatch(17, 19, null, AcknowledgeType.REJECT),
-                        new AcknowledgementBatch(20, 24, null, AcknowledgeType.RELEASE)
+                        new AcknowledgementBatch(10, 12, Collections.singletonList(AcknowledgeType.ACCEPT)),
+                        new AcknowledgementBatch(13, 16, Collections.singletonList(AcknowledgeType.RELEASE)),
+                        new AcknowledgementBatch(17, 19, Collections.singletonList(AcknowledgeType.REJECT)),
+                        new AcknowledgementBatch(20, 24, Collections.singletonList(AcknowledgeType.RELEASE))
                 )));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
@@ -1974,7 +1993,6 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.cachedState().get(0L).lastOffset());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).batchState());
         assertEquals(1, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
         assertNotNull(sharePartition.cachedState().get(0L).acquisitionLockTimeoutTask());
         assertEquals(1, sharePartition.timer().size());
@@ -1987,7 +2005,6 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.cachedState().get(0L).lastOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
         assertEquals(1, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
         assertNull(sharePartition.cachedState().get(0L).acquisitionLockTimeoutTask());
         assertEquals(0, sharePartition.timer().size());
@@ -2012,7 +2029,6 @@ public class SharePartitionTest {
         assertEquals(14, sharePartition.cachedState().get(10L).lastOffset());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(10L).batchState());
         assertEquals(1, sharePartition.cachedState().get(10L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(10L).gapOffsets());
         assertNull(sharePartition.cachedState().get(10L).offsetState());
         assertEquals(1, sharePartition.timer().size());
         assertNotNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
@@ -2025,7 +2041,6 @@ public class SharePartitionTest {
         assertEquals(14, sharePartition.cachedState().get(10L).lastOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
         assertEquals(1, sharePartition.cachedState().get(10L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(10L).gapOffsets());
         assertNull(sharePartition.cachedState().get(10L).offsetState());
         assertEquals(0, sharePartition.timer().size());
         assertNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
@@ -2125,7 +2140,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(0, 0, null, AcknowledgeType.RELEASE)));
+                Collections.singletonList(new AcknowledgementBatch(0, 0, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertNull(sharePartition.cachedState().get(0L).acquisitionLockTimeoutTask());
@@ -2135,7 +2150,6 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
         assertEquals(1, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
 
         // Allowing acquisition lock to expire.
@@ -2144,7 +2158,6 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
         assertEquals(1, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
         assertNull(sharePartition.cachedState().get(0L).acquisitionLockTimeoutTask());
         assertEquals(0, sharePartition.timer().size());
@@ -2166,7 +2179,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(5, 14, null, AcknowledgeType.RELEASE)));
+                Collections.singletonList(new AcknowledgementBatch(5, 14, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -2174,7 +2187,6 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
         assertEquals(1, sharePartition.cachedState().get(5L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(5L).gapOffsets());
         assertNull(sharePartition.cachedState().get(5L).offsetState());
         assertNull(sharePartition.cachedState().get(5L).acquisitionLockTimeoutTask());
         assertEquals(0, sharePartition.timer().size());
@@ -2185,7 +2197,6 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.cachedState().size());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
         assertEquals(1, sharePartition.cachedState().get(5L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(5L).gapOffsets());
         assertNull(sharePartition.cachedState().get(5L).offsetState());
         assertNull(sharePartition.cachedState().get(5L).acquisitionLockTimeoutTask());
         assertEquals(0, sharePartition.timer().size());
@@ -2234,7 +2245,8 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(5, 18, Arrays.asList(15L, 16L, 17L), AcknowledgeType.ACCEPT)));
+                // Do not send gap offsets to verify that they are ignored and accepted as per client ack.
+                Collections.singletonList(new AcknowledgementBatch(5, 18, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -2377,7 +2389,16 @@ public class SharePartitionTest {
         // Acknowledging over subset of both batch with subset of gap offsets.
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(6, 18, Arrays.asList(12L, 13L, 15L, 17L, 19L), AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(
+                    6, 18, Arrays.asList(
+                        // TODO: NOTE - untracked gap of 3 offsets from 7-9 has no effect on acknowledgment
+                        //  irrespective of acknowledgement type provided. While acquiring, the log start
+                        //  offset should be used to determine such gaps.
+                        AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT,
+                        AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT,
+                        AcknowledgeType.GAP, AcknowledgeType.GAP, AcknowledgeType.ACCEPT,
+                        AcknowledgeType.GAP, AcknowledgeType.ACCEPT, AcknowledgeType.GAP,
+                        AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -2422,11 +2443,6 @@ public class SharePartitionTest {
         assertNotNull(sharePartition.cachedState().get(10L).offsetState().get(20L).acquisitionLockTimeoutTask());
         assertEquals(3, sharePartition.timer().size());
 
-        assertNull(sharePartition.cachedState().get(5L).gapOffsets());
-        assertNotNull(sharePartition.cachedState().get(10L).gapOffsets());
-        // Gap offset 19 will be avoided as it's greater than the batch last offset.
-        assertEquals(new HashSet<>(Arrays.asList(12L, 13L, 15L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
-
         // Allowing acquisition lock to expire.
         Thread.sleep(200);
         assertEquals(5, sharePartition.nextFetchOffset());
@@ -2465,9 +2481,6 @@ public class SharePartitionTest {
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(19L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(20L).acquisitionLockTimeoutTask());
         assertEquals(0, sharePartition.timer().size());
-
-        // Gap offset 19 will be avoided as it's greater than the batch last offset.
-        assertEquals(new HashSet<>(Arrays.asList(12L, 13L, 15L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
     }
 
     @Test
@@ -2501,7 +2514,6 @@ public class SharePartitionTest {
         assertEquals(19, sharePartition.cachedState().get(10L).lastOffset());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(10L).batchState());
         assertEquals(1, sharePartition.cachedState().get(10L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(10L).gapOffsets());
         assertNull(sharePartition.cachedState().get(10L).offsetState());
         assertNotNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
         assertEquals(2, sharePartition.timer().size());
@@ -2514,7 +2526,6 @@ public class SharePartitionTest {
         assertEquals(19, sharePartition.cachedState().get(10L).lastOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
         assertEquals(1, sharePartition.cachedState().get(10L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(10L).gapOffsets());
         assertNull(sharePartition.cachedState().get(10L).offsetState());
         assertNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
         assertEquals(0, sharePartition.timer().size());
@@ -2533,7 +2544,6 @@ public class SharePartitionTest {
         assertEquals(19, sharePartition.cachedState().get(10L).lastOffset());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(10L).batchState());
         assertEquals(2, sharePartition.cachedState().get(10L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(10L).gapOffsets());
         assertNull(sharePartition.cachedState().get(10L).offsetState());
         assertNotNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
         assertEquals(1, sharePartition.timer().size());
@@ -2547,7 +2557,6 @@ public class SharePartitionTest {
         //After the second delivery attempt fails to acknowledge the record correctly, the record should be archived.
         assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(10L).batchState());
         assertEquals(2, sharePartition.cachedState().get(10L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(10L).gapOffsets());
         assertNull(sharePartition.cachedState().get(10L).offsetState());
         assertNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
         assertEquals(0, sharePartition.timer().size());
@@ -2575,7 +2584,6 @@ public class SharePartitionTest {
         assertEquals(9, sharePartition.cachedState().get(0L).lastOffset());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).batchState());
         assertEquals(1, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
         assertNotNull(sharePartition.cachedState().get(0L).acquisitionLockTimeoutTask());
         assertEquals(1, sharePartition.timer().size());
@@ -2588,7 +2596,6 @@ public class SharePartitionTest {
         assertEquals(9, sharePartition.cachedState().get(0L).lastOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
         assertEquals(1, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
         assertNull(sharePartition.cachedState().get(0L).acquisitionLockTimeoutTask());
         assertEquals(0, sharePartition.timer().size());
@@ -2694,7 +2701,6 @@ public class SharePartitionTest {
         assertEquals(9, sharePartition.cachedState().get(0L).lastOffset());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).batchState());
         assertEquals(1, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
         assertNotNull(sharePartition.cachedState().get(0L).acquisitionLockTimeoutTask());
         assertEquals(1, sharePartition.timer().size());
@@ -2707,7 +2713,6 @@ public class SharePartitionTest {
         assertEquals(9, sharePartition.cachedState().get(0L).lastOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
         assertEquals(1, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
         assertNull(sharePartition.cachedState().get(0L).acquisitionLockTimeoutTask());
         assertEquals(0, sharePartition.timer().size());
@@ -2726,7 +2731,6 @@ public class SharePartitionTest {
         assertEquals(9, sharePartition.cachedState().get(0L).lastOffset());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).batchState());
         assertEquals(2, sharePartition.cachedState().get(0L).batchDeliveryCount());
-        assertNull(sharePartition.cachedState().get(0L).gapOffsets());
         assertNull(sharePartition.cachedState().get(0L).offsetState());
         assertNotNull(sharePartition.cachedState().get(0L).acquisitionLockTimeoutTask());
         assertEquals(1, sharePartition.timer().size());
@@ -2766,7 +2770,7 @@ public class SharePartitionTest {
         // Acknowledge with ACCEPT type.
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(5, 9, null, AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(5, 9, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -2776,7 +2780,7 @@ public class SharePartitionTest {
         // Try acknowledging with REJECT type.
         ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(5, 9, null, AcknowledgeType.REJECT)));
+                Collections.singletonList(new AcknowledgementBatch(5, 9, Collections.singletonList(AcknowledgeType.REJECT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -2858,7 +2862,15 @@ public class SharePartitionTest {
         // Acknowledging over subset of both batch with subset of gap offsets.
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(6, 18, Arrays.asList(12L, 13L, 15L, 17L, 19L), AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(6, 18, Arrays.asList(
+                    // TODO: NOTE - untracked gap of 3 offsets from 7-9 has no effect on acknowledgment
+                    //  irrespective of acknowledgement type provided. While acquiring, the log start
+                    //  offset should be used to determine such gaps.
+                    AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT,
+                    AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT,
+                    AcknowledgeType.GAP, AcknowledgeType.GAP, AcknowledgeType.ACCEPT,
+                    AcknowledgeType.GAP, AcknowledgeType.ACCEPT, AcknowledgeType.GAP,
+                    AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -2888,12 +2900,6 @@ public class SharePartitionTest {
         expectedOffsetStateMap.put(19L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
         expectedOffsetStateMap.put(20L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
         assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
-
-        assertNull(sharePartition.cachedState().get(5L).gapOffsets());
-        assertNotNull(sharePartition.cachedState().get(10L).gapOffsets());
-        // Gap offset 19 will be avoided as it's greater than the batch last offset.
-        assertEquals(new HashSet<>(Arrays.asList(12L, 13L, 15L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
-
 
         // Check cached state.
         Map<Long, InFlightState> expectedOffsetStateMap1 = new HashMap<>();
@@ -2932,9 +2938,6 @@ public class SharePartitionTest {
 
         assertEquals(0, sharePartition.timer().size());
 
-        // Gap offset 19 will be avoided as it's greater than the batch last offset.
-        assertEquals(new HashSet<>(Arrays.asList(12L, 13L, 15L, 17L)), sharePartition.cachedState().get(10L).gapOffsets());
-
         // Allowing acquisition lock to expire. This won't change the state since the batches have been released.
         Thread.sleep(200);
         assertEquals(5, sharePartition.nextFetchOffset());
@@ -2962,7 +2965,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(5, 6, null, AcknowledgeType.RELEASE)));
+                Collections.singletonList(new AcknowledgementBatch(5, 6, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(5, sharePartition.nextFetchOffset());
@@ -2975,7 +2978,7 @@ public class SharePartitionTest {
 
         ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(8, 9, null, AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(8, 9, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         //Check cached state.
@@ -3029,7 +3032,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.cachedState().get(5L).batchDeliveryCount());
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge("member-1",
-                Collections.singletonList(new AcknowledgementBatch(5, 7, Collections.emptyList(), AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(5, 7, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(12, sharePartition.nextFetchOffset());
@@ -3049,7 +3052,7 @@ public class SharePartitionTest {
 
         // Acknowledge subset with another member.
         ackResult = sharePartition.acknowledge("member-2",
-                Collections.singletonList(new AcknowledgementBatch(9, 11, Collections.emptyList(), AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(9, 11, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -3070,7 +3073,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.cachedState().get(5L).batchDeliveryCount());
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge("member-1",
-                Collections.singletonList(new AcknowledgementBatch(5, 7, Collections.emptyList(), AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(5, 7, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(12, sharePartition.nextFetchOffset());
@@ -3121,14 +3124,17 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.cachedState().get(10L).batchDeliveryCount());
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge("member-1",
-                Collections.singletonList(new AcknowledgementBatch(5, 15, Arrays.asList(12L, 13L), AcknowledgeType.RELEASE)));
+                Arrays.asList(
+                    new AcknowledgementBatch(5, 11, Collections.singletonList(AcknowledgeType.RELEASE)),
+                    new AcknowledgementBatch(12, 13, Collections.singletonList(AcknowledgeType.GAP)),
+                    new AcknowledgementBatch(14, 15, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(5, sharePartition.nextFetchOffset());
 
         // Records 17-20 are released in the acknowledgement
         ackResult = sharePartition.acknowledge("member-1",
-                Collections.singletonList(new AcknowledgementBatch(17, 20, Collections.emptyList(), AcknowledgeType.RELEASE)));
+                Collections.singletonList(new AcknowledgementBatch(17, 20, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(5, sharePartition.nextFetchOffset());
@@ -3216,10 +3222,10 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Arrays.asList(
-                        new AcknowledgementBatch(5, 9, null, AcknowledgeType.RELEASE),
+                        new AcknowledgementBatch(5, 9, Collections.singletonList(AcknowledgeType.RELEASE)),
                         // Acknowledging batch with another member will cause failure and rollback.
-                        new AcknowledgementBatch(10, 14, null, AcknowledgeType.ACCEPT),
-                        new AcknowledgementBatch(15, 19, null, AcknowledgeType.ACCEPT)));
+                        new AcknowledgementBatch(10, 14, Collections.singletonList(AcknowledgeType.ACCEPT)),
+                        new AcknowledgementBatch(15, 19, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -3276,10 +3282,10 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Arrays.asList(
-                        new AcknowledgementBatch(5, 9, null, AcknowledgeType.RELEASE),
-                        new AcknowledgementBatch(10, 14, null, AcknowledgeType.ACCEPT),
+                        new AcknowledgementBatch(5, 9, Collections.singletonList(AcknowledgeType.RELEASE)),
+                        new AcknowledgementBatch(10, 14, Collections.singletonList(AcknowledgeType.ACCEPT)),
                         // Acknowledging subset with another member will cause failure and rollback.
-                        new AcknowledgementBatch(16, 18, null, AcknowledgeType.ACCEPT)));
+                        new AcknowledgementBatch(16, 18, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertTrue(ackResult.join().isPresent());
         assertEquals(InvalidRecordStateException.class, ackResult.join().get().getClass());
@@ -3351,7 +3357,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Collections.singletonList(
-                        new AcknowledgementBatch(0, 249, null, AcknowledgeType.ACCEPT)
+                        new AcknowledgementBatch(0, 249, Collections.singletonList(AcknowledgeType.ACCEPT))
                 )
         );
 
@@ -3392,7 +3398,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Collections.singletonList(
-                        new AcknowledgementBatch(0, 89, null, AcknowledgeType.RELEASE)
+                        new AcknowledgementBatch(0, 89, Collections.singletonList(AcknowledgeType.RELEASE))
                 )
         );
         assertFalse(ackResult.isCompletedExceptionally());
@@ -3434,7 +3440,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Collections.singletonList(
-                        new AcknowledgementBatch(0, 89, null, AcknowledgeType.REJECT)
+                        new AcknowledgementBatch(0, 89, Collections.singletonList(AcknowledgeType.REJECT))
                 )
         );
         assertFalse(ackResult.isCompletedExceptionally());
@@ -3476,7 +3482,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Collections.singletonList(
-                        new AcknowledgementBatch(0, 89, null, AcknowledgeType.ACCEPT)
+                        new AcknowledgementBatch(0, 89, Collections.singletonList(AcknowledgeType.ACCEPT))
                 )
         );
         assertFalse(ackResult.isCompletedExceptionally());
@@ -3513,7 +3519,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Collections.singletonList(
-                        new AcknowledgementBatch(0, 249, null, AcknowledgeType.ACCEPT)
+                        new AcknowledgementBatch(0, 249, Collections.singletonList(AcknowledgeType.ACCEPT))
                 )
         );
         assertFalse(ackResult.isCompletedExceptionally());
@@ -3549,7 +3555,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Collections.singletonList(
-                        new AcknowledgementBatch(0, 249, null, AcknowledgeType.REJECT)
+                        new AcknowledgementBatch(0, 249, Collections.singletonList(AcknowledgeType.REJECT))
                 )
         );
         assertFalse(ackResult.isCompletedExceptionally());
@@ -3585,7 +3591,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Collections.singletonList(
-                        new AcknowledgementBatch(0, 249, null, AcknowledgeType.RELEASE)
+                        new AcknowledgementBatch(0, 249, Collections.singletonList(AcknowledgeType.RELEASE))
                 )
         );
         assertFalse(ackResult.isCompletedExceptionally());
@@ -3646,7 +3652,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Collections.singletonList(
-                        new AcknowledgementBatch(0, 12, null, AcknowledgeType.ACCEPT)
+                        new AcknowledgementBatch(0, 12, Collections.singletonList(AcknowledgeType.ACCEPT))
                 )
         );
 
@@ -3713,7 +3719,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Collections.singletonList(
-                        new AcknowledgementBatch(0, 14, null, AcknowledgeType.REJECT)
+                        new AcknowledgementBatch(0, 14, Collections.singletonList(AcknowledgeType.REJECT))
                 )
         );
 
@@ -3774,7 +3780,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 "member-1",
                 Collections.singletonList(
-                        new AcknowledgementBatch(10, 14, null, AcknowledgeType.REJECT)
+                        new AcknowledgementBatch(10, 14, Collections.singletonList(AcknowledgeType.REJECT))
                 )
         );
 
@@ -3843,7 +3849,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             "member-1",
             Collections.singletonList(
-                new AcknowledgementBatch(0, 29, null, AcknowledgeType.ACCEPT)
+                new AcknowledgementBatch(0, 29, Collections.singletonList(AcknowledgeType.ACCEPT))
             )
         );
 
@@ -3927,7 +3933,7 @@ public class SharePartitionTest {
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
             "member-1",
             Collections.singletonList(
-                new AcknowledgementBatch(0, 19, null, AcknowledgeType.ACCEPT)
+                new AcknowledgementBatch(0, 19, Collections.singletonList(AcknowledgeType.ACCEPT))
             )
         );
 
@@ -3970,7 +3976,7 @@ public class SharePartitionTest {
         ackResult = sharePartition.acknowledge(
             "member-1",
             Collections.singletonList(
-                new AcknowledgementBatch(20, 49, null, AcknowledgeType.ACCEPT)
+                new AcknowledgementBatch(20, 49, Collections.singletonList(AcknowledgeType.ACCEPT))
             )
         );
 
@@ -4012,7 +4018,7 @@ public class SharePartitionTest {
         ackResult = sharePartition.acknowledge(
             "member-1",
             Collections.singletonList(
-                new AcknowledgementBatch(50, 179, null, AcknowledgeType.REJECT)
+                new AcknowledgementBatch(50, 179, Collections.singletonList(AcknowledgeType.REJECT))
             )
         );
 
@@ -4082,7 +4088,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 memberId1,
-                Collections.singletonList(new AcknowledgementBatch(5, 9, null, AcknowledgeType.RELEASE)));
+                Collections.singletonList(new AcknowledgementBatch(5, 9, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
         assertEquals(2, sharePartition.cachedState().size());
@@ -4124,7 +4130,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 memberId1,
-                Collections.singletonList(new AcknowledgementBatch(0, 2, null, AcknowledgeType.RELEASE)));
+                Collections.singletonList(new AcknowledgementBatch(0, 2, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -4161,7 +4167,7 @@ public class SharePartitionTest {
 
         ackResult = sharePartition.acknowledge(
                 memberId2,
-                Collections.singletonList(new AcknowledgementBatch(3, 4, null, AcknowledgeType.RELEASE)));
+                Collections.singletonList(new AcknowledgementBatch(3, 4, Collections.singletonList(AcknowledgeType.RELEASE))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -4335,7 +4341,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(5, 14, null, AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(5, 14, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -4371,7 +4377,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(8, 10, null, AcknowledgeType.REJECT)));
+                Collections.singletonList(new AcknowledgementBatch(8, 10, Collections.singletonList(AcknowledgeType.REJECT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -4451,7 +4457,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(8, 9, null, AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(8, 9, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 
@@ -4565,7 +4571,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new AcknowledgementBatch(8, 9, null, AcknowledgeType.ACCEPT)));
+                Collections.singletonList(new AcknowledgementBatch(8, 9, Collections.singletonList(AcknowledgeType.ACCEPT))));
         assertFalse(ackResult.isCompletedExceptionally());
         assertFalse(ackResult.join().isPresent());
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4484,7 +4484,7 @@ class KafkaApisTest extends Logging {
               new AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -4534,7 +4534,7 @@ class KafkaApisTest extends Logging {
             new AcknowledgementBatch()
               .setFirstOffset(0)
               .setLastOffset(9)
-              .setAcknowledgeType(1)
+              .setAcknowledgeTypes(Collections.singletonList(1.toByte))
           ).asJava)
         ).asJava)
       ).asJava)
@@ -4662,7 +4662,7 @@ class KafkaApisTest extends Logging {
               new AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -5023,7 +5023,6 @@ class KafkaApisTest extends Logging {
               new ShareFetchRequestData.AcknowledgementBatch().
                 setFirstOffset(0).
                 setLastOffset(9).
-                setAcknowledgeType(1).
                 setAcknowledgeTypes(List[java.lang.Byte](1.toByte).asJava)).asJava)).asJava)).asJava)
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
@@ -5062,7 +5061,6 @@ class KafkaApisTest extends Logging {
               new ShareFetchRequestData.AcknowledgementBatch().
                 setFirstOffset(10).
                 setLastOffset(19).
-                setAcknowledgeType(1).
                 setAcknowledgeTypes(List[java.lang.Byte](1.toByte).asJava)).asJava)).asJava)).asJava)
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
@@ -5367,7 +5365,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(9)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
@@ -5376,7 +5374,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(10)
                   .setLastOffset(19)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -5389,7 +5387,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(43)
                   .setLastOffset(52)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
@@ -5398,7 +5396,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(17)
                   .setLastOffset(26)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -5411,7 +5409,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(54)
                   .setLastOffset(93)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava),
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -5424,7 +5422,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(10)
                   .setLastOffset(24)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava),
           ).asJava),
       ).asJava)
@@ -6340,7 +6338,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(14)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
@@ -6349,7 +6347,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(45)
                   .setLastOffset(54)
-                  .setAcknowledgeType(2),
+                  .setAcknowledgeTypes(Collections.singletonList(2.toByte)),
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -6362,7 +6360,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(56)
                   .setLastOffset(67)
-                  .setAcknowledgeType(3),
+                  .setAcknowledgeTypes(Collections.singletonList(3.toByte)),
               ).asJava),
           ).asJava),
       ).asJava)
@@ -6464,7 +6462,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(14)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava),
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -6477,7 +6475,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(56)
                   .setLastOffset(67)
-                  .setAcknowledgeType(3),
+                  .setAcknowledgeTypes(Collections.singletonList(3.toByte)),
               ).asJava),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
@@ -6486,7 +6484,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(36)
                   .setLastOffset(52)
-                  .setAcknowledgeType(2),
+                  .setAcknowledgeTypes(Collections.singletonList(2.toByte)),
               ).asJava),
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -6499,7 +6497,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(3)
                   .setLastOffset(15)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava),
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -6512,7 +6510,7 @@ class KafkaApisTest extends Logging {
                 new AcknowledgementBatch()
                   .setFirstOffset(36)
                   .setLastOffset(78)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava),
           ).asJava),
       ).asJava)
@@ -9871,7 +9869,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -9947,7 +9945,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(2)
+                .setAcknowledgeTypes(Collections.singletonList(2.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10050,7 +10048,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(3)
+                .setAcknowledgeTypes(Collections.singletonList(3.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10152,7 +10150,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10222,7 +10220,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10299,7 +10297,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10370,7 +10368,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10499,7 +10497,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10554,7 +10552,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(24)
                 .setLastOffset(38)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10587,7 +10585,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(45)
                 .setLastOffset(68)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10656,7 +10654,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(10)
                 .setLastOffset(4) // end offset is less than base offset
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10744,8 +10742,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(10)
                 .setLastOffset(20)
-                .setAcknowledgeTypes(util.Arrays.asList(1.toByte,1.toByte,0.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte))
-                .setGapOffsets(List(12L.asInstanceOf[java.lang.Long]).asJava)
+                .setAcknowledgeTypes(util.Arrays.asList(1.toByte,1.toByte,0.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte))
             ).asJava)
         ).asJava)
       ).asJava)
@@ -10799,10 +10796,10 @@ class KafkaApisTest extends Logging {
                                    ) : Boolean = {
     if (baseOffset == acknowledgementBatch.firstOffset()
       && endOffset == acknowledgementBatch.lastOffset()
-      && AcknowledgeType.forId(acknowledgementType) == acknowledgementBatch.acknowledgeType()) {
+      && AcknowledgeType.forId(acknowledgementType) == acknowledgementBatch.acknowledgeTypes().get(0)) {
       return true
     }
-    return false
+    false
   }
 
   def compareAcknowledgeResponsePartitionData(
@@ -10813,7 +10810,7 @@ class KafkaApisTest extends Logging {
     if (partitionIndex == partitionData.partitionIndex() && ackErrorCode == partitionData.errorCode()) {
       return true
     }
-    return false
+    false
   }
 
   @Test
@@ -10836,11 +10833,11 @@ class KafkaApisTest extends Logging {
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1),
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setFirstOffset(10)
                 .setLastOffset(17)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava),
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(1)
@@ -10849,7 +10846,7 @@ class KafkaApisTest extends Logging {
               new ShareFetchRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(2)
+                .setAcknowledgeTypes(Collections.singletonList(2.toByte))
             ).asJava)
         ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -10862,7 +10859,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(24)
                   .setLastOffset(65)
-                  .setAcknowledgeType(3)
+                  .setAcknowledgeTypes(Collections.singletonList(3.toByte))
               ).asJava),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
@@ -10912,7 +10909,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(9)
-                  .setAcknowledgeType(7) // wrong acknowledgement type here (can only be 1, 2 or 3)
+                  .setAcknowledgeTypes(Collections.singletonList(7.toByte)) // wrong acknowledgement type here (can only be 0, 1, 2 or 3)
               ).asJava)
           ).asJava)
       ).asJava)
@@ -10953,11 +10950,11 @@ class KafkaApisTest extends Logging {
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(9)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(10)
                   .setLastOffset(17)
-                  .setAcknowledgeType(1)
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte))
               ).asJava),
             new ShareAcknowledgeRequestData.AcknowledgePartition()
               .setPartitionIndex(1)
@@ -10965,7 +10962,7 @@ class KafkaApisTest extends Logging {
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(9)
-                  .setAcknowledgeType(2)
+                  .setAcknowledgeTypes(Collections.singletonList(2.toByte))
               ).asJava)
           ).asJava),
         new ShareAcknowledgeRequestData.AcknowledgeTopic().
@@ -10977,7 +10974,7 @@ class KafkaApisTest extends Logging {
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(24)
                   .setLastOffset(65)
-                  .setAcknowledgeType(3)
+                  .setAcknowledgeTypes(Collections.singletonList(3.toByte))
               ).asJava)
           ).asJava)
       ).asJava)
@@ -11025,7 +11022,7 @@ class KafkaApisTest extends Logging {
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(9)
-                  .setAcknowledgeType(7) // wrong acknowledgement type here (can only be 1, 2 or 3)
+                  .setAcknowledgeTypes(Collections.singletonList(7.toByte)) // wrong acknowledgement type here (can only be 0, 1, 2 or 3)
               ).asJava)
         ).asJava)
       ).asJava)
@@ -11073,11 +11070,11 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(9)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(10)
                   .setLastOffset(19)
-                  .setAcknowledgeType(2)
+                  .setAcknowledgeTypes(Collections.singletonList(2.toByte))
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -11090,7 +11087,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(5)
                   .setLastOffset(19)
-                  .setAcknowledgeType(2),
+                  .setAcknowledgeTypes(Collections.singletonList(2.toByte)),
               ).asJava),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
@@ -11099,7 +11096,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(34)
                   .setLastOffset(56)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava)
           ).asJava)
       ).asJava)
@@ -11182,11 +11179,11 @@ class KafkaApisTest extends Logging {
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(9)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(10)
                   .setLastOffset(19)
-                  .setAcknowledgeType(2)
+                  .setAcknowledgeTypes(Collections.singletonList(2.toByte))
               ).asJava)
           ).asJava),
         new ShareAcknowledgeRequestData.AcknowledgeTopic().
@@ -11198,7 +11195,7 @@ class KafkaApisTest extends Logging {
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(5)
                   .setLastOffset(19)
-                  .setAcknowledgeType(2),
+                  .setAcknowledgeTypes(Collections.singletonList(2.toByte)),
               ).asJava),
             new ShareAcknowledgeRequestData.AcknowledgePartition()
               .setPartitionIndex(1)
@@ -11206,7 +11203,7 @@ class KafkaApisTest extends Logging {
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(34)
                   .setLastOffset(56)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava)
           ).asJava)
       ).asJava)
@@ -11290,11 +11287,11 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(39)
                   .setLastOffset(24) // this is an invalid batch because last offset is less than base offset
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(43)
                   .setLastOffset(56)
-                  .setAcknowledgeType(2)
+                  .setAcknowledgeTypes(Collections.singletonList(2.toByte))
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -11307,8 +11304,8 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(5)
                   .setLastOffset(19)
-                  .setGapOffsets(List(1L.asInstanceOf[java.lang.Long], 2L.asInstanceOf[java.lang.Long]).asJava) // this is an invalid batch because gap offsets are out of bounds
-                  .setAcknowledgeType(2),
+                  // this is an invalid batch because per offset ack is provided but doesn't cover all offsets
+                  .setAcknowledgeTypes(util.Arrays.asList(0.toByte, 2.toByte)),
               ).asJava),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
@@ -11317,11 +11314,11 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(34)
                   .setLastOffset(56)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(10) // this is an invalid batch because start is offset is less than previous end offset
                   .setLastOffset(19)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava)
           ).asJava)
       ).asJava)
@@ -11405,11 +11402,11 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(24)
                   .setLastOffset(39)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(43)
                   .setLastOffset(56)
-                  .setAcknowledgeType(2)
+                  .setAcknowledgeTypes(Collections.singletonList(2.toByte))
               ).asJava)
           ).asJava),
         new ShareFetchRequestData.FetchTopic().
@@ -11422,8 +11419,7 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(5)
                   .setLastOffset(19)
-                  .setGapOffsets(List(7L.asInstanceOf[java.lang.Long], 9L.asInstanceOf[java.lang.Long]).asJava)
-                  .setAcknowledgeType(2),
+                  .setAcknowledgeTypes(Collections.singletonList(2.toByte)),
               ).asJava),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
@@ -11432,11 +11428,11 @@ class KafkaApisTest extends Logging {
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(34)
                   .setLastOffset(56)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
                 new ShareFetchRequestData.AcknowledgementBatch()
                   .setFirstOffset(67)
                   .setLastOffset(87)
-                  .setAcknowledgeType(1),
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte)),
               ).asJava)
           ).asJava)
       ).asJava)
@@ -11530,7 +11526,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava),
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(1)
@@ -11538,7 +11534,7 @@ class KafkaApisTest extends Logging {
               new ShareAcknowledgeRequestData.AcknowledgementBatch()
                 .setFirstOffset(0)
                 .setLastOffset(9)
-                .setAcknowledgeType(1)
+                .setAcknowledgeTypes(Collections.singletonList(1.toByte))
             ).asJava)
         ).asJava),
         new ShareAcknowledgeRequestData.AcknowledgeTopic().
@@ -11550,7 +11546,7 @@ class KafkaApisTest extends Logging {
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(9)
-                  .setAcknowledgeType(1)
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte))
               ).asJava),
             new ShareAcknowledgeRequestData.AcknowledgePartition()
               .setPartitionIndex(1)
@@ -11558,7 +11554,7 @@ class KafkaApisTest extends Logging {
                 new ShareAcknowledgeRequestData.AcknowledgementBatch()
                   .setFirstOffset(0)
                   .setLastOffset(9)
-                  .setAcknowledgeType(1)
+                  .setAcknowledgeTypes(Collections.singletonList(1.toByte))
               ).asJava)
           ).asJava)
       ).asJava)


### PR DESCRIPTION
Handle changes to accept acknowledgement type as array instead of single value. Also removed gap offsets as they will be part of acknowledgment type now.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
