### PR TITLE
Fix build failure (#1582)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -353,7 +353,7 @@ subprojects {
   // don't publish it
   // We also don't publish artifacts for kafka-streams-upgrade-system-tests since they are not necessary,
   // and were resulting in conflicts due to duplicate artifacts
-  def shouldPublish = !project.name.equals('jmh-benchmarks') && !(project.path.startsWith(':streams') && project.name.startsWith("upgrade-system-tests"))
+  def shouldPublish = !project.name.equals('jmh-benchmarks') && !project.name.equals('test-common') && !(project.path.startsWith(':streams') && project.name.startsWith("upgrade-system-tests"))
   def shouldPublishWithShadow = (['clients'].contains(project.name))
 
   if (shouldPublish) {


### PR DESCRIPTION
backport of https://github.com/confluentinc/kafka/pull/1582 to 4.0 branch