### PR TITLE
AKCORE-149: Ensure when the Log Start Offset (LSO) moves underneath acquired records, nothing breaks (2/N)

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -972,9 +972,9 @@ public class SharePartition {
             }
             if (floorOffset == null) {
                 log.debug("Batch record {} not found for share partition: {}-{}", batch, groupId,
-                        topicIdPartition);
+                    topicIdPartition);
                 throw new InvalidRecordStateException(
-                        "Batch record not found. The base offset is not found in the cache.");
+                    "Batch record not found. The base offset is not found in the cache.");
             }
 
             NavigableMap<Long, InFlightBatch> subMap = cachedState.subMap(floorOffset.getKey(), true, batch.lastOffset, true);

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -647,6 +647,12 @@ public class SharePartition {
                     break;
                 }
 
+                if (batch.lastOffset < startOffset) {
+                    log.trace("All offsets in the acknowledgement batch {} are already archived: {}-{}",
+                        batch, groupId, topicIdPartition);
+                    continue;
+                }
+
                 // Fetch the sub-map from the cached map for the batch to acknowledge. The sub-map can
                 // be a full match, subset or spans over multiple fetched batches.
                 NavigableMap<Long, InFlightBatch> subMap;
@@ -663,6 +669,13 @@ public class SharePartition {
                 for (Map.Entry<Long, InFlightBatch> entry : subMap.entrySet()) {
                     InFlightBatch inFlightBatch = entry.getValue();
 
+                    // If startOffset has moved ahead of the in-flight batch, skip the batch.
+                    if (inFlightBatch.lastOffset < startOffset) {
+                        log.trace("All offsets in the inflight batch {} are already archived: {}-{}",
+                                inFlightBatch, groupId, topicIdPartition);
+                        continue;
+                    }
+
                     // Validate if the requested member id is the owner of the batch.
                     if (inFlightBatch.offsetState == null) {
                         throwable = validateAcknowledgementBatchMemberId(memberId, inFlightBatch).orElse(null);
@@ -674,10 +687,12 @@ public class SharePartition {
                     // Determine if the in-flight batch is a full match from the request batch.
                     boolean fullMatch = checkForFullMatch(inFlightBatch, batch.firstOffset, batch.lastOffset);
                     boolean isPerOffsetClientAck = batch.acknowledgeTypes().size() > 1;
+                    boolean hasStartOffsetMoved = checkForStartOffsetWithinBatch(inFlightBatch.firstOffset, inFlightBatch.lastOffset);
 
                     // Maintain state per offset if the inflight batch is not a full match or the
-                    // offset state is managed or client sent individual offsets state.
-                    if (!fullMatch || inFlightBatch.offsetState != null || isPerOffsetClientAck) {
+                    // offset state is managed or client sent individual offsets state or
+                    // the start offset is within this in-flight batch.
+                    if (!fullMatch || inFlightBatch.offsetState != null || isPerOffsetClientAck || hasStartOffsetMoved) {
                         log.debug("Subset or offset tracked batch record found for acknowledgement,"
                             + " batch: {}, request offsets - first: {}, last: {}, client per offset"
                             + "state {} for the share partition: {}-{}", inFlightBatch, batch.firstOffset,
@@ -949,11 +964,17 @@ public class SharePartition {
             // for a subset of the batch i.e. cached batch of offset 10-14 and request batch
             // of 12-13. Hence, floor entry is fetched to find the sub-map.
             Map.Entry<Long, InFlightBatch> floorOffset = cachedState.floorEntry(batch.firstOffset);
+            boolean hasStartOffsetMoved = checkForStartOffsetWithinBatch(batch.firstOffset, batch.lastOffset);
+            if (floorOffset == null && hasStartOffsetMoved) {
+                // If the start offset is between the first and last offset of the acknowledgment batch, then
+                // we need to get the floor offset using the last offset of the acknowledgment batch.
+                floorOffset = cachedState.floorEntry(batch.lastOffset);
+            }
             if (floorOffset == null) {
                 log.debug("Batch record {} not found for share partition: {}-{}", batch, groupId,
-                    topicIdPartition);
+                        topicIdPartition);
                 throw new InvalidRecordStateException(
-                    "Batch record not found. The base offset is not found in the cache.");
+                        "Batch record not found. The base offset is not found in the cache.");
             }
 
             NavigableMap<Long, InFlightBatch> subMap = cachedState.subMap(floorOffset.getKey(), true, batch.lastOffset, true);
@@ -1012,9 +1033,10 @@ public class SharePartition {
             RecordState recordStateDefault = recordStateMap.get(batch.firstOffset());
             for (Map.Entry<Long, InFlightState> offsetState : inFlightBatch.offsetState.entrySet()) {
 
-                // For the first batch which might have offsets prior to the request base
+                // 1. For the first batch which might have offsets prior to the request base
                 // offset i.e. cached batch of 10-14 offsets and request batch of 12-13.
-                if (offsetState.getKey() < batch.firstOffset) {
+                // 2. Skip the offsets which are below the start offset of the share partition
+                if (offsetState.getKey() < batch.firstOffset || offsetState.getKey() < startOffset) {
                     continue;
                 }
 

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -1821,7 +1821,9 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testCloseSharePartitionManager() throws Exception {
-        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder().build();
+        Persister persister = mock(Persister.class);
+        SharePartitionManager sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withShareGroupPersister(persister).build();
 
         List<Integer> mockList = new ArrayList<>();
         sharePartitionManager.timer().add(createTimerTask(mockList));

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -5970,6 +5970,259 @@ public class SharePartitionTest {
         assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
     }
 
+    @Test
+    public void testAcknowledgeBatchAndOffsetPostLsoMovement() {
+        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+        // LSO returned is 0.
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.of(0))));
+
+        SharePartition sharePartition = SharePartitionBuilder.builder().withReplicaManager(replicaManager).build();
+        sharePartition.updateOffsetsOnLsoMovement();
+        assertEquals(0, sharePartition.nextFetchOffset());
+        assertEquals(0, sharePartition.startOffset());
+        assertEquals(0, sharePartition.endOffset());
+
+        MemoryRecords records1 = memoryRecords(5, 2);
+        MemoryRecords records2 = memoryRecords(5, 10);
+
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records1, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records2, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(15, sharePartition.nextFetchOffset());
+        assertEquals(2, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+
+        // LSO returned is 12.
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 12, Optional.of(0))));
+
+        sharePartition.updateOffsetsOnLsoMovement();
+        assertEquals(15, sharePartition.nextFetchOffset());
+        assertEquals(12, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        // Checked cached state map.
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+        assertNotNull(sharePartition.cachedState().get(2L).acquisitionLockTimeoutTask());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(10L).batchState());
+        assertNotNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
+
+        // Acknowledge with RELEASE action.
+        CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
+                new AcknowledgementBatch(2, 6, Collections.singletonList((byte) 2)),
+                new AcknowledgementBatch(10, 14, Collections.singletonList((byte) 2))));
+
+        assertFalse(ackResult.isCompletedExceptionally());
+        assertFalse(ackResult.join().isPresent());
+
+        assertEquals(12, sharePartition.nextFetchOffset());
+        assertEquals(12, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+        assertNotNull(sharePartition.cachedState().get(2L).acquisitionLockTimeoutTask());
+
+        // Checked cached offset state map.
+        Map<Long, InFlightState>  expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(12L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(13L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+        expectedOffsetStateMap.put(14L, new InFlightState(RecordState.AVAILABLE, (short) 1, EMPTY_MEMBER_ID));
+
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
+
+        assertNotNull(sharePartition.cachedState().get(10L).offsetState().get(10L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(10L).offsetState().get(11L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(10L).offsetState().get(12L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(10L).offsetState().get(13L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(10L).offsetState().get(14L).acquisitionLockTimeoutTask());
+    }
+
+    @Test
+    public void testAcknowledgeBatchPostLsoMovement() {
+        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+        // LSO returned is 0.
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.of(0))));
+
+        SharePartition sharePartition = SharePartitionBuilder.builder().withReplicaManager(replicaManager).build();
+        sharePartition.updateOffsetsOnLsoMovement();
+        assertEquals(0, sharePartition.nextFetchOffset());
+        assertEquals(0, sharePartition.startOffset());
+        assertEquals(0, sharePartition.endOffset());
+
+        MemoryRecords records1 = memoryRecords(5, 2);
+        MemoryRecords records2 = memoryRecords(5, 10);
+        MemoryRecords records3 = memoryRecords(5, 20);
+
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records1, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records2, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records3, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        assertEquals(3, sharePartition.cachedState().size());
+        assertEquals(25, sharePartition.nextFetchOffset());
+        assertEquals(2, sharePartition.startOffset());
+        assertEquals(24, sharePartition.endOffset());
+
+        // LSO returned is 14.
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 14, Optional.of(0))));
+
+        sharePartition.updateOffsetsOnLsoMovement();
+        assertEquals(25, sharePartition.nextFetchOffset());
+        assertEquals(14, sharePartition.startOffset());
+        assertEquals(24, sharePartition.endOffset());
+        assertEquals(3, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+        assertNotNull(sharePartition.cachedState().get(2L).acquisitionLockTimeoutTask());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(10L).batchState());
+        assertNotNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(20L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(20L).batchState());
+        assertNotNull(sharePartition.cachedState().get(20L).acquisitionLockTimeoutTask());
+
+        // Acknowledge with ACCEPT action.
+        CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new AcknowledgementBatch(2, 14, Collections.singletonList((byte) 1))));
+        assertFalse(ackResult.isCompletedExceptionally());
+        assertFalse(ackResult.join().isPresent());
+
+        assertEquals(25, sharePartition.nextFetchOffset());
+        // For cached state corresponding to entry 2, the offset states will be ARCHIVED, ARCHIVED, ARCHIVED, ARCHIVED and ACKNOWLEDGED.
+        // Hence, it will get removed when calling maybeUpdateCachedStateAndOffsets() internally.
+        assertEquals(14, sharePartition.startOffset());
+        assertEquals(24, sharePartition.endOffset());
+        assertEquals(3, sharePartition.cachedState().size());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+        assertNotNull(sharePartition.cachedState().get(2L).acquisitionLockTimeoutTask());
+
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(20L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(20L).batchState());
+        assertNotNull(sharePartition.cachedState().get(20L).acquisitionLockTimeoutTask());
+
+        // Check cached state offset map.
+        Map<Long, InFlightState> expectedOffsetStateMap = new HashMap<>();
+        expectedOffsetStateMap.put(10L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(11L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(12L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(13L, new InFlightState(RecordState.ACQUIRED, (short) 1, MEMBER_ID));
+        expectedOffsetStateMap.put(14L, new InFlightState(RecordState.ACKNOWLEDGED, (short) 1, EMPTY_MEMBER_ID));
+        assertEquals(expectedOffsetStateMap, sharePartition.cachedState().get(10L).offsetState());
+
+        assertNotNull(sharePartition.cachedState().get(10L).offsetState().get(10L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(10L).offsetState().get(11L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(10L).offsetState().get(12L).acquisitionLockTimeoutTask());
+        assertNotNull(sharePartition.cachedState().get(10L).offsetState().get(13L).acquisitionLockTimeoutTask());
+        assertNull(sharePartition.cachedState().get(10L).offsetState().get(14L).acquisitionLockTimeoutTask());
+    }
+
+    @Test
+    public void testLsoMovementThenAcquisitionLockTimeoutThenAcknowledge() throws InterruptedException {
+        ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+        // LSO returned is 0.
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 0, Optional.of(0))));
+
+        SharePartition sharePartition = SharePartitionBuilder.builder().withReplicaManager(replicaManager)
+                .withAcquisitionLockTimeoutMs(ACQUISITION_LOCK_TIMEOUT_MS).build();
+        sharePartition.updateOffsetsOnLsoMovement();
+        assertEquals(0, sharePartition.nextFetchOffset());
+        assertEquals(0, sharePartition.startOffset());
+        assertEquals(0, sharePartition.endOffset());
+
+        MemoryRecords records1 = memoryRecords(5, 2);
+
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records1, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        assertEquals(1, sharePartition.cachedState().size());
+        assertEquals(7, sharePartition.nextFetchOffset());
+        assertEquals(2, sharePartition.startOffset());
+        assertEquals(6, sharePartition.endOffset());
+
+        // LSO returned is 7.
+        when(replicaManager.fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())).thenReturn(
+                new Some<>(new FileRecords.TimestampAndOffset(
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP, 7, Optional.of(0))));
+
+        sharePartition.updateOffsetsOnLsoMovement();
+        assertEquals(7, sharePartition.nextFetchOffset());
+        assertEquals(7, sharePartition.startOffset());
+        assertEquals(7, sharePartition.endOffset());
+        assertEquals(1, sharePartition.cachedState().size());
+
+        // Checked cached state map.
+        assertEquals(MEMBER_ID, sharePartition.cachedState().get(2L).batchMemberId());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
+        assertNotNull(sharePartition.cachedState().get(2L).acquisitionLockTimeoutTask());
+
+        // Allowing acquisition lock to expire.
+        Thread.sleep(200);
+        assertEquals(7, sharePartition.nextFetchOffset());
+        assertEquals(7, sharePartition.startOffset());
+        assertEquals(7, sharePartition.endOffset());
+        assertEquals(0, sharePartition.cachedState().size());
+
+        MemoryRecords records2 = memoryRecords(5, 10);
+
+        sharePartition.acquire(MEMBER_ID,
+                new FetchPartitionData(Errors.NONE, 20, 0, records2, Optional.empty(),
+                        OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false));
+
+        assertEquals(15, sharePartition.nextFetchOffset());
+        assertEquals(10, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(1, sharePartition.cachedState().size());
+
+        // Acknowledge with RELEASE action. This contains a batch that doesn't exist at all
+        CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
+                new AcknowledgementBatch(2, 14, Collections.singletonList((byte) 2))));
+
+        assertFalse(ackResult.isCompletedExceptionally());
+        assertFalse(ackResult.join().isPresent());
+
+        assertEquals(10, sharePartition.nextFetchOffset());
+        assertEquals(10, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        assertEquals(1, sharePartition.cachedState().size());
+
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(10L).batchState());
+        assertNull(sharePartition.cachedState().get(10L).acquisitionLockTimeoutTask());
+    }
+
     private MemoryRecords memoryRecords(int numOfRecords) {
         return memoryRecords(numOfRecords, 0);
     }

--- a/core/src/test/java/kafka/server/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionTest.java
@@ -6206,7 +6206,7 @@ public class SharePartitionTest {
         assertEquals(14, sharePartition.endOffset());
         assertEquals(1, sharePartition.cachedState().size());
 
-        // Acknowledge with RELEASE action. This contains a batch that doesn't exist at all
+        // Acknowledge with RELEASE action. This contains a batch that doesn't exist at all.
         CompletableFuture<Optional<Throwable>> ackResult = sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
                 new AcknowledgementBatch(2, 14, Collections.singletonList((byte) 2))));
 

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -19,6 +19,8 @@ package kafka.test.api;
 import kafka.api.AbstractShareConsumerTest;
 import kafka.api.BaseConsumerTest;
 import kafka.utils.TestUtils;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -656,11 +658,20 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         int messagesConsumed = 0;
         int retries = 0;
         try {
-            while (totalMessagesConsumed.get() < totalMessages && retries < maxPolls) {
-                ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(2000));
-                messagesConsumed += records.count();
-                totalMessagesConsumed.addAndGet(records.count());
-                retries++;
+            if (totalMessages > 0) {
+                while (totalMessagesConsumed.get() < totalMessages && retries < maxPolls) {
+                    ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(2000));
+                    messagesConsumed += records.count();
+                    totalMessagesConsumed.addAndGet(records.count());
+                    retries++;
+                }
+            } else {
+                while (retries < maxPolls) {
+                    ConsumerRecords<byte[], byte[]> records = shareConsumer.poll(Duration.ofMillis(2000));
+                    messagesConsumed += records.count();
+                    totalMessagesConsumed.addAndGet(records.count());
+                    retries++;
+                }
             }
             // One final poll to complete acknowledgement of the records (will be commit once we have that)
             shareConsumer.poll(Duration.ofMillis(2000));
@@ -1206,5 +1217,68 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         records = shareConsumer.poll(Duration.ofMillis(2000));
         assertEquals(1, records.count());
         shareConsumer.close();
+    }
+
+    @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
+    @ValueSource(strings = {"kraft+kip932"})
+    public void testLsoMovementByRecordsDeletion(String quorum) {
+        KafkaProducer<byte[], byte[]> producer = createProducer(new ByteArraySerializer(), new ByteArraySerializer(), new Properties());
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp().topic(), 0, null, "key".getBytes(), "value".getBytes());
+
+        // We write 10 records to the topic, so they would be written from offsets 0-9 on the topic.
+        try {
+            for (int i = 0; i < 10; i++) {
+                producer.send(record).get();
+            }
+        } catch (Exception e) {
+            fail("Failed to send records: " + e);
+        }
+        Admin adminClient = createAdminClient(listenerName(), new Properties());
+        // We delete records before offset 5, so the LSO should move to 5.
+        adminClient.deleteRecords(Collections.singletonMap(tp(), RecordsToDelete.beforeOffset(5L)));
+
+        AtomicInteger totalMessagesConsumed = new AtomicInteger(0);
+        CompletableFuture<Integer> future = consumeMessages(totalMessagesConsumed, 5, "group1", 1, 10);
+        // The records returned belong to offsets 5-9.
+        assertEquals(5, totalMessagesConsumed.get());
+        try {
+            assertEquals(5, future.get());
+        } catch (Exception e) {
+            fail("Exception occurred : " + e.getMessage());
+        }
+
+        // We write 5 records to the topic, so they would be written from offsets 10-14 on the topic.
+        try {
+            for (int i = 0; i < 5; i++) {
+                producer.send(record).get();
+            }
+        } catch (Exception e) {
+            fail("Failed to send records: " + e);
+        }
+
+        // We delete records before offset 14, so the LSO should move to 14.
+        adminClient.deleteRecords(Collections.singletonMap(tp(), RecordsToDelete.beforeOffset(14L)));
+
+        totalMessagesConsumed = new AtomicInteger(0);
+        future = consumeMessages(totalMessagesConsumed, 1, "group1", 1, 10);
+        // The record returned belong to offset 14.
+        assertEquals(1, totalMessagesConsumed.get());
+        try {
+            assertEquals(1, future.get());
+        } catch (Exception e) {
+            fail("Exception occurred : " + e.getMessage());
+        }
+
+        // We delete records before offset 15, so the LSO should move to 15 and now no records should be returned.
+        adminClient.deleteRecords(Collections.singletonMap(tp(), RecordsToDelete.beforeOffset(15L)));
+
+        totalMessagesConsumed = new AtomicInteger(0);
+        future = consumeMessages(totalMessagesConsumed, 0, "group1", 1, 5);
+        assertEquals(0, totalMessagesConsumed.get());
+        try {
+            assertEquals(0, future.get());
+        } catch (Exception e) {
+            fail("Exception occurred : " + e.getMessage());
+        }
     }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -83,7 +83,7 @@ import org.apache.kafka.server.authorizer.{Action, AuthorizationResult, Authoriz
 import org.apache.kafka.server.common.MetadataVersion.{IBP_0_10_2_IV0, IBP_2_2_IV1}
 import org.apache.kafka.server.common.{Features, MetadataVersion}
 import org.apache.kafka.server.config.{ConfigType, Defaults}
-import org.apache.kafka.server.group.share.Persister
+import org.apache.kafka.server.group.share.NoOpShareStatePersister
 import org.apache.kafka.server.metrics.ClientMetricsTestUtils
 import org.apache.kafka.server.util.{FutureUtils, MockTime}
 import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchParams, FetchPartitionData, LogConfig}
@@ -135,7 +135,7 @@ class KafkaApisTest extends Logging {
     clientControllerQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, None)
   private val fetchManager: FetchManager = mock(classOf[FetchManager])
   val sharePartitionManager : SharePartitionManager =
-    new SharePartitionManager(replicaManager, new SystemTime(), new ShareSessionCache(1000, 100), 30000, 5, 200, mock(classOf[Persister]))
+    new SharePartitionManager(replicaManager, new SystemTime(), new ShareSessionCache(1000, 100), 30000, 5, 200, NoOpShareStatePersister.getInstance())
   private val clientMetricsManager: ClientMetricsManager = mock(classOf[ClientMetricsManager])
   private val brokerTopicStats = new BrokerTopicStats
   private val clusterId = "clusterId"


### PR DESCRIPTION
### About
This PR carries on the work done in PR #1252 where we introduced the handling of in-flight records, start offset and end offset in share partition when LSO advances. In this PR, the following changes have been made - 
1. During `acknowledge()`, we need to take care that some records might have been archived due to LSO movement. So, in case we get an acknowledgement of a batch/offset which is earlier than the start offset, we will need to ignore them. Hence, client won't get any exceptions.
2. Integration tests for LSO movement.