### PR TITLE
MINOR: exclude debian control files from rat check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,7 @@ if (file('.git').exists()) {
     excludes = new ArrayList<String>(repo.clean(ignore: false, directories: true, dryRun: true))
     // And some of the files that we have checked in should also be excluded from this check
     excludes.addAll([
+        '**/debian/**',
         'build.log',
         '**/.git/**',
         '**/build/**',


### PR DESCRIPTION
This is fix to CP build failures