### PR TITLE
AKCORE-184: Added shareGroupCount and state metrics. [1/N]

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -834,7 +834,8 @@ public class GroupMetadataManager {
                 group = new ConsumerGroup(snapshotRegistry, groupId, metrics);
                 metrics.onConsumerGroupStateTransition(null, ((ConsumerGroup) group).state());
             } else if (groupType == SHARE) {
-                group = new ShareGroup(snapshotRegistry, groupId);
+                group = new ShareGroup(snapshotRegistry, groupId, metrics);
+                metrics.onShareGroupStateTransition(null, ((ShareGroup) group).state());
             } else {
                 throw new IllegalArgumentException("Invalid group type: " + groupType);
             }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TimelineGaugeCounter.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TimelineGaugeCounter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
+import org.apache.kafka.timeline.TimelineLong;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * This class represents a gauge counter for this shard. The TimelineLong object represents a gauge backed by
+ * the snapshot registry. Once we commit to a certain offset in the snapshot registry, we write the given
+ * TimelineLong's value to the AtomicLong. This AtomicLong represents the actual gauge counter that is queried
+ * when reporting the value to {@link GroupCoordinatorMetrics}.
+ */
+public class TimelineGaugeCounter {
+
+  public final TimelineLong timelineLong;
+
+  public final AtomicLong atomicLong;
+
+  public TimelineGaugeCounter(TimelineLong timelineLong, AtomicLong atomicLong) {
+    this.timelineLong = timelineLong;
+    this.atomicLong = atomicLong;
+  }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.Group;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroup.ConsumerGroupState;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
+import org.apache.kafka.coordinator.group.share.ShareGroup;
 import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
@@ -65,7 +66,9 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     public final static String GROUP_COUNT_METRIC_NAME = "group-count";
     public final static String GROUP_COUNT_PROTOCOL_TAG = "protocol";
     public final static String CONSUMER_GROUP_COUNT_METRIC_NAME = "consumer-group-count";
+    public final static String SHARE_GROUP_COUNT_METRIC_NAME = "share-group-count";
     public final static String CONSUMER_GROUP_COUNT_STATE_TAG = "state";
+    public final static String SHARE_GROUP_COUNT_STATE_TAG = CONSUMER_GROUP_COUNT_STATE_TAG;
 
     public static final String OFFSET_COMMITS_SENSOR_NAME = "OffsetCommits";
     public static final String OFFSET_EXPIRED_SENSOR_NAME = "OffsetExpired";
@@ -80,6 +83,11 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     private final MetricName consumerGroupCountReconcilingMetricName;
     private final MetricName consumerGroupCountStableMetricName;
     private final MetricName consumerGroupCountDeadMetricName;
+    private final MetricName shareGroupCountMetricName;
+    private final MetricName shareGroupCountEmptyMetricName;
+    private final MetricName shareGroupCountStableMetricName;
+    private final MetricName shareGroupCountDeadMetricName;
+    private final MetricName shareGroupCountUnknownMetricName;
 
     private final MetricsRegistry registry;
     private final Metrics metrics;
@@ -145,6 +153,41 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
             METRICS_GROUP,
             "The number of consumer groups in dead state.",
             Collections.singletonMap(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.DEAD.toString())
+        );
+
+        shareGroupCountMetricName = metrics.metricName(
+            SHARE_GROUP_COUNT_METRIC_NAME,
+            METRICS_GROUP,
+            "The total number of share groups.",
+            Collections.singletonMap(GROUP_COUNT_PROTOCOL_TAG, Group.GroupType.SHARE.toString())
+        );
+
+        shareGroupCountEmptyMetricName = metrics.metricName(
+            SHARE_GROUP_COUNT_METRIC_NAME,
+            METRICS_GROUP,
+            "The number of share groups in empty state.",
+            Collections.singletonMap(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.EMPTY.toString())
+        );
+
+        shareGroupCountStableMetricName = metrics.metricName(
+            SHARE_GROUP_COUNT_METRIC_NAME,
+            METRICS_GROUP,
+            "The number of share groups in stable state.",
+            Collections.singletonMap(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.STABLE.toString())
+        );
+
+        shareGroupCountDeadMetricName = metrics.metricName(
+            SHARE_GROUP_COUNT_METRIC_NAME,
+            METRICS_GROUP,
+            "The number of share groups in dead state.",
+            Collections.singletonMap(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.DEAD.toString())
+        );
+
+        shareGroupCountUnknownMetricName = metrics.metricName(
+            SHARE_GROUP_COUNT_METRIC_NAME,
+            METRICS_GROUP,
+            "The number of share groups in unknown state.",
+            Collections.singletonMap(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.UNKNOWN.toString())
         );
 
         registerGauges();
