### PR TITLE
AKCORE-188: Refactor handling of Acknowledgements object in ShareConsumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,7 +61,7 @@ import java.util.stream.Collectors;
  * {@link ShareAcknowledgeRequest} to fetch and acknowledge records being delivered for a consumer
  * in a share group.
  */
-public class ShareConsumeRequestManager implements RequestManager, MemberStateListener {
+public class ShareConsumeRequestManager implements RequestManager, MemberStateListener, Closeable {
 
     private final Logger log;
     private final LogContext logContext;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -77,7 +78,6 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
     private final Queue<AcknowledgeRequestState> acknowledgeRequestStates;
     private final long retryBackoffMs;
     private final long retryBackoffMaxMs;
-    private CompletableFuture<Map<TopicIdPartition, Acknowledgements>> commitSyncFuture;
 
     ShareConsumeRequestManager(final LogContext logContext,
                                final String groupId,
@@ -109,8 +109,8 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
         if (memberId == null) {
             return PollResult.EMPTY;
         }
-        PollResult pollResult = processAcknowledgements(currentTimeMs, false);
 
+        PollResult pollResult = processAcknowledgements(currentTimeMs, false);
         if (pollResult != null) {
             return pollResult;
         }
@@ -121,7 +121,6 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
 
         Map<Node, ShareSessionHandler> handlerMap = new HashMap<>();
         Map<String, Uuid> topicIds = metadata.topicIds();
-
         for (TopicPartition partition : partitionsToFetch()) {
             Optional<Node> leaderOpt = metadata.currentLeader(partition).leader;
 
@@ -185,58 +184,57 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             return PollResult.EMPTY;
         }
         long currentTimeMs = Time.SYSTEM.milliseconds();
+
         PollResult pollResult = processAcknowledgements(currentTimeMs, true);
         if (pollResult != null) {
             return pollResult;
         }
 
-        final Cluster cluster = metadata.fetch();
+        if (fetchAcknowledgementsMap.isEmpty()) {
+            return PollResult.EMPTY;
+        }
 
-        Map<Node, ShareSessionHandler> handlerMap = new HashMap<>();
+        final Cluster cluster = metadata.fetch();
+        List<UnsentRequest> requests = new LinkedList<>();
 
         sessionHandlers.forEach((nodeId, sessionHandler) -> {
             sessionHandler.notifyClose();
             Node node = cluster.nodeById(nodeId);
             if (node != null) {
-                handlerMap.put(node, sessionHandler);
-
+                Map<TopicIdPartition, Acknowledgements> acknowledgementsMapForNode = new HashMap<>();
                 for (TopicIdPartition tip : sessionHandler.sessionPartitions()) {
                     Acknowledgements acknowledgements = fetchAcknowledgementsMap.get(tip);
                     if (acknowledgements != null) {
-                        metricsManager.recordAcknowledgementSent(acknowledgements.size());
+                        acknowledgementsMapForNode.put(tip, acknowledgements);
                         sessionHandler.addPartitionToFetch(tip, acknowledgements);
 
+                        metricsManager.recordAcknowledgementSent(acknowledgements.size());
                         log.debug("Added closing acknowledge request for partition {} to node {}", tip.topicPartition(), node);
                     }
                 }
+
+                ShareAcknowledgeRequest.Builder requestBuilder = sessionHandler.newShareAcknowledgeBuilder(groupId, fetchConfig);
+                if (requestBuilder != null) {
+                    AcknowledgeRequestState requestState = new AcknowledgeRequestState(logContext,
+                            ShareConsumeRequestManager.class.getSimpleName(),
+                            retryBackoffMs,
+                            retryBackoffMaxMs,
+                            Optional.empty(),
+                            node.id(),
+                            acknowledgementsMapForNode,
+                            Optional.empty());
+
+                    BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, error) -> {
+                        if (error != null) {
+                            handleShareAcknowledgeCloseFailure(node, requestBuilder.data(), requestState, error, currentTimeMs);
+                        } else {
+                            handleShareAcknowledgeCloseSuccess(node, requestBuilder.data(), requestState, clientResponse, currentTimeMs);
+                        }
+                    };
+                    requests.add(new UnsentRequest(requestBuilder, Optional.of(node)).whenComplete(responseHandler));
+                }
             }
         });
-
-        Map<Node, ShareAcknowledgeRequest.Builder> builderMap = new LinkedHashMap<>();
-        for (Map.Entry<Node, ShareSessionHandler> entry : handlerMap.entrySet()) {
-            Node target = entry.getKey();
-            ShareSessionHandler handler = entry.getValue();
-            ShareAcknowledgeRequest.Builder builder = handler.newShareAcknowledgeBuilder(groupId, fetchConfig);
-            if (builder != null) {
-                builderMap.put(target, builder);
-            }
-        }
-
-        List<UnsentRequest> requests = builderMap.entrySet().stream().map(entry -> {
-            Node target = entry.getKey();
-            ShareAcknowledgeRequest.Builder requestBuilder = entry.getValue();
-
-            nodesWithPendingRequests.add(target.id());
-
-            BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, error) -> {
-                if (error != null) {
-                    handleShareAcknowledgeCloseFailure(target, requestBuilder.data(), error);
-                } else {
-                    handleShareAcknowledgeCloseSuccess(target, requestBuilder.data(), clientResponse);
-                }
-            };
-            return new UnsentRequest(requestBuilder, Optional.of(target)).whenComplete(responseHandler);
-        }).collect(Collectors.toList());
 
         return new PollResult(requests);
     }
@@ -246,57 +244,61 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             log.debug("Fetch more data");
             fetchMoreRecords = true;
         }
