### PR TITLE
Fix few master build issues

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -69,10 +69,6 @@ blocks:
                 make compile-validate
               fi
             - |
-              if [[ "${SEMAPHORE_ORGANIZATION_URL}" != *".semaphoreci.com" ]]; then
-                make check-scala-compatibility
-              fi
-            - |
               if [[ "${SEMAPHORE_ORGANIZATION_URL}" != *".semaphoreci.com" ]] && [ "$PUBLISH" = "true" ] && [ "$SEMAPHORE_GIT_REF_TYPE" != "pull-request" ] && [ "$ENABLE_PUBLISH_ARTIFACTS" = "true" ]; then \
                 if [[ "$RELEASE_JOB" = "false" ]]; then \
                   . ci-tools ci-push-tag; \

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 #Runs the compile and checkstyle error check
 .PHONY: compile-validate
 compile-validate:
-	./retry_zinc ./gradlew clean -PskipSigning=true publishToMavenLocal build -x test --no-daemon --stacktrace -PxmlSpotBugsReport=true 2>&1 | tee build.log
+	./gradlew clean -PskipSigning=true publishToMavenLocal build -x test --no-daemon --stacktrace -PxmlSpotBugsReport=true 2>&1 | tee build.log
 	@error_count=$$(grep -c -E "(ERROR|error:|\[Error\]|FAILED)" build.log); \
 	if [ $$error_count -ne 0 ]; then \
 		echo "Compile, checkstyle or spotbugs error found"; \
@@ -32,7 +32,7 @@ compile-validate:
 #Check compilation compatibility with Scala 2.12
 .PHONY: check-scala-compatibility
 check-scala-compatibility:
-	./retry_zinc ./gradlew clean build -x test --no-daemon --stacktrace -PxmlSpotBugsReport=true -PscalaVersion=2.12 2>&1 | tee build.log
+	./gradlew clean build -x test --no-daemon --stacktrace -PxmlSpotBugsReport=true -PscalaVersion=2.12 2>&1 | tee build.log
 	@error_count=$$(grep -c -E "(ERROR|error:|\[Error\]|FAILED)" build.log); \
 	if [ $$error_count -ne 0 ]; then \
 		grep -E "(ERROR|error:|\[Error\]|FAILED)" build.log | while read -r line; do \

--- a/Makefile
+++ b/Makefile
@@ -29,20 +29,6 @@ compile-validate:
 		echo "No errors found"; \
 	fi
 
-#Check compilation compatibility with Scala 2.12
-.PHONY: check-scala-compatibility
-check-scala-compatibility:
-	./gradlew clean build -x test --no-daemon --stacktrace -PxmlSpotBugsReport=true -PscalaVersion=2.12 2>&1 | tee build.log
-	@error_count=$$(grep -c -E "(ERROR|error:|\[Error\]|FAILED)" build.log); \
-	if [ $$error_count -ne 0 ]; then \
-		grep -E "(ERROR|error:|\[Error\]|FAILED)" build.log | while read -r line; do \
-			echo "$$line"; \
-		done; \
-		echo "Number of compile, checkstyle and spotbug errors: $$error_count"; \
-		exit $$error_count; \
-	else \
-		echo "No errors found"; \
-	fi
 # Below targets are used during kafka packaging for debian.
 
 .PHONY: clean

--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,8 @@ ext {
       options.compilerArgs << "-Xlint:-rawtypes"
       options.compilerArgs << "-Xlint:-serial"
       options.compilerArgs << "-Xlint:-try"
-      options.compilerArgs << "-Werror"
+      if (name == "compileJava")
+        options.compilerArgs << "-Werror"
       options.compilerArgs += ["--release", String.valueOf(minJavaVersion)]
     }
   }


### PR DESCRIPTION
1. Remove retry_zinc usage from Makefile. retry_zinc file is removed in AK
2. Remove check-scala-compatibility task. Scala 2.12 support is removed from AK trunk
3. Pass `-Werror` compiler args to compileJava task (I am not able to test this, will be known after merging the PR. 