@@ -223,6 +266,14 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         return shards.values().stream().mapToLong(shard -> shard.numConsumerGroups(state)).sum();
     }
 
+    private long numShareGroups() {
+        return shards.values().stream().mapToLong(GroupCoordinatorMetricsShard::numShareGroups).sum();
+    }
+
+    private long numShareGroups(ShareGroup.ShareGroupState state) {
+        return shards.values().stream().mapToLong(shard -> shard.numShareGroups(state)).sum();
+    }
+
     @Override
     public void close() {
         Arrays.asList(
@@ -242,7 +293,12 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
             consumerGroupCountAssigningMetricName,
             consumerGroupCountReconcilingMetricName,
             consumerGroupCountStableMetricName,
-            consumerGroupCountDeadMetricName
+            consumerGroupCountDeadMetricName,
+            shareGroupCountMetricName,
+            shareGroupCountEmptyMetricName,
+            shareGroupCountStableMetricName,
+            shareGroupCountDeadMetricName,
+            shareGroupCountUnknownMetricName
         ).forEach(metrics::removeMetric);
 
         Arrays.asList(
@@ -372,6 +428,31 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         metrics.addMetric(
             consumerGroupCountDeadMetricName,
             (Gauge<Long>) (config, now) -> numConsumerGroups(ConsumerGroupState.DEAD)
+        );
+
+        metrics.addMetric(
+            shareGroupCountMetricName,
+            (Gauge<Long>) (config, now) -> numShareGroups()
+        );
+
+        metrics.addMetric(
+            shareGroupCountEmptyMetricName,
+            (Gauge<Long>) (config, now) -> numShareGroups(ShareGroup.ShareGroupState.EMPTY)
+        );
+
+        metrics.addMetric(
+            shareGroupCountStableMetricName,
+            (Gauge<Long>) (config, now) -> numShareGroups(ShareGroup.ShareGroupState.STABLE)
+        );
+
+        metrics.addMetric(
+            shareGroupCountDeadMetricName,
+            (Gauge<Long>) (config, now) -> numShareGroups(ShareGroup.ShareGroupState.DEAD)
+        );
+
+        metrics.addMetric(
+            shareGroupCountUnknownMetricName,
+            (Gauge<Long>) (config, now) -> numShareGroups(ShareGroup.ShareGroupState.UNKNOWN)
         );
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -87,7 +87,6 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     private final MetricName shareGroupCountEmptyMetricName;
     private final MetricName shareGroupCountStableMetricName;
     private final MetricName shareGroupCountDeadMetricName;
-    private final MetricName shareGroupCountUnknownMetricName;
 
     private final MetricsRegistry registry;
     private final Metrics metrics;
@@ -181,13 +180,6 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
             METRICS_GROUP,
             "The number of share groups in dead state.",
             Collections.singletonMap(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.DEAD.toString())
-        );
-
-        shareGroupCountUnknownMetricName = metrics.metricName(
-            SHARE_GROUP_COUNT_METRIC_NAME,
-            METRICS_GROUP,
-            "The number of share groups in unknown state.",
-            Collections.singletonMap(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.UNKNOWN.toString())
         );
 
         registerGauges();
@@ -297,8 +289,7 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
             shareGroupCountMetricName,
             shareGroupCountEmptyMetricName,
             shareGroupCountStableMetricName,
-            shareGroupCountDeadMetricName,
-            shareGroupCountUnknownMetricName
+            shareGroupCountDeadMetricName
         ).forEach(metrics::removeMetric);
 
         Arrays.asList(
@@ -448,11 +439,6 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         metrics.addMetric(
             shareGroupCountDeadMetricName,
             (Gauge<Long>) (config, now) -> numShareGroups(ShareGroup.ShareGroupState.DEAD)
-        );
-
-        metrics.addMetric(
-            shareGroupCountUnknownMetricName,
-            (Gauge<Long>) (config, now) -> numShareGroups(ShareGroup.ShareGroupState.UNKNOWN)
         );
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
@@ -21,8 +21,10 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroup.ConsumerGroupState;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
+import org.apache.kafka.coordinator.group.share.ShareGroup;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineLong;
+import org.apache.kafka.coordinator.group.TimelineGaugeCounter;
 
 import java.util.Map;
 import java.util.Objects;
@@ -37,24 +39,6 @@ import java.util.concurrent.atomic.AtomicLong;
  * report.
  */
 public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
-
-    /**
-     * This class represents a gauge counter for this shard. The TimelineLong object represents a gauge backed by
-     * the snapshot registry. Once we commit to a certain offset in the snapshot registry, we write the given
-     * TimelineLong's value to the AtomicLong. This AtomicLong represents the actual gauge counter that is queried
-     * when reporting the value to {@link GroupCoordinatorMetrics}.
-     */
-    private static class TimelineGaugeCounter {
-
-        final TimelineLong timelineLong;
-
-        final AtomicLong atomicLong;
-
-        public TimelineGaugeCounter(TimelineLong timelineLong, AtomicLong atomicLong) {
-            this.timelineLong = timelineLong;
-            this.atomicLong = atomicLong;
-        }
-    }
     /**
      * Classic group size gauge counters keyed by the metric name.
      */
@@ -64,6 +48,11 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
      * Consumer group size gauge counters keyed by the metric name.
      */
     private final Map<ConsumerGroupState, TimelineGaugeCounter> consumerGroupGauges;
+
+    /**
+     * Consumer group size gauge counters keyed by the metric name.
+     */
+    private final Map<ShareGroup.ShareGroupState, TimelineGaugeCounter> shareGroupGauges;
 
     /**
      * All sensors keyed by the sensor name. A Sensor object is shared across all metrics shards.
@@ -112,6 +101,17 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
             Utils.mkEntry(ConsumerGroupState.STABLE,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
             Utils.mkEntry(ConsumerGroupState.DEAD,
+                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0)))
+        );
+
+        this.shareGroupGauges = Utils.mkMap(
+            Utils.mkEntry(ShareGroup.ShareGroupState.EMPTY,
+                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
+            Utils.mkEntry(ShareGroup.ShareGroupState.STABLE,
+                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
+            Utils.mkEntry(ShareGroup.ShareGroupState.DEAD,
+                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
+            Utils.mkEntry(ShareGroup.ShareGroupState.UNKNOWN,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0)))
         );
 
@@ -375,6 +375,77 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
                     break;
                 case DEAD:
                     decrementNumConsumerGroups(ConsumerGroupState.DEAD);
+            }
+        }
+    }
+
+    public void incrementNumShareGroups(ShareGroup.ShareGroupState state) {
+        TimelineGaugeCounter gaugeCounter = shareGroupGauges.get(state);
+        if (gaugeCounter != null) {
+            synchronized (gaugeCounter.timelineLong) {
+                gaugeCounter.timelineLong.increment();
+            }
+        }
+    }
+
+    public void decrementNumShareGroups(ShareGroup.ShareGroupState state) {
+        TimelineGaugeCounter gaugeCounter = shareGroupGauges.get(state);
+        if (gaugeCounter != null) {
+            synchronized (gaugeCounter.timelineLong) {
+                gaugeCounter.timelineLong.decrement();
+            }
+        }
+    }
+
+    public long numShareGroups(ShareGroup.ShareGroupState state) {
+        TimelineGaugeCounter gaugeCounter = shareGroupGauges.get(state);
+        if (gaugeCounter != null) {
+            return gaugeCounter.atomicLong.get();
+        }
+        return 0L;
+    }
+
+    public long numShareGroups() {
+        return shareGroupGauges.values().stream()
+            .mapToLong(timelineGaugeCounter -> timelineGaugeCounter.atomicLong.get()).sum();
+    }
+
+    // could be called from ShareGroup to indicate state transition
+    public void onShareGroupStateTransition(
+        ShareGroup.ShareGroupState oldState,
+        ShareGroup.ShareGroupState newState
+    ) {
+        if (newState != null) {
+            switch (newState) {
+                case EMPTY:
+                    incrementNumShareGroups(ShareGroup.ShareGroupState.EMPTY);
+                    break;
+                case STABLE:
+                    incrementNumShareGroups(ShareGroup.ShareGroupState.STABLE);
+                    break;
+                case DEAD:
+                    incrementNumShareGroups(ShareGroup.ShareGroupState.DEAD);
+                    break;
+                case UNKNOWN:
+                    incrementNumShareGroups(ShareGroup.ShareGroupState.UNKNOWN);
+                    break;
+            }
+        }
+
+        if (oldState != null) {
+            switch (oldState) {
+                case EMPTY:
+                    decrementNumShareGroups(ShareGroup.ShareGroupState.EMPTY);
+                    break;
+                case STABLE:
+                    decrementNumShareGroups(ShareGroup.ShareGroupState.STABLE);
+                    break;
+                case DEAD:
+                    decrementNumShareGroups(ShareGroup.ShareGroupState.DEAD);
+                    break;
+                case UNKNOWN:
+                    decrementNumShareGroups(ShareGroup.ShareGroupState.UNKNOWN);
+                    break;
             }
         }
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
@@ -25,6 +25,8 @@ import org.apache.kafka.coordinator.group.share.ShareGroup;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineLong;
 import org.apache.kafka.coordinator.group.TimelineGaugeCounter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Objects;
@@ -39,6 +41,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * report.
  */
 public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
+    private static final Logger log = LoggerFactory.getLogger(GroupCoordinatorMetricsShard.class);
     /**
      * Classic group size gauge counters keyed by the metric name.
      */
@@ -110,8 +113,6 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
             Utils.mkEntry(ShareGroup.ShareGroupState.STABLE,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
             Utils.mkEntry(ShareGroup.ShareGroupState.DEAD,
-                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
-            Utils.mkEntry(ShareGroup.ShareGroupState.UNKNOWN,
                 new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0)))
         );
 
