### PR TITLE
AKCORE-153: Tidy up handling of acknowledge types

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Acknowledgements.java
@@ -166,76 +166,37 @@ public class Acknowledgements {
                 currentBatch.setFirstOffset(entry.getKey());
                 currentBatch.setLastOffset(entry.getKey());
                 if (entry.getValue() != null) {
-                    currentBatch.setAcknowledgeType(entry.getValue().id);
                     currentBatch.acknowledgeTypes().add(entry.getValue().id);
                 } else {
-                    // Put a marker value of -1 while this batch only has gaps
-                    currentBatch.setAcknowledgeType((byte) -1);
-                    currentBatch.gapOffsets().add(entry.getKey());
                     currentBatch.acknowledgeTypes().add(ACKNOWLEDGE_TYPE_GAP);
                 }
             } else {
                 if (entry.getValue() != null) {
                     if (entry.getKey() == currentBatch.lastOffset() + 1) {
-                        if (entry.getValue().id == currentBatch.acknowledgeType()) {
-                            currentBatch.setLastOffset(entry.getKey());
-                            currentBatch.acknowledgeTypes().add(entry.getValue().id);
-                        } else if (currentBatch.acknowledgeType() == (byte) -1) {
-                            currentBatch.setAcknowledgeType(entry.getValue().id);
-                            currentBatch.setLastOffset(entry.getKey());
-                            currentBatch.acknowledgeTypes().add(entry.getValue().id);
-                        } else {
-                            if (currentBatch.acknowledgeType() == -1) {
-                                // Even though this batch is just gaps, we mark it as ACCEPT.
-                                currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
-                            }
-                            batches.add(currentBatch);
-
-                            currentBatch = new ShareFetchRequestData.AcknowledgementBatch();
-                            currentBatch.setFirstOffset(entry.getKey());
-                            currentBatch.setLastOffset(entry.getKey());
-                            currentBatch.setAcknowledgeType(entry.getValue().id);
-                            currentBatch.acknowledgeTypes().add(entry.getValue().id);
-                        }
+                        currentBatch.setLastOffset(entry.getKey());
+                        currentBatch.acknowledgeTypes().add(entry.getValue().id);
                     } else {
-                        if (currentBatch.acknowledgeType() == -1) {
-                            // Even though this batch is just gaps, we mark it as ACCEPT.
-                            currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
-                        }
                         batches.add(currentBatch);
 
                         currentBatch = new ShareFetchRequestData.AcknowledgementBatch();
                         currentBatch.setFirstOffset(entry.getKey());
                         currentBatch.setLastOffset(entry.getKey());
-                        currentBatch.setAcknowledgeType(entry.getValue().id);
                         currentBatch.acknowledgeTypes().add(entry.getValue().id);
                     }
                 } else {
                     if (entry.getKey() == currentBatch.lastOffset() + 1) {
                         currentBatch.setLastOffset(entry.getKey());
-                        currentBatch.gapOffsets().add(entry.getKey());
                         currentBatch.acknowledgeTypes().add(ACKNOWLEDGE_TYPE_GAP);
                     } else {
-                        if (currentBatch.acknowledgeType() == -1) {
-                            // Even though this batch is just gaps, we mark it as ACCEPT.
-                            currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
-                        }
                         batches.add(currentBatch);
 
                         currentBatch = new ShareFetchRequestData.AcknowledgementBatch();
                         currentBatch.setFirstOffset(entry.getKey());
                         currentBatch.setLastOffset(entry.getKey());
-                        // Put a marker value of -1 while this batch only has gaps
-                        currentBatch.setAcknowledgeType((byte) -1);
-                        currentBatch.gapOffsets().add(entry.getKey());
                         currentBatch.acknowledgeTypes().add(ACKNOWLEDGE_TYPE_GAP);
                     }
                 }
             }
-        }
-        if (currentBatch.acknowledgeType() == -1) {
-            // Even though this batch is just gaps, we mark it as ACCEPT.
-            currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
         }
         batches.add(currentBatch);
         return batches;
