### PR TITLE
AKCORE-221: Handle queued up ShareAcknowledge requests properly

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
@@ -311,7 +311,7 @@ public class ShareHeartbeatRequestManager implements RequestManager {
                     exception.getMessage());
             logger.debug(message);
         } else {
-            logger.error("ShareGroupHeartbeatRequest failed due to fatal error: " + exception.getMessage());
+            logger.error("ShareGroupHeartbeatRequest failed due to fatal error: {}", exception.getMessage());
             handleFatalFailure(exception);
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -762,6 +762,9 @@ public class ShareConsumeRequestManagerTest {
 
     private <K, V> Map<TopicPartition, List<ConsumerRecord<K, V>>> fetchRecords() {
         ShareFetch<K, V> fetch = collectFetch();
+        if (fetch.isEmpty()) {
+            return Collections.emptyMap();
+        }
         return fetch.records();
     }
 
@@ -771,14 +774,12 @@ public class ShareConsumeRequestManagerTest {
     }
 
     private void buildFetcher() {
-        buildFetcher(new ByteArrayDeserializer(), new ByteArrayDeserializer()
-        );
+        buildFetcher(new ByteArrayDeserializer(), new ByteArrayDeserializer());
     }
 
     private <K, V> void buildFetcher(Deserializer<K> keyDeserializer,
                                      Deserializer<V> valueDeserializer) {
-        buildFetcher(new MetricConfig(), keyDeserializer, valueDeserializer
-        );
+        buildFetcher(new MetricConfig(), keyDeserializer, valueDeserializer);
     }
 
     private <K, V> void buildFetcher(MetricConfig metricConfig,
@@ -825,8 +826,7 @@ public class ShareConsumeRequestManagerTest {
                 new ShareFetchBuffer(logContext),
                 backgroundEventHandler,
                 metricsManager,
-                shareFetchCollector
-        ));
+                shareFetchCollector));
     }
 
     private void buildDependencies(MetricConfig metricConfig,


### PR DESCRIPTION
The code was queuing up multiple ShareAcknowledge requests for a node, which unfortunately all had the same share session epoch. This is not allowed and made the broker very sad.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
