### PR TITLE
AKCORE-214: Use background event to drive callback

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -306,6 +306,7 @@ public class RequestManagers implements Closeable {
                         subscriptions,
                         fetchConfig,
                         fetchBuffer,
+                        backgroundEventHandler,
                         shareFetchMetricsManager,
                         retryBackoffMs,
                         retryBackoffMaxMs);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchBuffer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchBuffer.java
@@ -24,9 +24,6 @@ import org.apache.kafka.common.utils.Timer;
 import org.slf4j.Logger;
 
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
@@ -54,40 +51,11 @@ public class ShareFetchBuffer implements AutoCloseable {
     private final AtomicBoolean wokenUp = new AtomicBoolean(false);
     private ShareCompletedFetch nextInLineFetch;
 
-    // These are the acknowledgements for which the ShareConsumeRequestManager has received responses
-    private List<Map<TopicIdPartition, Acknowledgements>> completeAcknowledgements;
-
     public ShareFetchBuffer(final LogContext logContext) {
         this.log = logContext.logger(ShareFetchBuffer.class);
         this.completedFetches = new ConcurrentLinkedQueue<>();
         this.lock = new ReentrantLock();
         this.notEmptyCondition = lock.newCondition();
-        this.completeAcknowledgements = new LinkedList<>();
-    }
-
-    List<Map<TopicIdPartition, Acknowledgements>> getCompletedAcknowledgements() {
-        lock.lock();
-        try {
-            List<Map<TopicIdPartition, Acknowledgements>> complete = completeAcknowledgements;
-            completeAcknowledgements = new LinkedList<>();
-            return complete;
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    /**
-     * Add a completed acknowledgements map to the list to be picked up by the consumer.
-     *
-     * @param acknowledgementsMap Map of completed acknowledgements
-     */
-    public void addCompletedAcknowledgements(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
-        lock.lock();
-        try {
-            completeAcknowledgements.add(acknowledgementsMap);
-        } finally {
-            lock.unlock();
-        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -144,11 +144,11 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
                 return;
 
             case SHARE_ACKNOWLEDGE_SYNC:
-                process((SyncShareAcknowledgeEvent) event);
+                process((ShareAcknowledgeSyncEvent) event);
                 return;
 
             case SHARE_ACKNOWLEDGE_ASYNC:
-                process((AsyncShareAcknowledgeEvent) event);
+                process((ShareAcknowledgeAsyncEvent) event);
                 return;
 
             case SHARE_SUBSCRIPTION_CHANGE:
@@ -160,7 +160,7 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
                 return;
 
             case SHARE_LEAVE_ON_CLOSE:
-                process((ShareLeaveOnCloseApplicationEvent) event);
+                process((ShareLeaveOnCloseEvent) event);
                 return;
 
             default:
@@ -330,7 +330,7 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
     /**
      * Process event that indicates the consumer acknowledged delivery of records synchronously.
      */
-    private void process(final SyncShareAcknowledgeEvent event) {
+    private void process(final ShareAcknowledgeSyncEvent event) {
         if (!requestManagers.shareConsumeRequestManager.isPresent()) {
             return;
         }
@@ -344,7 +344,7 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
     /**
      * Process event that indicates the consumer acknowledged delivery of records asynchronously.
      */
-    private void process(final AsyncShareAcknowledgeEvent event) {
+    private void process(final ShareAcknowledgeAsyncEvent event) {
         if (!requestManagers.shareConsumeRequestManager.isPresent()) {
             return;
         }
@@ -387,7 +387,7 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
         future.whenComplete(complete(event.future()));
     }
 
-    private void process(final ShareLeaveOnCloseApplicationEvent event) {
+    private void process(final ShareLeaveOnCloseEvent event) {
         if (!requestManagers.shareHeartbeatRequestManager.isPresent()) {
             event.future().complete(null);
             return;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEvent.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 public abstract class BackgroundEvent {
 
     public enum Type {
-        ERROR, CONSUMER_REBALANCE_LISTENER_CALLBACK_NEEDED
+        ERROR, CONSUMER_REBALANCE_LISTENER_CALLBACK_NEEDED, SHARE_ACKNOWLEDGEMENT_COMMIT_CALLBACK
     }
 
     private final Type type;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeAsyncEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeAsyncEvent.java
@@ -21,11 +21,11 @@ import org.apache.kafka.common.TopicIdPartition;
 
 import java.util.Map;
 
-public class AsyncShareAcknowledgeEvent extends ApplicationEvent {
+public class ShareAcknowledgeAsyncEvent extends ApplicationEvent {
 
     private final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap;
 
-    public AsyncShareAcknowledgeEvent(final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
+    public ShareAcknowledgeAsyncEvent(final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
         super(Type.SHARE_ACKNOWLEDGE_ASYNC);
         this.acknowledgementsMap = acknowledgementsMap;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeSyncEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeSyncEvent.java
@@ -18,15 +18,16 @@ package org.apache.kafka.clients.consumer.internals.events;
 
 import org.apache.kafka.clients.consumer.internals.Acknowledgements;
 import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.utils.Timer;
 
 import java.util.Map;
 
-public class ShareFetchEvent extends ApplicationEvent {
+public class ShareAcknowledgeSyncEvent extends CompletableApplicationEvent<Map<TopicIdPartition, Acknowledgements>> {
 
     private Map<TopicIdPartition, Acknowledgements> acknowledgementsMap;
 
-    public ShareFetchEvent(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
-        super(Type.SHARE_FETCH);
+    public ShareAcknowledgeSyncEvent(final Timer timer, final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
+        super(Type.SHARE_ACKNOWLEDGE_SYNC, timer);
         this.acknowledgementsMap = acknowledgementsMap;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgementCommitCallbackEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgementCommitCallbackEvent.java
@@ -18,20 +18,24 @@ package org.apache.kafka.clients.consumer.internals.events;
 
 import org.apache.kafka.clients.consumer.internals.Acknowledgements;
 import org.apache.kafka.common.TopicIdPartition;
-import org.apache.kafka.common.utils.Timer;
 
 import java.util.Map;
 
-public class SyncShareAcknowledgeEvent extends CompletableApplicationEvent<Map<TopicIdPartition, Acknowledgements>> {
+public class ShareAcknowledgementCommitCallbackEvent extends BackgroundEvent {
 
     private Map<TopicIdPartition, Acknowledgements> acknowledgementsMap;
 
-    public SyncShareAcknowledgeEvent(final Timer timer, final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
-        super(Type.SHARE_ACKNOWLEDGE_SYNC, timer);
+    public ShareAcknowledgementCommitCallbackEvent(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
+        super(Type.SHARE_ACKNOWLEDGEMENT_COMMIT_CALLBACK);
         this.acknowledgementsMap = acknowledgementsMap;
     }
 
     public Map<TopicIdPartition, Acknowledgements> acknowledgementsMap() {
         return acknowledgementsMap;
+    }
+
+    @Override
+    public String toStringBase() {
+        return super.toStringBase() + ", acknowledgementsMap=" + acknowledgementsMap;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareLeaveOnCloseEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareLeaveOnCloseEvent.java
@@ -22,11 +22,11 @@ import org.apache.kafka.common.utils.Timer;
 
 import java.util.Map;
 
-public class ShareLeaveOnCloseApplicationEvent extends CompletableApplicationEvent<Void> {
+public class ShareLeaveOnCloseEvent extends CompletableApplicationEvent<Void> {
 
     private Map<TopicIdPartition, Acknowledgements> acknowledgementsMap;
 
-    public ShareLeaveOnCloseApplicationEvent(final Timer timer, final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
+    public ShareLeaveOnCloseEvent(final Timer timer, final Map<TopicIdPartition, Acknowledgements> acknowledgementsMap) {
         super(Type.SHARE_LEAVE_ON_CLOSE, timer);
         this.acknowledgementsMap = acknowledgementsMap;
     }
@@ -36,9 +36,7 @@ public class ShareLeaveOnCloseApplicationEvent extends CompletableApplicationEve
     }
 
     @Override
-    public String toString() {
-        return "LeaveOnCloseApplicationEvent{" +
-                toStringBase() +
-                '}';
+    protected String toStringBase() {
+        return super.toStringBase() + ", acknowledgementsMap=" + acknowledgementsMap;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
@@ -21,7 +21,7 @@ import org.apache.kafka.clients.consumer.internals.events.ApplicationEventHandle
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventProcessor;
-import org.apache.kafka.clients.consumer.internals.events.ShareLeaveOnCloseApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.ShareLeaveOnCloseEvent;
 import org.apache.kafka.clients.consumer.internals.events.ShareSubscriptionChangeApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ShareUnsubscribeApplicationEvent;
 import org.apache.kafka.common.KafkaException;
@@ -151,7 +151,7 @@ public class ShareConsumerImplTest {
         consumer = newConsumer();
         doReturn(null).when(applicationEventHandler).addAndGet(any(), any());
         consumer.close();
-        verify(applicationEventHandler).addAndGet(any(ShareLeaveOnCloseApplicationEvent.class), any());
+        verify(applicationEventHandler).addAndGet(any(ShareLeaveOnCloseEvent.class), any());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerTestBuilder.java
@@ -152,6 +152,7 @@ public class ShareConsumerTestBuilder implements Closeable {
                 subscriptions,
                 fetchConfig,
                 fetchBuffer,
+                backgroundEventHandler,
                 metricsManager,
                 retryBackoffMs,
                 retryBackoffMs));


### PR DESCRIPTION
Drive the acknowledgement commit callback using background events. This fits better with the design of the new consumer.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
