### PR TITLE
AKCORE_182: Improve command-line tool error handling

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareGroup.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.share;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
+import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.coordinator.group.AbstractGroup;
@@ -41,6 +42,8 @@ import static org.apache.kafka.coordinator.group.share.ShareGroup.ShareGroupStat
  * A Share Group.
  */
 public class ShareGroup extends AbstractGroup {
+
+    public static final String PROTOCOL_TYPE = "share";
 
     public enum ShareGroupState {
         EMPTY("empty"),
@@ -79,6 +82,17 @@ public class ShareGroup extends AbstractGroup {
     @Override
     public GroupType type() {
         return GroupType.SHARE;
+    }
+
+    /**
+     * @return the group formatted as a list group response based on the committed offset.
+     */
+    public ListGroupsResponseData.ListedGroup asListedGroup(long committedOffset) {
+        return new ListGroupsResponseData.ListedGroup()
+                .setGroupId(groupId)
+                .setProtocolType(PROTOCOL_TYPE)
+                .setGroupState(stateAsString(committedOffset))
+                .setGroupType(type().toString());
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -8301,7 +8301,7 @@ public class GroupMetadataManagerTest {
                     .setGroupType(Group.GroupType.CONSUMER.toString()),
                 new ListGroupsResponseData.ListedGroup()
                     .setGroupId(shareGroupId)
-                    .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
+                    .setProtocolType(ShareGroup.PROTOCOL_TYPE)
                     .setGroupState(ShareGroup.ShareGroupState.EMPTY.toString())
                     .setGroupType(Group.GroupType.SHARE.toString())
             ).collect(Collectors.toMap(ListGroupsResponseData.ListedGroup::groupId, Function.identity()));
@@ -8342,7 +8342,7 @@ public class GroupMetadataManagerTest {
                 .setGroupType(Group.GroupType.CLASSIC.toString()),
             new ListGroupsResponseData.ListedGroup()
                 .setGroupId(shareGroupId)
-                .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
+                .setProtocolType(ShareGroup.PROTOCOL_TYPE)
                 .setGroupState(ShareGroup.ShareGroupState.EMPTY.toString())
                 .setGroupType(Group.GroupType.SHARE.toString())
         ).collect(Collectors.toMap(ListGroupsResponseData.ListedGroup::groupId, Function.identity()));
@@ -8380,7 +8380,7 @@ public class GroupMetadataManagerTest {
         expectAllGroupMap = Stream.of(
             new ListGroupsResponseData.ListedGroup()
                 .setGroupId(shareGroupId)
-                .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
+                .setProtocolType(ShareGroup.PROTOCOL_TYPE)
                 .setGroupState(ShareGroup.ShareGroupState.EMPTY.toString())
                 .setGroupType(GroupType.SHARE.toString())
         ).collect(Collectors.toMap(ListGroupsResponseData.ListedGroup::groupId, Function.identity()));
@@ -8402,7 +8402,7 @@ public class GroupMetadataManagerTest {
                 .setGroupType(Group.GroupType.CONSUMER.toString()),
             new ListGroupsResponseData.ListedGroup()
                 .setGroupId(shareGroupId)
-                .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
+                .setProtocolType(ShareGroup.PROTOCOL_TYPE)
                 .setGroupState(ShareGroup.ShareGroupState.EMPTY.toString())
                 .setGroupType(GroupType.SHARE.toString())
         ).collect(Collectors.toMap(ListGroupsResponseData.ListedGroup::groupId, Function.identity()));

--- a/tools/src/main/java/org/apache/kafka/tools/ShareGroupCommandOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ShareGroupCommandOptions.java
@@ -47,13 +47,11 @@ public class ShareGroupCommandOptions extends CommandDefaultOptions {
     public static final String TIMEOUT_MS_DOC = "The timeout that can be set for some use cases. For example, it can be used when describing the group " +
             "to specify the maximum amount of time in milliseconds to wait before the group stabilizes (when the group is just created, " +
             "or is going through some changes).";
-    public static final String COMMAND_CONFIG_DOC = "Property file containing configs to be passed to Admin Client and Consumer.";
-    public static final String RESET_OFFSETS_DOC = "Reset offsets of share group. Supports one share group at the time, and instances should be inactive" + NL +
-            "Has 2 execution options: --dry-run (the default) to plan which offsets to reset, and --execute to update the offsets. " +
-            "Additionally, the --export option is used to export the results to a CSV format." + NL +
-            "You must choose one of the following reset specifications: --to-datetime, --by-duration, --to-earliest, " +
-            "--to-latest, --shift-by, --from-file, --to-current, --to-offset." + NL +
-            "To define the scope use --all-topics or --topic. One scope must be specified unless you use '--from-file'.";
+    public static final String COMMAND_CONFIG_DOC = "Property file containing configs to be passed to Admin Client.";
+    public static final String RESET_OFFSETS_DOC = "Reset offsets of share group. Supports one share group at the time, and instances must be inactive." + NL +
+            "Has 2 execution options: --dry-run to plan which offsets to reset, and --execute to update the offsets. " + NL +
+            "You must choose one of the following reset specifications: --to-datetime, --to-earliest, --to-latest." + NL +
+            "To define the scope use --all-topics or --topic.";
     public static final String DRY_RUN_DOC = "Only show results without executing changes on Share Groups. Supported operations: reset-offsets.";
     public static final String EXECUTE_DOC = "Execute operation. Supported operations: reset-offsets.";
     public static final String RESET_TO_DATETIME_DOC = "Reset offsets to offset from datetime. Format: 'YYYY-MM-DDTHH:mm:SS.sss'";
@@ -190,10 +188,7 @@ public class ShareGroupCommandOptions extends CommandDefaultOptions {
                 CommandLineUtils.printUsageAndExit(parser, "Option " + resetOffsetsOpt + " only accepts one of " + executeOpt + " and " + dryRunOpt);
 
             if (!options.has(dryRunOpt) && !options.has(executeOpt)) {
-                System.err.println("WARN: No action will be performed as the --execute option is missing." +
-                        "In a future major release, the default behavior of this command will be to prompt the user before " +
-                        "executing the reset rather than doing a dry run. You should add the --dry-run option explicitly " +
-                        "if you are scripting this command and want to keep the current default behavior without prompting.");
+                CommandLineUtils.printUsageAndExit(parser, "Option " + resetOffsetsOpt + " takes the option: " + executeOpt + " or " + dryRunOpt);
             }
 
             if (!options.has(groupOpt))

--- a/tools/src/main/java/org/apache/kafka/tools/ShareGroupsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ShareGroupsCommand.java
@@ -62,7 +62,7 @@ public class ShareGroupsCommand {
       // should have exactly one action
       long actions = Stream.of(opts.listOpt, opts.describeOpt, opts.deleteOpt, opts.resetOffsetsOpt, opts.deleteOffsetsOpt).filter(opts.options::has).count();
       if (actions != 1)
-        CommandLineUtils.printUsageAndExit(opts.parser, "Command must include exactly one action: --list, --describe, --delete, --reset-offsets, --delete-offsets");
+        CommandLineUtils.printUsageAndExit(opts.parser, "Command must include exactly one action: --list, --describe, --delete, --reset-offsets, --delete-offsets.");
 
       run(opts);
     } catch (OptionException e) {
@@ -177,7 +177,7 @@ public class ShareGroupsCommand {
         printMemberDetails(description.members());
         return;
       }
-      printGroupDescriptionTable(description, shouldPrintState, shouldPrintMemDetails);
+      printGroupDescriptionTable(description, shouldPrintState);
     }
 
     ShareGroupDescription getDescribeGroup(String group) throws ExecutionException, InterruptedException {
@@ -212,9 +212,9 @@ public class ShareGroupsCommand {
       return lag;
     }
 
-    private void printGroupDescriptionTable(ShareGroupDescription description, boolean shouldPrintState, boolean shouldPrintMemDetails) throws ExecutionException, InterruptedException {
+    private void printGroupDescriptionTable(ShareGroupDescription description, boolean shouldPrintState) throws ExecutionException, InterruptedException {
       Map<TopicPartition, Long> offsets = getOffsetLag(description.members());
-      boolean notOffset = offsets == null || offsets.size() == 0;
+      boolean notOffset = offsets == null || offsets.isEmpty();
       if (notOffset) {
         offsets = new HashMap<>();
         offsets.put(new TopicPartition("SENTINEL", -1), -1L);


### PR DESCRIPTION
Change the protocol type of share groups so that they do not appear to be consumer groups. Also make the usage messages for `kafka-share-groups.sh` match KIP-932 rather than `kafka-consumer-groups.sh`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
