### PR TITLE
AKCORE-184: Share coordinator and coordinator runtime metrics. [4/N]

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -629,7 +629,7 @@ class BrokerServer(
         .withTimer(timer)
         .withLoader(loader)
         .withWriter(writer)
-        .withCoordinatorRuntimeMetrics(new GroupCoordinatorRuntimeMetrics(metrics))
+        .withCoordinatorRuntimeMetrics(new GroupCoordinatorRuntimeMetrics(metrics, GroupCoordinatorRuntimeMetrics.METRICS_GROUP))
         .withGroupCoordinatorMetrics(new GroupCoordinatorMetrics(KafkaYammerMetrics.defaultRegistry, metrics))
         .build()
     } else {
@@ -676,8 +676,8 @@ class BrokerServer(
       .withTime(time)
       .withLoader(loader)
       .withWriter(writer)
-      .withCoordinatorRuntimeMetrics(new ShareCoordinatorRuntimeMetrics(metrics))
-      .withCoordinatorMetrics(new ShareCoordinatorMetrics(KafkaYammerMetrics.defaultRegistry, metrics))
+      .withCoordinatorRuntimeMetrics(new ShareCoordinatorRuntimeMetrics(metrics, ShareCoordinatorRuntimeMetrics.METRICS_GROUP))
+      .withCoordinatorMetrics(new ShareCoordinatorMetrics(metrics))
       .build()
   }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
@@ -78,10 +78,13 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
      * The thread idle sensor.
      */
     private final Sensor threadIdleRatioSensor;
+    
+    private final String metricsGroup;
 
-    public GroupCoordinatorRuntimeMetrics(Metrics metrics) {
+    public GroupCoordinatorRuntimeMetrics(Metrics metrics, String metricsGroup) {
         this.metrics = Objects.requireNonNull(metrics);
-
+        this.metricsGroup = Objects.requireNonNull(metricsGroup);
+        
         this.numPartitionsLoading = kafkaMetricName(
             NUM_PARTITIONS_METRIC_NAME,
             "The number of partitions in Loading state.",
@@ -110,13 +113,13 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
         this.partitionLoadSensor.add(
             metrics.metricName(
                 "partition-load-time-max",
-                METRICS_GROUP,
+                metricsGroup,
                 "The max time it took to load the partitions in the last 30 sec."
             ), new Max());
         this.partitionLoadSensor.add(
             metrics.metricName(
                 "partition-load-time-avg",
-                METRICS_GROUP,
+                metricsGroup,
                 "The average time it took to load the partitions in the last 30 sec."
             ), new Avg());
 
@@ -124,13 +127,13 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
         this.threadIdleRatioSensor.add(
             metrics.metricName(
                 "thread-idle-ratio-min",
-                METRICS_GROUP,
+                metricsGroup,
                 "The minimum thread idle ratio over the last 30 seconds."
             ), new Min());
         this.threadIdleRatioSensor.add(
             metrics.metricName(
                 "thread-idle-ratio-avg",
-                METRICS_GROUP,
+                metricsGroup,
                 "The average thread idle ratio over the last 30 seconds."
             ), new Avg());
     }
@@ -143,7 +146,7 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
      * @return The kafka metric name.
      */
     private MetricName kafkaMetricName(String name, String description, String... keyValue) {
-        return metrics.metricName(name, METRICS_GROUP, description, keyValue);
+        return metrics.metricName(name, metricsGroup, description, keyValue);
     }
 
     @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorMetrics.java
@@ -21,20 +21,31 @@ import com.yammer.metrics.core.MetricsRegistry;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Meter;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.metrics.CoordinatorMetrics;
 import org.apache.kafka.coordinator.group.metrics.CoordinatorMetricsShard;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoCloseable {
+  //write (write-rate and write-total) Meter share-coordinator-metric The number of share-group state write calls per second.
+  //write-latency (write-latency-avg and write-latency-total) Meter share-coordinator-metrics The time taken for a share-group state write call, including the time to write to the share-group state topic.
   public static final String METRICS_GROUP = "share-coordinator-metrics";
 
   private final Metrics metrics;
   private final Map<TopicPartition, ShareCoordinatorMetricsShard> shards = new ConcurrentHashMap<>();
+
+  public static final String SHARE_COORDINATOR_WRITE_SENSOR_NAME = "ShareCoordinatorWrite";
+  public static final String SHARE_COORDINATOR_WRITE_LATENCY_AVG_SENSOR_NAME = "ShareCoordinatorWriteLatencyAvg";
+  public static final String SHARE_COORDINATOR_WRITE_LATENCY_TOTAL_SENSOR_NAME = "ShareCoordinatorWriteLatencyTotal";
 
   /**
    * Global sensors. These are shared across all metrics shards.
@@ -47,12 +58,41 @@ public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoC
 
   public ShareCoordinatorMetrics(Metrics metrics) {
     this.metrics = Objects.requireNonNull(metrics);
-    this.globalSensors = Collections.emptyMap();  //todo smjn: replace with unmodifiable map
+
+    Sensor shareCoordinatorWriteSensor = metrics.sensor(SHARE_COORDINATOR_WRITE_SENSOR_NAME);
+    shareCoordinatorWriteSensor.add(new Meter(
+        metrics.metricName("write-rate",
+            METRICS_GROUP,
+            "The number of share-group state write calls per second."),
+        metrics.metricName("write-total",
+            METRICS_GROUP,
+            "Total number of share-group state write calls.")));
+
+    Sensor shareCoordinatorWriteLatencyAvgSensor = metrics.sensor(SHARE_COORDINATOR_WRITE_LATENCY_AVG_SENSOR_NAME);
+    Sensor shareCoordinatorWriteLatencyTotalSensor = metrics.sensor(SHARE_COORDINATOR_WRITE_LATENCY_TOTAL_SENSOR_NAME);
+    shareCoordinatorWriteLatencyAvgSensor.add(
+        metrics.metricName("write-latency-avg",
+            METRICS_GROUP,
+            "Average latency in write state per second."),
+        new Avg());
+    shareCoordinatorWriteLatencyTotalSensor.add(
+        metrics.metricName("write-latency-total",
+            METRICS_GROUP,
+            "Cumulative total latency in write state per second."),
+        new CumulativeSum());
+
+    this.globalSensors = Collections.unmodifiableMap(Utils.mkMap(
+        Utils.mkEntry(SHARE_COORDINATOR_WRITE_SENSOR_NAME, shareCoordinatorWriteSensor),
+        Utils.mkEntry(SHARE_COORDINATOR_WRITE_LATENCY_AVG_SENSOR_NAME, shareCoordinatorWriteSensor),
+        Utils.mkEntry(SHARE_COORDINATOR_WRITE_LATENCY_TOTAL_SENSOR_NAME, shareCoordinatorWriteSensor)
+    ));
   }
 
   @Override
   public void close() throws Exception {
-
+    Arrays.asList(
+        SHARE_COORDINATOR_WRITE_SENSOR_NAME
+    ).forEach(metrics::removeSensor);
   }
 
   @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorMetrics.java
@@ -83,15 +83,17 @@ public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoC
 
     this.globalSensors = Collections.unmodifiableMap(Utils.mkMap(
         Utils.mkEntry(SHARE_COORDINATOR_WRITE_SENSOR_NAME, shareCoordinatorWriteSensor),
-        Utils.mkEntry(SHARE_COORDINATOR_WRITE_LATENCY_AVG_SENSOR_NAME, shareCoordinatorWriteSensor),
-        Utils.mkEntry(SHARE_COORDINATOR_WRITE_LATENCY_TOTAL_SENSOR_NAME, shareCoordinatorWriteSensor)
+        Utils.mkEntry(SHARE_COORDINATOR_WRITE_LATENCY_AVG_SENSOR_NAME, shareCoordinatorWriteLatencyAvgSensor),
+        Utils.mkEntry(SHARE_COORDINATOR_WRITE_LATENCY_TOTAL_SENSOR_NAME, shareCoordinatorWriteLatencyTotalSensor)
     ));
   }
 
   @Override
   public void close() throws Exception {
     Arrays.asList(
-        SHARE_COORDINATOR_WRITE_SENSOR_NAME
+        SHARE_COORDINATOR_WRITE_SENSOR_NAME,
+        SHARE_COORDINATOR_WRITE_LATENCY_AVG_SENSOR_NAME,
+        SHARE_COORDINATOR_WRITE_LATENCY_TOTAL_SENSOR_NAME
     ).forEach(metrics::removeSensor);
   }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorMetricsShard.java
@@ -18,10 +18,26 @@
 package org.apache.kafka.coordinator.group.share;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.coordinator.group.metrics.CoordinatorMetricsShard;
+import org.apache.kafka.timeline.SnapshotRegistry;
 
-// todo smjn - currently placeholder
+import java.util.Map;
+
 public class ShareCoordinatorMetricsShard implements CoordinatorMetricsShard {
+
+  private final SnapshotRegistry snapshotRegistry;
+  private final Map<String, Sensor> globalSensors;
+  private final TopicPartition topicPartition;
+
+  public ShareCoordinatorMetricsShard(SnapshotRegistry snapshotRegistry,
+                                      Map<String, Sensor> globalSensors,
+                                      TopicPartition topicPartition) {
+    this.snapshotRegistry = snapshotRegistry;
+    this.globalSensors = globalSensors;
+    this.topicPartition = topicPartition;
+  }
+
   @Override
   public void record(String sensorName) {
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorMetricsShard.java
@@ -40,17 +40,21 @@ public class ShareCoordinatorMetricsShard implements CoordinatorMetricsShard {
 
   @Override
   public void record(String sensorName) {
-
+    if (this.globalSensors.containsKey(sensorName)) {
+      this.globalSensors.get(sensorName).record();
+    }
   }
 
   @Override
   public void record(String sensorName, double val) {
-
+    if (this.globalSensors.containsKey(sensorName)) {
+      this.globalSensors.get(sensorName).record(val);
+    }
   }
 
   @Override
   public TopicPartition topicPartition() {
-    return null;
+    return this.topicPartition;
   }
 
   @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorRuntimeMetrics.java
@@ -18,53 +18,16 @@
 package org.apache.kafka.coordinator.group.share;
 
 import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.coordinator.group.metrics.CoordinatorRuntimeMetrics;
-import org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime;
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics;
 
-import java.util.Objects;
-import java.util.function.Supplier;
+public class ShareCoordinatorRuntimeMetrics extends GroupCoordinatorRuntimeMetrics {
 
-//todo smjn- need to add metrics. Currently placeholder for adhering to coordinator API
-public class ShareCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics {
+  public static final String METRICS_GROUP = "share-coordinator-metrics";
 
-  private final Metrics metrics;
-
-  public ShareCoordinatorRuntimeMetrics(Metrics metrics) {
-    this.metrics = Objects.requireNonNull(metrics);
-  }
-
-  @Override
-  public void recordPartitionStateChange(CoordinatorRuntime.CoordinatorState oldState, CoordinatorRuntime.CoordinatorState newState) {
-
-  }
-
-  @Override
-  public void recordPartitionLoadSensor(long startTimeMs, long endTimeMs) {
-
-  }
-
-  @Override
-  public void recordEventQueueTime(long durationMs) {
-
-  }
-
-  @Override
-  public void recordEventQueueProcessingTime(long durationMs) {
-
-  }
-
-  @Override
-  public void recordThreadIdleRatio(double ratio) {
-
-  }
-
-  @Override
-  public void registerEventQueueSizeGauge(Supplier<Integer> sizeSupplier) {
-
-  }
-
-  @Override
-  public void close() throws Exception {
-
+  public ShareCoordinatorRuntimeMetrics(Metrics metrics, String metricsGroup) {
+    //partition-load-time (partition-load-time-avg and partition-load-time-max) Meter share-coordinator-metrics The time taken in milliseconds to load the share-group state from the share-group state partitions.
+    //thread-idle-ratio (thread-idle-ratio-min and thread-idle-ratio-avg) Meter share-coordinator-metrics The fraction of time the share coordinator thread is idle.
+    //num-partitions Gauge share-coordinator-metrics The number of partitions in the share-state topic.
+    super(metrics, METRICS_GROUP);
   }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorService.java
@@ -64,6 +64,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
   private final CoordinatorRuntime<ShareCoordinatorShard, Record> runtime;
   private final ShareCoordinatorMetrics shareCoordinatorMetrics;
   private volatile int numPartitions = -1; // Number of partitions for __share_group_state. Provided when component is started.
+  private final Time time;
 
   public static class Builder {
     private final int nodeId;
@@ -169,7 +170,8 @@ public class ShareCoordinatorService implements ShareCoordinator {
           logContext,
           config,
           runtime,
-          coordinatorMetrics
+          coordinatorMetrics,
+          time
       );
     }
   }
@@ -178,11 +180,13 @@ public class ShareCoordinatorService implements ShareCoordinator {
       LogContext logContext,
       ShareCoordinatorConfig config,
       CoordinatorRuntime<ShareCoordinatorShard, Record> runtime,
-      ShareCoordinatorMetrics shareCoordinatorMetrics) {
+      ShareCoordinatorMetrics shareCoordinatorMetrics,
+      Time time) {
     this.log = logContext.logger(ShareCoordinatorService.class);
     this.config = config;
     this.runtime = runtime;
     this.shareCoordinatorMetrics = shareCoordinatorMetrics;
+    this.time = time;
   }
 
   @Override
@@ -233,6 +237,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     log.info("ShareCoordinatorService writeState request received - {}", request);
     String groupId = request.groupId();
     Map<Uuid, Map<Integer, CompletableFuture<WriteShareGroupStateResponseData>>> futureMap = new HashMap<>();
+    long startTime = time.hiResClockMs();
 
     // Send an empty response if topic data is empty
     if (isEmpty(request.topics())) {
@@ -309,7 +314,14 @@ public class ShareCoordinatorService implements ShareCoordinator {
                   CompletableFuture<WriteShareGroupStateResponseData> future = topicEntry.getValue();
                   int partition = topicEntry.getKey();
                   try {
+                    long timeTaken = time.hiResClockMs() - startTime;
                     WriteShareGroupStateResponseData partitionData = future.get();
+                    // This is the future returned by runtime.scheduleWriteOperation which returns when the
+                    // operation has completed including
+                    shareCoordinatorMetrics.globalSensors.get(ShareCoordinatorMetrics.SHARE_COORDINATOR_WRITE_LATENCY_AVG_SENSOR_NAME)
+                        .record(timeTaken);
+                    shareCoordinatorMetrics.globalSensors.get(ShareCoordinatorMetrics.SHARE_COORDINATOR_WRITE_LATENCY_TOTAL_SENSOR_NAME)
+                        .record(timeTaken);
                     // error check if the partitionData results contains only 1 row (corresponding to topicId)
                     return partitionData.results().get(0).partitions();
                   } catch (Exception e) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
@@ -172,6 +172,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
 
   @Override
   public void onLoaded(MetadataImage newImage) {
+    // record shard load
     coordinatorMetrics.activateMetricsShard(metricsShard);
   }
 
@@ -182,6 +183,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
 
   @Override
   public void onUnloaded() {
+    // reset start timer
     coordinatorMetrics.deactivateMetricsShard(metricsShard);
   }
 
@@ -235,6 +237,8 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
     log.info("Shard writeState request received - {}", request);
     // records to write (with both key and value of snapshot type), response to caller
     // only one key will be there in the request by design
+
+    metricsShard.record(ShareCoordinatorMetrics.SHARE_COORDINATOR_WRITE_SENSOR_NAME);
     Optional<CoordinatorResult<WriteShareGroupStateResponseData, Record>> error = maybeGetWriteStateError(request);
     if (error.isPresent()) {
       return error.get();
@@ -396,5 +400,10 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
   // Visible for testing
   public ShareSnapshotValue getShareStateMapValue(String key) {
     return this.shareStateMap.get(key);
+  }
+
+  // Visible for testing
+  CoordinatorMetricsShard getMetricsShard() {
+    return metricsShard;
   }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
@@ -172,7 +172,6 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
 
   @Override
   public void onLoaded(MetadataImage newImage) {
-    // record shard load
     coordinatorMetrics.activateMetricsShard(metricsShard);
   }
 
@@ -183,7 +182,6 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
 
   @Override
   public void onUnloaded() {
-    // reset start timer
     coordinatorMetrics.deactivateMetricsShard(metricsShard);
   }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorRuntimeMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorRuntimeMetricsTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.coordinator.group.share;
+
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetricsTest;
+
+public class ShareCoordinatorRuntimeMetricsTest extends GroupCoordinatorRuntimeMetricsTest {
+  @Override
+  public String metricsGroup() {
+    return ShareCoordinatorRuntimeMetrics.METRICS_GROUP;
+  }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShardTest.java
@@ -55,6 +55,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class ShareCoordinatorShardTest {
 
@@ -247,6 +248,7 @@ class ShareCoordinatorShardTest {
         GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request.topics().get(0).partitions().get(0))
     ).value().message(), shard.getShareStateMapValue(shareCoordinatorKey));
     assertEquals(0, shard.getLeaderMapValue(shareCoordinatorKey));
+    verify(shard.getMetricsShard()).record(ShareCoordinatorMetrics.SHARE_COORDINATOR_WRITE_SENSOR_NAME);
   }
 
   @Test


### PR DESCRIPTION
* Added write-total and write-rate metrics to track number of write state RPCs.
* Added write-latency-avg and write-latency-total to track time taken for write state RPC calls.
* Added share state group num-partition, partition-load-time, idle-thread metrics (via ShareCoordinatorRuntimeMetrics).
* Added tests wherever applicable.