### PR TITLE
AKCORE-242: Correct RPC schemas so AK client talks to kip-932 broker

### DIFF
--- a/clients/src/main/resources/common/message/ShareFetchResponse.json
+++ b/clients/src/main/resources/common/message/ShareFetchResponse.json
@@ -37,6 +37,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+", "ignorable": true,
       "about": "The top level response error code." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Responses", "type": "[]ShareFetchableTopicResponse", "versions": "0+",
       "about": "The response topics.", "fields": [
       { "name": "TopicId", "type": "uuid", "versions": "0+", "ignorable": true,

--- a/clients/src/main/resources/common/message/ShareGroupHeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/ShareGroupHeartbeatRequest.json
@@ -34,13 +34,6 @@
     { "name": "RackId", "type": "string", "versions": "0+",  "nullableVersions": "0+", "default": "null",
       "about": "null if not provided or if it didn't change since the last heartbeat; the rack ID of consumer otherwise." },
     { "name": "SubscribedTopicNames", "type": "[]string", "versions": "0+", "nullableVersions": "0+", "default": "null",
-      "about": "null if it didn't change since the last heartbeat; the subscribed topic names otherwise." },
-    { "name": "TopicPartitions", "type": "[]TopicPartitions", "versions": "0+", "nullableVersions": "0+", "default": "null",
-      "about": "null if it didn't change since the last heartbeat; the partitions owned by the member.", "fields": [
-      { "name": "TopicId", "type": "uuid", "versions": "0+",
-        "about": "The topic ID." },
-      { "name": "Partitions", "type": "[]int32", "versions": "0+",
-        "about": "The partitions." }
-    ]}
+      "about": "null if it didn't change since the last heartbeat; the subscribed topic names otherwise." }
   ]
 }


### PR DESCRIPTION
Some of the kip-932 RPC schemas in the kip-932 branch were out of date relative to the KIP. This meant that a client built off the AK trunk definitions would not work with a kip-932 broker. This PR corrects the definitions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
