### PR TITLE
AKCORE-251: ShareConsumerPerformance works for multiple share consumers

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ShareConsumerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ShareConsumerPerformance.java
@@ -128,7 +128,7 @@ public class ShareConsumerPerformance {
         executorService.shutdown();
 
         try {
-            // Adding 100 ms to the timeout so all the threads can finish.
+            // Adding 100 ms to the timeout so all the threads can finish before we reach this part of code.
             executorService.awaitTermination(recordFetchTimeoutMs + 100, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             System.out.println("Error while consuming messages in share consumer: " + e.getMessage());

--- a/tools/src/main/java/org/apache/kafka/tools/ShareConsumerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ShareConsumerPerformance.java
@@ -128,7 +128,8 @@ public class ShareConsumerPerformance {
         executorService.shutdown();
 
         try {
-            executorService.awaitTermination(recordFetchTimeoutMs, TimeUnit.MILLISECONDS);
+            // Adding 100 ms to the timeout so all the threads can finish.
+            executorService.awaitTermination(recordFetchTimeoutMs + 100, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             System.out.println("Error while consuming messages in share consumer: " + e.getMessage());
         }


### PR DESCRIPTION
### About
Until now, `ShareConsumerPerformance.java` could only spawn a single share consumer and test its performance. With this PR, we'll be able to use `ShareConsumerPerformance.java` to measure performance for share groups as well by spawning multiple share consumers belonging to a single share group. Following options are now available to the user - 
1. `--threads` - Determines the no. of share consumers to spawn.
2.  `--show-consumer-stats` - Show the performance metrics for individual share consumers along with a combined result.

### Screenshots

- 3 share consumers showing the individual consumer performance metrics along with overall stats for the group

<img width="1205" alt="Screenshot 2024-07-09 at 7 07 10 PM" src="https://github.com/confluentinc/kafka/assets/144765188/d3bb0634-5456-481a-9db4-85e806c7a8b5">

- 3 share consumers showing only the group performance metrics

<img width="1203" alt="Screenshot 2024-07-09 at 7 07 28 PM" src="https://github.com/confluentinc/kafka/assets/144765188/8de021e9-74f0-4d37-a7a5-9f7ee49650f5">
