### PR TITLE
MINOR: Cleanup of ShareConsumerPerformance to remove duplicate fields

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ShareConsumerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ShareConsumerPerformance.java
@@ -80,16 +80,14 @@ public class ShareConsumerPerformance {
             long fetchTimeInMs = (endMs - startMs) - joinTimeMs.get();
             if (!options.showDetailedStats()) {
                 double totalMbRead = (totalBytesRead.get() * 1.0) / (1024 * 1024);
-                System.out.printf("%s, %s, %.4f, %.4f, %d, %.4f, %d, %.4f, %.4f%n",
+                System.out.printf("%s, %s, %.4f, %.4f, %.4f, %d, %d%n",
                     options.dateFormat().format(startMs),
                     options.dateFormat().format(endMs),
                     totalMbRead,
                     totalMbRead / elapsedSec,
-                    totalMessagesRead.get(),
                     totalMessagesRead.get() / elapsedSec,
-                    fetchTimeInMs,
-                    totalMbRead / (fetchTimeInMs / 1000.0),
-                    totalMessagesRead.get() / (fetchTimeInMs / 1000.0)
+                    totalMessagesRead.get(),
+                    fetchTimeInMs
                 );
             }
 
@@ -103,9 +101,9 @@ public class ShareConsumerPerformance {
     }
 
     protected static void printHeader(boolean showDetailedStats) {
-        String newFieldsInHeader = ", fetch.time.ms, fetch.MB.sec, fetch.nMsg.sec";
+        String newFieldsInHeader = ", fetch.time.ms";
         if (!showDetailedStats)
-            System.out.printf("start.time, end.time, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec%s%n", newFieldsInHeader);
+            System.out.printf("start.time, end.time, data.consumed.in.MB, MB.sec, nMsg.sec, data.consumed.in.nMsg%s%n", newFieldsInHeader);
         else
             System.out.printf("time, threadId, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec%s%n", newFieldsInHeader);
     }


### PR DESCRIPTION
### About
Removed a couple of duplicate output fields from `ShareConsumerPerformance.java` since we do not have any rebalance time accounted as of now as per discussion [here](https://confluentinc.atlassian.net/wiki/spaces/~712020072219e356b44c9baf2bf96249cf8a9b/pages/3483961953/Share+Consumer+Performance+Evaluation?focusedCommentId=3509978176) . The entire time output by the script is the fetch time itself.