### PR TITLE
AKCORE-183: kafka-share-groups.sh --version works without bootstrap server

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ShareGroupCommandOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ShareGroupCommandOptions.java
@@ -149,6 +149,8 @@ public class ShareGroupCommandOptions extends CommandDefaultOptions {
 
     @SuppressWarnings({"CyclomaticComplexity", "NPathComplexity"})
     public void checkArgs() {
+        CommandLineUtils.maybePrintHelpOrVersion(this, "This tool helps to list, describe, reset and delete share groups.");
+
         CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt);
 
         if (options.has(describeOpt)) {


### PR DESCRIPTION
The command line argument handling was not checking for --help or --version in the usual way. It does now.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
