### PR TITLE
AKCORE-167-2: Minor bugfix, shareStateMap was being updated twice for a single WriteShareGroupState operation

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
@@ -223,6 +223,10 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
   }
 
   /**
+   * This method generates the ShareSnapshotValue record corresponding to the requested topic partition information.
+   * The generated record is then written to the __share_group_state topic and replayed to the in-memory state
+   * of the coordinator shard, shareStateMap, by CoordinatorRuntime.
+   *
    * This method as called by the ShareCoordinatorService will be provided with
    * the request data which covers only key i.e. group1:topic1:partition1. The implementation
    * below was done keeping this in mind.
@@ -255,12 +259,12 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
     WriteShareGroupStateResponseData responseData = new WriteShareGroupStateResponseData();
     for (Record record : recordList) {  // should be single record
       if (record.key().message() instanceof ShareSnapshotKey && record.value().message() instanceof ShareSnapshotValue) {
-        ShareSnapshotKey recordKeyKey = (ShareSnapshotKey) record.key().message();
+        ShareSnapshotKey recordKey = (ShareSnapshotKey) record.key().message();
         responseData.setResults(Collections.singletonList(WriteShareGroupStateResponse.toResponseWriteStateResult(
-            recordKeyKey.topicId(), Collections.singletonList(WriteShareGroupStateResponse.toResponsePartitionResult(
-                recordKeyKey.partition())))));
+            recordKey.topicId(), Collections.singletonList(WriteShareGroupStateResponse.toResponsePartitionResult(
+                recordKey.partition())))));
 
-        String mapKey = ShareGroupHelper.coordinatorKey(recordKeyKey.groupId(), recordKeyKey.topicId(), recordKeyKey.partition());
+        String mapKey = ShareGroupHelper.coordinatorKey(recordKey.groupId(), recordKey.topicId(), recordKey.partition());
 
         if (shareStateMap.containsKey(mapKey)) {
           ShareSnapshotValue oldValue = shareStateMap.get(mapKey);
@@ -274,6 +278,9 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
   }
 
   /**
+   * This method finds the ShareSnapshotValue record corresponding to the requested topic partition from the
+   * in-memory state of coordinator shard, the shareStateMap.
+   *
    * This method as called by the ShareCoordinatorService will be provided with
    * the request data which covers only key i.e. group1:topic1:partition1. The implementation
    * below was done keeping this in mind.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
@@ -255,20 +255,18 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
     WriteShareGroupStateResponseData responseData = new WriteShareGroupStateResponseData();
     for (Record record : recordList) {  // should be single record
       if (record.key().message() instanceof ShareSnapshotKey && record.value().message() instanceof ShareSnapshotValue) {
-        ShareSnapshotKey newKey = (ShareSnapshotKey) record.key().message();
-        ShareSnapshotValue newValue = (ShareSnapshotValue) record.value().message();
+        ShareSnapshotKey recordKeyKey = (ShareSnapshotKey) record.key().message();
         responseData.setResults(Collections.singletonList(WriteShareGroupStateResponse.toResponseWriteStateResult(
-            newKey.topicId(), Collections.singletonList(WriteShareGroupStateResponse.toResponsePartitionResult(
-                newKey.partition())))));
+            recordKeyKey.topicId(), Collections.singletonList(WriteShareGroupStateResponse.toResponsePartitionResult(
+                recordKeyKey.partition())))));
 
-        String mapKey = ShareGroupHelper.coordinatorKey(newKey.groupId(), newKey.topicId(), newKey.partition());
+        String mapKey = ShareGroupHelper.coordinatorKey(recordKeyKey.groupId(), recordKeyKey.topicId(), recordKeyKey.partition());
 
         if (shareStateMap.containsKey(mapKey)) {
           ShareSnapshotValue oldValue = shareStateMap.get(mapKey);
-          newValue.setSnapshotEpoch(oldValue.snapshotEpoch() + 1);  // increment the snapshot epoch
+          ((ShareSnapshotValue) record.value().message()).setSnapshotEpoch(oldValue.snapshotEpoch() + 1);  // increment the snapshot epoch
         }
         validRecords.add(record); // this will have updated snapshot epoch
-        shareStateMap.put(mapKey, newValue);
       }
     }
 


### PR DESCRIPTION
According to the `CoordinatorRuntime` code, the replay method is called eventually, which should be responsible for the updations to the TimelineHashMaps (`shareStateMap` in our case). The replay function correctly updates the `shareStateMap` with the generated records, but an additional update to the `shareStateMap` was being made in the `writeState` function to update the snapshot epoch, causing double updates for a single `WriteShareGroupState` operation. This PR removes this additional update in the `writeState` function and generates the corrected records with the correct snapshot epoch value, which will be put in the `shareStateMap` during replay