@@ -253,76 +214,37 @@ public class Acknowledgements {
                 currentBatch.setFirstOffset(entry.getKey());
                 currentBatch.setLastOffset(entry.getKey());
                 if (entry.getValue() != null) {
-                    currentBatch.setAcknowledgeType(entry.getValue().id);
                     currentBatch.acknowledgeTypes().add(entry.getValue().id);
                 } else {
-                    // Put a marker value of -1 while this batch only has gaps
-                    currentBatch.setAcknowledgeType((byte) -1);
-                    currentBatch.gapOffsets().add(entry.getKey());
                     currentBatch.acknowledgeTypes().add(ACKNOWLEDGE_TYPE_GAP);
                 }
             } else {
                 if (entry.getValue() != null) {
                     if (entry.getKey() == currentBatch.lastOffset() + 1) {
-                        if (entry.getValue().id == currentBatch.acknowledgeType()) {
-                            currentBatch.setLastOffset(entry.getKey());
-                            currentBatch.acknowledgeTypes().add(entry.getValue().id);
-                        } else if (currentBatch.acknowledgeType() == (byte) -1) {
-                            currentBatch.setAcknowledgeType(entry.getValue().id);
-                            currentBatch.setLastOffset(entry.getKey());
-                            currentBatch.acknowledgeTypes().add(entry.getValue().id);
-                        } else {
-                            if (currentBatch.acknowledgeType() == -1) {
-                                // Even though this batch is just gaps, we mark it as ACCEPT.
-                                currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
-                            }
-                            batches.add(currentBatch);
-
-                            currentBatch = new ShareAcknowledgeRequestData.AcknowledgementBatch();
-                            currentBatch.setFirstOffset(entry.getKey());
-                            currentBatch.setLastOffset(entry.getKey());
-                            currentBatch.setAcknowledgeType(entry.getValue().id);
-                            currentBatch.acknowledgeTypes().add(entry.getValue().id);
-                        }
+                        currentBatch.setLastOffset(entry.getKey());
+                        currentBatch.acknowledgeTypes().add(entry.getValue().id);
                     } else {
-                        if (currentBatch.acknowledgeType() == -1) {
-                            // Even though this batch is just gaps, we mark it as ACCEPT.
-                            currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
-                        }
                         batches.add(currentBatch);
 
                         currentBatch = new ShareAcknowledgeRequestData.AcknowledgementBatch();
                         currentBatch.setFirstOffset(entry.getKey());
                         currentBatch.setLastOffset(entry.getKey());
-                        currentBatch.setAcknowledgeType(entry.getValue().id);
                         currentBatch.acknowledgeTypes().add(entry.getValue().id);
                     }
                 } else {
                     if (entry.getKey() == currentBatch.lastOffset() + 1) {
                         currentBatch.setLastOffset(entry.getKey());
-                        currentBatch.gapOffsets().add(entry.getKey());
                         currentBatch.acknowledgeTypes().add(ACKNOWLEDGE_TYPE_GAP);
                     } else {
-                        if (currentBatch.acknowledgeType() == -1) {
-                            // Even though this batch is just gaps, we mark it as ACCEPT.
-                            currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
-                        }
                         batches.add(currentBatch);
 
                         currentBatch = new ShareAcknowledgeRequestData.AcknowledgementBatch();
                         currentBatch.setFirstOffset(entry.getKey());
                         currentBatch.setLastOffset(entry.getKey());
-                        // Put a marker value of -1 while this batch only has gaps
-                        currentBatch.setAcknowledgeType((byte) -1);
-                        currentBatch.gapOffsets().add(entry.getKey());
                         currentBatch.acknowledgeTypes().add(ACKNOWLEDGE_TYPE_GAP);
                     }
                 }
             }
-        }
-        if (currentBatch.acknowledgeType() == -1) {
-            // Even though this batch is just gaps, we mark it as ACCEPT.
-            currentBatch.setAcknowledgeType(AcknowledgeType.ACCEPT.id);
         }
         batches.add(currentBatch);
         return batches;

