### PR TITLE
MINOR: Changed log level for RPC logs.

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorService.java
@@ -230,7 +230,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
 
   @Override
   public CompletableFuture<WriteShareGroupStateResponseData> writeState(RequestContext context, WriteShareGroupStateRequestData request) {
-    log.info("ShareCoordinatorService writeState request received - {}", request);
+    log.info("ShareCoordinatorService writeState request received");
+    log.debug("ShareCoordinatorService writeState request dump - {}", request);
+
     String groupId = request.groupId();
     Map<Uuid, Map<Integer, CompletableFuture<WriteShareGroupStateResponseData>>> futureMap = new HashMap<>();
 
@@ -334,7 +336,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
 
   @Override
   public CompletableFuture<ReadShareGroupStateResponseData> readState(RequestContext context, ReadShareGroupStateRequestData request) {
-    log.info("ShareCoordinatorService readState request received - {}", request);
+    log.info("ShareCoordinatorService readState request received");
+    log.debug("ShareCoordinatorService readState request dump - {}", request);
+
     String groupId = request.groupId();
     // A map to store the futures for each topicId and partition.
     Map<Uuid, Map<Integer, CompletableFuture<ReadShareGroupStateResponseData>>> futureMap = new HashMap<>();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/share/ShareCoordinatorShard.java
@@ -232,7 +232,8 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
    * @return CoordinatorResult(records, response)
    */
   public CoordinatorResult<WriteShareGroupStateResponseData, Record> writeState(RequestContext context, WriteShareGroupStateRequestData request) {
-    log.info("Shard writeState request received - {}", request);
+    log.info("Shard writeState request received");
+    log.debug("Write request dump - {}", request);
     // records to write (with both key and value of snapshot type), response to caller
     // only one key will be there in the request by design
     Optional<CoordinatorResult<WriteShareGroupStateResponseData, Record>> error = maybeGetWriteStateError(request);
@@ -282,7 +283,8 @@ public class ShareCoordinatorShard implements CoordinatorShard<Record> {
    * @return CoordinatorResult(records, response)
    */
   public ReadShareGroupStateResponseData readState(ReadShareGroupStateRequestData request, Long offset) {
-    log.info("Shard readState request received - {}", request);
+    log.info("Shard readState request received");
+    log.debug("Read request dump - {}", request);
     // records to read (with the key of snapshot type), response to caller
     // only one key will be there in the request by design
     Optional<ReadShareGroupStateResponseData> error = maybeGetReadStateError(request);

--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
@@ -254,6 +254,8 @@ public class PersisterStateManager {
      */
     protected void handleFindCoordinatorResponse(ClientResponse response) {
       log.info("Find coordinator response received.");
+      log.debug("Find coordinator response dump - {}", response);
+      
       // Incrementing the number of find coordinator attempts
       findCoordattempts++;
       List<FindCoordinatorResponseData.Coordinator> coordinators = ((FindCoordinatorResponse) response.responseBody()).coordinators();
@@ -391,7 +393,8 @@ public class PersisterStateManager {
 
     @Override
     protected void handleRequestResponse(ClientResponse response) {
-      log.info("Write state response received. - {}", response);
+      log.info("Write state response received.");
+      log.debug("Write state response: {}", response);
       this.result.complete((WriteShareGroupStateResponse) response.responseBody());
     }
 
@@ -473,7 +476,9 @@ public class PersisterStateManager {
 
     @Override
     protected void handleRequestResponse(ClientResponse response) {
-      log.info("Read state response received. - {}", response);
+      log.info("Read state response received.");
+      log.debug("Read state response: {}", response);
+
       ReadShareGroupStateResponseData readShareGroupStateResponseData = ((ReadShareGroupStateResponse) response.responseBody()).data();
       String errorMessage = "Failed to read state for partition " + partition + " in topic " + topicId + " for group " + groupId;
       if (readShareGroupStateResponseData.results().size() != 1) {


### PR DESCRIPTION
* Read and write RPC logs were generating a lot of noise in the logs.
* This PR moves the request and response dumping to debug level instead of info.