@@ -426,9 +427,8 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
                 case DEAD:
                     incrementNumShareGroups(ShareGroup.ShareGroupState.DEAD);
                     break;
-                case UNKNOWN:
-                    incrementNumShareGroups(ShareGroup.ShareGroupState.UNKNOWN);
-                    break;
+                default:
+                    log.warn("Unknown new share group state: {}", newState);
             }
         }
 
@@ -443,9 +443,8 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
                 case DEAD:
                     decrementNumShareGroups(ShareGroup.ShareGroupState.DEAD);
                     break;
-                case UNKNOWN:
-                    decrementNumShareGroups(ShareGroup.ShareGroupState.UNKNOWN);
-                    break;
+                default:
+                    log.warn("Unknown previous share group state: {}", oldState);
             }
         }
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
@@ -172,7 +172,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
 
   @Override
   public void onLoaded(MetadataImage newImage) {
-    CoordinatorShard.super.onLoaded(newImage);
+    coordinatorMetrics.activateMetricsShard(metricsShard);
   }
 
   @Override
@@ -182,7 +182,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
 
   @Override
   public void onUnloaded() {
-    CoordinatorShard.super.onUnloaded();
+    coordinatorMetrics.deactivateMetricsShard(metricsShard);
   }
 
   @Override


### PR DESCRIPTION
* Added share group count and associated state metrics to ShareGroup.
* The ShareGroup is initialised in the GroupMetadataManager which gets a reference to GroupCoordinatorMetricsShard from the GroupCoordinatorShard.
* Hence, the share group count metric has been added in that specific metrics file.
* The other metrics related to the __share_group_state partition will be added in the  ShareCoordinatorMetricsShard.