-        acknowledgementsMap.forEach((tip, acks) -> {
-            fetchAcknowledgementsMap.merge(tip, acks, Acknowledgements::merge);
-        });
+        acknowledgementsMap.forEach((tip, acks) -> fetchAcknowledgementsMap.merge(tip, acks, Acknowledgements::merge));
+    }
+
+    public void acknowledgeOnClose(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
+        acknowledgementsMap.forEach((tip, acks) -> fetchAcknowledgementsMap.merge(tip, acks, Acknowledgements::merge));
     }
 
     private PollResult processAcknowledgements(long currentTimeMs, boolean onClose) {
         List<UnsentRequest> unsentRequests = new ArrayList<>();
         for (AcknowledgeRequestState acknowledgeRequestState : acknowledgeRequestStates) {
             if (acknowledgeRequestState.isProcessed()) {
+                acknowledgeRequestState.complete();
                 acknowledgeRequestStates.remove(acknowledgeRequestState);
             } else if (!acknowledgeRequestState.retryTimeoutExpired(currentTimeMs)) {
                 if (acknowledgeRequestState.canSendRequest(currentTimeMs)) {
                     acknowledgeRequestState.onSendAttempt(currentTimeMs);
                     if (onClose) {
-                        unsentRequests.add(acknowledgeRequestState.buildRequestOnClose(currentTimeMs));
+                        unsentRequests.add(acknowledgeRequestState.buildRequest(
+                                this::handleShareAcknowledgeCloseSuccess,
+                                this::handleShareAcknowledgeCloseFailure,
+                                currentTimeMs));
                     } else {
-                        unsentRequests.add(acknowledgeRequestState.buildRequest(currentTimeMs));
+                        unsentRequests.add(acknowledgeRequestState.buildRequest(
+                                this::handleShareAcknowledgeSuccess,
+                                this::handleShareAcknowledgeFailure,
+                                currentTimeMs));
                     }
                 }
             } else {
                 // Fill in TimeoutException
                 for (TopicIdPartition tip : acknowledgeRequestState.acknowledgementsMap.keySet()) {
-                    metricsManager.recordFailedAcknowledgements(shareFetchBuffer.getPendingAcknowledgementsCount(tip));
-                    shareFetchBuffer.handleAcknowledgementResponses(tip, Errors.REQUEST_TIMED_OUT);
+                    metricsManager.recordFailedAcknowledgements(acknowledgeRequestState.getAcknowledgementsCount(tip));
+                    acknowledgeRequestState.handleAcknowledgeErrorCode(tip, Errors.REQUEST_TIMED_OUT);
                 }
+                acknowledgeRequestState.complete();
                 acknowledgeRequestStates.remove(acknowledgeRequestState);
             }
         }
+
         PollResult pollResult = null;
         if (!unsentRequests.isEmpty()) {
             pollResult = new PollResult(unsentRequests);
-        } else if (acknowledgeRequestStates.isEmpty()) {
-            // Complete the future.
-            if (commitSyncFuture != null) {
-                commitSyncFuture.complete(null);
-                commitSyncFuture = null;
-            }
-        } else {
-            // Return empty result until all the acknowledgement request states are processed.
+        } else if (!acknowledgeRequestStates.isEmpty()) {
+            // Return empty result until all the acknowledgement request states are processed
             pollResult = PollResult.EMPTY;
         }
         return pollResult;
     }
 
+    // Build a list of ShareAcknowledge requests to be picked up on the next poll
     public CompletableFuture<Map<TopicIdPartition, Acknowledgements>> commitSync(
             final long retryExpirationTimeMs,
             final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
-        if (commitSyncFuture != null) return commitSyncFuture;
-        commitSyncFuture = new CompletableFuture<>();
+        final CompletableFuture<Map<TopicIdPartition, Acknowledgements>> commitSyncFuture = new CompletableFuture<>();
 
-        // Build a list of ShareAcknowledge requests to be picked up on the next poll
         final Cluster cluster = metadata.fetch();
 
         sessionHandlers.forEach((nodeId, sessionHandler) -> {
@@ -318,7 +320,8 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                         retryBackoffMaxMs,
                         Optional.of(retryExpirationTimeMs),
                         nodeId,
-                        acknowledgementsMapForNode
+                        acknowledgementsMapForNode,
+                        Optional.of(commitSyncFuture)
                 ));
             }
         });
@@ -360,21 +363,25 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             final ShareFetchMetricsAggregator shareFetchMetricsAggregator = new ShareFetchMetricsAggregator(metricsManager, partitions);
 
             for (Map.Entry<TopicIdPartition, ShareFetchResponseData.PartitionData> entry : responseData.entrySet()) {
-                TopicIdPartition partition = entry.getKey();
+                TopicIdPartition tip = entry.getKey();
 
                 ShareFetchResponseData.PartitionData partitionData = entry.getValue();
 
-                log.debug("ShareFetch for partition {} returned fetch data {}", partition, partitionData);
+                log.debug("ShareFetch for partition {} returned fetch data {}", tip, partitionData);
 
-                if (partitionData.acknowledgeErrorCode() != 0) {
-                    metricsManager.recordFailedAcknowledgements(shareFetchBuffer.getPendingAcknowledgementsCount(partition));
+                Acknowledgements acks = fetchAcknowledgementsMap.remove(tip);
+                if (acks != null) {
+                    if (partitionData.acknowledgeErrorCode() != Errors.NONE.code()) {
+                        metricsManager.recordFailedAcknowledgements(acks.size());
+                    }
+                    acks.setAcknowledgeErrorCode(Errors.forCode(partitionData.acknowledgeErrorCode()));
+                    shareFetchBuffer.addCompletedAcknowledgements(Collections.singletonMap(tip, acks));
                 }
-                shareFetchBuffer.handleAcknowledgementResponses(partition, Errors.forCode(partitionData.acknowledgeErrorCode()));
 
                 ShareCompletedFetch completedFetch = new ShareCompletedFetch(
                         logContext,
                         BufferSupplier.create(),
-                        partition,
+                        tip,
                         partitionData,
                         shareFetchMetricsAggregator,
                         requestVersion);
@@ -405,8 +412,13 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 TopicIdPartition tip = new TopicIdPartition(topic.topicId(),
                         partition.partitionIndex(),
                         metadata.topicNames().get(topic.topicId()));
-                metricsManager.recordFailedAcknowledgements(shareFetchBuffer.getPendingAcknowledgementsCount(tip));
-                shareFetchBuffer.handleAcknowledgementResponses(tip, Errors.forException(error));
+
+                Acknowledgements acks = fetchAcknowledgementsMap.remove(tip);
+                if (acks != null) {
+                    metricsManager.recordFailedAcknowledgements(acks.size());
+                    acks.setAcknowledgeErrorCode(Errors.forException(error));
+                    shareFetchBuffer.addCompletedAcknowledgements(Collections.singletonMap(tip, acks));
+                }
             }));
         } finally {
             log.debug("Removing pending request for node {} - failed", fetchTarget);
@@ -416,8 +428,8 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
 
     private void handleShareAcknowledgeSuccess(Node fetchTarget,
                                                ShareAcknowledgeRequestData requestData,
-                                               ClientResponse resp,
                                                AcknowledgeRequestState acknowledgeRequestState,
+                                               ClientResponse resp,
                                                long currentTimeMs) {
         try {
             final ShareAcknowledgeResponse response = (ShareAcknowledgeResponse) resp.responseBody();
@@ -429,14 +441,14 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 acknowledgeRequestState.onFailedAttempt(currentTimeMs);
                 return;
             }
-            final short requestVersion = resp.requestHeader().apiVersion();
 
+            final short requestVersion = resp.requestHeader().apiVersion();
             if (!handler.handleResponse(response, requestVersion)) {
                 acknowledgeRequestState.onFailedAttempt(currentTimeMs);
                 if (response.error() != Errors.INVALID_SHARE_SESSION_EPOCH) {
                     return;
                 } else {
-                    // We pop this request of the queue as the error was not retriable.
+                    // We pop this request off the queue as the error was not retriable.
                     acknowledgeRequestState.isProcessed = true;
                 }
             }
@@ -445,10 +457,10 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 TopicIdPartition tip = new TopicIdPartition(topic.topicId(),
                         partition.partitionIndex(),
                         metadata.topicNames().get(topic.topicId()));
-                if (partition.errorCode() != 0) {
-                    metricsManager.recordFailedAcknowledgements(shareFetchBuffer.getPendingAcknowledgementsCount(tip));
+                if (partition.errorCode() != Errors.NONE.code()) {
+                    metricsManager.recordFailedAcknowledgements(acknowledgeRequestState.getAcknowledgementsCount(tip));
                 }
-                shareFetchBuffer.handleAcknowledgementResponses(tip, Errors.forCode(partition.errorCode()));
+                acknowledgeRequestState.handleAcknowledgeErrorCode(tip, Errors.forCode(partition.errorCode()));
             }));
 
             metricsManager.recordLatency(resp.requestLatencyMs());
