### PR TITLE
MINOR: Set sourceCompatibility/targetCompatibility properties to ScalaCompile task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -339,13 +339,6 @@ subprojects {
     addParametersForTests(name, options)
   }
 
-  java {
-    // We should only set this if Java version is < 9 (--release is recommended for >= 9), but the Scala plugin for IntelliJ sets
-    // `-target` incorrectly if this is unset
-    sourceCompatibility = minJavaVersion
-    targetCompatibility = minJavaVersion
-  }
-
   if (shouldPublish) {
 
     publishing {
@@ -794,8 +787,9 @@ subprojects {
     scalaCompileOptions.additionalParameters += ["-opt-warnings", "-Xlint:strict-unsealed-patmat"]
     // Scala 2.13.2 introduces compiler warnings suppression, which is a pre-requisite for -Xfatal-warnings
     scalaCompileOptions.additionalParameters += ["-Xfatal-warnings"]
-
     scalaCompileOptions.additionalParameters += ["-release", String.valueOf(minJavaVersion)]
+    sourceCompatibility = minJavaVersion
+    targetCompatibility = minJavaVersion
 
     addParametersForTests(name, options)
 

--- a/build.gradle
+++ b/build.gradle
@@ -339,6 +339,13 @@ subprojects {
     addParametersForTests(name, options)
   }
 
+  java {
+    // We should only set this if Java version is < 9 (--release is recommended for >= 9), but the Scala plugin for IntelliJ sets
+    // `-target` incorrectly if this is unset
+    sourceCompatibility = minJavaVersion
+    targetCompatibility = minJavaVersion
+  }
+
   if (shouldPublish) {
 
     publishing {


### PR DESCRIPTION
looks like removal of sourceCompatibility, targetCompatibility java compile options from `build.gradle` in https://github.com/apache/kafka/commit/9b62c861fa4650e58a393384ed16dcec9df32fc5 is not setting the expected Java compile target version to Java classes present in core module.

I have added sourceCompatibility/targetCompatibility to ScalaCompile task. 