### PR TITLE
Fix build failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -356,7 +356,7 @@ subprojects {
   // don't publish it
   // We also don't publish artifacts for kafka-streams-upgrade-system-tests since they are not necessary,
   // and were resulting in conflicts due to duplicate artifacts
-  def shouldPublish = !project.name.equals('jmh-benchmarks') && !(project.path.startsWith(':streams') && project.name.startsWith("upgrade-system-tests"))
+  def shouldPublish = !project.name.equals('jmh-benchmarks') && !project.name.equals('test-common') && !(project.path.startsWith(':streams') && project.name.startsWith("upgrade-system-tests"))
   def shouldPublishWithShadow = (['clients'].contains(project.name))
 
   if (shouldPublish) {


### PR DESCRIPTION
attempt to fix build failure on master while publishing maven artefacts . looks like maven publish is failing due to empty jars. I am disabling publishing test-common jar as it does not contain any classes after [PR #18602](https://github.com/apache/kafka/pull/18602) 