### PR TITLE
RCCA-23509: Modified Set.of usage in ReplicationControlManagerTest.java to resolve build failures.

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -123,6 +123,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -588,7 +589,7 @@ public class ReplicationControlManagerTest {
         ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.CREATE_TOPICS);
         PolicyViolationException error = assertThrows(
                 PolicyViolationException.class,
-                () -> replicationControl.createTopics(requestContext, request, Set.of("foo", "bar", "baz")));
+                () -> replicationControl.createTopics(requestContext, request, Stream.of("foo", "bar", "baz").collect(Collectors.toSet())));
         assertEquals(error.getMessage(), "Excessively large number of partitions per request.");
     }
 


### PR DESCRIPTION
*What*
Removed Set.of usage in ReplicationControlManagerTest as it is not compatible with java 8. This was causing build failures with 3.9 branch.
RCCA - https://confluentinc.atlassian.net/browse/RCCA-23509

Build passes locally after change :
```
shivsundarr@W61GQPN4PD kafka % ./gradlew build -x test

> Configure project :
Starting build with version 7.9.0-0-ccs (commit id ac0e49ca) using Gradle 8.8, Java 17 and Scala 2.13.14
Build properties: maxParallelForks=12, maxScalacThreads=8, maxTestRetries=0

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.8/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1m 32s
440 actionable tasks: 283 executed, 157 up-to-date
```