### PR TITLE
MINOR: Fail RPC if no nodes in cache.

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/group/share/PersisterStateManager.java
@@ -558,6 +558,9 @@ public class PersisterStateManager {
           Node randomNode = randomNode();
           if (randomNode == Node.noNode()) {
             log.error("Unable to find node to use for coordinator lookup.");
+            // fatal failure, cannot retry or progress
+            // fail the RPC
+            handler.findCoordinatorErrorResponse(Errors.COORDINATOR_NOT_AVAILABLE, Errors.COORDINATOR_NOT_AVAILABLE.exception());
             return Collections.emptyList();
           }
           log.debug("Sending find coordinator RPC");


### PR DESCRIPTION
* Fail share state RPCs if find coordinator is needed but the cluster metadata cache has no node info. Because of this we don't have a destination node to send the RPC.