### PR TITLE
[CVE5274] Bump protobuf to 3.25.5 for 3.8

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -336,7 +336,7 @@ BSD 3-Clause
 jline-3.25.1, see: licenses/jline-BSD-3-clause
 jsr305-3.0.2, see: licenses/jsr305-BSD-3-clause
 paranamer-2.8, see: licenses/paranamer-BSD-3-clause
-protobuf-java-3.23.4, see: licenses/protobuf-java-BSD-3-clause
+protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
 
 ---------------------------------------
 Do What The F*ck You Want To Public License

--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,7 @@ allprojects {
           // ZooKeeper (potentially older and containing CVEs)
           libs.nettyHandler,
           libs.nettyTransportNativeEpoll,
+          libs.protobuf,
 	  // be explicit about the reload4j version instead of relying on the transitive versions
 	  libs.log4j
         )

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -151,6 +151,7 @@ versions += [
   opentelemetryProto: "1.0.0-alpha",
   pcollections: "4.0.1",
   powermock: "2.0.9",
+  protobuf: "3.25.5",
   reflections: "0.10.2",
   reload4j: "1.2.25",
   rocksDB: "7.9.2",
@@ -269,4 +270,5 @@ libs += [
   mavenArtifact: "org.apache.maven:maven-artifact:$versions.mavenArtifact",
   zstd: "com.github.luben:zstd-jni:$versions.zstd",
   httpclient: "org.apache.httpcomponents:httpclient:$versions.httpclient",
+  protobuf: "com.google.protobuf:protobuf-java:$versions.protobuf",
 ]


### PR DESCRIPTION
Bump protobuf to 3.25.5 for 3.8