### PR TITLE
KSECURITY-2454 Bump commonsIo to version 2.16.0 in 3.6

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -81,6 +81,7 @@ versions += [
   caffeine: "2.9.3", // 3.x supports JDK 11 and above
   checkstyle: "8.36.2",
   commonsCli: "1.4",
+  commonsIo: "2.16.0", // ZooKeeper dependency. Do not use, this is going away.
   commonsValidator: "1.7",
   dropwizardMetrics: "4.1.12.1",
   gradle: "8.2.1",


### PR DESCRIPTION
Bump commonsIo to version 2.16.0 on branch master 3.6

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
