### PR TITLE
AKCORE-209: Bug fix for LSO movement when ack comes for an earlier InFlightBatch

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -955,7 +955,7 @@ public class SharePartition {
             if (floorOffset == null && hasStartOffsetMoved) {
                 // If the start offset is between the first and last offset of the acknowledgment batch, then
                 // we need to get the floor offset using the last offset of the acknowledgment batch.
-                floorOffset = cachedState.floorEntry(batch.lastOffset());
+                floorOffset = cachedState.floorEntry(startOffset);
             }
             if (floorOffset == null) {
                 log.debug("Batch record {} not found for share partition: {}-{}", batch, groupId,

--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -954,7 +954,7 @@ public class SharePartition {
             boolean hasStartOffsetMoved = checkForStartOffsetWithinBatch(batch.firstOffset(), batch.lastOffset());
             if (floorOffset == null && hasStartOffsetMoved) {
                 // If the start offset is between the first and last offset of the acknowledgment batch, then
-                // we need to get the floor offset using the last offset of the acknowledgment batch.
+                // we need to get the floor offset using the start offset.
                 floorOffset = cachedState.floorEntry(startOffset);
             }
             if (floorOffset == null) {


### PR DESCRIPTION
### About
Bug fix for LSO movement when ack comes for an earlier InFlightBatch. Earlier code wasn't taking into account that the startOffset might be batches behind the inFlightBatch that contains the last offset of the acknowledgement batch.

 ### Testing
Added a unit test to verify the logic change