### PR TITLE
3.1 removed mk-include and make init-ci from semaphore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,3 @@ jmh-benchmarks/src/main/generated
 raft/.jqwik-database
 **/src/generated
 **/src/generated-test
-
-mk-include/
-.mk-include-timestamp

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -58,10 +58,6 @@ blocks:
           commands:
             - |
               if [[ "${SEMAPHORE_ORGANIZATION_URL}" != *".semaphoreci.com" ]]; then
-                make init-ci
-              fi
-            - |
-              if [[ "${SEMAPHORE_ORGANIZATION_URL}" != *".semaphoreci.com" ]]; then
                 . vault-setup
               fi
             - >-

--- a/Makefile
+++ b/Makefile
@@ -1,69 +1,3 @@
-### BEGIN MK-INCLUDE UPDATE ###
-CURL ?= curl
-FIND ?= find
-TAR ?= tar
-
-# Mount netrc so curl can work from inside a container
-DOCKER_NETRC_MOUNT ?= 1
-
-GITHUB_API = api.github.com
-GITHUB_MK_INCLUDE_OWNER := confluentinc
-GITHUB_MK_INCLUDE_REPO := cc-mk-include
-GITHUB_API_CC_MK_INCLUDE := https://$(GITHUB_API)/repos/$(GITHUB_MK_INCLUDE_OWNER)/$(GITHUB_MK_INCLUDE_REPO)
-GITHUB_API_CC_MK_INCLUDE_TARBALL := $(GITHUB_API_CC_MK_INCLUDE)/tarball
-GITHUB_API_CC_MK_INCLUDE_VERSION ?= $(GITHUB_API_CC_MK_INCLUDE_TARBALL)/$(MK_INCLUDE_VERSION)
-
-MK_INCLUDE_DIR := mk-include
-MK_INCLUDE_LOCKFILE := .mk-include-lockfile
-MK_INCLUDE_TIMESTAMP_FILE := .mk-include-timestamp
-# For optimum performance, you should override MK_INCLUDE_TIMEOUT_MINS above the managed section headers to be
-# a little longer than the worst case cold build time for this repo.
-MK_INCLUDE_TIMEOUT_MINS ?= 240
-# If this latest validated release is breaking you, please file a ticket with DevProd describing the issue, and
-# if necessary you can temporarily override MK_INCLUDE_VERSION above the managed section headers until the bad
-# release is yanked.
-MK_INCLUDE_VERSION ?= v0.1038.0
-
-# Make sure we always have a copy of the latest cc-mk-include release less than $(MK_INCLUDE_TIMEOUT_MINS) old:
-./$(MK_INCLUDE_DIR)/%.mk: .mk-include-check-FORCE
-	@trap "rm -f $(MK_INCLUDE_LOCKFILE); exit" 0 2 3 15; \
-	waitlock=0; while ! ( set -o noclobber; echo > $(MK_INCLUDE_LOCKFILE) ); do \
-	   sleep $$waitlock; waitlock=`expr $$waitlock + 1`; \
-	   test 14 -lt $$waitlock && { \
-	      echo 'stealing stale lock after 105s' >&2; \
-	      break; \
-	   } \
-	done; \
-	test -s $(MK_INCLUDE_TIMESTAMP_FILE) || rm -f $(MK_INCLUDE_TIMESTAMP_FILE); \
-	test -z "`$(FIND) $(MK_INCLUDE_TIMESTAMP_FILE) -mmin +$(MK_INCLUDE_TIMEOUT_MINS) 2>&1`" || { \
-	   grep -q 'machine $(GITHUB_API)' ~/.netrc 2>/dev/null || { \
-	      echo 'error: follow https://confluentinc.atlassian.net/l/cp/0WXXRLDh to fix your ~/.netrc'; \
-	      exit 1; \
-	   }; \
-	   $(CURL) --fail --silent --netrc --location "$(GITHUB_API_CC_MK_INCLUDE_VERSION)" --output $(MK_INCLUDE_TIMESTAMP_FILE)T --write-out '$(GITHUB_API_CC_MK_INCLUDE_VERSION): %{errormsg}\n' >&2 \
-	   && $(TAR) zxf $(MK_INCLUDE_TIMESTAMP_FILE)T \
-	   && rm -rf $(MK_INCLUDE_DIR) \
-	   && mv $(GITHUB_MK_INCLUDE_OWNER)-$(GITHUB_MK_INCLUDE_REPO)-* $(MK_INCLUDE_DIR) \
-	   && mv -f $(MK_INCLUDE_TIMESTAMP_FILE)T $(MK_INCLUDE_TIMESTAMP_FILE) \
-	   && echo 'installed cc-mk-include-$(MK_INCLUDE_VERSION) from $(GITHUB_MK_INCLUDE_REPO)' \
-	   ; \
-	} || { \
-	   rm -f $(MK_INCLUDE_TIMESTAMP_FILE)T; \
-	   if test -f $(MK_INCLUDE_TIMESTAMP_FILE); then \
-	      touch $(MK_INCLUDE_TIMESTAMP_FILE); \
-	      echo 'unable to access $(GITHUB_MK_INCLUDE_REPO) fetch API to check for latest release; next try in $(MK_INCLUDE_TIMEOUT_MINS) minutes' >&2; \
-	   else \
-	      echo 'unable to access $(GITHUB_MK_INCLUDE_REPO) fetch API to bootstrap mk-include subdirectory' >&2 && false; \
-	   fi; \
-	}
-
-.PHONY: .mk-include-check-FORCE
-.mk-include-check-FORCE:
-	@test -z "`git ls-files $(MK_INCLUDE_DIR)`" || { \
-		echo 'fatal: checked in $(MK_INCLUDE_DIR)/ directory is preventing make from fetching recent cc-mk-include releases for CI' >&2; \
-		exit 1; \
-	}
-### END MK-INCLUDE UPDATE ###
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -78,18 +12,6 @@ MK_INCLUDE_VERSION ?= v0.1038.0
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-IMAGE_NAME := kafka
-MASTER_BRANCH := master
-KAFKA_VERSION := $(shell awk 'sub(/.*version=/,""){print $1}' ./gradle.properties)
-VERSION_POST := -$(KAFKA_VERSION)
-
-include ./mk-include/cc-begin.mk
-include ./mk-include/cc-testbreak.mk
-include ./mk-include/cc-vault.mk
-include ./mk-include/cc-semver.mk
-include ./mk-include/cc-docker.mk
-include ./mk-include/cc-end.mk
 
 #Runs the compile and checkstyle error check
 .PHONY: compile-validate


### PR DESCRIPTION
Removed mk-include and make [init-ci](https://confluentinc.atlassian.net/browse/INIT-ci) in this build as it is unecessary

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
