### PR TITLE
CPBR-2586 Trigger cp-jar-build to verify CP packaging in after_pipeline job

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -123,3 +123,17 @@ after_pipeline:
           - checkout
           - sem-version java 11
           - emit-sonarqube-data -a test-results
+      - name: Trigger cp-jar-build to verify CP packaging
+        commands:
+          - |
+            if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_GIT_BRANCH" == "master" ]]; then \
+              echo "Commit to master (not a PR), triggering cp-jar-build task to verify CP packaging"; \
+              sem-trigger -p packaging \
+              -t cp-jar-build-on-commit \
+              -d "|" -i "UPSTREAM_COMPONENT|$SEMAPHORE_PROJECT_NAME" \
+              -i "UPSTREAM_GIT_SHA|$SEMAPHORE_GIT_SHA" \
+              -i "UPSTREAM_WORKFLOW_LINK|https://semaphore.ci.confluent.io/workflows/${SEMAPHORE_WORKFLOW_ID}" \
+              -b $SEMAPHORE_GIT_BRANCH; \
+            else \
+              echo "Skipping: either it's a PR or not a commit to master branch"; \
+            fi; 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -136,4 +136,4 @@ after_pipeline:
               -b $SEMAPHORE_GIT_BRANCH; \
             else \
               echo "Skipping: either it's a PR or not a commit to master branch"; \
-            fi; 
+            fi;


### PR DESCRIPTION
This PR adds a trigger for the cp-jar-build pipeline (a minimal CP packaging workflow) in the after_pipeline job. The cp-jar-build pipeline will run automatically on every commit to the master branch for upstream repositories such as ce-kafka, kafka, and others.

Purpose:
- Proactively catch breaking changes or compilation issues introduced upstream.
- Automatically notify downstream components of failing builds.
- Continuously monitor build results and pass rates to improve stability and visibility.