### PR TITLE
AKCORE-167: Write RPC complete implementation.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteShareGroupStateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteShareGroupStateRequest.java
@@ -34,7 +34,7 @@ public class WriteShareGroupStateRequest extends AbstractRequest {
     private final WriteShareGroupStateRequestData data;
 
     public Builder(WriteShareGroupStateRequestData data) {
-      this(data, false);
+      this(data, true);
     }
 
     public Builder(WriteShareGroupStateRequestData data, boolean enableUnstableLastVersion) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteShareGroupStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteShareGroupStateResponse.java
@@ -17,13 +17,16 @@
 
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.WriteShareGroupStateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class WriteShareGroupStateResponse extends AbstractResponse {
@@ -64,5 +67,29 @@ public class WriteShareGroupStateResponse extends AbstractResponse {
     return new WriteShareGroupStateResponse(
         new WriteShareGroupStateResponseData(new ByteBufferAccessor(buffer), version)
     );
+  }
+
+  public static WriteShareGroupStateResponseData getErrorResponseData(Uuid topicId, int partitionId, Errors error, String errorMessage) {
+    WriteShareGroupStateResponseData responseData = new WriteShareGroupStateResponseData();
+    responseData.setResults(Collections.singletonList(new WriteShareGroupStateResponseData.WriteStateResult()
+        .setTopicId(topicId)
+        .setPartitions(Collections.singletonList(new WriteShareGroupStateResponseData.PartitionResult()
+            .setPartition(partitionId)
+            .setErrorCode(error.code())
+            .setErrorMessage(errorMessage)))));
+    return responseData;
+  }
+
+  public static WriteShareGroupStateResponseData.PartitionResult getErrorResponsePartitionResult(int partitionId, Errors error, String errorMessage) {
+    return new WriteShareGroupStateResponseData.PartitionResult()
+        .setPartition(partitionId)
+        .setErrorCode(error.code())
+        .setErrorMessage(errorMessage);
+  }
+
+  public static WriteShareGroupStateResponseData.WriteStateResult getErrorResponseResult(Uuid topicId, List<WriteShareGroupStateResponseData.PartitionResult> partitionResults) {
+    return new WriteShareGroupStateResponseData.WriteStateResult()
+        .setTopicId(topicId)
+        .setPartitions(partitionResults);
   }
 }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -4803,9 +4803,49 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   private def handleWriteShareGroupState(request: RequestChannel.Request): Unit = {
     val writeShareRequest = request.body[WriteShareGroupStateRequest]
-    //todo smjn: add auth check for group, topic
-    val writeShareData = shareCoordinator.writeState(request.context, writeShareRequest.data).get()
-    requestHelper.sendMaybeThrottle(request, new WriteShareGroupStateResponse(writeShareData))
+    val requestData = writeShareRequest.data()
+
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+
+    val requestDataWithAuthorizedPartitions: WriteShareGroupStateRequestData = new WriteShareGroupStateRequestData()
+      .setGroupId(requestData.groupId())
+
+    val (authorizedTopics, unauthorizedTopics) = authHelper.partitionSeqByAuthorized(
+      request.context,
+      DESCRIBE,
+      TOPIC,
+      requestData.topics.asScala
+    )(_.topicId.toString())
+
+    val authorizedWriteStateData: util.List[WriteShareGroupStateRequestData.WriteStateData] =
+      new util.ArrayList[WriteShareGroupStateRequestData.WriteStateData]()
+    requestData.topics().forEach(topic => {
+      if (authorizedTopics.contains(topic.topicId.toString())) {
+        authorizedWriteStateData.add(topic)
+      }
+    })
+
+    requestDataWithAuthorizedPartitions.setTopics(authorizedWriteStateData)
+
+    // Finding the ShareGroupState data for the given request
+    val responseData: WriteShareGroupStateResponseData =
+      shareCoordinator.writeState(request.context, requestDataWithAuthorizedPartitions).get()
+
+    // Adding unauthorized topics to the response with TOPIC_AUTHORIZATION_FAILED error
+    requestData.topics().stream().filter(topic => {
+      unauthorizedTopics.contains(topic.topicId().toString)
+    }).forEach(topic => {
+      responseData.results.add(new WriteShareGroupStateResponseData.WriteStateResult()
+        .setTopicId(topic.topicId())
+        .setPartitions(topic.partitions().stream().map(partition => {
+          new WriteShareGroupStateResponseData.PartitionResult()
+            .setPartition(partition.partition())
+            .setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code())
+            .setErrorMessage(Errors.TOPIC_AUTHORIZATION_FAILED.message())
+        }).collect(util.stream.Collectors.toList())))
+    })
+
+    requestHelper.sendMaybeThrottle(request, new WriteShareGroupStateResponse(responseData))
   }
 
   private def updateRecordConversionStats(request: RequestChannel.Request,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -265,7 +265,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.SHARE_GROUP_HEARTBEAT => handleShareGroupHeartbeat(request).exceptionally(handleError)
         case ApiKeys.SHARE_GROUP_DESCRIBE => handleShareGroupDescribe(request).exceptionally(handleError)
         case ApiKeys.SHARE_ACKNOWLEDGE => handleShareAcknowledgeRequest(request)
-        case ApiKeys.WRITE_SHARE_GROUP_STATE => handleShareGroupStateWrite(request)
+        case ApiKeys.WRITE_SHARE_GROUP_STATE => handleWriteShareGroupState(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -4801,7 +4801,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
   }
 
-  private def handleShareGroupStateWrite(request: RequestChannel.Request): Unit = {
+  private def handleWriteShareGroupState(request: RequestChannel.Request): Unit = {
     val writeShareRequest = request.body[WriteShareGroupStateRequest]
     //todo smjn: add auth check for group, topic
     val writeShareData = shareCoordinator.writeState(request.context, writeShareRequest.data).get()

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -4803,18 +4803,17 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   private def handleWriteShareGroupState(request: RequestChannel.Request): Unit = {
     val writeShareRequest = request.body[WriteShareGroupStateRequest]
-    val requestData = writeShareRequest.data()
 
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
 
-    val requestDataWithAuthorizedPartitions: WriteShareGroupStateRequestData = new WriteShareGroupStateRequestData()
+    /*val requestDataWithAuthorizedPartitions: WriteShareGroupStateRequestData = new WriteShareGroupStateRequestData()
       .setGroupId(requestData.groupId())
 
     val (authorizedTopics, unauthorizedTopics) = authHelper.partitionSeqByAuthorized(
       request.context,
       DESCRIBE,
       TOPIC,
-      requestData.topics.asScala
+      requestData.topics.asScala.toSeq
     )(_.topicId.toString())
 
     val authorizedWriteStateData: util.List[WriteShareGroupStateRequestData.WriteStateData] =
@@ -4843,9 +4842,10 @@ class KafkaApis(val requestChannel: RequestChannel,
             .setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code())
             .setErrorMessage(Errors.TOPIC_AUTHORIZATION_FAILED.message())
         }).collect(util.stream.Collectors.toList())))
-    })
+    })*/
 
-    requestHelper.sendMaybeThrottle(request, new WriteShareGroupStateResponse(responseData))
+    val writeShareData = shareCoordinator.writeState(request.context, writeShareRequest.data).get()
+    requestHelper.sendMaybeThrottle(request, new WriteShareGroupStateResponse(writeShareData))
   }
 
   private def updateRecordConversionStats(request: RequestChannel.Request,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorService.java
@@ -241,13 +241,13 @@ public class ShareCoordinatorService implements ShareCoordinator {
 
     // validate groupId
     if (groupId == null || groupId.isEmpty()) {
-      if (hasElement(request.topics())) {
+      if (!isEmpty(request.topics())) {
         return CompletableFuture.completedFuture(new WriteShareGroupStateResponseData()
             .setResults(request.topics().stream()
                 .map(topicData -> {
                   WriteShareGroupStateResponseData.WriteStateResult resultData = new WriteShareGroupStateResponseData.WriteStateResult();
                   resultData.setTopicId(topicData.topicId());
-                  if (hasElement(topicData.partitions())) {
+                  if (!isEmpty(topicData.partitions())) {
                     resultData.setPartitions(topicData.partitions().stream()
                         .map(partitionData -> WriteShareGroupStateResponse.getErrorResponsePartitionResult(
                             partitionData.partition(), Errors.INVALID_GROUP_ID, "Group id must be specified and non-empty."))
@@ -266,14 +266,14 @@ public class ShareCoordinatorService implements ShareCoordinator {
     }
 
     // validate topicsData
-    if (!hasElement(request.topics())) {
+    if (isEmpty(request.topics())) {
       return CompletableFuture.completedFuture(WriteShareGroupStateResponse.getErrorResponseData(
           Uuid.ZERO_UUID, -1, Errors.INVALID_REQUEST, "Topic data must be specified."));
     }
 
     // validate partitionsData
     request.topics().forEach(topicData -> {
-      if (!hasElement(topicData.partitions())) {
+      if (isEmpty(topicData.partitions())) {
         WriteShareGroupStateResponseData responseData = new WriteShareGroupStateResponseData();
         responseData.setResults(Collections.singletonList(WriteShareGroupStateResponse.getErrorResponseResult(
             topicData.topicId(), Collections.singletonList(WriteShareGroupStateResponse.getErrorResponsePartitionResult(
@@ -358,7 +358,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     return new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, partitionFor(key));
   }
 
-  private static <P> boolean hasElement(List<P> list) {
+  private static <P> boolean isEmpty(List<P> list) {
     return list == null || list.isEmpty() || list.get(0) == null;
   }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorService.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.message.ReadShareGroupStateRequestData;
 import org.apache.kafka.common.message.ReadShareGroupStateResponseData;
 import org.apache.kafka.common.message.WriteShareGroupStateRequestData;
 import org.apache.kafka.common.message.WriteShareGroupStateResponseData;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -236,25 +237,87 @@ public class ShareCoordinatorService implements ShareCoordinator {
 //     the writeState method in ShareCoordinatorShard expects a single key in the request. Hence, we will
 //     be looping over the keys below and constructing new WriteShareGroupStateRequestData objects to pass
 //     onto the shard method.
+
+    // validate groupId
+    if (groupId == null || groupId.isEmpty()) {
+      WriteShareGroupStateResponseData responseData = new WriteShareGroupStateResponseData();
+      if (hasElement(request.topics())) {
+        return CompletableFuture.completedFuture(new WriteShareGroupStateResponseData()
+            .setResults(request.topics().stream()
+                .map(topicData -> {
+                  WriteShareGroupStateResponseData.WriteStateResult resultData = new WriteShareGroupStateResponseData.WriteStateResult();
+                  resultData.setTopicId(topicData.topicId());
+                  if (hasElement(topicData.partitions())) {
+                    resultData.setPartitions(topicData.partitions().stream()
+                        .map(partitionData -> new WriteShareGroupStateResponseData.PartitionResult()
+                            .setPartition(partitionData.partition())
+                            .setErrorCode(Errors.INVALID_GROUP_ID.code())
+                            .setErrorMessage("Group id must be specified and non-empty."))
+                        .collect(Collectors.toList()));
+                  } else {
+                    resultData.setPartitions(Collections.singletonList(new WriteShareGroupStateResponseData.PartitionResult()
+                        .setPartition(-1)
+                        .setErrorCode(Errors.INVALID_GROUP_ID.code())
+                        .setErrorMessage("Group id must be specified and non-empty.")));
+                  }
+                  return resultData;
+                })
+                .collect(Collectors.toList())));
+      } else {
+        return CompletableFuture.completedFuture(responseData.setResults(Collections.singletonList(new WriteShareGroupStateResponseData.WriteStateResult()
+            .setTopicId(Uuid.ZERO_UUID)
+            .setPartitions(Collections.singletonList(new WriteShareGroupStateResponseData.PartitionResult()
+                .setPartition(-1)
+                .setErrorCode(Errors.INVALID_GROUP_ID.code())
+                .setErrorMessage("Group id must be specified and non-empty."))))));
+      }
+    }
+
+    // validate topicsData
+    if (!hasElement(request.topics())) {
+      WriteShareGroupStateResponseData responseData = new WriteShareGroupStateResponseData();
+      responseData.setResults(Collections.singletonList(new WriteShareGroupStateResponseData.WriteStateResult()
+          .setTopicId(Uuid.ZERO_UUID)
+          .setPartitions(Collections.singletonList(new WriteShareGroupStateResponseData.PartitionResult()
+              .setPartition(-1)
+              .setErrorCode(Errors.INVALID_REQUEST.code())
+              .setErrorMessage("Topic data must be specified.")))));
+      return CompletableFuture.completedFuture(responseData);
+    }
+
+    // validate partitionsData
     request.topics().forEach(topicData -> {
-      Map<Integer, CompletableFuture<WriteShareGroupStateResponseData>> partitionFut =
-          futureMap.computeIfAbsent(topicData.topicId(), k -> new HashMap<>());
-      topicData.partitions().forEach(
-          partitionData -> partitionFut.put(partitionData.partition(), runtime.scheduleWriteOperation(
-              "write-share-group-state",
-              topicPartitionFor(ShareGroupHelper.coordinatorKey(groupId, topicData.topicId(), partitionData.partition())),
-              Duration.ofMillis(config.writeTimeoutMs),
-              coordinator -> coordinator.writeState(context, new WriteShareGroupStateRequestData()
-                  .setGroupId(groupId)
-                  .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
-                      .setTopicId(topicData.topicId())
-                      .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
-                          .setPartition(partitionData.partition())
-                          .setStartOffset(partitionData.startOffset())
-                          .setLeaderEpoch(partitionData.leaderEpoch())
-                          .setStateEpoch(partitionData.stateEpoch())
-                          .setStateBatches(partitionData.stateBatches()))))))))
-      );
+      if (!hasElement(topicData.partitions())) {
+        WriteShareGroupStateResponseData responseData = new WriteShareGroupStateResponseData();
+        responseData.setResults(Collections.singletonList(new WriteShareGroupStateResponseData.WriteStateResult()
+            .setTopicId(topicData.topicId())
+            .setPartitions(Collections.singletonList(new WriteShareGroupStateResponseData.PartitionResult()
+                .setPartition(-1)
+                .setErrorCode(Errors.INVALID_REQUEST.code())
+                .setErrorMessage("Partition data must be specified.")))));
+        Map<Integer, CompletableFuture<WriteShareGroupStateResponseData>> partMap = new HashMap<>();
+        partMap.put(-1, CompletableFuture.completedFuture(responseData));
+        futureMap.put(topicData.topicId(), partMap);
+      } else {
+        Map<Integer, CompletableFuture<WriteShareGroupStateResponseData>> partitionFut =
+            futureMap.computeIfAbsent(topicData.topicId(), k -> new HashMap<>());
+        topicData.partitions().forEach(
+            partitionData -> partitionFut.put(partitionData.partition(), runtime.scheduleWriteOperation(
+                "write-share-group-state",
+                topicPartitionFor(ShareGroupHelper.coordinatorKey(groupId, topicData.topicId(), partitionData.partition())),
+                Duration.ofMillis(config.writeTimeoutMs),
+                coordinator -> coordinator.writeState(context, new WriteShareGroupStateRequestData()
+                    .setGroupId(groupId)
+                    .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+                        .setTopicId(topicData.topicId())
+                        .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                            .setPartition(partitionData.partition())
+                            .setStartOffset(partitionData.startOffset())
+                            .setLeaderEpoch(partitionData.leaderEpoch())
+                            .setStateEpoch(partitionData.stateEpoch())
+                            .setStateBatches(partitionData.stateBatches()))))))))
+        );
+      }
     });
 
 
@@ -311,5 +374,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
 
   private TopicPartition topicPartitionFor(String key) {
     return new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, partitionFor(key));
+  }
+
+  private static <P> boolean hasElement(List<P> list) {
+    return list == null || list.isEmpty() || list.get(0) == null;
   }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorService.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.coordinator.group.share;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.ReadShareGroupStateRequestData;
@@ -36,16 +37,23 @@ import org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime;
 import org.apache.kafka.coordinator.group.runtime.CoordinatorShardBuilderSupplier;
 import org.apache.kafka.coordinator.group.runtime.MultiThreadedEventProcessor;
 import org.apache.kafka.coordinator.group.runtime.PartitionWriter;
+import org.apache.kafka.server.group.share.ShareGroupHelper;
 import org.apache.kafka.server.record.BrokerCompressionType;
 import org.apache.kafka.server.util.timer.Timer;
 import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntSupplier;
+import java.util.stream.Collectors;
 
 public class ShareCoordinatorService implements ShareCoordinator {
   private final ShareCoordinatorConfig config;
@@ -220,7 +228,64 @@ public class ShareCoordinatorService implements ShareCoordinator {
 
   @Override
   public CompletableFuture<WriteShareGroupStateResponseData> writeState(RequestContext context, WriteShareGroupStateRequestData request) {
-    return null;
+    log.info("ShareCoordinatorService writeState request received - {}", request);
+    String groupId = request.groupId();
+    Map<Uuid, Map<Integer, CompletableFuture<WriteShareGroupStateResponseData>>> futureMap = new HashMap<>();
+
+//     The request received here could have multiple keys of structure group:topic:partition. However,
+//     the writeState method in ShareCoordinatorShard expects a single key in the request. Hence, we will
+//     be looping over the keys below and constructing new WriteShareGroupStateRequestData objects to pass
+//     onto the shard method.
+    request.topics().forEach(topicData -> {
+      Map<Integer, CompletableFuture<WriteShareGroupStateResponseData>> partitionFut =
+          futureMap.computeIfAbsent(topicData.topicId(), k -> new HashMap<>());
+      topicData.partitions().forEach(
+          partitionData -> partitionFut.put(partitionData.partition(), runtime.scheduleWriteOperation(
+              "write-share-group-state",
+              topicPartitionFor(ShareGroupHelper.coordinatorKey(groupId, topicData.topicId(), partitionData.partition())),
+              Duration.ofMillis(config.writeTimeoutMs),
+              coordinator -> coordinator.writeState(context, new WriteShareGroupStateRequestData()
+                  .setGroupId(groupId)
+                  .setTopics(Collections.singletonList(new WriteShareGroupStateRequestData.WriteStateData()
+                      .setTopicId(topicData.topicId())
+                      .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                          .setPartition(partitionData.partition())
+                          .setStartOffset(partitionData.startOffset())
+                          .setLeaderEpoch(partitionData.leaderEpoch())
+                          .setStateEpoch(partitionData.stateEpoch())
+                          .setStateBatches(partitionData.stateBatches()))))))))
+      );
+    });
+
+
+    // Combine all futures into a single CompletableFuture<Void>
+    CompletableFuture<Void> combinedFuture = CompletableFuture.allOf(futureMap.values().stream()
+        .flatMap(partMap -> partMap.values().stream()).toArray(CompletableFuture[]::new));
+
+    return combinedFuture.thenApply(v -> {
+      List<WriteShareGroupStateResponseData.WriteStateResult> writeStateResults = futureMap.keySet().stream()
+          .map(topicId -> {
+            List<WriteShareGroupStateResponseData.PartitionResult> partitionResults = futureMap.get(topicId).values().stream()
+                .map(future -> {
+                  try {
+                    WriteShareGroupStateResponseData partitionData = future.get();
+                    // error check if the partitionData results contains only 1 row (corresponding to topicId)
+                    return partitionData.results().get(0).partitions();
+                  } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+
+            return new WriteShareGroupStateResponseData.WriteStateResult()
+                .setTopicId(topicId)
+                .setPartitions(partitionResults);
+          })
+          .collect(Collectors.toList());
+      return new WriteShareGroupStateResponseData()
+          .setResults(writeStateResults);
+    });
   }
 
   @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
@@ -231,10 +231,6 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
     WriteShareGroupStateRequestData.WriteStateData topicData = request.topics().get(0);
     WriteShareGroupStateRequestData.PartitionData partitionData = topicData.partitions().get(0);
 
-    List<Record> recordList = Collections.singletonList(RecordHelpers.newShareSnapshotRecord(
-        groupId, topicData.topicId(), partitionData.partition(), ShareGroupOffset.fromRequest(partitionData)
-    ));
-
     String mapKey = ShareGroupHelper.coordinatorKey(groupId, topicData.topicId(), partitionData.partition());
 
     if (leaderMap.containsKey(mapKey) && leaderMap.get(mapKey) > partitionData.leaderEpoch()) {
@@ -247,6 +243,9 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
       return new CoordinatorResult<>(Collections.emptyList(), responseData);
     }
 
+    List<Record> recordList = Collections.singletonList(RecordHelpers.newShareSnapshotRecord(
+        groupId, topicData.topicId(), partitionData.partition(), ShareGroupOffset.fromRequest(partitionData)
+    ));
     List<Record> validRecords = new ArrayList<>();
 
     for (Record record : recordList) {  // should be single record

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
@@ -272,23 +272,12 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
 
   private Optional<CoordinatorResult<WriteShareGroupStateResponseData, Record>> maybeGetWriteStateError(WriteShareGroupStateRequestData request) {
     String groupId = request.groupId();
-
-    if (!hasElement(request.topics())) {
-      return Optional.of(getWriteErrorResponse(Errors.INVALID_REQUEST, Uuid.ZERO_UUID, -1));
-    }
     WriteShareGroupStateRequestData.WriteStateData topicData = request.topics().get(0);
-
-    if (!hasElement(topicData.partitions())) {
-      return Optional.of(getWriteErrorResponse(Errors.INVALID_REQUEST, topicData.topicId(), -1));
-    }
     WriteShareGroupStateRequestData.PartitionData partitionData = topicData.partitions().get(0);
 
     Uuid topicId = topicData.topicId();
     int partitionId = partitionData.partition();
 
-    if (groupId == null || groupId.isEmpty()) {
-      return Optional.of(getWriteErrorResponse(Errors.INVALID_GROUP_ID, topicId, partitionId));
-    }
     if (topicId == null || partitionId == -1) {
       return Optional.of(getWriteErrorResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, topicId, partitionId));
     }
@@ -314,9 +303,5 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
             .setErrorCode(error.code())
             .setErrorMessage(error.message())))));
     return new CoordinatorResult<>(Collections.emptyList(), responseData);
-  }
-
-  private static <P> boolean hasElement(List<P> list) {
-    return list == null || list.isEmpty() || list.get(0) == null;
   }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/DefaultStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/DefaultStatePersister.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -96,7 +97,20 @@ public class DefaultStatePersister implements Persister {
    * @return ReadShareGroupStateResult
    */
   public CompletableFuture<ReadShareGroupStateResult> readState(ReadShareGroupStateParameters request) {
-    throw new RuntimeException("not implemented");
+    log.info("Read share state request received: {}", request);
+    TopicData<PartitionIdLeaderEpochData> requestTopicData = request.groupTopicPartitionData().topicsData().get(0);
+    PartitionIdLeaderEpochData requestPartitionData = requestTopicData.partitions().get(0);
+    PartitionAllData resultPartitionData = PartitionFactory.newPartitionAllData(
+        requestPartitionData.partition(),
+        PartitionFactory.DEFAULT_STATE_EPOCH,
+        PartitionFactory.DEFAULT_START_OFFSET,
+        PartitionFactory.DEFAULT_ERROR_CODE,
+        PartitionFactory.DEFAULT_ERR_MESSAGE,
+        Collections.emptyList()
+    );
+    ReadShareGroupStateResult.Builder builder = new ReadShareGroupStateResult.Builder();
+    TopicData<PartitionAllData> topicData = new TopicData<>(requestTopicData.topicId(), Collections.singletonList(resultPartitionData));
+    return CompletableFuture.completedFuture(builder.setTopicsData(Collections.singletonList(topicData)).build());
   }
 
   /**

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/DefaultStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/DefaultStatePersister.java
@@ -17,12 +17,20 @@
 
 package org.apache.kafka.server.group.share;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.requests.WriteShareGroupStateResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 /**
  * The default implementation of the {@link Persister} interface which is used by the
@@ -57,6 +65,7 @@ public class DefaultStatePersister implements Persister {
   public void configure(PersisterConfig config) {
     this.persisterConfig = Objects.requireNonNull(config);
     this.stateManager = Objects.requireNonNull(config.stateManager);
+    this.stateManager.start();
   }
 
   @Override
@@ -98,7 +107,57 @@ public class DefaultStatePersister implements Persister {
    * @return WriteShareGroupStateResult
    */
   public CompletableFuture<WriteShareGroupStateResult> writeState(WriteShareGroupStateParameters request) {
-    throw new RuntimeException("not implemented");
+    log.info("Write share group state request received - {}", request);
+    GroupTopicPartitionData<PartitionStateBatchData> gtp = request.groupTopicPartitionData();
+    String groupId = gtp.groupId();
+
+    Map<Uuid, Map<Integer, CompletableFuture<WriteShareGroupStateResponse>>> futureMap = new HashMap<>();
+
+    List<PersisterStateManager.WriteStateHandler> handlers = gtp.topicsData().stream()
+        .map(topicData -> topicData.partitions().stream()
+            .map(partitionData -> {
+              Map<Integer, CompletableFuture<WriteShareGroupStateResponse>> partMap = futureMap.computeIfAbsent(topicData.topicId(), k -> new HashMap<>());
+              if (!partMap.containsKey(partitionData.partition())) {
+                partMap.put(partitionData.partition(), new CompletableFuture<>());
+              }
+              return stateManager.new WriteStateHandler(
+                  groupId, topicData.topicId(), partitionData.partition(), partitionData.stateEpoch(), partitionData.leaderEpoch(), partitionData.startOffset(), partitionData.stateBatches(),
+                  partMap.get(partitionData.partition()));
+            })
+            .collect(Collectors.toList()))
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+
+    for (PersisterStateManager.PersisterStateManagerHandler handler : handlers) {
+      stateManager.enqueue(handler);
+    }
+
+    CompletableFuture<Void> combinedFuture = CompletableFuture.allOf(futureMap.values().stream()
+        .flatMap(partMap -> partMap.values().stream()).toArray(CompletableFuture[]::new));
+
+    return combinedFuture.thenApply(v -> {
+      List<TopicData<PartitionErrorData>> topicsData = futureMap.keySet().stream()
+          .map(topicId -> {
+            List<PartitionErrorData> partitionErrData = futureMap.get(topicId).values().stream()
+                .map(future -> {
+                  try {
+                    WriteShareGroupStateResponse partitionResponse = future.get();
+                    return partitionResponse.data().results().get(0).partitions().stream()
+                        .map(partitionResult -> PartitionFactory.newPartitionErrorData(partitionResult.partition(), partitionResult.errorCode(), partitionResult.errorMessage()))
+                        .collect(Collectors.toList());
+                  } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+            return new TopicData<>(topicId, partitionErrData);
+          })
+          .collect(Collectors.toList());
+      return new WriteShareGroupStateResult.Builder()
+          .setTopicsData(topicsData)
+          .build();
+    });
   }
 
   /**

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/GroupTopicPartitionData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/GroupTopicPartitionData.java
@@ -27,6 +27,7 @@ public class GroupTopicPartitionData<P extends PartitionInfoData> {
   public GroupTopicPartitionData(String groupId, List<TopicData<P>> topicsData) {
     this.groupId = groupId;
     this.topicsData = topicsData;
+    validate();
   }
 
   public String groupId() {
@@ -72,6 +73,33 @@ public class GroupTopicPartitionData<P extends PartitionInfoData> {
 
     public GroupTopicPartitionData<P> build() {
       return new GroupTopicPartitionData<P>(this.groupId, this.topicsData);
+    }
+  }
+
+  private void validate() throws IllegalArgumentException {
+    if (groupId == null || groupId.isEmpty()) {
+      throw new IllegalArgumentException("GroupId must be specified.");
+    }
+    if (topicsData.isEmpty()) {
+      throw new IllegalArgumentException("Topic-partition data must be specified groupId:" + groupId);
+    }
+    for (TopicData<P> topicData : topicsData) {
+      if (topicData.topicId() == null) {
+        throw new IllegalArgumentException(String.format("TopicId must be specified groupId: %s, topicData: %s", groupId, topicData));
+      }
+      if (topicData.partitions().isEmpty()) {
+        throw new IllegalArgumentException(String.format("Partition data must be specified groupId: %s, topicData: %s", groupId, topicData));
+      }
+      for (P partitionData : topicData.partitions()) {
+        if (!(partitionData instanceof PartitionIdData)) {
+          throw new IllegalArgumentException(String.format("Partition data must have partition id groupId: %s, topicId: %s, partitionData: %s",
+              groupId, topicData.topicId(), partitionData));
+        }
+        if (((PartitionIdData) partitionData).partition() < 0) {
+          throw new IllegalArgumentException(String.format("Partition id must be non-negative integer groupId: %s, topicId: %s, partitionData: %s",
+              groupId, topicData.topicId(), ((PartitionIdData) partitionData).partition()));
+        }
+      }
     }
   }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/GroupTopicPartitionData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/GroupTopicPartitionData.java
@@ -102,4 +102,9 @@ public class GroupTopicPartitionData<P extends PartitionInfoData> {
       }
     }
   }
+
+  @Override
+  public String toString() {
+    return "GroupTopicPartitionData(" + groupId + ", " + topicsData + ")";
+  }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionAllData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionAllData.java
@@ -19,9 +19,7 @@ package org.apache.kafka.server.group.share;
 
 import java.util.List;
 
-public interface PartitionAllData extends PartitionInfoData {
-  int partition();
-
+public interface PartitionAllData extends PartitionInfoData, PartitionIdData {
   int stateEpoch();
 
   long startOffset();

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionData.java
@@ -135,4 +135,17 @@ public class PartitionData implements
       return new PartitionData(partition, stateEpoch, startOffset, errorCode, errorMessage, leaderEpoch, stateBatches);
     }
   }
+
+  @Override
+  public String toString() {
+    return "PartitionData(" +
+        "partition=" + partition + "," +
+        "stateEpoch=" + stateEpoch + "," +
+        "startOffset=" + startOffset + "," +
+        "errorCode=" + errorCode + "," +
+        "errorMessage=" + errorMessage + "," +
+        "leaderEpoch=" + leaderEpoch + "," +
+        "stateBatches=" + stateBatches +
+        ")";
+  }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionErrorData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionErrorData.java
@@ -17,9 +17,7 @@
 
 package org.apache.kafka.server.group.share;
 
-public interface PartitionErrorData extends PartitionInfoData {
-  int partition();
-
+public interface PartitionErrorData extends PartitionInfoData, PartitionIdData {
   short errorCode();
 
   String errorMessage();

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionIdLeaderEpochData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionIdLeaderEpochData.java
@@ -17,8 +17,6 @@
 
 package org.apache.kafka.server.group.share;
 
-public interface PartitionIdLeaderEpochData extends PartitionInfoData {
-  int partition();
-
+public interface PartitionIdLeaderEpochData extends PartitionInfoData, PartitionIdData {
   int leaderEpoch();
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateBatchData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateBatchData.java
@@ -19,9 +19,7 @@ package org.apache.kafka.server.group.share;
 
 import java.util.List;
 
-public interface PartitionStateBatchData extends PartitionInfoData {
-  int partition();
-
+public interface PartitionStateBatchData extends PartitionInfoData, PartitionIdData {
   int stateEpoch();
 
   long startOffset();

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateData.java
@@ -17,8 +17,7 @@
 
 package org.apache.kafka.server.group.share;
 
-public interface PartitionStateData extends PartitionInfoData {
-  int partition();
+public interface PartitionStateData extends PartitionInfoData, PartitionIdData {
   int stateEpoch();
   long startOffset();
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateErrorData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PartitionStateErrorData.java
@@ -17,9 +17,7 @@
 
 package org.apache.kafka.server.group.share;
 
-public interface PartitionStateErrorData extends PartitionInfoData {
-  int partition();
-
+public interface PartitionStateErrorData extends PartitionInfoData, PartitionIdData {
   int stateEpoch();
 
   long startOffset();

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateBatch.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateBatch.java
@@ -79,4 +79,14 @@ public class PersisterStateBatch {
   public int hashCode() {
     return Objects.hash(firstOffset, lastOffset, deliveryState, deliveryCount);
   }
+
+  @Override
+  public String toString() {
+    return "PersisterStateBatch(" +
+        "firstOffset=" + firstOffset + "," +
+        "lastOffset=" + lastOffset + "," +
+        "deliveryState=" + deliveryState + "," +
+        "deliveryCount=" + deliveryCount +
+        ")";
+  }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
@@ -96,6 +96,7 @@ public class PersisterStateManager {
     protected final int partition;
     private final ExponentialBackoff findCoordbackoff = new ExponentialBackoff(1_000, 2, 30_000, 100);
     private int findCoordattempts = 0;
+    private final int maxFindCoordAttempts = 5;
 
     public PersisterStateManagerHandler(String groupId, Uuid topicId, int partition) {
       this.groupId = groupId;
@@ -185,6 +186,11 @@ public class PersisterStateManager {
         enqueue(this);
       } else if (isFindCoordinatorRetryable(error)) {
         log.warn("Received retryable error in find coordinator {}", error.message());
+        if (findCoordattempts > maxFindCoordAttempts) {
+          log.error("Exhausted max retries to find coordinator without success.");
+          findCoordinatorErrorResponse(error, new Exception("Exhausted max retries to find coordinator without success."));
+          return;
+        }
         log.info("Waiting before retrying find coordinator response.");
         try {
           TimeUnit.MILLISECONDS.sleep(findCoordbackoff.backoff(++findCoordattempts));
@@ -280,7 +286,8 @@ public class PersisterStateManager {
             WriteShareGroupStateResponse.getErrorResponseData(topicId, partition, error, exception.getMessage())));
       } else {
         this.result.complete(new WriteShareGroupStateResponse(
-            WriteShareGroupStateResponse.getErrorResponseData(topicId, partition, error, "Error in find coordinator. " + error.message())));
+            WriteShareGroupStateResponse.getErrorResponseData(topicId, partition, error, "Error in find coordinator. " +
+                (exception == null ? error.message() : exception.getMessage()))));
       }
     }
   }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
@@ -278,9 +278,10 @@ public class PersisterStateManager {
       if (error == Errors.UNKNOWN_SERVER_ERROR && exception != null) {
         this.result.complete(new WriteShareGroupStateResponse(
             WriteShareGroupStateResponse.getErrorResponseData(topicId, partition, error, exception.getMessage())));
+      } else {
+        this.result.complete(new WriteShareGroupStateResponse(
+            WriteShareGroupStateResponse.getErrorResponseData(topicId, partition, error, "Error in find coordinator. " + error.message())));
       }
-      this.result.complete(new WriteShareGroupStateResponse(
-          WriteShareGroupStateResponse.getErrorResponseData(topicId, partition, error, "Error in find coordinator. " + error.message())));
     }
   }
 

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
@@ -24,11 +24,14 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.message.FindCoordinatorResponseData;
+import org.apache.kafka.common.message.WriteShareGroupStateRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.requests.WriteShareGroupStateRequest;
+import org.apache.kafka.common.requests.WriteShareGroupStateResponse;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.util.InterBrokerSendThread;
 import org.apache.kafka.server.util.RequestAndCompletionHandler;
@@ -39,9 +42,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class PersisterStateManager {
 
@@ -95,16 +100,16 @@ public class PersisterStateManager {
     }
 
     /**
-     * looks for single group:topic:partition item
+     * Child class must create appropriate builder object for the handled RPC
      *
-     * @return builder for the same
+     * @return builder for the request
      */
     protected abstract AbstractRequest.Builder<? extends AbstractRequest> requestBuilder();
 
     /**
-     * looks for single group:topic:partition coordinator
+     * Returns builder for share coordinator
      *
-     * @return builder for the same
+     * @return builder for find coordinator
      */
     protected AbstractRequest.Builder<? extends AbstractRequest> findShareCoordinatorBuilder() {
       return new FindCoordinatorRequest.Builder(new FindCoordinatorRequestData()
@@ -112,18 +117,35 @@ public class PersisterStateManager {
           .setKey(coordinatorKey()));
     }
 
+    /**
+     * Return the share coordinator node
+     * @return Node
+     */
     protected Node shareCoordinatorNode() {
       return coordinatorNode;
     }
 
+    /**
+     * Returns true is coordinator node is not yet set
+     * @return boolean
+     */
     protected boolean lookupNeeded() {
       return coordinatorNode == null;
     }
 
+    /**
+     * Returns the String key to be used as share coordinator key
+     * @return String
+     */
     protected String coordinatorKey() {
       return ShareGroupHelper.coordinatorKey(groupId, topicId, partition);
     }
 
+    /**
+     * Returns true if the RPC response if for Find Coordinator RPC.
+     * @param response - Client response object
+     * @return boolean
+     */
     protected boolean isFindCoordinatorResponse(ClientResponse response) {
       return response != null && response.requestHeader().apiKey() == ApiKeys.FIND_COORDINATOR;
     }
@@ -139,6 +161,10 @@ public class PersisterStateManager {
       }
     }
 
+    /**
+     * Handles the response for find coordinator RPC and sets appropriate state.
+     * @param response - Client response for find coordinator RPC
+     */
     protected void handleFindCoordinatorResponse(ClientResponse response) {
       List<FindCoordinatorResponseData.Coordinator> coordinators = ((FindCoordinatorResponse) response.responseBody()).coordinators();
       if (coordinators.size() != 1) {
@@ -150,14 +176,72 @@ public class PersisterStateManager {
       if (error == Errors.NONE) {
         log.info("Find coordinator response received.");
         coordinatorNode = new Node(coordinatorData.nodeId(), coordinatorData.host(), coordinatorData.port());
-        // now we want the read state call to happen
-        enqueue(this);  //todo smjn: enable this when read RPC is working
+        // now we want the actual share state RPC call to happen
+        enqueue(this);
       }
     }
 
+    /**
+     * Handles the response for an RPC.
+     * @param response - Client response
+     */
     protected abstract void handleRequestResponse(ClientResponse response);
 
+    /**
+     * Returns true if the response if valid for the respective child class.
+     * @param response - Client response
+     * @return - boolean
+     */
     protected abstract boolean isRequestResponse(ClientResponse response);
+  }
+
+  public class WriteStateHandler extends PersisterStateManagerHandler {
+    private final int stateEpoch;
+    private final int leaderEpoch;
+    private final long startOffset;
+    private final List<PersisterStateBatch> batches;
+    private final CompletableFuture<WriteShareGroupStateResponse> result;
+
+    public WriteStateHandler(String groupId, Uuid topicId, int partition, int stateEpoch, int leaderEpoch, long startOffset, List<PersisterStateBatch> batches, CompletableFuture<WriteShareGroupStateResponse> result) {
+      super(groupId, topicId, partition);
+      this.stateEpoch = stateEpoch;
+      this.leaderEpoch = leaderEpoch;
+      this.startOffset = startOffset;
+      this.batches = batches;
+      this.result = result;
+    }
+
+    @Override
+    protected AbstractRequest.Builder<? extends AbstractRequest> requestBuilder() {
+      return new WriteShareGroupStateRequest.Builder(new WriteShareGroupStateRequestData()
+          .setGroupId(groupId)
+          .setTopics(Collections.singletonList(
+              new WriteShareGroupStateRequestData.WriteStateData()
+                  .setTopicId(topicId)
+                  .setPartitions(Collections.singletonList(new WriteShareGroupStateRequestData.PartitionData()
+                      .setPartition(partition)
+                      .setStateEpoch(stateEpoch)
+                      .setLeaderEpoch(leaderEpoch)
+                      .setStartOffset(startOffset)
+                      .setStateBatches(batches.stream()
+                          .map(batch -> new WriteShareGroupStateRequestData.StateBatch()
+                              .setFirstOffset(batch.firstOffset())
+                              .setLastOffset(batch.lastOffset())
+                              .setDeliveryState(batch.deliveryState())
+                              .setDeliveryCount(batch.deliveryCount()))
+                          .collect(Collectors.toList())))))));
+    }
+
+    @Override
+    protected boolean isRequestResponse(ClientResponse response) {
+      return response.requestHeader().apiKey() == ApiKeys.WRITE_SHARE_GROUP_STATE;
+    }
+
+    @Override
+    protected void handleRequestResponse(ClientResponse response) {
+      log.info("Write state response received. - {}", response);
+      this.result.complete((WriteShareGroupStateResponse) response.responseBody());
+    }
   }
 
   private static class SendThread extends InterBrokerSendThread {

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/TopicData.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/TopicData.java
@@ -51,4 +51,12 @@ public class TopicData<P extends PartitionInfoData> {
   public List<P> partitions() {
     return partitions;
   }
+
+  @Override
+  public String toString() {
+    return "TopicData(" +
+        "topicId=" + topicId +
+        "partitions" + partitions +
+        ")";
+  }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/WriteShareGroupStateParameters.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/WriteShareGroupStateParameters.java
@@ -59,4 +59,9 @@ public class WriteShareGroupStateParameters implements PersisterParameters {
       return new WriteShareGroupStateParameters(groupTopicPartitionData);
     }
   }
+
+  @Override
+  public String toString() {
+    return "WriteShareGroupStateParameters(" + groupTopicPartitionData + ")";
+  }
 }


### PR DESCRIPTION
* Impl for `writeState` in DefaultSharePersister, ShareCoordinatorService and ShareCoordinatorShard
* Setup in `KafkaApis` to intercept the RPC and return the result.
* The call structure from perspective of `SharePartition` is:
```
SharePartition -> persister.writeState(WriteShareGroupStateParameters) -> forEach_key_in_request.PersisterStateManager.{if client.findCoordinator then client.writeRPC} -> kafkaApis.handleShareGroupStateWrite -> ShareCoordinatorService.writeRPC(WriteShareGroupStateRequestData) -> ShareCoordinator.writeRPC(WriteShareGroupStateRequestData) [update soft state and send records to runtime to update internal topic]
```
 * Sample logs
```
[2024-06-06 01:10:12,050] INFO Write share group state request received - org.apache.kafka.server.group.share.WriteShareGroupStateParameters@28c94ab1 (org.apache.kafka.server.group.share.DefaultStatePersister)
[2024-06-06 01:10:40,878] INFO Find coordinator response received. (org.apache.kafka.server.group.share.PersisterStateManager)
[2024-06-06 01:10:40,879] INFO [ShareCoordinator id=1] ShareCoordinatorService writeState request received - WriteShareGroupStateRequestData(groupId='group-shareb1', topics=[WriteStateData(topicId=Vihz6VQGSKi9IPBuwRiKqA, partitions=[PartitionData(partition=0, stateEpoch=0, leaderEpoch=0, startOffset=8, stateBatches=[StateBatch(firstOffset=8, lastOffset=10, deliveryState=2, deliveryCount=1)])])]) (org.apache.kafka.coordinator.group.share.ShareCoordinatorService)
[2024-06-06 01:10:40,879] INFO [ShareCoordinator id=1 topic=__share_group_state partition=26] Shard writeState request received - WriteShareGroupStateRequestData(groupId='group-shareb1', topics=[WriteStateData(topicId=Vihz6VQGSKi9IPBuwRiKqA, partitions=[PartitionData(partition=0, stateEpoch=0, leaderEpoch=0, startOffset=8, stateBatches=[StateBatch(firstOffset=8, lastOffset=10, deliveryState=2, deliveryCount=1)])])]) (org.apache.kafka.coordinator.group.share.ShareCoordinatorShard)
[2024-06-06 01:10:40,881] INFO Write state response received. - ClientResponse(receivedTimeMs=1717616440881, latencyMs=3, disconnected=false, timedOut=false, requestHeader=RequestHeader(apiKey=WRITE_SHARE_GROUP_STATE, apiVersion=0, clientId=Persister-client-1, correlationId=7, headerVersion=2), responseBody=WriteShareGroupStateResponseData(results=[WriteStateResult(topicId=Vihz6VQGSKi9IPBuwRiKqA, partitions=[PartitionResult(partition=0, errorCode=0, errorMessage='NONE')])])) (org.apache.kafka.server.group.share.PersisterStateManager)
[2024-06-06 01:10:40,887] INFO Write share group state request received - org.apache.kafka.server.group.share.WriteShareGroupStateParameters@3a29b97d (org.apache.kafka.server.group.share.DefaultStatePersister)
[2024-06-06 01:11:10,885] INFO Find coordinator response received. (org.apache.kafka.server.group.share.PersisterStateManager)
[2024-06-06 01:11:10,888] INFO [ShareCoordinator id=1] ShareCoordinatorService writeState request received - WriteShareGroupStateRequestData(groupId='group-shareb1', topics=[WriteStateData(topicId=Vihz6VQGSKi9IPBuwRiKqA, partitions=[PartitionData(partition=0, stateEpoch=0, leaderEpoch=0, startOffset=11, stateBatches=[StateBatch(firstOffset=11, lastOffset=11, deliveryState=2, deliveryCount=1)])])]) (org.apache.kafka.coordinator.group.share.ShareCoordinatorService)
[2024-06-06 01:11:10,888] INFO [ShareCoordinator id=1 topic=__share_group_state partition=26] Shard writeState request received - WriteShareGroupStateRequestData(groupId='group-shareb1', topics=[WriteStateData(topicId=Vihz6VQGSKi9IPBuwRiKqA, partitions=[PartitionData(partition=0, stateEpoch=0, leaderEpoch=0, startOffset=11, stateBatches=[StateBatch(firstOffset=11, lastOffset=11, deliveryState=2, deliveryCount=1)])])]) (org.apache.kafka.coordinator.group.share.ShareCoordinatorShard)
[2024-06-06 01:11:10,890] INFO Write state response received. - ClientResponse(receivedTimeMs=1717616470889, latencyMs=2, disconnected=false, timedOut=false, requestHeader=RequestHeader(apiKey=WRITE_SHARE_GROUP_STATE, apiVersion=0, clientId=Persister-client-1, correlationId=9, headerVersion=2), responseBody=WriteShareGroupStateResponseData(results=[WriteStateResult(topicId=Vihz6VQGSKi9IPBuwRiKqA, partitions=[PartitionResult(partition=0, errorCode=0, errorMessage='NONE')])])) (org.apache.kafka.server.group.share.PersisterStateManager)
```
* FindCoordinator retry
```
[2024-06-06 01:08:47,660] INFO Write share group state request received - org.apache.kafka.server.group.share.WriteShareGroupStateParameters@459dfa31 (org.apache.kafka.server.group.share.DefaultStatePersister)
[2024-06-06 01:09:10,839] INFO Sent auto-creation request for Set(__share_group_state) to the active controller. (kafka.server.DefaultAutoTopicCreationManager)
[2024-06-06 01:09:10,840] WARN Received retryable error in find coordinator The coordinator is not available. (org.apache.kafka.server.group.share.PersisterStateManager)
[2024-06-06 01:09:10,840] INFO Waiting before retrying find coordinator response. (org.apache.kafka.server.group.share.PersisterStateManager)
[2024-06-06 01:09:10,842] WARN Received retryable error in find coordinator The coordinator is not available. (org.apache.kafka.server.group.share.PersisterStateManager)
[2024-06-06 01:09:10,842] INFO Waiting before retrying find coordinator response. (org.apache.kafka.server.group.share.PersisterStateManager)
...
[2024-06-06 01:09:40,850] INFO Find coordinator response received. (org.apache.kafka.server.group.share.PersisterStateManager)
```