### PR TITLE
Add back deprecated constructors in KafkaBasedLog

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -115,6 +115,34 @@ public class KafkaBasedLog<K, V> {
      * Create a new KafkaBasedLog object. This does not start reading the log and writing is not permitted until
      * {@link #start()} is invoked.
      *
+     * @param topic the topic to treat as a log
+     * @param producerConfigs configuration options to use when creating the internal producer. At a minimum this must
+     *                        contain compatible serializer settings for the generic types used on this class. Some
+     *                        setting, such as the number of acks, will be overridden to ensure correct behavior of this
+     *                        class.
+     * @param consumerConfigs configuration options to use when creating the internal consumer. At a minimum this must
+     *                        contain compatible serializer settings for the generic types used on this class. Some
+     *                        setting, such as the auto offset reset policy, will be overridden to ensure correct
+     *                        behavior of this class.
+     * @param consumedCallback callback to invoke for each {@link ConsumerRecord} consumed when tailing the log
+     * @param time Time interface
+     * @param initializer the component that should be run when this log is {@link #start() started}; may be null
+     * @deprecated Replaced by {@link #KafkaBasedLog(String, Map, Map, Supplier, Callback, Time, java.util.function.Consumer)}
+     */
+    @Deprecated
+    public KafkaBasedLog(String topic,
+                         Map<String, Object> producerConfigs,
+                         Map<String, Object> consumerConfigs,
+                         Callback<ConsumerRecord<K, V>> consumedCallback,
+                         Time time,
+                         Runnable initializer) {
+        this(topic, producerConfigs, consumerConfigs, () -> null, consumedCallback, time, initializer != null ? admin -> initializer.run() : null);
+    }
+
+    /**
+     * Create a new KafkaBasedLog object. This does not start reading the log and writing is not permitted until
+     * {@link #start()} is invoked.
+     *
      * @param topic              the topic to treat as a log
      * @param producerConfigs    configuration options to use when creating the internal producer. At a minimum this must
      *                           contain compatible serializer settings for the generic types used on this class. Some


### PR DESCRIPTION
This PR adds back deprecated constructor for `KafkaBasedLog`