### PR TITLE
AKCORE-187: Use metadata cache to speed up FC RPC.

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -346,7 +346,7 @@ class BrokerServer(
 
       val persisterStateManager = new PersisterStateManager(
         NetworkUtils.buildNetworkClient("Persister", config, metrics, Time.SYSTEM, new LogContext(s"[PersisterStateManager broker=${config.brokerId}]")),
-        Time.SYSTEM, new ShareCoordinatorMetadataCacheHelperImpl(metadataCache, shareCoordinator, config.interBrokerListenerName))
+        Time.SYSTEM, new ShareCoordinatorMetadataCacheHelperImpl(metadataCache, key => shareCoordinator.partitionFor(key), config.interBrokerListenerName))
       persister.configure(new PersisterConfig(persisterStateManager))
 
       groupCoordinator = createGroupCoordinator(persister)

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -338,16 +338,18 @@ class BrokerServer(
       tokenManager = new DelegationTokenManager(config, tokenCache, time)
       tokenManager.startup()
 
+      shareCoordinator = createShareCoordinator()
+
       /* setup and configure the persister */
       persister = if (config.shareGroupPersisterClassName.nonEmpty)
         CoreUtils.createObject[Persister](config.shareGroupPersisterClassName) else NoOpShareStatePersister.getInstance()
+
       val persisterStateManager = new PersisterStateManager(
         NetworkUtils.buildNetworkClient("Persister", config, metrics, Time.SYSTEM, new LogContext(s"[PersisterStateManager broker=${config.brokerId}]")),
-        () => metadataCache.getAliveBrokerNodes(config.interBrokerListenerName).asJava, Time.SYSTEM)
+        Time.SYSTEM, new ShareCoordinatorMetadataCacheHelperImpl(metadataCache, shareCoordinator, config.interBrokerListenerName))
       persister.configure(new PersisterConfig(persisterStateManager))
 
       groupCoordinator = createGroupCoordinator(persister)
