### PR TITLE
MINOR: Commit the acknowledgements for fetched records in ShareConsumerPerformance

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ShareConsumerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ShareConsumerPerformance.java
@@ -73,6 +73,7 @@ public class ShareConsumerPerformance {
             Map<MetricName, ? extends Metric> metrics = null;
             if (options.printMetrics())
                 metrics = shareConsumer.metrics();
+            shareConsumer.commitAsync();
             shareConsumer.close();
 
             // print final stats


### PR DESCRIPTION
### About
On digging into the reliability issue "The number of records consumed are greater than the number of records produced", I found out that this was happening in the successive runs of produce-consume cycle apart from the first run. It was happening because share session was closing without committing the acknowledgements for the records returned.