--- a/clients/src/main/resources/common/message/ShareAcknowledgeRequest.json
+++ b/clients/src/main/resources/common/message/ShareAcknowledgeRequest.json
@@ -46,11 +46,7 @@
           { "name": "LastOffset", "type": "int64", "versions": "0+",
             "about": "Last offset (inclusive) of batch of records to acknowledge."},
           { "name": "AcknowledgeTypes", "type": "[]int8", "versions": "0+",
-            "about": "Array of acknowledge types - 0:Gap,1:Accept,2:Release,3:Reject."},
-          { "name": "GapOffsets", "type": "[]int64", "versions": "0+",
-            "about": "[TO BE REMOVED] Array of offsets in this range which do not correspond to records."},
-          { "name": "AcknowledgeType", "type": "int8", "versions": "0+", "default": "1",
-            "about": "[TO BE REMOVED] The type of acknowledgement - 1:Accept,2:Release,3:Reject."}
+            "about": "Array of acknowledge types - 0:Gap,1:Accept,2:Release,3:Reject."}
         ]}
       ]}
     ]}

--- a/clients/src/main/resources/common/message/ShareFetchRequest.json
+++ b/clients/src/main/resources/common/message/ShareFetchRequest.json
@@ -53,11 +53,7 @@
           { "name": "LastOffset", "type": "int64", "versions": "0+",
             "about": "Last offset (inclusive) of batch of records to acknowledge."},
           { "name": "AcknowledgeTypes", "type": "[]int8", "versions": "0+",
-            "about": "Array of acknowledge types - 0:Gap,1:Accept,2:Release,3:Reject."},
-          { "name": "GapOffsets", "type": "[]int64", "versions": "0+",
-            "about": "[TO BE REMOVED] Array of offsets in this range which do not correspond to records."},
-          { "name": "AcknowledgeType", "type": "int8", "versions": "0+", "default": "1",
-            "about": "[TO BE REMOVED] The type of acknowledgement - 1:Accept,2:Release,3:Reject."}
+            "about": "Array of acknowledge types - 0:Gap,1:Accept,2:Release,3:Reject."}
         ]}
       ]}
     ]},

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AcknowledgementsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AcknowledgementsTest.java
@@ -41,15 +41,13 @@ public class AcknowledgementsTest {
     }
 
     @Test
