### PR TITLE
MINOR: Override doWork for fast RPC handling.

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
@@ -495,5 +495,15 @@ public class PersisterStateManager {
     public void enqueue(PersisterStateManagerHandler handler) {
       queue.add(handler);
     }
+
+    @Override
+    public void doWork() {
+      try {
+        TimeUnit.MILLISECONDS.sleep(10);
+        this.pollOnce(100L);
+      } catch (Exception e) {
+        log.error("Timed out", e);
+      }
+    }
   }
 }


### PR DESCRIPTION
* Override doWork to poll requests every 10 ms
* Needs more analysis for large scale deployment