### PR TITLE
AKCORE-149: Ensure when the Log Start Offset (LSO) moves underneath acquired records, nothing breaks (1/N)

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -409,7 +409,7 @@ public class SharePartition {
 
 
     // This function provides the logic to get the earliest valid offset for a topic partition.
-    public long offsetForEarliestTimestamp() {
+    private long offsetForEarliestTimestamp() {
         // TODO: We need to know the isolation level from group configs, for now we are passing Option.empty() for isolationLevel
         Option<FileRecords.TimestampAndOffset> timestampAndOffset = replicaManager.fetchOffsetForTimestamp(
                 topicIdPartition.topicPartition(), ListOffsetsRequest.EARLIEST_TIMESTAMP, Option.empty(),

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -359,13 +359,12 @@ public class SharePartition {
                 if (cachedState.isEmpty()) {
                     startOffset = logStartOffset;
                     endOffset = logStartOffset;
-                    // Even if write share group state RPC call fails, we will still go ahead with the state transition.
+                    // Even if write share group state RPC call fails, we will not be rolling back startOffset and endOffset.
                     isWriteShareGroupStateSuccessful(stateBatches);
-                    // TODO: do we need to verify the persister write result
                 } else {
                     for (Map.Entry<Long, InFlightBatch> entry : cachedState.entrySet()) {
                         long batchStartOffset = entry.getKey();
-                        // We do not need to transition state of batches/offsets that are ahead of the new log start offset
+                        // We do not need to transition state of batches/offsets that are ahead of the new log start offset.
                         if (batchStartOffset >= logStartOffset) {
                             break;
                         }
@@ -500,7 +499,7 @@ public class SharePartition {
         lock.writeLock().lock();
         try {
             if (throwable != null || !isWriteShareGroupStateSuccessful(stateBatches)) {
-                // TODO: We do not rollback startOffset and endOffset here.
+                // We do not rollback startOffset and endOffset here.
                 log.debug("Request failed for archiving records, rollback any changed state"
                         + " for the share partition: {}-{}", groupId, topicIdPartition);
                 updatedStates.forEach(state -> state.completeStateTransition(false));

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -288,7 +288,7 @@ public class SharePartition {
         try {
             // When none of the records in the cachedState are in the AVAILABLE state, findNextFetchOffset will be false
             if (!findNextFetchOffset.get()) {
-                if (cachedState.isEmpty()) {
+                if (cachedState.isEmpty() || startOffset > cachedState.lastEntry().getValue().lastOffset) {
                     // when cachedState is empty, endOffset is set to the next offset of the last offset removed from
                     // batch, which is the next offset to be fetched
                     return endOffset;
@@ -298,7 +298,7 @@ public class SharePartition {
             }
 
             // If this piece of code is reached, it means that findNextFetchOffset is true
-            if (cachedState.isEmpty()) {
+            if (cachedState.isEmpty() || startOffset > cachedState.lastEntry().getValue().lastOffset) {
                 // If cachedState is empty, there is no need of re-computing next fetch offset in future fetch requests
                 findNextFetchOffset.set(false);
                 return endOffset;

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -351,9 +351,9 @@ public class SharePartition {
         Throwable throwable = null;
         if (logStartOffset > startOffset) {
             lock.writeLock().lock();
-            List<PersisterStateBatch> stateBatches = new ArrayList<>();
-            List<InFlightState> updatedStates = new ArrayList<>();
             try {
+                List<PersisterStateBatch> stateBatches = new ArrayList<>();
+                List<InFlightState> updatedStates = new ArrayList<>();
                 log.debug("Updating start offset for share partition: {}-{} from: {} to: {} since LSO has moved to: {}",
                         groupId, topicIdPartition, startOffset, logStartOffset, logStartOffset);
                 if (cachedState.isEmpty()) {
@@ -423,7 +423,6 @@ public class SharePartition {
                                                              long endOffset,
                                                              List<InFlightState> updatedStates,
                                                              List<PersisterStateBatch> stateBatches) {
-
         Throwable throwable = null;
         lock.writeLock().lock();
         try {

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -431,12 +431,10 @@ public class SharePartition {
                     isAnyBatchArchived = isAnyBatchArchived || archiveCompleteBatch(inFlightBatch);
                 }
             }
-            if (isAnyOffsetArchived || isAnyBatchArchived)
-                return true;
+            return isAnyOffsetArchived || isAnyBatchArchived;
         } finally {
             lock.writeLock().unlock();
         }
-        return false;
     }
 
     private boolean archivePerOffsetBatchRecords(InFlightBatch inFlightBatch,

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -107,16 +107,12 @@ public class SharePartition {
                     + "the same as the current state");
             }
 
-            if (this == ARCHIVED) {
+            if (this == ACKNOWLEDGED || this == ARCHIVED) {
                 throw new IllegalStateException("The state transition is invalid from the current state: " + this);
             }
 
-            if (this == ACKNOWLEDGED && newState != ARCHIVED) {
-                throw new IllegalStateException("The state can be only transitioned to ARCHIVED from ACKNOWLEDGED");
-            }
-
-            if (this == AVAILABLE && newState == ACKNOWLEDGED) {
-                throw new IllegalStateException("The state can not be transitioned to ACKNOWLEDGED from AVAILABLE");
+            if (this == AVAILABLE && newState != ACQUIRED) {
+                throw new IllegalStateException("The state can only be transitioned to ACQUIRED from AVAILABLE");
             }
 
             // Either the transition is from Available -> Acquired or from Acquired -> Available/
@@ -290,7 +286,6 @@ public class SharePartition {
         // and findNextFetchOffset flag is set to false
         lock.writeLock().lock();
         try {
-            updateOffsetsOnLsoMovement();
             // When none of the records in the cachedState are in the AVAILABLE state, findNextFetchOffset will be false
             if (!findNextFetchOffset.get()) {
                 if (cachedState.isEmpty()) {
@@ -346,25 +341,23 @@ public class SharePartition {
         }
     }
 
-    private void updateOffsetsOnLsoMovement() {
+    void updateOffsetsOnLsoMovement() {
         long logStartOffset = offsetForEarliestTimestamp();
-        Throwable throwable = null;
-        if (logStartOffset > startOffset) {
-            lock.writeLock().lock();
-            try {
-                List<PersisterStateBatch> stateBatches = new ArrayList<>();
-                List<InFlightState> updatedStates = new ArrayList<>();
+        lock.writeLock().lock();
+        try {
+            if (logStartOffset > startOffset) {
                 log.debug("Updating start offset for share partition: {}-{} from: {} to: {} since LSO has moved to: {}",
                         groupId, topicIdPartition, startOffset, logStartOffset, logStartOffset);
                 if (cachedState.isEmpty()) {
                     startOffset = logStartOffset;
                     endOffset = logStartOffset;
                     // Even if write share group state RPC call fails, we will not be rolling back startOffset and endOffset.
-                    isWriteShareGroupStateSuccessful(stateBatches);
+                    isWriteShareGroupStateSuccessful(new ArrayList<>());
                 } else {
+                    List<PersisterStateBatch> stateBatches = new ArrayList<>();
                     for (Map.Entry<Long, InFlightBatch> entry : cachedState.entrySet()) {
                         long batchStartOffset = entry.getKey();
-                        // We do not need to transition state of batches/offsets that are ahead of the new log start offset.
+                        // We do not need to transition state of batches/offsets that are later than the new log start offset.
                         if (batchStartOffset >= logStartOffset) {
                             break;
                         }
@@ -379,34 +372,32 @@ public class SharePartition {
                                     logStartOffset - 1, groupId, topicIdPartition);
 
                             if (inFlightBatch.offsetState == null) {
-                                if (inFlightBatch.batchState() == RecordState.ARCHIVED) {
+                                if (inFlightBatch.batchState() != RecordState.AVAILABLE) {
                                     continue;
                                 }
                                 inFlightBatch.maybeInitializeOffsetStateUpdate();
                             }
-                            throwable = archivePerOffsetBatchRecords(inFlightBatch, startOffset, logStartOffset - 1,
-                                    updatedStates, stateBatches).orElse(null);
-                            if (throwable != null) {
-                                break;
-                            }
+
+                            archivePerOffsetBatchRecords(inFlightBatch, startOffset, logStartOffset - 1, stateBatches);
                         } else {
                             // The in-flight batch is a full match hence change the state of the complete batch.
-                            throwable = archiveCompleteBatch(inFlightBatch, updatedStates, stateBatches).orElse(null);
-                            if (throwable != null) {
-                                break;
-                            }
+                            archiveCompleteBatch(inFlightBatch, stateBatches);
                         }
                     }
-                    // If the transitions to archive is successful then persist state, complete the state transition
-                    // and update the cached state for start offset. Else rollback the state transition.
-                    rollbackOrProcessArchivedStates(throwable, updatedStates, stateBatches);
+                    if (!stateBatches.isEmpty()) {
+                        findNextFetchOffset.set(true);
+                    }
+
+                    startOffset = logStartOffset;
+                    if (endOffset < startOffset) {
+                        endOffset = startOffset;
+                    }
                 }
-            } finally {
-                lock.writeLock().unlock();
             }
+        } finally {
+            lock.writeLock().unlock();
         }
     }
-
 
     // This function provides the logic to get the earliest valid offset for a topic partition.
     private long offsetForEarliestTimestamp() {
@@ -417,12 +408,10 @@ public class SharePartition {
         return timestampAndOffset.isEmpty() ? (long) 0 : timestampAndOffset.get().offset;
     }
 
-    private Optional<Throwable> archivePerOffsetBatchRecords(InFlightBatch inFlightBatch,
-                                                             long startOffset,
-                                                             long endOffset,
-                                                             List<InFlightState> updatedStates,
-                                                             List<PersisterStateBatch> stateBatches) {
-        Throwable throwable = null;
+    private void archivePerOffsetBatchRecords(InFlightBatch inFlightBatch,
+                                              long startOffset,
+                                              long endOffset,
+                                              List<PersisterStateBatch> stateBatches) {
         lock.writeLock().lock();
         try {
             log.trace("Archiving offset tracked batch: {} for the share partition: {}-{}", inFlightBatch, groupId, topicIdPartition);
@@ -434,87 +423,28 @@ public class SharePartition {
                     // No further offsets to process.
                     break;
                 }
-                if (offsetState.getValue().state == RecordState.ARCHIVED) {
+                if (offsetState.getValue().state != RecordState.AVAILABLE) {
                     continue;
                 }
 
-                InFlightState updateResult = offsetState.getValue().startStateTransition(RecordState.ARCHIVED, false,
-                        this.maxDeliveryCount, EMPTY_MEMBER_ID);
-                if (updateResult == null) {
-                    log.debug("Unable to archive records for the offset: {} in batch: {} for the share partition: {}-{}",
-                            offsetState.getKey(), inFlightBatch, groupId, topicIdPartition);
-                    throwable = new InvalidRecordStateException("Unable to archive records for the batch");
-                    break;
-                }
-                // Successfully updated the state of the offset.
-                updatedStates.add(updateResult);
+                InFlightState updateResult = offsetState.getValue().archive(EMPTY_MEMBER_ID);
                 stateBatches.add(new PersisterStateBatch(offsetState.getKey(), offsetState.getKey(),
                         updateResult.state.id, (short) updateResult.deliveryCount));
             }
         } finally {
             lock.writeLock().unlock();
         }
-        if (throwable !=  null)
-            return Optional.of(throwable);
-        return Optional.empty();
     }
 
-    private Optional<Throwable> archiveCompleteBatch(InFlightBatch inFlightBatch,
-                                                     List<InFlightState> updatedStates,
-                                                     List<PersisterStateBatch> stateBatches) {
-        Throwable throwable = null;
+    private void archiveCompleteBatch(InFlightBatch inFlightBatch, List<PersisterStateBatch> stateBatches) {
         lock.writeLock().lock();
         try {
             log.trace("Archiving complete batch: {} for the share partition: {}-{}", inFlightBatch, groupId, topicIdPartition);
-            if (inFlightBatch.batchState() == RecordState.ARCHIVED) {
-                return Optional.empty();
-            }
-            // Change the state of complete batch since the same state exists for the entire inFlight batch.
-            InFlightState updateResult = inFlightBatch.startBatchStateTransition(RecordState.ARCHIVED,
-                    false, this.maxDeliveryCount, EMPTY_MEMBER_ID);
-
-            if (updateResult == null) {
-                log.debug("Unable to archive records for the batch: {} for the share partition: {}-{}",
-                        inFlightBatch, groupId, topicIdPartition);
-                throwable = new InvalidRecordStateException("Unable to archive records for the batch");
-            } else {
-                // Successfully updated the state of the batch.
-                updatedStates.add(updateResult);
+            if (inFlightBatch.batchState() == RecordState.AVAILABLE) {
+                // Change the state of complete batch since the same state exists for the entire inFlight batch.
+                InFlightState updateResult = inFlightBatch.archiveBatch(EMPTY_MEMBER_ID);
                 stateBatches.add(new PersisterStateBatch(inFlightBatch.firstOffset, inFlightBatch.lastOffset,
                         updateResult.state.id, (short) updateResult.deliveryCount));
-            }
-        } finally {
-            lock.writeLock().unlock();
-        }
-        if (throwable !=  null)
-            return Optional.of(throwable);
-        return Optional.empty();
-    }
-
-    private void rollbackOrProcessArchivedStates(
-            Throwable throwable,
-            List<InFlightState> updatedStates,
-            List<PersisterStateBatch> stateBatches
-    ) {
-        lock.writeLock().lock();
-        try {
-            if (throwable != null || !isWriteShareGroupStateSuccessful(stateBatches)) {
-                // We do not rollback startOffset and endOffset here.
-                log.debug("Request failed for archiving records, rollback any changed state"
-                        + " for the share partition: {}-{}", groupId, topicIdPartition);
-                updatedStates.forEach(state -> state.completeStateTransition(false));
-            } else {
-                log.trace("Archiving request successful for share partition: {}-{}",
-                        groupId, topicIdPartition);
-                updatedStates.forEach(state -> {
-                    // Cancel the acquisition lock timeout task for the state in case they moved from Acquired to Archived state.
-                    if (state.rollbackState.state == RecordState.ACQUIRED) {
-                        state.cancelAndClearAcquisitionLockTimeoutTask();
-                    }
-                    state.completeStateTransition(true);
-                });
-                // Update the cached state and start and end offsets after archiving the acquired records.
-                maybeUpdateCachedStateAndOffsets();
             }
         } finally {
             lock.writeLock().unlock();
@@ -1635,6 +1565,13 @@ public class SharePartition {
             return offsetState;
         }
 
+        private InFlightState archiveBatch(String newMemberId) {
+            if (inFlightState == null) {
+                throw new IllegalStateException("The batch state is not available as the offset state is maintained");
+            }
+            return inFlightState.archive(newMemberId);
+        }
+
         private InFlightState tryUpdateBatchState(RecordState newState, boolean incrementDeliveryCount, int maxDeliveryCount, String newMemberId) {
             if (inFlightState == null) {
                 throw new IllegalStateException("The batch state update is not available as the offset state is maintained");
@@ -1803,6 +1740,12 @@ public class SharePartition {
                 log.info("Failed to update state of the records", e);
                 return null;
             }
+        }
+
+        private InFlightState archive(String newMemberId) {
+            state = RecordState.ARCHIVED;
+            memberId = newMemberId;
+            return this;
         }
 
         private InFlightState startStateTransition(RecordState newState, boolean incrementDeliveryCount, int maxDeliveryCount, String newMemberId) {

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -357,8 +357,6 @@ public class SharePartition {
                 if (cachedState.isEmpty()) {
                     startOffset = logStartOffset;
                     endOffset = logStartOffset;
-                    // Even if write share group state RPC call fails, we will not be rolling back startOffset and endOffset.
-                    isWriteShareGroupStateSuccessful(new ArrayList<>());
                 } else {
                     List<PersisterStateBatch> stateBatches = new ArrayList<>();
                     for (Map.Entry<Long, InFlightBatch> entry : cachedState.entrySet()) {
@@ -404,6 +402,9 @@ public class SharePartition {
                         endOffset = startOffset;
                     }
                 }
+                // We will only write the start and end offset to the persister actively.
+                // Even if write share group state RPC call fails, we will not be rolling back startOffset and endOffset.
+                isWriteShareGroupStateSuccessful(new ArrayList<>());
             }
         } finally {
             lock.writeLock().unlock();

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -776,8 +776,7 @@ public class SharePartition {
                 if (inFlightBatch.offsetState == null
                         && inFlightBatch.batchState() == RecordState.ACQUIRED
                         && inFlightBatch.batchMemberId().equals(memberId)
-                        && inFlightBatch.firstOffset < startOffset
-                        && inFlightBatch.lastOffset >= startOffset) {
+                        && checkForStartOffsetWithinBatch(inFlightBatch.firstOffset, inFlightBatch.lastOffset)) {
                     // For the case when batch.firstOffset < start offset <= batch.lastOffset, we will be having some
                     // acquired records that need to move to archived state despite their delivery count.
                     inFlightBatch.maybeInitializeOffsetStateUpdate();
@@ -1411,8 +1410,7 @@ public class SharePartition {
 
                     if (inFlightBatch.offsetState == null
                             && inFlightBatch.batchState() == RecordState.ACQUIRED
-                            && inFlightBatch.firstOffset < startOffset
-                            && inFlightBatch.lastOffset >= startOffset) {
+                            && checkForStartOffsetWithinBatch(inFlightBatch.firstOffset, inFlightBatch.lastOffset)) {
                         // For the case when batch.firstOffset < start offset <= batch.lastOffset, we will be having some
                         // acquired records that need to move to archived state despite their delivery count.
                         inFlightBatch.maybeInitializeOffsetStateUpdate();
@@ -1540,6 +1538,10 @@ public class SharePartition {
 
     private boolean checkForFullMatch(InFlightBatch inFlightBatch, long firstOffsetToCompare, long lastOffsetToCompare) {
         return inFlightBatch.firstOffset >= firstOffsetToCompare && inFlightBatch.lastOffset <= lastOffsetToCompare;
+    }
+
+    private boolean checkForStartOffsetWithinBatch(long batchFirstOffset, long batchLastOffset) {
+        return batchFirstOffset < startOffset && batchLastOffset >= startOffset;
     }
 
     // Visible for testing. Should only be used for testing purposes.

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -170,7 +170,7 @@ public class SharePartitionManager implements AutoCloseable {
                 );
                 SharePartition sharePartition = partitionCacheMap.computeIfAbsent(sharePartitionKey,
                     k -> new SharePartition(shareFetchPartitionData.groupId, topicIdPartition, maxInFlightMessages, maxDeliveryCount,
-                            recordLockDurationMs, timer, time, persister));
+                            recordLockDurationMs, timer, time, persister, replicaManager));
                 int partitionMaxBytes = shareFetchPartitionData.partitionMaxBytes.getOrDefault(topicIdPartition, 0);
                 // Add the share partition to the list of partitions to be fetched only if we can
                 // acquire the fetch lock on it.

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -289,7 +289,7 @@ public class SharePartitionManager implements AutoCloseable {
                             .setErrorCode(fetchPartitionData.error.code())
                             .setAcquiredRecords(acquiredRecords)
                             .setAcknowledgeErrorCode(Errors.NONE.code());
-                        }
+                    }
                     return partitionData;
                 }));
         });

--- a/core/src/main/java/kafka/server/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/SharePartitionManager.java
@@ -267,32 +267,29 @@ public class SharePartitionManager implements AutoCloseable {
 
                     if (throwable != null) {
                         partitionData.setErrorCode(Errors.forException(throwable).code());
+                    } else if (fetchPartitionData.error.code() == Errors.OFFSET_OUT_OF_RANGE.code()) {
+                        // In case we get OFFSET_OUT_OF_RANGE error, that's because the LSO is later than the fetch offset.
+                        // So, we would update the start and end offset of the share partition and still return an empty
+                        // response and let the client retry the fetch. This way we do not lose out on the data that
+                        // would be returned for other share partitions in the fetch request.
+                        sharePartition.updateOffsetsOnLsoMovement();
+                        partitionData
+                                .setPartitionIndex(topicIdPartition.partition())
+                                .setRecords(null)
+                                .setErrorCode(Errors.NONE.code())
+                                .setAcquiredRecords(Collections.emptyList())
+                                .setAcknowledgeErrorCode(Errors.NONE.code());
                     } else {
                         // Maybe check if no records are acquired and we want to retry replica
                         // manager fetch. Depends on the share partition manager implementation,
                         // if we want parallel requests for the same share partition or not.
-                        if (fetchPartitionData.error.code() == Errors.OFFSET_OUT_OF_RANGE.code()) {
-                            // In case we get OFFSET_OUT_OF_RANGE error, that's because the LSO is later than the fetch offset.
-                            // So, we would update the start and end offset of the share partition and still return an empty
-                            // response and let the client retry the fetch. This way we do not lose out on the data that
-                            // would be returned for other share partitions in the fetch request.
-                            sharePartition.updateOffsetsOnLsoMovement();
-                            partitionData
-                                .setPartitionIndex(topicIdPartition.partition())
-                                .setRecords(fetchPartitionData.records)
-                                .setErrorCode(Errors.NONE.code())
-                                .setAcquiredRecords(acquiredRecords)
-                                .setAcknowledgeErrorCode(Errors.NONE.code());
-
-                        } else {
-                            partitionData
-                                .setPartitionIndex(topicIdPartition.partition())
-                                .setRecords(fetchPartitionData.records)
-                                .setErrorCode(fetchPartitionData.error.code())
-                                .setAcquiredRecords(acquiredRecords)
-                                .setAcknowledgeErrorCode(Errors.NONE.code());
+                        partitionData
+                            .setPartitionIndex(topicIdPartition.partition())
+                            .setRecords(fetchPartitionData.records)
+                            .setErrorCode(fetchPartitionData.error.code())
+                            .setAcquiredRecords(acquiredRecords)
+                            .setAcknowledgeErrorCode(Errors.NONE.code());
                         }
-                    }
                     return partitionData;
                 }));
         });

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -1268,6 +1268,7 @@ public class SharePartitionManagerTest {
             return null;
         }).when(replicaManager).fetchMessages(any(), any(), any(ReplicaQuota.class), any());
 
+        // LSO returned is 0.
         when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
                 new Some<>(new FileRecords.TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.of(0))));
 
@@ -1490,6 +1491,7 @@ public class SharePartitionManagerTest {
             return null;
         }).when(replicaManager).fetchMessages(any(), any(), any(ReplicaQuota.class), any());
 
+        // LSO returned is 0.
         when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
                 new Some<>(new FileRecords.TimestampAndOffset(
                         ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.of(0))));

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -28,11 +28,9 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.record.CompressionType;
-import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.requests.FetchRequest;
-import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.ShareFetchMetadata;
 import org.apache.kafka.common.requests.ShareFetchRequest;
 import org.apache.kafka.common.requests.ShareFetchResponse;
@@ -85,7 +83,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import scala.Some;
 import scala.Tuple2;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -97,10 +94,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.internal.verification.VerificationModeFactory.atLeast;
 import static org.mockito.internal.verification.VerificationModeFactory.atMost;
@@ -1268,10 +1264,6 @@ public class SharePartitionManagerTest {
             return null;
         }).when(replicaManager).fetchMessages(any(), any(), any(ReplicaQuota.class), any());
 
-        // LSO returned is 0.
-        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
-                new Some<>(new FileRecords.TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.of(0))));
-
         sharePartitionManager.fetchMessages(groupId, memberId1.toString(), fetchParams, Arrays.asList(tp0, tp1, tp2, tp3), partitionMaxBytes);
         Mockito.verify(replicaManager, times(1)).fetchMessages(
                 any(), any(), any(ReplicaQuota.class), any());
@@ -1490,11 +1482,6 @@ public class SharePartitionManagerTest {
             sharePartitionManager.releaseFetchQueueAndPartitionsLock(groupId, partitionMaxBytes.keySet());
             return null;
         }).when(replicaManager).fetchMessages(any(), any(), any(ReplicaQuota.class), any());
-
-        // LSO returned is 0.
-        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
-                new Some<>(new FileRecords.TimestampAndOffset(
-                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.of(0))));
 
         int threadCount = 100;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
@@ -1891,6 +1878,109 @@ public class SharePartitionManagerTest {
 
         mockUtils.when(() -> Utils.newInstance(ArgumentMatchers.anyString(), ArgumentMatchers.any())).thenReturn(persister);
         assertDoesNotThrow(() -> SharePartitionManagerBuilder.builder().withShareGroupPersisterClassName("mockShareGroupPersisterClass").build());
+    }
+
+    @Test
+    public void testProcessFetchResponseWithLsoMovementForTopicPartition() {
+        String groupId = "grp";
+        Uuid memberId = Uuid.randomUuid();
+        Uuid fooId = Uuid.randomUuid();
+        TopicIdPartition tp0 = new TopicIdPartition(fooId, new TopicPartition("foo", 0));
+        TopicIdPartition tp1 = new TopicIdPartition(fooId, new TopicPartition("foo", 1));
+
+        Map<TopicIdPartition, Integer> partitionMaxBytes = new HashMap<>();
+        partitionMaxBytes.put(tp0, PARTITION_MAX_BYTES);
+        partitionMaxBytes.put(tp1, PARTITION_MAX_BYTES);
+
+        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+        SharePartition sp0 = Mockito.mock(SharePartition.class);
+        SharePartition sp1 = Mockito.mock(SharePartition.class);
+
+        Map<SharePartitionManager.SharePartitionKey, SharePartition> partitionCacheMap = new ConcurrentHashMap<>();
+        partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp0), sp0);
+        partitionCacheMap.put(new SharePartitionManager.SharePartitionKey(groupId, tp1), sp1);
+
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withPartitionCacheMap(partitionCacheMap).withReplicaManager(replicaManager).build();
+
+        when(sp0.nextFetchOffset()).thenReturn((long) 0, (long) 5);
+        when(sp1.nextFetchOffset()).thenReturn((long) 4, (long) 4);
+
+        when(sp0.acquire(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Collections.emptyList()),
+                CompletableFuture.completedFuture(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
+                        .setFirstOffset(0).setLastOffset(3).setDeliveryCount((short) 1))));
+        when(sp1.acquire(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
+                        .setFirstOffset(100).setLastOffset(103).setDeliveryCount((short) 1))),
+                CompletableFuture.completedFuture(Collections.emptyList()));
+
+        doNothing().when(sp1).updateOffsetsOnLsoMovement();
+        doNothing().when(sp0).updateOffsetsOnLsoMovement();
+
+        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
+        SharePartitionManager.ShareFetchPartitionData shareFetchPartitionData = new SharePartitionManager.ShareFetchPartitionData(
+                new FetchParams(ApiKeys.SHARE_FETCH.latestVersion(), FetchRequest.ORDINARY_CONSUMER_ID, -1, 0,
+                        1, 1024 * 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()),
+                groupId, memberId.toString(), Arrays.asList(tp0, tp1), future, partitionMaxBytes);
+
+        MemoryRecords records1 = MemoryRecords.withRecords(CompressionType.NONE,
+                new SimpleRecord("0".getBytes(), "v".getBytes()),
+                new SimpleRecord("1".getBytes(), "v".getBytes()),
+                new SimpleRecord("2".getBytes(), "v".getBytes()),
+                new SimpleRecord(null, "value".getBytes()));
+
+        List<Tuple2<TopicIdPartition, FetchPartitionData>> responseData1 = new ArrayList<>();
+        responseData1.add(new Tuple2<>(tp0, new FetchPartitionData(Errors.OFFSET_OUT_OF_RANGE, 0L, 0L,
+                MemoryRecords.EMPTY, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false)));
+        responseData1.add(new Tuple2<>(tp1, new FetchPartitionData(Errors.NONE, 0L, 0L,
+                records1, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false)));
+        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> result1 =
+                sharePartitionManager.processFetchResponse(shareFetchPartitionData, responseData1);
+
+        assertTrue(result1.isDone());
+        Map<TopicIdPartition, ShareFetchResponseData.PartitionData> resultData1 = result1.join();
+        assertEquals(2, resultData1.size());
+        assertTrue(resultData1.containsKey(tp0));
+        assertTrue(resultData1.containsKey(tp1));
+        assertEquals(0, resultData1.get(tp0).partitionIndex());
+        assertEquals(1, resultData1.get(tp1).partitionIndex());
+        assertEquals(Errors.NONE.code(), resultData1.get(tp0).errorCode());
+        assertEquals(Errors.NONE.code(), resultData1.get(tp1).errorCode());
+
+        Mockito.verify(sp0, times(1)).updateOffsetsOnLsoMovement();
+        Mockito.verify(sp1, times(0)).updateOffsetsOnLsoMovement();
+
+        MemoryRecords records2 = MemoryRecords.withRecords(100L, CompressionType.NONE,
+                new SimpleRecord("0".getBytes(), "v".getBytes()),
+                new SimpleRecord("1".getBytes(), "v".getBytes()),
+                new SimpleRecord("2".getBytes(), "v".getBytes()),
+                new SimpleRecord(null, "value".getBytes()));
+
+        List<Tuple2<TopicIdPartition, FetchPartitionData>> responseData2 = new ArrayList<>();
+        responseData2.add(new Tuple2<>(tp0, new FetchPartitionData(Errors.NONE, 0L, 0L,
+                records2, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false)));
+        responseData2.add(new Tuple2<>(tp1, new FetchPartitionData(Errors.NONE, 0L, 0L,
+                MemoryRecords.EMPTY, Optional.empty(), OptionalLong.empty(), Optional.empty(),
+                OptionalInt.empty(), false)));
+        CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> result2 =
+                sharePartitionManager.processFetchResponse(shareFetchPartitionData, responseData2);
+
+        assertTrue(result2.isDone());
+        Map<TopicIdPartition, ShareFetchResponseData.PartitionData> resultData2 = result2.join();
+        assertEquals(2, resultData2.size());
+        assertTrue(resultData2.containsKey(tp0));
+        assertTrue(resultData2.containsKey(tp1));
+        assertEquals(0, resultData2.get(tp0).partitionIndex());
+        assertEquals(1, resultData2.get(tp1).partitionIndex());
+        assertEquals(Errors.NONE.code(), resultData2.get(tp0).errorCode());
+        assertEquals(Errors.NONE.code(), resultData2.get(tp1).errorCode());
+
+        Mockito.verify(sp0, times(1)).updateOffsetsOnLsoMovement();
+        Mockito.verify(sp1, times(0)).updateOffsetsOnLsoMovement();
     }
 
     private static class SharePartitionManagerBuilder {

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -4656,6 +4656,7 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition1.nextFetchOffset());
         assertEquals(0, sharePartition1.startOffset());
         assertEquals(0, sharePartition1.endOffset());
+        assertEquals(0, sharePartition1.pendingWriteStateBatches().size());
 
         // LSO returned is 5.
         when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
@@ -4666,6 +4667,7 @@ public class SharePartitionTest {
         assertEquals(5, sharePartition2.nextFetchOffset());
         assertEquals(5, sharePartition2.startOffset());
         assertEquals(5, sharePartition2.endOffset());
+        assertEquals(0, sharePartition2.pendingWriteStateBatches().size());
     }
 
     @Test
@@ -4734,6 +4736,7 @@ public class SharePartitionTest {
         assertEquals(36, sharePartition.endOffset());
         // For cached state corresponding to entry 2, the batch state will be ACKNOWLEDGED, hence it will be cleared as part of acknowledgment().
         assertEquals(6, sharePartition.cachedState().size());
+        assertEquals(1, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -4800,6 +4803,7 @@ public class SharePartitionTest {
         assertEquals(5, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         // Checked cached offset state map.
         Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
@@ -4868,6 +4872,7 @@ public class SharePartitionTest {
         assertEquals(4, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -4887,6 +4892,7 @@ public class SharePartitionTest {
         assertEquals(8, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -4933,6 +4939,7 @@ public class SharePartitionTest {
         assertEquals(4, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -4952,6 +4959,7 @@ public class SharePartitionTest {
         assertEquals(7, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -4998,6 +5006,7 @@ public class SharePartitionTest {
         assertEquals(4, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -5021,6 +5030,7 @@ public class SharePartitionTest {
         assertEquals(7, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5079,6 +5089,7 @@ public class SharePartitionTest {
         assertEquals(4, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -5102,6 +5113,7 @@ public class SharePartitionTest {
         assertEquals(7, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5152,6 +5164,7 @@ public class SharePartitionTest {
         assertEquals(12, sharePartition.nextFetchOffset());
         assertEquals(2, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         // Acknowledge with RELEASE action.
         sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
@@ -5172,6 +5185,7 @@ public class SharePartitionTest {
         assertEquals(11, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(2, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5243,6 +5257,7 @@ public class SharePartitionTest {
         assertEquals(11, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(2, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5313,6 +5328,7 @@ public class SharePartitionTest {
         assertEquals(12, sharePartition.startOffset());
         assertEquals(12, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(2, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5374,6 +5390,7 @@ public class SharePartitionTest {
         assertEquals(14, sharePartition.startOffset());
         assertEquals(14, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5429,6 +5446,7 @@ public class SharePartitionTest {
         assertEquals(18, sharePartition.startOffset());
         assertEquals(24, sharePartition.endOffset());
         assertEquals(3, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5499,6 +5517,7 @@ public class SharePartitionTest {
         assertEquals(10, sharePartition.startOffset());
         assertEquals(14, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5574,6 +5593,7 @@ public class SharePartitionTest {
         assertEquals(18, sharePartition.startOffset());
         assertEquals(18, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(6, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(5L).batchMemberId());
         assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(5L).batchState());
@@ -5601,6 +5621,55 @@ public class SharePartitionTest {
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(16L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(17L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(18L).acquisitionLockTimeoutTask());
+    }
+
+    @Test
+    public void testPendingWriteStateBatchesWritten() {
+        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+        Persister persister = Mockito.mock(Persister.class);
+        mockPersisterReadStateMethod(persister);
+        // Mock persister write state method.
+        WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+                        PartitionFactory.newPartitionErrorData(0, Errors.NONE.code())))));
+        Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
+
+        SharePartition sharePartition = SharePartitionBuilder.builder().withReplicaManager(replicaManager)
+                .withPersister(persister).build();
+
+        MemoryRecords records1 = memoryRecords(5, 2);
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records1, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        // Acknowledge with RELEASE action.
+        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new AcknowledgementBatch(2, 6, Collections.singletonList((byte) 2))));
+
+        // LSO returned is 8.
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 8, Optional.of(0))));
+        sharePartition.updateOffsetsOnLsoMovement();
+
+        assertEquals(8, sharePartition.nextFetchOffset());
+        assertEquals(8, sharePartition.startOffset());
+        assertEquals(8, sharePartition.endOffset());
+        assertEquals(1, sharePartition.cachedState().size());
+        assertEquals(1, sharePartition.pendingWriteStateBatches().size());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(2L).batchState());
+        assertNull(sharePartition.cachedState().get(2L).acquisitionLockTimeoutTask());
+
+        sharePartition.rollbackOrProcessStateUpdates(null, new ArrayList<>(), new ArrayList<>());
+        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
+        // 3 calls to write state method-
+        // 1. On acknowledge in the test above.
+        // 2. On rollbackOrProcessStateUpdates for the state batches above.
+        // 3. On rollbackOrProcessStateUpdates for the pending write state batches.
+        Mockito.verify(persister, Mockito.times(3)).writeState(Mockito.any());
     }
 
     private MemoryRecords memoryRecords(int numOfRecords) {

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -5665,11 +5665,12 @@ public class SharePartitionTest {
 
         sharePartition.rollbackOrProcessStateUpdates(null, new ArrayList<>(), new ArrayList<>());
         assertEquals(0, sharePartition.pendingWriteStateBatches().size());
-        // 3 calls to write state method-
+        // 4 calls are made to write state method-
         // 1. On acknowledge in the test above.
-        // 2. On rollbackOrProcessStateUpdates for the state batches above.
-        // 3. On rollbackOrProcessStateUpdates for the pending write state batches.
-        Mockito.verify(persister, Mockito.times(3)).writeState(Mockito.any());
+        // 2. On updateOffsetsOnLsoMovement, to write the start offset to the persister.
+        // 3. On rollbackOrProcessStateUpdates for the state batches above.
+        // 4. On rollbackOrProcessStateUpdates for the pending write state batches.
+        Mockito.verify(persister, Mockito.times(4)).writeState(Mockito.any());
     }
 
     @Test

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -4656,7 +4656,6 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition1.nextFetchOffset());
         assertEquals(0, sharePartition1.startOffset());
         assertEquals(0, sharePartition1.endOffset());
-        assertEquals(0, sharePartition1.pendingWriteStateBatches().size());
 
         // LSO returned is 5.
         when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
@@ -4667,7 +4666,6 @@ public class SharePartitionTest {
         assertEquals(5, sharePartition2.nextFetchOffset());
         assertEquals(5, sharePartition2.startOffset());
         assertEquals(5, sharePartition2.endOffset());
-        assertEquals(0, sharePartition2.pendingWriteStateBatches().size());
     }
 
     @Test
@@ -4736,7 +4734,6 @@ public class SharePartitionTest {
         assertEquals(36, sharePartition.endOffset());
         // For cached state corresponding to entry 2, the batch state will be ACKNOWLEDGED, hence it will be cleared as part of acknowledgment().
         assertEquals(6, sharePartition.cachedState().size());
-        assertEquals(1, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -4803,7 +4800,6 @@ public class SharePartitionTest {
         assertEquals(5, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         // Checked cached offset state map.
         Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
@@ -4872,7 +4868,6 @@ public class SharePartitionTest {
         assertEquals(4, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -4892,7 +4887,6 @@ public class SharePartitionTest {
         assertEquals(8, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -4939,7 +4933,6 @@ public class SharePartitionTest {
         assertEquals(4, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -4959,7 +4952,6 @@ public class SharePartitionTest {
         assertEquals(7, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -5006,7 +4998,6 @@ public class SharePartitionTest {
         assertEquals(4, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -5030,7 +5021,6 @@ public class SharePartitionTest {
         assertEquals(7, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5089,7 +5079,6 @@ public class SharePartitionTest {
         assertEquals(4, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(7L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(7L).batchState());
@@ -5113,7 +5102,6 @@ public class SharePartitionTest {
         assertEquals(7, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5164,7 +5152,6 @@ public class SharePartitionTest {
         assertEquals(12, sharePartition.nextFetchOffset());
         assertEquals(2, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         // Acknowledge with RELEASE action.
         sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
@@ -5185,7 +5172,6 @@ public class SharePartitionTest {
         assertEquals(11, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(2, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5257,7 +5243,6 @@ public class SharePartitionTest {
         assertEquals(11, sharePartition.startOffset());
         assertEquals(11, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(2, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5328,7 +5313,6 @@ public class SharePartitionTest {
         assertEquals(12, sharePartition.startOffset());
         assertEquals(12, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(2, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5390,7 +5374,6 @@ public class SharePartitionTest {
         assertEquals(14, sharePartition.startOffset());
         assertEquals(14, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5446,7 +5429,6 @@ public class SharePartitionTest {
         assertEquals(18, sharePartition.startOffset());
         assertEquals(24, sharePartition.endOffset());
         assertEquals(3, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5517,7 +5499,6 @@ public class SharePartitionTest {
         assertEquals(10, sharePartition.startOffset());
         assertEquals(14, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
@@ -5593,7 +5574,6 @@ public class SharePartitionTest {
         assertEquals(18, sharePartition.startOffset());
         assertEquals(18, sharePartition.endOffset());
         assertEquals(2, sharePartition.cachedState().size());
-        assertEquals(6, sharePartition.pendingWriteStateBatches().size());
 
         assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(5L).batchMemberId());
         assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(5L).batchState());
@@ -5621,56 +5601,6 @@ public class SharePartitionTest {
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(16L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(17L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(18L).acquisitionLockTimeoutTask());
-    }
-
-    @Test
-    public void testPendingWriteStateBatchesWritten() {
-        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
-        Persister persister = Mockito.mock(Persister.class);
-        mockPersisterReadStateMethod(persister);
-        // Mock persister write state method.
-        WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
-                        PartitionFactory.newPartitionErrorData(0, Errors.NONE.code())))));
-        Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
-
-        SharePartition sharePartition = SharePartitionBuilder.builder().withReplicaManager(replicaManager)
-                .withPersister(persister).build();
-
-        MemoryRecords records1 = memoryRecords(5, 2);
-        sharePartition.acquire(MEMBER_ID,
-                new FetchPartitionData(Errors.NONE, 20, 0, records1, Optional.empty(),
-                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
-
-        // Acknowledge with RELEASE action.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new AcknowledgementBatch(2, 6, Collections.singletonList((byte) 2))));
-
-        // LSO returned is 8.
-        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
-                new Some<>(new FileRecords.TimestampAndOffset(
-                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 8, Optional.of(0))));
-        sharePartition.updateOffsetsOnLsoMovement();
-
-        assertEquals(8, sharePartition.nextFetchOffset());
-        assertEquals(8, sharePartition.startOffset());
-        assertEquals(8, sharePartition.endOffset());
-        assertEquals(1, sharePartition.cachedState().size());
-        assertEquals(1, sharePartition.pendingWriteStateBatches().size());
-
-        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
-        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(2L).batchState());
-        assertNull(sharePartition.cachedState().get(2L).acquisitionLockTimeoutTask());
-
-        sharePartition.rollbackOrProcessStateUpdates(null, new ArrayList<>(), new ArrayList<>());
-        assertEquals(0, sharePartition.pendingWriteStateBatches().size());
-        // 4 calls are made to write state method-
-        // 1. On acknowledge in the test above.
-        // 2. On updateOffsetsOnLsoMovement, to write the start offset to the persister.
-        // 3. On rollbackOrProcessStateUpdates for the state batches above.
-        // 4. On rollbackOrProcessStateUpdates for the pending write state batches.
-        Mockito.verify(persister, Mockito.times(4)).writeState(Mockito.any());
     }
 
     @Test

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -25,10 +25,12 @@ import org.apache.kafka.common.errors.InvalidRecordStateException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.message.ShareFetchResponseData.AcquiredRecords;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.group.share.NoOpShareStatePersister;
@@ -48,6 +50,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import scala.Some;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -70,6 +73,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.when;
 
 public class SharePartitionTest {
 
@@ -81,11 +88,16 @@ public class SharePartitionTest {
     private static final Time MOCK_TIME = new MockTime();
     private static final int ACQUISITION_LOCK_TIMEOUT_MS = 100;
     private static final short MAX_IN_FLIGHT_MESSAGES = 200;
+    private static final ReplicaManager REPLICA_MANAGER = Mockito.mock(ReplicaManager.class);
 
     @BeforeEach
     public void setUp() {
         mockTimer = new SystemTimerReaper("share-group-lock-timeout-test-reaper",
                 new SystemTimer("share-group-lock-test-timeout"));
+        Mockito.when(REPLICA_MANAGER.fetchOffsetForTimestamp(
+                any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.of(0))));
     }
 
     @AfterEach
@@ -105,14 +117,12 @@ public class SharePartitionTest {
         // Invalid state transition to any other state from Acknowledged state.
         assertThrows(IllegalStateException.class, () -> RecordState.ACKNOWLEDGED.validateTransition(RecordState.AVAILABLE));
         assertThrows(IllegalStateException.class, () -> RecordState.ACKNOWLEDGED.validateTransition(RecordState.ACQUIRED));
-        assertThrows(IllegalStateException.class, () -> RecordState.ACKNOWLEDGED.validateTransition(RecordState.ARCHIVED));
         // Invalid state transition to any other state from Archived state.
         assertThrows(IllegalStateException.class, () -> RecordState.ARCHIVED.validateTransition(RecordState.AVAILABLE));
         assertThrows(IllegalStateException.class, () -> RecordState.ARCHIVED.validateTransition(RecordState.ACKNOWLEDGED));
         assertThrows(IllegalStateException.class, () -> RecordState.ARCHIVED.validateTransition(RecordState.ARCHIVED));
         // Invalid state transition to any other state from Available state other than Acquired.
         assertThrows(IllegalStateException.class, () -> RecordState.AVAILABLE.validateTransition(RecordState.ACKNOWLEDGED));
-        assertThrows(IllegalStateException.class, () -> RecordState.AVAILABLE.validateTransition(RecordState.ARCHIVED));
 
         // Successful transition from Available to Acquired.
         assertEquals(RecordState.ACQUIRED, RecordState.AVAILABLE.validateTransition(RecordState.ACQUIRED));
@@ -4631,6 +4641,121 @@ public class SharePartitionTest {
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(10L).acquisitionLockTimeoutTask());
     }
 
+    @Test
+    public void testLsoMovementOnInitializationSharePartition() {
+        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+        // LSO returned is 0
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.of(0))));
+
+        SharePartition sharePartition1 = SharePartitionBuilder.builder().withReplicaManager(replicaManager).build();
+        assertEquals(0, sharePartition1.nextFetchOffset());
+        assertEquals(0, sharePartition1.startOffset());
+        assertEquals(0, sharePartition1.endOffset());
+
+        // LSO returned is 5
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 5, Optional.of(0))));
+        SharePartition sharePartition2 = SharePartitionBuilder.builder().withReplicaManager(replicaManager).build();
+        assertEquals(5, sharePartition2.nextFetchOffset());
+        assertEquals(5, sharePartition2.startOffset());
+        assertEquals(5, sharePartition2.endOffset());
+    }
+
+    @Test
+    public void testLsoMovementForArchivingBatches() {
+        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+        // LSO returned is 0
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.of(0))));
+
+        SharePartition sharePartition = SharePartitionBuilder.builder().withReplicaManager(replicaManager).build();
+        assertEquals(0, sharePartition.nextFetchOffset());
+        assertEquals(0, sharePartition.startOffset());
+        assertEquals(0, sharePartition.endOffset());
+
+        MemoryRecords records1 = memoryRecords(5, 2);
+        MemoryRecords records2 = memoryRecords(5, 7);
+        MemoryRecords records3 = memoryRecords(5, 12);
+        MemoryRecords records4 = memoryRecords(5, 17);
+        MemoryRecords records5 = memoryRecords(5, 22);
+        MemoryRecords records6 = memoryRecords(5, 27);
+        MemoryRecords records7 = memoryRecords(5, 32);
+
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records1, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records2, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records3, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records4, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records5, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records6, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records7, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        assertEquals(7, sharePartition.cachedState().size());
+
+        CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
+                new AcknowledgementBatch(2, 6, Collections.singletonList((byte) 1)),
+                new AcknowledgementBatch(12, 16, Collections.singletonList((byte) 2)),
+                new AcknowledgementBatch(22, 26, Collections.singletonList((byte) 2)),
+                new AcknowledgementBatch(27, 31, Collections.singletonList((byte) 3))
+                ));
+        assertEquals(6, sharePartition.cachedState().size());
+        assertEquals(12, sharePartition.nextFetchOffset());
+
+        // LSO returned is 20
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 20, Optional.of(0))));
+
+        assertEquals(22, sharePartition.nextFetchOffset());
+        assertEquals(20, sharePartition.startOffset());
+        assertEquals(36, sharePartition.endOffset());
+        assertEquals(4, sharePartition.cachedState().size());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(22L).batchMemberId());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(22L).batchState());
+        assertNull(sharePartition.cachedState().get(22L).acquisitionLockTimeoutTask());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(27L).batchMemberId());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(27L).batchState());
+        assertNull(sharePartition.cachedState().get(27L).acquisitionLockTimeoutTask());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(32L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(32L).batchState());
+        assertNotNull(sharePartition.cachedState().get(32L).acquisitionLockTimeoutTask());
+
+        // Checked cached offset state map
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(17L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(18L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(19L, new InFlightState(RecordState.ARCHIVED, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(20L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(21L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(17L).offsetState());
+        assertNull(sharePartition.cachedState().get(17L).offsetState().get(17L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(17L).offsetState().get(18L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(17L).offsetState().get(19L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(17L).offsetState().get(20L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(17L).offsetState().get(21L).acquisitionLockTimeoutTask());
+    }
+
     private MemoryRecords memoryRecords(int numOfRecords) {
         return memoryRecords(numOfRecords, 0);
     }
@@ -4683,6 +4808,7 @@ public class SharePartitionTest {
         private int maxDeliveryCount = MAX_DELIVERY_COUNT;
         private int maxInflightMessages = MAX_IN_FLIGHT_MESSAGES;
         private Persister persister = NoOpShareStatePersister.getInstance();
+        private ReplicaManager replicaManager = REPLICA_MANAGER;
 
         private SharePartitionBuilder withAcquisitionLockTimeoutMs(int acquisitionLockTimeoutMs) {
             this.acquisitionLockTimeoutMs = acquisitionLockTimeoutMs;
@@ -4704,13 +4830,18 @@ public class SharePartitionTest {
             return this;
         }
 
+        private SharePartitionBuilder withReplicaManager(ReplicaManager replicaManager) {
+            this.replicaManager = replicaManager;
+            return this;
+        }
+
         public static SharePartitionBuilder builder() {
             return new SharePartitionBuilder();
         }
 
         public SharePartition build() {
             return new SharePartition(GROUP_ID, TOPIC_ID_PARTITION, maxInflightMessages, maxDeliveryCount,
-                acquisitionLockTimeoutMs, mockTimer, MOCK_TIME, persister);
+                acquisitionLockTimeoutMs, mockTimer, MOCK_TIME, persister, replicaManager);
         }
     }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4372,6 +4372,9 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
+
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
 
@@ -4434,6 +4437,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -4575,6 +4581,9 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
+
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
     kafkaApis.handleShareFetchRequest(request)
@@ -4612,6 +4621,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -4695,6 +4707,9 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
+
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
 
@@ -4750,6 +4765,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -4850,6 +4868,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -4966,6 +4987,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -5147,6 +5171,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -5469,6 +5496,9 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
+
     val shareFetchData : util.Map[TopicIdPartition, ShareFetchRequest.SharePartitionData] = new util.HashMap()
     shareFetchData.put(
       new TopicIdPartition(topicId1, new TopicPartition(topicName1, 0)),
@@ -5640,6 +5670,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     val shareFetchData : util.Map[TopicIdPartition, ShareFetchRequest.SharePartitionData] = new util.HashMap()
     shareFetchData.put(
@@ -5909,6 +5942,9 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
+
     val shareFetchData : util.Map[TopicIdPartition, ShareFetchRequest.SharePartitionData] = new util.HashMap()
     shareFetchData.put(
       new TopicIdPartition(topicId1, new TopicPartition(topicName1, 0)),
@@ -6086,6 +6122,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     val shareFetchData : util.Map[TopicIdPartition, ShareFetchRequest.SharePartitionData] = new util.HashMap()
     shareFetchData.put(
@@ -9841,6 +9880,9 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
+
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
 
@@ -9916,6 +9958,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -10020,6 +10065,9 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
+
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
 
@@ -10121,6 +10169,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -10269,6 +10320,9 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
+
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
 
@@ -10339,6 +10393,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -10431,6 +10488,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -10625,6 +10685,9 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
+
+    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
+    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4372,9 +4372,6 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
 
@@ -4437,9 +4434,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -4581,9 +4575,6 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
-
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
     kafkaApis.handleShareFetchRequest(request)
@@ -4621,9 +4612,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -4707,9 +4695,6 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
 
@@ -4765,9 +4750,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -4868,9 +4850,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -4987,9 +4966,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -5171,9 +5147,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -5496,9 +5469,6 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
-
     val shareFetchData : util.Map[TopicIdPartition, ShareFetchRequest.SharePartitionData] = new util.HashMap()
     shareFetchData.put(
       new TopicIdPartition(topicId1, new TopicPartition(topicName1, 0)),
@@ -5670,9 +5640,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     val shareFetchData : util.Map[TopicIdPartition, ShareFetchRequest.SharePartitionData] = new util.HashMap()
     shareFetchData.put(
@@ -5942,9 +5909,6 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
-
     val shareFetchData : util.Map[TopicIdPartition, ShareFetchRequest.SharePartitionData] = new util.HashMap()
     shareFetchData.put(
       new TopicIdPartition(topicId1, new TopicPartition(topicName1, 0)),
@@ -6122,9 +6086,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     val shareFetchData : util.Map[TopicIdPartition, ShareFetchRequest.SharePartitionData] = new util.HashMap()
     shareFetchData.put(
@@ -9880,9 +9841,6 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
 
@@ -9958,9 +9916,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -10065,9 +10020,6 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
 
@@ -10169,9 +10121,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -10320,9 +10269,6 @@ class KafkaApisTest extends Logging {
       callback(responseCallbackParams)
     }
 
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
 
@@ -10393,9 +10339,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -10488,9 +10431,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
@@ -10685,9 +10625,6 @@ class KafkaApisTest extends Logging {
       )
       callback(responseCallbackParams)
     }
-
-    when(replicaManager.fetchOffsetForTimestamp(any(), any(), any(), any(), any())
-    ).thenReturn(Some(new TimestampAndOffset(ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.empty[Integer]())))
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)


### PR DESCRIPTION
### About
Introduces the handling of in-flight records, start offset and end offset in share partition when LSO advances.

### Item for discussion
In case, there are failures to write the updated states and startOffset to the persister, currently I do not rollback the startOffset and endOffset. I am rolling back the archived state updates though. In case, we decide to rollback the startOffset and endOffset, there can be cases where the consumers could terminate because of an invalid fetch offset.

### Items to be covered in next PR
1. Integration tests for LSO movement.
2. During `acknowledge()`, we need to take care that some records might have been archived due to LSO movement. So, in case we get an acknowledgement of a batch/offset which is earlier than the start offset, we will need to ignore them. 