### PR TITLE
AKCORE-168-3: Minor bugfix, sending an empty response instead of error in readState when no value is found in shareStateMap

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
@@ -46,6 +46,7 @@ import org.apache.kafka.coordinator.group.runtime.CoordinatorTimer;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.group.share.PartitionFactory;
 import org.apache.kafka.server.group.share.ShareGroupHelper;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;
@@ -293,6 +294,16 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
     int partition = request.topics().get(0).partitions().get(0).partition();
 
     String coordinatorKey = ShareGroupHelper.coordinatorKey(request.groupId(), topicId, partition);
+
+    if (!shareStateMap.containsKey(coordinatorKey)) {
+      return ReadShareGroupStateResponse.toResponseData(
+          topicId,
+          partition,
+          PartitionFactory.DEFAULT_START_OFFSET,
+          PartitionFactory.DEFAULT_STATE_EPOCH,
+          Collections.emptyList()
+      );
+    }
 
     ShareSnapshotValue snapshotValue = shareStateMap.get(coordinatorKey, offset);
 


### PR DESCRIPTION
Currently, inside the `readState` in `ShareCoordinatorShard`, when no data is found inside the shareStateMap, an error is returned. But the expected behaviour is to send a default response with no data, because the readState would be called whenever a share partition is initialised for the first time, at which point there is no data persisted for this share partition. This PR corrects this behavior