-    public void testSingleBatchSingleRecord() {
+    public void testSingleStateSingleRecord() {
         acks.add(0L, AcknowledgeType.ACCEPT);
 
         List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(0L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertTrue(ackList.get(0).gapOffsets().isEmpty());
         assertEquals(1, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
 
@@ -57,14 +55,12 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
         assertEquals(0L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
         assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
     }
 
     @Test
-    public void testSingleBatchMultiRecord() {
+    public void testSingleStateMultiRecord() {
         acks.add(0L, AcknowledgeType.ACCEPT);
         acks.add(1L, AcknowledgeType.ACCEPT);
         acks.add(2L, AcknowledgeType.ACCEPT);
@@ -75,8 +71,6 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(4L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertTrue(ackList.get(0).gapOffsets().isEmpty());
         assertNotEquals(0, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
 
@@ -84,14 +78,12 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
         assertEquals(4L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
         assertNotEquals(0, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
     }
 
     @Test
-    public void testMultiBatchMultiRecord() {
+    public void testMultiStateMultiRecord() {
         acks.add(0L, AcknowledgeType.ACCEPT);
         acks.add(1L, AcknowledgeType.ACCEPT);
         acks.add(2L, AcknowledgeType.ACCEPT);
@@ -99,44 +91,30 @@ public class AcknowledgementsTest {
         acks.add(4L, AcknowledgeType.RELEASE);
 
         List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
-        assertEquals(2, ackList.size());
+        assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
-        assertEquals(2L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertTrue(ackList.get(0).gapOffsets().isEmpty());
-        assertEquals(3, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(4L, ackList.get(0).lastOffset());
+        assertEquals(5, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(1));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(2));
-        assertEquals(3L, ackList.get(1).firstOffset());
-        assertEquals(4L, ackList.get(1).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
-        assertTrue(ackList.get(1).gapOffsets().isEmpty());
-        assertEquals(2, ackList.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(3));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(4));
 
         List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
-        assertEquals(2, ackList2.size());
+        assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
-        assertEquals(2L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
-        assertEquals(3, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(4L, ackList2.get(0).lastOffset());
+        assertEquals(5, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(1));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(2));
-        assertEquals(3L, ackList2.get(1).firstOffset());
-        assertEquals(4L, ackList2.get(1).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeType());
-        assertTrue(ackList2.get(1).gapOffsets().isEmpty());
-        assertEquals(2, ackList2.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(0));
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(3));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(4));
     }
 
     @Test
-    public void testMultiBatchSingleMultiRecord() {
+    public void testMultiStateSingleMultiRecord() {
         acks.add(0L, AcknowledgeType.ACCEPT);
         acks.add(1L, AcknowledgeType.RELEASE);
         acks.add(2L, AcknowledgeType.RELEASE);
@@ -144,44 +122,30 @@ public class AcknowledgementsTest {
         acks.add(4L, AcknowledgeType.RELEASE);
 
         List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
-        assertEquals(2, ackList.size());
+        assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
-        assertEquals(0L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertTrue(ackList.get(0).gapOffsets().isEmpty());
-        assertEquals(1, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(4L, ackList.get(0).lastOffset());
+        assertEquals(5, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
-        assertEquals(1L, ackList.get(1).firstOffset());
-        assertEquals(4L, ackList.get(1).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
-        assertTrue(ackList.get(1).gapOffsets().isEmpty());
-        assertEquals(4, ackList.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(1));
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(2));
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(3));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(2));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(3));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(4));
 
         List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
-        assertEquals(2, ackList2.size());
+        assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
-        assertEquals(0L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
-        assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(4L, ackList2.get(0).lastOffset());
+        assertEquals(5, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
-        assertEquals(1L, ackList2.get(1).firstOffset());
-        assertEquals(4L, ackList2.get(1).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeType());
-        assertTrue(ackList2.get(1).gapOffsets().isEmpty());
-        assertEquals(4, ackList2.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(0));
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(1));
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(2));
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(3));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(2));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(3));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(4));
     }
 
     @Test
-    public void testMultiBatchMultiSingleRecord() {
+    public void testMultiStateMultiSingleRecord() {
         acks.add(0L, AcknowledgeType.ACCEPT);
         acks.add(1L, AcknowledgeType.ACCEPT);
         acks.add(2L, AcknowledgeType.ACCEPT);
@@ -189,52 +153,36 @@ public class AcknowledgementsTest {
         acks.add(4L, AcknowledgeType.RELEASE);
 
         List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
-        assertEquals(2, ackList.size());
+        assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
-        assertEquals(3L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertTrue(ackList.get(0).gapOffsets().isEmpty());
-        assertEquals(4, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(4L, ackList.get(0).lastOffset());
+        assertEquals(5, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(1));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(2));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(3));
-        assertEquals(4L, ackList.get(1).firstOffset());
-        assertEquals(4L, ackList.get(1).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
-        assertTrue(ackList.get(1).gapOffsets().isEmpty());
-        assertEquals(1, ackList.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(4));
 
         List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
-        assertEquals(2, ackList2.size());
+        assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
-        assertEquals(3L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
-        assertEquals(4, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(4L, ackList2.get(0).lastOffset());
+        assertEquals(5, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(1));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(2));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(3));
-        assertEquals(4L, ackList2.get(1).firstOffset());
-        assertEquals(4L, ackList2.get(1).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeType());
-        assertTrue(ackList2.get(1).gapOffsets().isEmpty());
-        assertEquals(1, ackList2.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(4));
     }
 
     @Test
-    public void testSingleBatchSingleGap() {
+    public void testSingleGap() {
         acks.addGap(0L);
 
         List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(0L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertEquals(1, ackList.get(0).gapOffsets().size());
         assertEquals(1, ackList.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
 
@@ -242,14 +190,12 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
         assertEquals(0L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertEquals(1, ackList2.get(0).gapOffsets().size());
         assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(0));
     }
 
     @Test
-    public void testSingleBatchMultiGap() {
+    public void testMultiGap() {
         acks.addGap(0L);
         acks.addGap(1L);
 
@@ -257,8 +203,6 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(1L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertEquals(2, ackList.get(0).gapOffsets().size());
         assertEquals(2, ackList.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(1));
@@ -267,15 +211,13 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
         assertEquals(1L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertEquals(2, ackList2.get(0).gapOffsets().size());
         assertEquals(2, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(0));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(1));
     }
 
     @Test
-    public void testSingleBatchSingleGapSingleRecord() {
+    public void testSingleGapSingleState() {
         acks.addGap(0L);
         acks.add(1L, AcknowledgeType.ACCEPT);
 
@@ -283,8 +225,6 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(1L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertEquals(1, ackList.get(0).gapOffsets().size());
         assertEquals(2, ackList.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(1));
@@ -293,15 +233,13 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
         assertEquals(1L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertEquals(1, ackList2.get(0).gapOffsets().size());
         assertEquals(2, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(0));
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(1));
     }
 
     @Test
-    public void testSingleBatchSingleRecordSingleGap() {
+    public void testSingleStateSingleGap() {
         acks.add(0L, AcknowledgeType.ACCEPT);
         acks.addGap(1L);
 
@@ -309,8 +247,6 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
         assertEquals(1L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertEquals(1, ackList.get(0).gapOffsets().size());
         assertEquals(2, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(1));
@@ -319,15 +255,13 @@ public class AcknowledgementsTest {
         assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
         assertEquals(1L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertEquals(1, ackList2.get(0).gapOffsets().size());
         assertEquals(2, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(1));
     }
 
     @Test
-    public void testMultiBatchSingleMultiGapRecords() {
+    public void testMultiStateMultiGap() {
         acks.add(0L, AcknowledgeType.RELEASE);
         acks.addGap(1L);
         acks.addGap(2L);
@@ -335,44 +269,30 @@ public class AcknowledgementsTest {
         acks.add(4L, AcknowledgeType.ACCEPT);
 
         List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
-        assertEquals(2, ackList.size());
+        assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
-        assertEquals(2L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeType());
-        assertEquals(2, ackList.get(0).gapOffsets().size());
-        assertEquals(3, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(4L, ackList.get(0).lastOffset());
+        assertEquals(5, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(1));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(2));
-        assertEquals(3L, ackList.get(1).firstOffset());
-        assertEquals(4L, ackList.get(1).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeType());
-        assertTrue(ackList.get(1).gapOffsets().isEmpty());
-        assertEquals(2, ackList.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeTypes().get(0));
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(3));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(4));
 
         List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
-        assertEquals(2, ackList2.size());
+        assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
-        assertEquals(2L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeType());
-        assertEquals(2, ackList2.get(0).gapOffsets().size());
-        assertEquals(3, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(4L, ackList2.get(0).lastOffset());
+        assertEquals(5, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(0));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(1));
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(2));
-        assertEquals(3L, ackList2.get(1).firstOffset());
-        assertEquals(4L, ackList2.get(1).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(1).acknowledgeType());
-        assertTrue(ackList2.get(1).gapOffsets().isEmpty());
-        assertEquals(2, ackList2.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(1).acknowledgeTypes().get(0));
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(1).acknowledgeTypes().get(1));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(3));
+        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(4));
     }
 
     @Test
-    public void testMultiBatchSingleMultiRecordGaps() {
+    public void testMultiStateMultiGaps() {
         acks.add(0L, AcknowledgeType.ACCEPT);
         acks.add(1L, AcknowledgeType.RELEASE);
         acks.addGap(2L);
@@ -380,40 +300,26 @@ public class AcknowledgementsTest {
         acks.addGap(4L);
 
         List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
-        assertEquals(2, ackList.size());
+        assertEquals(1, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
-        assertEquals(0L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertTrue(ackList.get(0).gapOffsets().isEmpty());
-        assertEquals(1, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(4L, ackList.get(0).lastOffset());
+        assertEquals(5, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
-        assertEquals(1L, ackList.get(1).firstOffset());
-        assertEquals(4L, ackList.get(1).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
-        assertEquals(2, ackList.get(1).gapOffsets().size());
-        assertEquals(4, ackList.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
-        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(1).acknowledgeTypes().get(1));
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(2));
-        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(1).acknowledgeTypes().get(3));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(1));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(2));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(3));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(4));
 
         List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
-        assertEquals(2, ackList2.size());
+        assertEquals(1, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
-        assertEquals(0L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
-        assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(4L, ackList2.get(0).lastOffset());
+        assertEquals(5, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
-        assertEquals(1L, ackList2.get(1).firstOffset());
-        assertEquals(4L, ackList2.get(1).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeType());
-        assertEquals(2, ackList2.get(1).gapOffsets().size());
-        assertEquals(4, ackList2.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(0));
-        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(1).acknowledgeTypes().get(1));
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(2));
-        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(1).acknowledgeTypes().get(3));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(1));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(2));
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(3));
+        assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(4));
     }
 
     @Test
@@ -425,60 +331,38 @@ public class AcknowledgementsTest {
         acks.add(6L, AcknowledgeType.REJECT);
 
         List<ShareFetchRequestData.AcknowledgementBatch> ackList = acks.getShareFetchBatches();
-        assertEquals(4, ackList.size());
+        assertEquals(3, ackList.size());
         assertEquals(0L, ackList.get(0).firstOffset());
-        assertEquals(0L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertTrue(ackList.get(0).gapOffsets().isEmpty());
-        assertEquals(1, ackList.get(0).acknowledgeTypes().size());
+        assertEquals(1L, ackList.get(0).lastOffset());
+        assertEquals(2, ackList.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeTypes().get(0));
-        assertEquals(1L, ackList.get(1).firstOffset());
-        assertEquals(1L, ackList.get(1).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeType());
-        assertTrue(ackList.get(1).gapOffsets().isEmpty());
-        assertEquals(1, ackList.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(1).acknowledgeTypes().get(0));
-        assertEquals(3L, ackList.get(2).firstOffset());
-        assertEquals(4L, ackList.get(2).lastOffset());
-        assertEquals(AcknowledgeType.REJECT.id, ackList.get(2).acknowledgeType());
-        assertTrue(ackList.get(2).gapOffsets().isEmpty());
-        assertEquals(2, ackList.get(2).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList.get(0).acknowledgeTypes().get(1));
+        assertEquals(3L, ackList.get(1).firstOffset());
+        assertEquals(4L, ackList.get(1).lastOffset());
+        assertEquals(2, ackList.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.REJECT.id, ackList.get(1).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.REJECT.id, ackList.get(1).acknowledgeTypes().get(1));
+        assertEquals(6L, ackList.get(2).firstOffset());
+        assertEquals(6L, ackList.get(2).lastOffset());
+        assertEquals(1, ackList.get(2).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.REJECT.id, ackList.get(2).acknowledgeTypes().get(0));
-        assertEquals(AcknowledgeType.REJECT.id, ackList.get(2).acknowledgeTypes().get(1));
-        assertEquals(6L, ackList.get(3).firstOffset());
-        assertEquals(6L, ackList.get(3).lastOffset());
-        assertEquals(AcknowledgeType.REJECT.id, ackList.get(3).acknowledgeType());
-        assertTrue(ackList.get(3).gapOffsets().isEmpty());
-        assertEquals(1, ackList.get(3).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.REJECT.id, ackList.get(3).acknowledgeTypes().get(0));
 
         List<ShareAcknowledgeRequestData.AcknowledgementBatch> ackList2 = acks.getShareAcknowledgeBatches();
-        assertEquals(4, ackList2.size());
+        assertEquals(3, ackList2.size());
         assertEquals(0L, ackList2.get(0).firstOffset());
-        assertEquals(0L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertTrue(ackList2.get(0).gapOffsets().isEmpty());
-        assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
+        assertEquals(1L, ackList2.get(0).lastOffset());
+        assertEquals(2, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeTypes().get(0));
-        assertEquals(1L, ackList2.get(1).firstOffset());
-        assertEquals(1L, ackList2.get(1).lastOffset());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeType());
-        assertTrue(ackList2.get(1).gapOffsets().isEmpty());
-        assertEquals(1, ackList2.get(1).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(1).acknowledgeTypes().get(0));
-        assertEquals(3L, ackList2.get(2).firstOffset());
-        assertEquals(4L, ackList2.get(2).lastOffset());
-        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(2).acknowledgeType());
-        assertTrue(ackList2.get(2).gapOffsets().isEmpty());
-        assertEquals(2, ackList2.get(2).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.RELEASE.id, ackList2.get(0).acknowledgeTypes().get(1));
+        assertEquals(3L, ackList2.get(1).firstOffset());
+        assertEquals(4L, ackList2.get(1).lastOffset());
+        assertEquals(2, ackList2.get(1).acknowledgeTypes().size());
+        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(1).acknowledgeTypes().get(0));
+        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(1).acknowledgeTypes().get(1));
+        assertEquals(6L, ackList2.get(2).firstOffset());
+        assertEquals(6L, ackList2.get(2).lastOffset());
+        assertEquals(1, ackList2.get(2).acknowledgeTypes().size());
         assertEquals(AcknowledgeType.REJECT.id, ackList2.get(2).acknowledgeTypes().get(0));
-        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(2).acknowledgeTypes().get(1));
-        assertEquals(6L, ackList2.get(3).firstOffset());
-        assertEquals(6L, ackList2.get(3).lastOffset());
-        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(3).acknowledgeType());
-        assertTrue(ackList2.get(3).gapOffsets().isEmpty());
-        assertEquals(1, ackList2.get(3).acknowledgeTypes().size());
-        assertEquals(AcknowledgeType.REJECT.id, ackList2.get(3).acknowledgeTypes().get(0));
     }
 
 
@@ -491,14 +375,10 @@ public class AcknowledgementsTest {
         assertEquals(2, ackList.size());
         assertEquals(2L, ackList.get(0).firstOffset());
         assertEquals(2L, ackList.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(0).acknowledgeType());
-        assertEquals(1, ackList.get(0).gapOffsets().size());
         assertEquals(1, ackList.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(0).acknowledgeTypes().get(0));
         assertEquals(4L, ackList.get(1).firstOffset());
         assertEquals(4L, ackList.get(1).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList.get(1).acknowledgeType());
-        assertEquals(1, ackList.get(1).gapOffsets().size());
         assertEquals(1, ackList.get(1).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList.get(1).acknowledgeTypes().get(0));
 
@@ -506,14 +386,10 @@ public class AcknowledgementsTest {
         assertEquals(2, ackList2.size());
         assertEquals(2L, ackList2.get(0).firstOffset());
         assertEquals(2L, ackList2.get(0).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(0).acknowledgeType());
-        assertEquals(1, ackList2.get(0).gapOffsets().size());
         assertEquals(1, ackList2.get(0).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(0).acknowledgeTypes().get(0));
         assertEquals(4L, ackList2.get(1).firstOffset());
         assertEquals(4L, ackList2.get(1).lastOffset());
-        assertEquals(AcknowledgeType.ACCEPT.id, ackList2.get(1).acknowledgeType());
-        assertEquals(1, ackList2.get(1).gapOffsets().size());
         assertEquals(1, ackList2.get(1).acknowledgeTypes().size());
         assertEquals(Acknowledgements.ACKNOWLEDGE_TYPE_GAP, ackList2.get(1).acknowledgeTypes().get(0));
     }


### PR DESCRIPTION
Complete the change from a single acknowledge type and a gap array per batch to an array of acknowledge types per batch. This PR does not include the planned optimisations.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
