### PR TITLE
AKCORE-184: Added share-group-metrics as defined in kip-932. [2/N]

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -418,7 +418,8 @@ class BrokerServer(
         config.shareGroupRecordLockDurationMs,
         config.shareGroupDeliveryCountLimit,
         config.shareGroupPartitionMaxRecordLocks,
-        persister
+        persister,
+        metrics
       )
 
       // Create the request processor objects.

--- a/core/src/test/java/kafka/server/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/SharePartitionManagerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.errors.InvalidShareSessionEpochException;
 import org.apache.kafka.common.errors.ShareSessionNotFoundException;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
@@ -2011,7 +2012,7 @@ public class SharePartitionManagerTest {
             return new SharePartitionManagerBuilder();
         }
         public SharePartitionManager build() {
-            return new SharePartitionManager(replicaManager, time, cache, partitionCacheMap, RECORD_LOCK_DURATION_MS, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES, persister);
+            return new SharePartitionManager(replicaManager, time, cache, partitionCacheMap, RECORD_LOCK_DURATION_MS, MAX_DELIVERY_COUNT, MAX_IN_FLIGHT_MESSAGES, persister, new Metrics());
         }
     }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -136,7 +136,7 @@ class KafkaApisTest extends Logging {
     clientControllerQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, None)
   private val fetchManager: FetchManager = mock(classOf[FetchManager])
   val sharePartitionManager : SharePartitionManager =
-    new SharePartitionManager(replicaManager, new SystemTime(), new ShareSessionCache(1000, 100), 30000, 5, 200, NoOpShareStatePersister.getInstance())
+    new SharePartitionManager(replicaManager, new SystemTime(), new ShareSessionCache(1000, 100), 30000, 5, 200, NoOpShareStatePersister.getInstance(), metrics)
   private val clientMetricsManager: ClientMetricsManager = mock(classOf[ClientMetricsManager])
   private val brokerTopicStats = new BrokerTopicStats
   private val clusterId = "clusterId"


### PR DESCRIPTION
Added the following metrics:
```
         * share-acknowledgement (share-acknowledgement-rate and share-acknowledgement-count) - The total number of offsets acknowledged for share groups (requests to be ack).
         * record-acknowledgement (record-acknowledgement-rate and record-acknowledgement-count) - The number of records acknowledged per acknowledgement type.
         * partition-load-time (partition-load-time-avg and partition-load-time-max) - The time taken to load the share partitions.
```