@@ -461,7 +473,9 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
 
     private void handleShareAcknowledgeFailure(Node fetchTarget,
                                                ShareAcknowledgeRequestData requestData,
-                                               Throwable error) {
+                                               AcknowledgeRequestState acknowledgeRequestState,
+                                               Throwable error,
+                                               long currentTimeMs) {
         try {
             final ShareSessionHandler handler = sessionHandler(fetchTarget.id());
             if (handler != null) {
@@ -472,8 +486,8 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 TopicIdPartition tip = new TopicIdPartition(topic.topicId(),
                         partition.partitionIndex(),
                         metadata.topicNames().get(topic.topicId()));
-                metricsManager.recordAcknowledgementSent(shareFetchBuffer.getPendingAcknowledgementsCount(tip));
-                shareFetchBuffer.handleAcknowledgementResponses(tip, Errors.forException(error));
+                    metricsManager.recordFailedAcknowledgements(acknowledgeRequestState.getAcknowledgementsCount(tip));
+                    acknowledgeRequestState.handleAcknowledgeErrorCode(tip, Errors.forException(error));
             }));
         } finally {
             log.debug("Removing pending request for node {} - failed", fetchTarget);
@@ -483,7 +497,9 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
 
     private void handleShareAcknowledgeCloseSuccess(Node fetchTarget,
                                                     ShareAcknowledgeRequestData requestData,
-                                                    ClientResponse resp) {
+                                                    AcknowledgeRequestState acknowledgeRequestState,
+                                                    ClientResponse resp,
+                                                    long currentTimeMs) {
         try {
             final ShareAcknowledgeResponse response = (ShareAcknowledgeResponse) resp.responseBody();
 
@@ -491,10 +507,10 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 TopicIdPartition tip = new TopicIdPartition(topic.topicId(),
                         partition.partitionIndex(),
                         metadata.topicNames().get(topic.topicId()));
-                if (partition.errorCode() != 0) {
-                    metricsManager.recordFailedAcknowledgements(shareFetchBuffer.getPendingAcknowledgementsCount(tip));
+                if (partition.errorCode() != Errors.NONE.code()) {
+                    metricsManager.recordFailedAcknowledgements(acknowledgeRequestState.getAcknowledgementsCount(tip));
                 }
-                shareFetchBuffer.handleAcknowledgementResponses(tip, Errors.forCode(partition.errorCode()));
+                acknowledgeRequestState.handleAcknowledgeErrorCode(tip, Errors.forCode(partition.errorCode()));
             }));
 
             metricsManager.recordLatency(resp.requestLatencyMs());
@@ -507,7 +523,9 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
 
     private void handleShareAcknowledgeCloseFailure(Node fetchTarget,
                                                     ShareAcknowledgeRequestData requestData,
-                                                    Throwable error) {
+                                                    AcknowledgeRequestState acknowledgeRequestState,
+                                                    Throwable error,
+                                                    long currentTimeMs) {
         try {
             final ShareSessionHandler handler = sessionHandler(fetchTarget.id());
             if (handler != null) {
@@ -518,8 +536,8 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 TopicIdPartition tip = new TopicIdPartition(topic.topicId(),
                         partition.partitionIndex(),
                         metadata.topicNames().get(topic.topicId()));
-                metricsManager.recordAcknowledgementSent(shareFetchBuffer.getPendingAcknowledgementsCount(tip));
-                shareFetchBuffer.handleAcknowledgementResponses(tip, Errors.forException(error));
+                metricsManager.recordFailedAcknowledgements(acknowledgeRequestState.getAcknowledgementsCount(tip));
+                acknowledgeRequestState.handleAcknowledgeErrorCode(tip, Errors.forException(error));
             }));
         } finally {
             log.debug("Removing pending request for node {} - failed", fetchTarget);
@@ -580,22 +598,31 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
          */
         private boolean isProcessed = false;
 
+        /**
+         * For a synchronous request, this future is completed when it's completed.
+         */
+        private final Optional<CompletableFuture<Map<TopicIdPartition, Acknowledgements>>> future;
+
         AcknowledgeRequestState(LogContext logContext, String owner,
                                 long retryBackoffMs, long retryBackoffMaxMs,
                                 Optional<Long> expirationTimeMs,
                                 int nodeId,
-                                Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
+                                Map<TopicIdPartition, Acknowledgements> acknowledgementsMap,
+                                Optional<CompletableFuture<Map<TopicIdPartition, Acknowledgements>>> future) {
             super(logContext, owner, retryBackoffMs, retryBackoffMaxMs);
             this.expirationTimeMs = expirationTimeMs;
             this.nodeId = nodeId;
             this.acknowledgementsMap = acknowledgementsMap;
+            this.future = future;
         }
 
-        UnsentRequest buildRequest(long currentTimeMs) {
-
+        UnsentRequest buildRequest(ResponseHandler<ClientResponse> successHandler,
+                                   ResponseHandler<Throwable> errorHandler,
+                                   long currentTimeMs) {
             ShareSessionHandler handler = sessionHandlers.get(nodeId);
-
-            if (handler == null) return null;
+            if (handler == null) {
+                return null;
+            }
 
             for (Map.Entry<TopicIdPartition, Acknowledgements> entry : acknowledgementsMap.entrySet()) {
                 handler.addPartitionToFetch(entry.getKey(), entry.getValue());
@@ -608,12 +635,13 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, error) -> {
                 if (error != null) {
                     onFailedAttempt(currentTimeMs);
-                    handleShareAcknowledgeFailure(nodeToSend, requestBuilder.data(), error);
+                    errorHandler.handle(nodeToSend, requestBuilder.data(), this, error, currentTimeMs);
                     isProcessed = true;
                 } else {
-                    handleShareAcknowledgeSuccess(nodeToSend, requestBuilder.data(), clientResponse, this, currentTimeMs);
+                    successHandler.handle(nodeToSend, requestBuilder.data(), this, clientResponse, currentTimeMs);
                 }
             };
+
             if (requestBuilder == null) {
                 return null;
             } else {
@@ -621,33 +649,19 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             }
         }
 
-        UnsentRequest buildRequestOnClose(long currentTimeMs) {
-
-            ShareSessionHandler handler = sessionHandlers.get(nodeId);
-
-            if (handler == null) return null;
-
-            for (Map.Entry<TopicIdPartition, Acknowledgements> entry : acknowledgementsMap.entrySet()) {
-                handler.addPartitionToFetch(entry.getKey(), entry.getValue());
-            }
-            ShareAcknowledgeRequest.Builder requestBuilder = handler.newShareAcknowledgeBuilder(groupId, fetchConfig);
-            Node nodeToSend = metadata.fetch().nodeById(nodeId);
-
-            nodesWithPendingRequests.add(nodeId);
-
-            BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, error) -> {
-                if (error != null) {
-                    onFailedAttempt(currentTimeMs);
-                    handleShareAcknowledgeCloseFailure(nodeToSend, requestBuilder.data(), error);
-                    isProcessed = true;
-                } else {
-                    handleShareAcknowledgeCloseSuccess(nodeToSend, requestBuilder.data(), clientResponse);
-                }
-            };
-            if (requestBuilder == null) {
-                return null;
+        int getAcknowledgementsCount(TopicIdPartition tip) {
+            Acknowledgements acks = acknowledgementsMap.get(tip);
+            if (acks == null) {
+                return 0;
             } else {
-                return new UnsentRequest(requestBuilder, Optional.of(nodeToSend)).whenComplete(responseHandler);
+                return acks.size();
+            }
+        }
+
+        void handleAcknowledgeErrorCode(TopicIdPartition tip, Errors acknowledgeErrorCode) {
+            Acknowledgements acks = acknowledgementsMap.get(tip);
+            if (acks != null) {
+                acks.setAcknowledgeErrorCode(acknowledgeErrorCode);
             }
         }
 
@@ -658,5 +672,27 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
         boolean isProcessed() {
             return isProcessed;
         }
+
+        void complete() {
+            if (future.isPresent()) {
+                CompletableFuture<Map<TopicIdPartition, Acknowledgements>> cf = future.get();
+                if (!cf.isDone()) {
+                    cf.complete(acknowledgementsMap);
+                }
+            }
+        }
+    }
+
+    /**
+     * Defines the contract for handling responses from brokers.
+     * @param <T> Type of response, usually either {@link ClientResponse} or {@link Throwable}
+     */
+    @FunctionalInterface
+    protected interface ResponseHandler<T> {
+
+        /**
+         * Handle the response from the given {@link Node target}
+         */
+        void handle(Node target, ShareAcknowledgeRequestData request, AcknowledgeRequestState requestState, T response, long currentTimeMs);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -904,11 +904,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     }
 
     /**
-     * Called to progressively move the acknowledgement mode into IMPLICIT if it is not known to be EXPLICIT.
-     * If the acknowledgement mode is IMPLICIT, acknowledges the current batch and puts them into the fetch
-     * buffer for the background thread to pick up.
-     * If the acknowledgement mode is EXPLICIT, puts any ready acknowledgements into the fetch buffer for the
-     * background thread to pick up.
+     * Returns any ready acknowledgements to be sent to the cluster.
      */
     private Map<TopicIdPartition, Acknowledgements> acknowledgementsToSend() {
         if (currentFetch != null) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -793,7 +793,6 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     void prepareShutdown(final Timer timer, final AtomicReference<Throwable> firstException) {
         completeQuietly(
             () -> {
-//                maybeSendAcknowledgementsOnClose2();
                 applicationEventHandler.addAndGet(new ShareLeaveOnCloseApplicationEvent(timer, acknowledgementsToSend()), timer);
             },
             "Failed to send leaveGroup heartbeat with a timeout(ms)=" + timer.timeoutMs(), firstException);
@@ -914,37 +913,6 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
             return Collections.emptyMap();
         }
     }
-
-//    /**
-//     * If the acknowledgement mode is IMPLICIT, acknowledges the current batch and puts them into the fetch
-//     * buffer for the background thread to pick up.
-//     * If the acknowledgement mode is EXPLICIT, puts any ready acknowledgements into the fetch buffer for the
-//     * background thread to pick up.
-//     */
-//    private void sendAcknowledgements2() {
-//        if (currentFetch != null) {
-//            // If IMPLICIT, acknowledge all records and send
-//            if ((acknowledgementMode == AcknowledgementMode.PENDING) ||
-//                    (acknowledgementMode == AcknowledgementMode.IMPLICIT)) {
-//                currentFetch.acknowledgeAll(AcknowledgeType.ACCEPT);
-//                fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
-//            } else if (acknowledgementMode == AcknowledgementMode.EXPLICIT) {
-//                // If EXPLICIT, send any acknowledgements which are ready
-//                fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
-//            }
-//
-//            currentFetch = null;
-//        }
-//    }
-//
-//    /**
-//     * Called to send any outstanding acknowledgements during close.
-//     */
-//    private void maybeSendAcknowledgementsOnClose() {
-//        if (currentFetch != null) {
-//            fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
-//        }
-//    }
 
     /**
      * Called to move the acknowledgement mode into EXPLICIT, if it is not known to be IMPLICIT.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -527,7 +527,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
             handleCompletedAcknowledgements();
 
             // If using implicit acknowledgement, acknowledge the previously fetched records
-            maybeSendAcknowledgements();
+            prepareToSendAcknowledgements(true);
 
             kafkaShareConsumerMetrics.recordPollStart(timer.currentTimeMs());
 
@@ -594,7 +594,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
         final ShareFetch<K, V> fetch = fetchCollector.collect(fetchBuffer);
         if (fetch.isEmpty()) {
             // Make sure the network thread can tell the application is actively polling
-            applicationEventHandler.add(new ShareFetchEvent());
+            applicationEventHandler.add(new ShareFetchEvent(acknowledgementsToSend()));
 
             // Notify the network thread to wake up and start the next round of fetching
             applicationEventHandler.wakeupNetworkThread();
@@ -648,17 +648,16 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
             handleCompletedAcknowledgements();
 
             // Acknowledge the previously fetched records
-            sendAcknowledgements();
+            prepareToSendAcknowledgements(false);
 
             Timer requestTimer = time.timer(timeout.toMillis());
-            SyncShareAcknowledgeEvent event = new SyncShareAcknowledgeEvent(requestTimer);
+            SyncShareAcknowledgeEvent event = new SyncShareAcknowledgeEvent(requestTimer, acknowledgementsToSend());
             applicationEventHandler.add(event);
-            CompletableFuture<Void> commitFuture = event.future();
+            CompletableFuture<Map<TopicIdPartition, Acknowledgements>> commitFuture = event.future();
             wakeupTrigger.setActiveTask(commitFuture);
             try {
                 Map<TopicIdPartition, Optional<KafkaException>> result = new HashMap<>();
-                ConsumerUtils.getResult(commitFuture, requestTimer);
-                Map<TopicIdPartition, Acknowledgements> completedAcknowledgements = fetchBuffer.getCompletedAcknowledgements();
+                Map<TopicIdPartition, Acknowledgements> completedAcknowledgements = ConsumerUtils.getResult(commitFuture, requestTimer);
                 completedAcknowledgements.forEach((tip, acks) -> {
                     Errors ackErrorCode = acks.getAcknowledgeErrorCode();
                     if (ackErrorCode == null) {
@@ -794,8 +793,8 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     void prepareShutdown(final Timer timer, final AtomicReference<Throwable> firstException) {
         completeQuietly(
             () -> {
-                maybeSendAcknowledgementsOnClose();
-                applicationEventHandler.addAndGet(new ShareLeaveOnCloseApplicationEvent(timer), timer);
+//                maybeSendAcknowledgementsOnClose2();
+                applicationEventHandler.addAndGet(new ShareLeaveOnCloseApplicationEvent(timer, acknowledgementsToSend()), timer);
             },
             "Failed to send leaveGroup heartbeat with a timeout(ms)=" + timer.timeoutMs(), firstException);
     }
@@ -869,9 +868,32 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
      */
     private void handleCompletedAcknowledgements() {
         if (fetchBuffer != null) {
-            Map<TopicIdPartition, Acknowledgements> completedAcknowledgements = fetchBuffer.getCompletedAcknowledgements();
+            List<Map<TopicIdPartition, Acknowledgements>> completedAcknowledgements = fetchBuffer.getCompletedAcknowledgements();
             if (!completedAcknowledgements.isEmpty() && acknowledgementCommitCallbackHandler != null) {
                 acknowledgementCommitCallbackHandler.onComplete(completedAcknowledgements);
+            }
+        }
+    }
+
+    /**
+     * Called to progressively move the acknowledgement mode into IMPLICIT if it is not known to be EXPLICIT.
+     * If the acknowledgement mode is IMPLICIT, acknowledges the current batch.
+     */
+    private void prepareToSendAcknowledgements(boolean calledOnPoll) {
+        if (calledOnPoll) {
+            if (acknowledgementMode == AcknowledgementMode.UNKNOWN) {
+                // The first call to poll(Duration) moves into PENDING
+                acknowledgementMode = AcknowledgementMode.PENDING;
+            } else if (acknowledgementMode == AcknowledgementMode.PENDING) {
+                // The second call to poll(Duration) if PENDING moves into IMPLICIT
+                acknowledgementMode = AcknowledgementMode.IMPLICIT;
+            }
+        }
+
+        if (currentFetch != null) {
+            // If IMPLICIT, acknowledge all records and send
+            if (acknowledgementMode == AcknowledgementMode.IMPLICIT) {
+                currentFetch.acknowledgeAll(AcknowledgeType.ACCEPT);
             }
         }
     }
@@ -883,59 +905,46 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
      * If the acknowledgement mode is EXPLICIT, puts any ready acknowledgements into the fetch buffer for the
      * background thread to pick up.
      */
-    private void maybeSendAcknowledgements() {
-        if (acknowledgementMode == AcknowledgementMode.UNKNOWN) {
-            // The first call to poll(Duration) moves into PENDING
-            acknowledgementMode = AcknowledgementMode.PENDING;
-        } else if (acknowledgementMode == AcknowledgementMode.PENDING) {
-            // The second call to poll(Duration) if PENDING moves into IMPLICIT
-            acknowledgementMode = AcknowledgementMode.IMPLICIT;
-        }
-
+    private Map<TopicIdPartition, Acknowledgements> acknowledgementsToSend() {
         if (currentFetch != null) {
-            // If IMPLICIT, acknowledge all records and send
-            if (acknowledgementMode == AcknowledgementMode.IMPLICIT) {
-                currentFetch.acknowledgeAll(AcknowledgeType.ACCEPT);
-                fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
-            } else if (acknowledgementMode == AcknowledgementMode.EXPLICIT) {
-                // If EXPLICIT, send any acknowledgements which are ready
-                fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
-            }
-
+            Map<TopicIdPartition, Acknowledgements> acknowledgementsMap = currentFetch.acknowledgementsByPartition();
             currentFetch = null;
+            return acknowledgementsMap;
+        } else {
+            return Collections.emptyMap();
         }
     }
 
-    /**
-     * If the acknowledgement mode is IMPLICIT, acknowledges the current batch and puts them into the fetch
-     * buffer for the background thread to pick up.
-     * If the acknowledgement mode is EXPLICIT, puts any ready acknowledgements into the fetch buffer for the
-     * background thread to pick up.
-     */
-    private void sendAcknowledgements() {
-        if (currentFetch != null) {
-            // If IMPLICIT, acknowledge all records and send
-            if ((acknowledgementMode == AcknowledgementMode.PENDING) ||
-                    (acknowledgementMode == AcknowledgementMode.IMPLICIT)) {
-                currentFetch.acknowledgeAll(AcknowledgeType.ACCEPT);
-                fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
-            } else if (acknowledgementMode == AcknowledgementMode.EXPLICIT) {
-                // If EXPLICIT, send any acknowledgements which are ready
-                fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
-            }
-
-            currentFetch = null;
-        }
-    }
-
-    /**
-     * Called to send any outstanding acknowledgements during close.
-     */
-    private void maybeSendAcknowledgementsOnClose() {
-        if (currentFetch != null) {
-            fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
-        }
-    }
+//    /**
+//     * If the acknowledgement mode is IMPLICIT, acknowledges the current batch and puts them into the fetch
+//     * buffer for the background thread to pick up.
+//     * If the acknowledgement mode is EXPLICIT, puts any ready acknowledgements into the fetch buffer for the
+//     * background thread to pick up.
+//     */
+//    private void sendAcknowledgements2() {
+//        if (currentFetch != null) {
+//            // If IMPLICIT, acknowledge all records and send
+//            if ((acknowledgementMode == AcknowledgementMode.PENDING) ||
+//                    (acknowledgementMode == AcknowledgementMode.IMPLICIT)) {
+//                currentFetch.acknowledgeAll(AcknowledgeType.ACCEPT);
+//                fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
+//            } else if (acknowledgementMode == AcknowledgementMode.EXPLICIT) {
+//                // If EXPLICIT, send any acknowledgements which are ready
+//                fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
+//            }
+//
+//            currentFetch = null;
+//        }
+//    }
+//
+//    /**
+//     * Called to send any outstanding acknowledgements during close.
+//     */
+//    private void maybeSendAcknowledgementsOnClose() {
+//        if (currentFetch != null) {
+//            fetchBuffer.acknowledgementsReadyToSend(currentFetch.acknowledgementsByPartition());
+//        }
+//    }
 
     /**
      * Called to move the acknowledgement mode into EXPLICIT, if it is not known to be IMPLICIT.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchBuffer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchBuffer.java
@@ -19,13 +19,15 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.internals.IdempotentCloser;
-import org.apache.kafka.common.protocol.Errors;
+//import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Timer;
 import org.slf4j.Logger;
 
-import java.util.HashMap;
+//import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -54,107 +56,121 @@ public class ShareFetchBuffer implements AutoCloseable {
     private final AtomicBoolean wokenUp = new AtomicBoolean(false);
     private ShareCompletedFetch nextInLineFetch;
 
-    // These are the acknowledgements being accumulated to send to the brokers
-    private Map<TopicIdPartition, Acknowledgements> readyAcknowledgements;
-    // These are the acknowledgements that the ShareFetchRequestManager has sent to the brokers
-    private Map<TopicIdPartition, Acknowledgements> pendingAcknowledgements;
-    // These are the acknowledgements that the ShareFetchRequestManager has received responses
-    private Map<TopicIdPartition, Acknowledgements> completeAcknowledgements;
+//    // These are the acknowledgements being accumulated to send to the brokers
+//    private Map<TopicIdPartition, Acknowledgements> readyAcknowledgements;
+//    // These are the acknowledgements that the ShareConsumeRequestManager has sent to the brokers
+//    private Map<TopicIdPartition, Acknowledgements> pendingAcknowledgements;
+    // These are the acknowledgements for which the ShareConsumeRequestManager has received responses
+    private List<Map<TopicIdPartition, Acknowledgements>> completeAcknowledgements;
 
     public ShareFetchBuffer(final LogContext logContext) {
         this.log = logContext.logger(ShareFetchBuffer.class);
         this.completedFetches = new ConcurrentLinkedQueue<>();
         this.lock = new ReentrantLock();
         this.notEmptyCondition = lock.newCondition();
-        this.readyAcknowledgements = new HashMap<>();
-        this.pendingAcknowledgements = new HashMap<>();
-        this.completeAcknowledgements = new HashMap<>();
+//        this.readyAcknowledgements = new HashMap<>();
+//        this.pendingAcknowledgements = new HashMap<>();
+        this.completeAcknowledgements = new LinkedList<>();
     }
 
-    public void acknowledgementsReadyToSend(Map<TopicIdPartition, Acknowledgements> acknowledgements) {
-        lock.lock();
-        try {
-            acknowledgements.forEach((tip, partAcknowledgements) ->  {
-                if (readyAcknowledgements.get(tip) != null) {
-                    readyAcknowledgements.computeIfPresent(tip, (__, ready) -> ready.merge(partAcknowledgements));
-                } else {
-                    readyAcknowledgements.put(tip, partAcknowledgements);
-                }
-            });
-        } finally {
-            lock.unlock();
-        }
-    }
+//    public void acknowledgementsReadyToSend(Map<TopicIdPartition, Acknowledgements> acknowledgements) {
+//        lock.lock();
+//        try {
+//            acknowledgements.forEach((tip, partAcknowledgements) ->  {
+//                if (readyAcknowledgements.get(tip) != null) {
+//                    readyAcknowledgements.computeIfPresent(tip, (__, ready) -> ready.merge(partAcknowledgements));
+//                } else {
+//                    readyAcknowledgements.put(tip, partAcknowledgements);
+//                }
+//            });
+//        } finally {
+//            lock.unlock();
+//        }
+//    }
 
-    Map<TopicIdPartition, Acknowledgements> getCompletedAcknowledgements() {
+    List<Map<TopicIdPartition, Acknowledgements>> getCompletedAcknowledgements() {
         lock.lock();
         try {
-            Map<TopicIdPartition, Acknowledgements> complete = completeAcknowledgements;
-            completeAcknowledgements = new HashMap<>();
+            List<Map<TopicIdPartition, Acknowledgements>> complete = completeAcknowledgements;
+            completeAcknowledgements = new LinkedList<>();
             return complete;
         } finally {
             lock.unlock();
         }
     }
 
+//    /**
+//     * Gets the ready acknowledgements for a topic-partition, so they can be sent to the broker.
+//     * Moves the acknowledgements into the pending map awaiting responses.
+//     *
+//     * @param partition the topic-partition
+//     * @return the acknowledgements for the topic-partition to send to the leader
+//     */
+//    public Acknowledgements getAcknowledgementsToSend(TopicIdPartition partition) {
+//        lock.lock();
+//        try {
+//            Acknowledgements acknowledgements = readyAcknowledgements.remove(partition);
+//            if (acknowledgements != null) {
+//                pendingAcknowledgements.put(partition, acknowledgements);
+//            }
+//            return acknowledgements;
+//        } finally {
+//            lock.unlock();
+//        }
+//    }
+//
+//    /**
+//     *
+//     */
+//    public void handleAcknowledgementResponses(TopicIdPartition partition, Errors acknowledgeErrorCode) {
+//        lock.lock();
+//        try {
+//            Acknowledgements pending = pendingAcknowledgements.remove(partition);
+//            if (pending != null) {
+//                pending.setAcknowledgeErrorCode(acknowledgeErrorCode);
+//                Acknowledgements complete = completeAcknowledgements.get(partition);
+//                if (complete != null) {
+//                    complete.merge(pending);
+//                } else {
+//                    completeAcknowledgements.put(partition, pending);
+//                }
+//            }
+//        } finally {
+//            lock.unlock();
+//        }
+//    }
+
     /**
-     * Gets the ready acknowledgements for a topic-partition, so they can be sent to the broker.
-     * Moves the acknowledgements into the pending map awaiting responses.
+     * Add a completed acknowledgements map to the list to be picked up by the consumer.
      *
-     * @param partition the topic-partition
-     * @return the acknowledgements for the topic-partition to send to the leader
+     * @param acknowledgementsMap Map of completed acknowledgements
      */
-    public Acknowledgements getAcknowledgementsToSend(TopicIdPartition partition) {
+    public void addCompletedAcknowledgements(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
         lock.lock();
         try {
-            Acknowledgements acknowledgements = readyAcknowledgements.remove(partition);
-            if (acknowledgements != null) {
-                pendingAcknowledgements.put(partition, acknowledgements);
-            }
-            return acknowledgements;
+            completeAcknowledgements.add(acknowledgementsMap);
         } finally {
             lock.unlock();
         }
     }
 
-    /**
-     *
-     */
-    public void handleAcknowledgementResponses(TopicIdPartition partition, Errors acknowledgeErrorCode) {
-        lock.lock();
-        try {
-            Acknowledgements pending = pendingAcknowledgements.remove(partition);
-            if (pending != null) {
-                pending.setAcknowledgeErrorCode(acknowledgeErrorCode);
-                Acknowledgements complete = completeAcknowledgements.get(partition);
-                if (complete != null) {
-                    complete.merge(pending);
-                } else {
-                    completeAcknowledgements.put(partition, pending);
-                }
-            }
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    /**
-     * Returns the number of acknowledgements which have been sent
-     * to the broker and are still in pending state.
-     */
-    public int getPendingAcknowledgementsCount(TopicIdPartition partition) {
-        lock.lock();
-        try {
-            Acknowledgements pending = pendingAcknowledgements.get(partition);
-            if (pending != null) {
-                return pending.size();
-            } else {
-                return 0;
-            }
-        } finally {
-            lock.unlock();
-        }
-    }
+//    /**
+//     * Returns the number of acknowledgements which have been sent
+//     * to the broker and are still in pending state.
+//     */
+//    public int getPendingAcknowledgementsCount(TopicIdPartition partition) {
+//        lock.lock();
+//        try {
+//            Acknowledgements pending = pendingAcknowledgements.get(partition);
+//            if (pending != null) {
+//                return pending.size();
+//            } else {
+//                return 0;
+//            }
+//        } finally {
+//            lock.unlock();
+//        }
+//    }
 
     /**
      * Returns {@code true} if there are no completed fetches pending to return to the user.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchBuffer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchBuffer.java
@@ -19,12 +19,10 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.internals.IdempotentCloser;
-//import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Timer;
 import org.slf4j.Logger;
 
-//import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -56,10 +54,6 @@ public class ShareFetchBuffer implements AutoCloseable {
     private final AtomicBoolean wokenUp = new AtomicBoolean(false);
     private ShareCompletedFetch nextInLineFetch;
 
-//    // These are the acknowledgements being accumulated to send to the brokers
-//    private Map<TopicIdPartition, Acknowledgements> readyAcknowledgements;
-//    // These are the acknowledgements that the ShareConsumeRequestManager has sent to the brokers
-//    private Map<TopicIdPartition, Acknowledgements> pendingAcknowledgements;
     // These are the acknowledgements for which the ShareConsumeRequestManager has received responses
     private List<Map<TopicIdPartition, Acknowledgements>> completeAcknowledgements;
 
@@ -68,25 +62,8 @@ public class ShareFetchBuffer implements AutoCloseable {
         this.completedFetches = new ConcurrentLinkedQueue<>();
         this.lock = new ReentrantLock();
         this.notEmptyCondition = lock.newCondition();
-//        this.readyAcknowledgements = new HashMap<>();
-//        this.pendingAcknowledgements = new HashMap<>();
         this.completeAcknowledgements = new LinkedList<>();
     }
-
-//    public void acknowledgementsReadyToSend(Map<TopicIdPartition, Acknowledgements> acknowledgements) {
-//        lock.lock();
-//        try {
-//            acknowledgements.forEach((tip, partAcknowledgements) ->  {
-//                if (readyAcknowledgements.get(tip) != null) {
-//                    readyAcknowledgements.computeIfPresent(tip, (__, ready) -> ready.merge(partAcknowledgements));
-//                } else {
-//                    readyAcknowledgements.put(tip, partAcknowledgements);
-//                }
-//            });
-//        } finally {
-//            lock.unlock();
-//        }
-//    }
 
     List<Map<TopicIdPartition, Acknowledgements>> getCompletedAcknowledgements() {
         lock.lock();
@@ -98,47 +75,6 @@ public class ShareFetchBuffer implements AutoCloseable {
             lock.unlock();
         }
     }
-
-//    /**
-//     * Gets the ready acknowledgements for a topic-partition, so they can be sent to the broker.
-//     * Moves the acknowledgements into the pending map awaiting responses.
-//     *
-//     * @param partition the topic-partition
-//     * @return the acknowledgements for the topic-partition to send to the leader
-//     */
-//    public Acknowledgements getAcknowledgementsToSend(TopicIdPartition partition) {
-//        lock.lock();
-//        try {
-//            Acknowledgements acknowledgements = readyAcknowledgements.remove(partition);
-//            if (acknowledgements != null) {
-//                pendingAcknowledgements.put(partition, acknowledgements);
-//            }
-//            return acknowledgements;
-//        } finally {
-//            lock.unlock();
-//        }
-//    }
-//
-//    /**
-//     *
-//     */
-//    public void handleAcknowledgementResponses(TopicIdPartition partition, Errors acknowledgeErrorCode) {
-//        lock.lock();
-//        try {
-//            Acknowledgements pending = pendingAcknowledgements.remove(partition);
-//            if (pending != null) {
-//                pending.setAcknowledgeErrorCode(acknowledgeErrorCode);
-//                Acknowledgements complete = completeAcknowledgements.get(partition);
-//                if (complete != null) {
-//                    complete.merge(pending);
-//                } else {
-//                    completeAcknowledgements.put(partition, pending);
-//                }
-//            }
-//        } finally {
-//            lock.unlock();
-//        }
-//    }
 
     /**
      * Add a completed acknowledgements map to the list to be picked up by the consumer.
@@ -153,24 +89,6 @@ public class ShareFetchBuffer implements AutoCloseable {
             lock.unlock();
         }
     }
-
-//    /**
-//     * Returns the number of acknowledgements which have been sent
-//     * to the broker and are still in pending state.
-//     */
-//    public int getPendingAcknowledgementsCount(TopicIdPartition partition) {
-//        lock.lock();
-//        try {
-//            Acknowledgements pending = pendingAcknowledgements.get(partition);
-//            if (pending != null) {
-//                return pending.size();
-//            } else {
-//                return 0;
-//            }
-//        } finally {
-//            lock.unlock();
-//        }
-//    }
 
     /**
      * Returns {@code true} if there are no completed fetches pending to return to the user.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -377,6 +377,8 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
             return;
         }
 
+        requestManagers.shareConsumeRequestManager.ifPresent(scrm -> scrm.acknowledgeOnClose(event.acknowledgementsMap()));
+
         ShareMembershipManager membershipManager =
                 Objects.requireNonNull(requestManagers.shareHeartbeatRequestManager.get().membershipManager(),
                         "Expecting membership manager to be non-null");

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer.internals.events;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.internals.Acknowledgements;
 import org.apache.kafka.clients.consumer.internals.CachedSupplier;
 import org.apache.kafka.clients.consumer.internals.CommitRequestManager;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
@@ -28,6 +29,7 @@ import org.apache.kafka.clients.consumer.internals.ShareConsumeRequestManager;
 import org.apache.kafka.clients.consumer.internals.ShareMembershipManager;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
@@ -158,7 +160,7 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
                 return;
 
             default:
-                log.warn("Application event type " + event.type() + " was not expected");
+                log.warn("Application event type {} was not expected", event.type());
         }
     }
 
@@ -318,7 +320,7 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
      * Process event that tells the share consume request manager to fetch more records.
      */
     private void process(final ShareFetchEvent event) {
-        requestManagers.shareConsumeRequestManager.ifPresent(scrm -> scrm.fetch());
+        requestManagers.shareConsumeRequestManager.ifPresent(scrm -> scrm.fetch(event.acknowledgementsMap()));
     }
 
     /**
@@ -330,7 +332,8 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
         }
 
         ShareConsumeRequestManager manager = requestManagers.shareConsumeRequestManager.get();
-        CompletableFuture<Void> future = manager.commitSync(event.deadlineMs());
+        CompletableFuture<Map<TopicIdPartition, Acknowledgements>> future =
+                manager.commitSync(event.deadlineMs(), event.acknowledgementsMap());
         future.whenComplete(complete(event.future()));
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/AsyncShareAcknowledgeEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/AsyncShareAcknowledgeEvent.java
@@ -16,11 +16,15 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import org.apache.kafka.clients.consumer.internals.Acknowledgements;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.utils.Timer;
+
+import java.util.Map;
 
 public class AsyncShareAcknowledgeEvent extends ShareAcknowledgeEvent {
 
-    public AsyncShareAcknowledgeEvent(final Timer timer) {
-        super(Type.SHARE_ACKNOWLEDGE_ASYNC, timer);
+    public AsyncShareAcknowledgeEvent(final Timer timer, final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
+        super(Type.SHARE_ACKNOWLEDGE_ASYNC, timer, acknowledgementsMap);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeEvent.java
@@ -16,11 +16,25 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import org.apache.kafka.clients.consumer.internals.Acknowledgements;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.utils.Timer;
 
-public abstract class ShareAcknowledgeEvent extends CompletableApplicationEvent<Void> {
+import java.util.Map;
 
-    public ShareAcknowledgeEvent(final Type type, final Timer timer) {
+public abstract class ShareAcknowledgeEvent extends CompletableApplicationEvent<Map<TopicIdPartition, Acknowledgements>> {
+
+    private Map<TopicIdPartition, Acknowledgements> acknowledgementsMap;
+
+    public ShareAcknowledgeEvent(
+            final Type type,
+            final Timer timer,
+            final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
         super(type, timer);
+        this.acknowledgementsMap = acknowledgementsMap;
+    }
+
+    public Map<TopicIdPartition, Acknowledgements> acknowledgementsMap() {
+        return acknowledgementsMap;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareFetchEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareFetchEvent.java
@@ -16,9 +16,21 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import org.apache.kafka.clients.consumer.internals.Acknowledgements;
+import org.apache.kafka.common.TopicIdPartition;
+
+import java.util.Map;
+
 public class ShareFetchEvent extends ApplicationEvent {
 
-    public ShareFetchEvent() {
+    private Map<TopicIdPartition, Acknowledgements> acknowledgementsMap;
+
+    public ShareFetchEvent(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
         super(Type.SHARE_FETCH);
+        this.acknowledgementsMap = acknowledgementsMap;
+    }
+
+    public Map<TopicIdPartition, Acknowledgements> acknowledgementsMap() {
+        return acknowledgementsMap;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareLeaveOnCloseApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareLeaveOnCloseApplicationEvent.java
@@ -16,11 +16,23 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import org.apache.kafka.clients.consumer.internals.Acknowledgements;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.utils.Timer;
 
+import java.util.Map;
+
 public class ShareLeaveOnCloseApplicationEvent extends CompletableApplicationEvent<Void> {
-    public ShareLeaveOnCloseApplicationEvent(Timer timer) {
+
+    private Map<TopicIdPartition, Acknowledgements> acknowledgementsMap;
+
+    public ShareLeaveOnCloseApplicationEvent(final Timer timer, final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
         super(Type.SHARE_LEAVE_ON_CLOSE, timer);
+        this.acknowledgementsMap = acknowledgementsMap;
+    }
+
+    public Map<TopicIdPartition, Acknowledgements> acknowledgementsMap() {
+        return acknowledgementsMap;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/SyncShareAcknowledgeEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/SyncShareAcknowledgeEvent.java
@@ -16,11 +16,15 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import org.apache.kafka.clients.consumer.internals.Acknowledgements;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.utils.Timer;
+
+import java.util.Map;
 
 public class SyncShareAcknowledgeEvent extends ShareAcknowledgeEvent {
 
-    public SyncShareAcknowledgeEvent(final Timer timer) {
-        super(Type.SHARE_ACKNOWLEDGE_SYNC, timer);
+    public SyncShareAcknowledgeEvent(final Timer timer, final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
+        super(Type.SHARE_ACKNOWLEDGE_SYNC, timer, acknowledgementsMap);
     }
 }

--- a/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
+++ b/core/src/test/java/kafka/test/api/PlaintextShareConsumerTest.java
@@ -726,6 +726,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         return future;
     }
 
+    @Disabled
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
     public void testMultipleConsumersInGroupConcurrentConsumption(String quorum) {
@@ -769,6 +770,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
     }
 
     // This test is disabled because it is not stable and fails intermittently.
+    @Disabled
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
     public void testMultipleConsumersInMultipleGroupsConcurrentConsumption(String quorum) {
@@ -911,6 +913,7 @@ public class PlaintextShareConsumerTest extends AbstractShareConsumerTest {
         assertEquals(totalMessages, consumer1MessageCount + consumer2MessageCount);
     }
 
+    @Disabled
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"kraft+kip932"})
     public void testMultipleConsumersInGroupFailureConcurrentConsumption(String quorum) {


### PR DESCRIPTION
Add Acknowledgements maps to the events sent to the background thread to enable any combination of calls to poll, commitAsync and commitSync.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
