### PR TITLE
MINOR: Write state RPC does not need to be called when the stateBatches are empty

### DIFF
--- a/core/src/main/java/kafka/server/SharePartition.java
+++ b/core/src/main/java/kafka/server/SharePartition.java
@@ -1145,6 +1145,8 @@ public class SharePartition {
         List<InFlightState> updatedStates,
         List<PersisterStateBatch> stateBatches
     ) {
+        if (stateBatches.isEmpty() && updatedStates.isEmpty())
+            return;
         lock.writeLock().lock();
         try {
             if (throwable != null || !isWriteShareGroupStateSuccessful(stateBatches)) {


### PR DESCRIPTION
### About
While performance testing, I noticed that we were making an extra write state RPC call in the cases where session was getting closed and there was no records to be moved from ACQUIRED to AVAILABLE/ACKNOWLEDGED state. Hence, I have removed the cases when such extra RPC calls can occur.