### PR TITLE
AKCORE-164: Adopt KafkaClusterTestKit for integration tests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
@@ -518,9 +518,11 @@ public class ShareHeartbeatRequestManager implements RequestManager {
                 sentFields.rackId = shareMembershipManager.rackId();
             }
 
-            // SubscribedTopicNames - only sent if changed since the last heartbeat
+            boolean sendAllFields = shareMembershipManager.state() == MemberState.JOINING;
+
+            // SubscribedTopicNames - only sent when joining or if it has changed since the last heartbeat
             TreeSet<String> subscribedTopicNames = new TreeSet<>(this.subscriptions.subscription());
-            if (!subscribedTopicNames.equals(sentFields.subscribedTopicNames)) {
+            if (sendAllFields || !subscribedTopicNames.equals(sentFields.subscribedTopicNames)) {
                 data.setSubscribedTopicNames(new ArrayList<>(this.subscriptions.subscription()));
                 sentFields.subscribedTopicNames = subscribedTopicNames;
             }


### PR DESCRIPTION
Replace the integration test PlaintextShareConsumerTest with ShareConsumerTest, moving over to the newer KafkaClusterTestKit. This is much neater because it no longer inherits a load of behaviour from days before KRaft.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