-      shareCoordinator = createShareCoordinator()
 
       val producerIdManagerSupplier = () => ProducerIdManager.rpc(
         config.brokerId,

--- a/core/src/main/scala/kafka/server/metadata/ShareCoordinatorMetadataCacheHelperImpl.scala
+++ b/core/src/main/scala/kafka/server/metadata/ShareCoordinatorMetadataCacheHelperImpl.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.metadata
+
+import org.apache.kafka.common.Node
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.MetadataResponse
+import org.apache.kafka.coordinator.group.share.ShareCoordinator
+import org.apache.kafka.server.group.share.ShareCoordinatorMetadataCacheHelper
+
+import java.util
+import scala.jdk.CollectionConverters._
+
+class ShareCoordinatorMetadataCacheHelperImpl(
+                                               val metadataCache: KRaftMetadataCache,
+                                               val shareCoordinator: ShareCoordinator,
+                                               val interBrokerListenerName: ListenerName
+                                             ) extends ShareCoordinatorMetadataCacheHelper {
+  override def containsTopic(topicName: String): Boolean = {
+    metadataCache.contains(topicName)
+  }
+
+  override def getShareCoordinator(key: String, internalTopicName: String): Node = {
+    if (metadataCache.contains(internalTopicName)) {
+      val topicMetadata = metadataCache.getTopicMetadata(Set(internalTopicName), interBrokerListenerName)
+
+      if (topicMetadata.headOption.isEmpty || topicMetadata.head.errorCode != Errors.NONE.code) {
+        Node.noNode
+      } else {
+        val partition = shareCoordinator.partitionFor(key)
+        val coordinatorEndpoint = topicMetadata.head.partitions.asScala
+          .find(_.partitionIndex == partition)
+          .filter(_.leaderId != MetadataResponse.NO_LEADER_ID)
+          .flatMap(metadata => metadataCache.
+            getAliveBrokerNode(metadata.leaderId, interBrokerListenerName))
+
+        coordinatorEndpoint match {
+          case Some(endpoint) =>
+            endpoint
+          case _ =>
+            Node.noNode
+        }
+      }
+    } else {
+      Node.noNode
+    }
+  }
+
+  override def getClusterNodes: util.List[Node] = {
+    metadataCache.getAliveBrokerNodes(interBrokerListenerName).asJava
+  }
+}

--- a/core/src/main/scala/kafka/server/metadata/ShareCoordinatorMetadataCacheHelperImpl.scala
+++ b/core/src/main/scala/kafka/server/metadata/ShareCoordinatorMetadataCacheHelperImpl.scala
@@ -21,7 +21,6 @@ import org.apache.kafka.common.Node
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.MetadataResponse
-import org.apache.kafka.coordinator.group.share.ShareCoordinator
 import org.apache.kafka.server.group.share.ShareCoordinatorMetadataCacheHelper
 
 import java.util
@@ -29,7 +28,7 @@ import scala.jdk.CollectionConverters._
 
 class ShareCoordinatorMetadataCacheHelperImpl(
                                                val metadataCache: KRaftMetadataCache,
-                                               val shareCoordinator: ShareCoordinator,
+                                               val keyToPartitionSupplier: (String) => Int,
                                                val interBrokerListenerName: ListenerName
                                              ) extends ShareCoordinatorMetadataCacheHelper {
   override def containsTopic(topicName: String): Boolean = {
@@ -43,7 +42,7 @@ class ShareCoordinatorMetadataCacheHelperImpl(
       if (topicMetadata.headOption.isEmpty || topicMetadata.head.errorCode != Errors.NONE.code) {
         Node.noNode
       } else {
-        val partition = shareCoordinator.partitionFor(key)
+        val partition = keyToPartitionSupplier(key)
         val coordinatorEndpoint = topicMetadata.head.partitions.asScala
           .find(_.partitionIndex == partition)
           .filter(_.leaderId != MetadataResponse.NO_LEADER_ID)

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.RequestCompletionHandler;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.message.ReadShareGroupStateRequestData;
@@ -37,6 +38,7 @@ import org.apache.kafka.common.requests.ReadShareGroupStateResponse;
 import org.apache.kafka.common.requests.WriteShareGroupStateRequest;
 import org.apache.kafka.common.requests.WriteShareGroupStateResponse;
 import org.apache.kafka.common.utils.ExponentialBackoff;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.util.InterBrokerSendThread;
 import org.apache.kafka.server.util.RequestAndCompletionHandler;
@@ -51,29 +53,28 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class PersisterStateManager {
 
   private SendThread sender;
-  private static Logger log = LoggerFactory.getLogger(PersisterStateManager.class);
   private final AtomicBoolean isStarted = new AtomicBoolean(false);
+  private final ShareCoordinatorMetadataCacheHelper cacheHelper;
 
-  public PersisterStateManager(KafkaClient client, Supplier<List<Node>> nodeSupplier, Time time) {
+  public PersisterStateManager(KafkaClient client, Time time, ShareCoordinatorMetadataCacheHelper cacheHelper) {
     if (client == null) {
       throw new IllegalArgumentException("Kafkaclient must not be null.");
     }
-    if (nodeSupplier == null) {
-      throw new IllegalArgumentException("NodeSupplier must not be null.");
+    if(cacheHelper == null) {
+      throw new IllegalArgumentException("ShareCoordinatorMetadataCacheHelper must not be null.");
     }
+    this.cacheHelper = cacheHelper;
     this.sender = new SendThread(
         "PersisterStateManager",
         client,
         30_000,  //30 seconds
         time == null ? Time.SYSTEM : time,
-        true,
-        nodeSupplier);
+        true);
   }
 
   public void enqueue(PersisterStateManagerHandler handler) {
@@ -101,6 +102,7 @@ public class PersisterStateManager {
     private final ExponentialBackoff findCoordbackoff = new ExponentialBackoff(1_000, 2, 30_000, 100);
     private int findCoordattempts = 0;
     private static final int MAX_FIND_COORD_ATTEMPTS = 5;
+    protected final Logger log = LoggerFactory.getLogger(getClass());
 
     public PersisterStateManagerHandler(String groupId, Uuid topicId, int partition) {
       this.groupId = groupId;
@@ -114,6 +116,27 @@ public class PersisterStateManager {
      * @return builder for the request
      */
     protected abstract AbstractRequest.Builder<? extends AbstractRequest> requestBuilder();
+
+    /**
+     * Handles the response for an RPC.
+     * @param response - Client response
+     */
+    protected abstract void handleRequestResponse(ClientResponse response);
+
+    /**
+     * Returns true if the response if valid for the respective child class.
+     * @param response - Client response
+     * @return - boolean
+     */
+    protected abstract boolean isRequestResponse(ClientResponse response);
+
+    /**
+     * Handle invalid find coordinator response. If error is UNKNOWN_SERVER_ERROR. Look at the
+     * exception details to figure out the problem.
+     * @param error
+     * @param exception
+     */
+    protected abstract void findCoordinatorErrorResponse(Errors error, Exception exception);
 
     /**
      * Returns builder for share coordinator
@@ -141,7 +164,19 @@ public class PersisterStateManager {
      * @return boolean
      */
     protected boolean lookupNeeded() {
-      return coordinatorNode == null;
+      if (coordinatorNode != null) {
+        return false;
+      }
+      if (cacheHelper.containsTopic(Topic.SHARE_GROUP_STATE_TOPIC_NAME)) {
+        log.info("{} internal topic already exists.", Topic.SHARE_GROUP_STATE_TOPIC_NAME);
+        Node node = cacheHelper.getShareCoordinator(coordinatorKey(), Topic.SHARE_GROUP_STATE_TOPIC_NAME);
+        if (node != Node.noNode()) {
+          log.info("Found coordinator node in cache: {}", node);
+          coordinatorNode = node;
+          return false;
+        }
+      }
+      return true;
     }
 
     /**
@@ -174,74 +209,63 @@ public class PersisterStateManager {
       }
     }
 
+    private void resetAttempts() {
+      findCoordattempts = 0;
+    }
+
+    private void resetCoordinatorNode() {
+      coordinatorNode = null;
+    }
+
     /**
      * Handles the response for find coordinator RPC and sets appropriate state.
      *
      * @param response - Client response for find coordinator RPC
      */
     protected void handleFindCoordinatorResponse(ClientResponse response) {
+      log.info("Find coordinator response received.");
       List<FindCoordinatorResponseData.Coordinator> coordinators = ((FindCoordinatorResponse) response.responseBody()).coordinators();
       if (coordinators.size() != 1) {
         log.error("Find coordinator response for {} is invalid", coordinatorKey());
         findCoordinatorErrorResponse(Errors.UNKNOWN_SERVER_ERROR, new IllegalStateException("Invalid response with multiple coordinators."));
         return;
       }
+
       FindCoordinatorResponseData.Coordinator coordinatorData = coordinators.get(0);
       Errors error = Errors.forCode(coordinatorData.errorCode());
-      if (error == Errors.NONE) {
-        findCoordattempts = 0;
-        log.info("Find coordinator response received.");
-        coordinatorNode = new Node(coordinatorData.nodeId(), coordinatorData.host(), coordinatorData.port());
-        // now we want the actual share state RPC call to happen
-        enqueue(this);
-      } else if (isFindCoordinatorRetryable(error)) {
-        log.warn("Received retryable error in find coordinator {}", error.message());
-        if (findCoordattempts > MAX_FIND_COORD_ATTEMPTS) {
-          log.error("Exhausted max retries to find coordinator without success.");
-          findCoordinatorErrorResponse(error, new Exception("Exhausted max retries to find coordinator without success."));
-          return;
-        }
-        log.info("Waiting before retrying find coordinator RPC.");
-        try {
-          TimeUnit.MILLISECONDS.sleep(findCoordbackoff.backoff(++findCoordattempts));
-        } catch (InterruptedException e) {
-          log.warn("Interrupted waiting before retrying find coordinator request", e);
-        }
-        enqueue(this);
-      } else {
-        log.error("Unable to find coordinator.");
-        findCoordinatorErrorResponse(error, null);
+
+      switch (error) {
+        case NONE:
+          log.info("Find coordinator response valid. Enqueuing actual request.");
+          resetAttempts();
+          coordinatorNode = new Node(coordinatorData.nodeId(), coordinatorData.host(), coordinatorData.port());
+          // now we want the actual share state RPC call to happen
+          enqueue(this);
+          break;
+
+        case COORDINATOR_NOT_AVAILABLE: // retryable error codes
+        case COORDINATOR_LOAD_IN_PROGRESS:
+          log.warn("Received retryable error in find coordinator {}", error.message());
+          if (findCoordattempts > MAX_FIND_COORD_ATTEMPTS) {
+            log.error("Exhausted max retries to find coordinator without success.");
+            findCoordinatorErrorResponse(error, new Exception("Exhausted max retries to find coordinator without success."));
+            break;
+          }
+          log.info("Waiting before retrying find coordinator RPC.");
+          try {
+            TimeUnit.MILLISECONDS.sleep(findCoordbackoff.backoff(++findCoordattempts));
+          } catch (InterruptedException e) {
+            log.warn("Interrupted waiting before retrying find coordinator request", e);
+          }
+          resetCoordinatorNode();
+          enqueue(this);
+          break;
+
+        default:
+          log.error("Unable to find coordinator.");
+          findCoordinatorErrorResponse(error, null);
       }
     }
-
-    private boolean isFindCoordinatorRetryable(Errors error) {
-      return error == Errors.COORDINATOR_NOT_AVAILABLE ||
-          error == Errors.COORDINATOR_LOAD_IN_PROGRESS;
-    }
-
-    /**
-     * Handles the response for an RPC.
-     *
-     * @param response - Client response
-     */
-    protected abstract void handleRequestResponse(ClientResponse response);
-
-    /**
-     * Returns true if the response if valid for the respective child class.
-     *
-     * @param response - Client response
-     * @return - boolean
-     */
-    protected abstract boolean isRequestResponse(ClientResponse response);
-
-    /**
-     * Handle invalid find coordinator response. If error is UNKNOWN_SERVER_ERROR. Look at the
-     * exception details to figure out the problem.
-     *
-     * @param error
-     * @param exception
-     */
-    protected abstract void findCoordinatorErrorResponse(Errors error, Exception exception);
   }
 
   public class WriteStateHandler extends PersisterStateManagerHandler {
@@ -368,18 +392,16 @@ public class PersisterStateManager {
     }
   }
 
-  private static class SendThread extends InterBrokerSendThread {
+  private class SendThread extends InterBrokerSendThread {
     private final ConcurrentLinkedQueue<PersisterStateManagerHandler> queue = new ConcurrentLinkedQueue<>();
-    private final Supplier<List<Node>> nodeSupplier;
-    private static final Random RAND = new Random(System.currentTimeMillis());
+    private final Random RAND = new Random(System.currentTimeMillis());
 
-    public SendThread(String name, KafkaClient networkClient, int requestTimeoutMs, Time time, boolean isInterruptible, Supplier<List<Node>> nodeSupplier) {
+    public SendThread(String name, KafkaClient networkClient, int requestTimeoutMs, Time time, boolean isInterruptible) {
       super(name, networkClient, requestTimeoutMs, time, isInterruptible);
-      this.nodeSupplier = nodeSupplier;
     }
 
     private Node randomNode() {
-      List<Node> nodes = nodeSupplier.get();
+      List<Node> nodes = cacheHelper.getClusterNodes();
       return nodes.get(RAND.nextInt(nodes.size()));
     }
 

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
@@ -139,6 +139,12 @@ public class PersisterStateManager {
     protected abstract void findCoordinatorErrorResponse(Errors error, Exception exception);
 
     /**
+     * Child class must provide a descriptive name for the implementation.
+     * @return String
+     */
+    protected abstract String name();
+
+    /**
      * Returns builder for share coordinator
      *
      * @return builder for find coordinator
@@ -285,6 +291,11 @@ public class PersisterStateManager {
     }
 
     @Override
+    protected String name() {
+      return "WriteStateHandler";
+    }
+
+    @Override
     protected AbstractRequest.Builder<? extends AbstractRequest> requestBuilder() {
       return new WriteShareGroupStateRequest.Builder(new WriteShareGroupStateRequestData()
           .setGroupId(groupId)
@@ -334,6 +345,11 @@ public class PersisterStateManager {
       this.leaderEpoch = leaderEpoch;
       this.coordinatorKey = ShareGroupHelper.coordinatorKey(groupId, topicId, partition);
       this.result = result;
+    }
+
+    @Override
+    protected String name() {
+      return "ReadStateHandler";
     }
 
     @Override
@@ -444,7 +460,7 @@ public class PersisterStateManager {
               handler
           ));
         } else {
-          log.info("Sending share state RPC");
+          log.info("Sending share state RPC - {}", handler.name());
           // share coord node already available
           return Collections.singletonList(new RequestAndCompletionHandler(
               System.currentTimeMillis(),

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
@@ -403,6 +403,9 @@ public class PersisterStateManager {
 
     private Node randomNode() {
       List<Node> nodes = cacheHelper.getClusterNodes();
+      if (nodes == null || nodes.isEmpty()) {
+        return Node.noNode();
+      }
       return nodes.get(random.nextInt(nodes.size()));
     }
 
@@ -428,10 +431,15 @@ public class PersisterStateManager {
         queue.poll();
         if (handler.lookupNeeded()) {
           // we need to find the coordinator node
+          Node randomNode = randomNode();
+          if (randomNode == Node.noNode()) {
+            log.error("Unable to find node to use for coordinator lookup.");
+            return Collections.emptyList();
+          }
           log.info("Sending find coordinator RPC");
           return Collections.singletonList(new RequestAndCompletionHandler(
               System.currentTimeMillis(),
-              randomNode(),
+              randomNode,
               handler.findShareCoordinatorBuilder(),
               handler
           ));

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/ShareCoordinatorMetadataCacheHelper.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/ShareCoordinatorMetadataCacheHelper.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.group.share;
+
+import org.apache.kafka.common.Node;
+
+import java.util.List;
+
+public interface ShareCoordinatorMetadataCacheHelper {
+  boolean containsTopic(String topic);
+
+  Node getShareCoordinator(String key, String internalTopicName);
+
+  List<Node> getClusterNodes();
+}


### PR DESCRIPTION
* Currently find share coordinator operation is accomplished by issuing FC RPC to a random node.
* If the cluster is absolutely fresh, WE NEED the RPC as it will create the internal topic __share_group_state as a side effect.
* However, subsequent RPCs aren't necessary since the required information is present in the metadata cache.
* In this PR we have introduced the changes to facilitate this optimization. 
* The code checks if internal topic is created and if created whether it can locate the share coordinator in the cache. If it can then the node is returned from the cache.
* Otherwise, FC RPC is issued.

Sample logs

```
[2024-06-08 13:46:04,126] INFO __share_group_state internal topic already exists. (org.apache.kafka.server.group.share.PersisterStateManager$WriteStateHandler)
[2024-06-08 13:46:04,128] INFO Found coordinator node in cache: localhost:9092 (id: 1 rack: null) (org.apache.kafka.server.group.share.PersisterStateManager$WriteStateHandler)
[2024-06-08 13:46:04,128] INFO [PersisterStateManager]: Sending share state RPC (org.apache.kafka.server.group.share.PersisterStateManager$SendThread)
[2024-06-08 13:46:04,134] INFO [ShareCoordinator id=1] ShareCoordinatorService writeState request received - WriteShareGroupStateRequestData(groupId='group-share2', topics=[WriteStateData(topicId=1Cp3ZinQS4S2Dz2P-C3FYQ, partitions=[PartitionData(partition=0, stateEpoch=0, leaderEpoch=0, startOffset=41, stateBatches=[])])]) (org.apache.kafka.coordinator.group.share.ShareCoordinatorService)
```