### PR TITLE
Cherry pick fix for Dexcom

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -617,6 +617,25 @@ public final class Utils {
     }
 
     /**
+     * Create a string representation of a stream surrounded by `begin` and `end` and joined by `separator`.
+     *
+     * @return The string representation.
+     */
+    public static <T> String mkString(Stream<T> stream, String begin, String end, String separator) {
+        Objects.requireNonNull(stream);
+        StringBuilder sb = new StringBuilder();
+        sb.append(begin);
+        Iterator<T> iter = stream.iterator();
+        while (iter.hasNext()) {
+            sb.append(iter.next());
+            if (iter.hasNext())
+                sb.append(separator);
+        }
+        sb.append(end);
+        return sb.toString();
+    }
+
+    /**
      *  Converts a {@code Map} class into a string, concatenating keys and values
      *  Example:
      *      {@code mkString({ key: "hello", keyTwo: "hi" }, "|START|", "|END|", "=", ",")

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -594,6 +594,29 @@ public final class Utils {
     }
 
     /**
+     * Create a string representation of an array joined by the given separator
+     * @param strs The array of items
+     * @param separator The separator
+     * @return The string representation.
+     */
+    @Deprecated
+    public static <T> String join(T[] strs, String separator) {
+        return join(Arrays.asList(strs), separator);
+    }
+
+    /**
+     * Create a string representation of a collection joined by the given separator
+     * @param collection The list of items
+     * @param separator The separator
+     * @return The string representation.
+     */
+    @Deprecated
+    public static <T> String join(Collection<T> collection, String separator) {
+        Objects.requireNonNull(collection);
+        return mkString(collection.stream(), "", "", separator);
+    }
+
+    /**
      *  Converts a {@code Map} class into a string, concatenating keys and values
      *  Example:
      *      {@code mkString({ key: "hello", keyTwo: "hi" }, "|START|", "|END|", "=", ",")


### PR DESCRIPTION
Cherry-pick https://github.com/confluentinc/ce-kafka/commit/f5ae98deae79451def0bb681a22ad90a95226a59

Relevant incident - [dexcom-connect-docker-community-edition](https://confluent.enterprise.slack.com/archives/C08PR0E0EDT)

Also added correct overload of mkString - https://github.com/confluentinc/ce-kafka/blob/84be57d572a6f39a623b4a7522d8e68778720bb7/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L640