### PR TITLE
KAFKA-19359: force bump commons-beanutils for CVE-2025-48734 (#19939)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -207,13 +207,13 @@ License Version 2.0:
 
 audience-annotations-0.12.0
 caffeine-2.9.3
-commons-beanutils-1.9.4
+commons-beanutils-1.11.0
 commons-cli-1.4
 commons-collections-3.2.2
 commons-digester-2.1
 commons-io-2.14.0
 commons-lang3-3.8.1
-commons-logging-1.2
+commons-logging-1.3.5
 commons-validator-1.7
 error_prone_annotations-2.10.0
 jackson-annotations-2.16.1

--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,8 @@ allprojects {
           // ensure we have a single version in the classpath despite transitive dependencies
           libs.scalaLibrary,
           libs.scalaReflect,
+          // Workaround before `commons-validator` has new release. See KAFKA-19359.
+          libs.commonsBeanutils,
           libs.jacksonAnnotations,
           // be explicit about the Netty dependency version instead of relying on the version set by
           // ZooKeeper (potentially older and containing CVEs)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -97,6 +97,7 @@ versions += [
   // CVE-2023-2976 and CVE-2020-8908 can be dropped from
   // gradle/resources/dependencycheck-suppressions.xml
   checkstyle: "8.36.2",
+  commonsBeanutils: "1.11.0",
   commonsCli: "1.4",
   commonsIo: "2.16.0", // ZooKeeper dependency. Do not use, this is going away.
   commonsValidator: "1.7",
@@ -186,6 +187,7 @@ libs += [
   caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",
   commonsIo: "commons-io:commons-io:$versions.commonsIo",
+  commonsBeanutils: "commons-beanutils:commons-beanutils:$versions.commonsBeanutils",
   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
   commonsCodec: "commons-codec:commons-codec:$versions.commonsCodec",
   easymock: "org.easymock:easymock:$easymockVersion",


### PR DESCRIPTION
```
trunk PR: https://github.com/apache/kafka/pull/19939

Bump the commons-beanutils for
https://github.com/advisories/GHSA-wxr5-93ph-8wr9. Since commons-validator hasn't had new release with newer commons-beanutils versions, we manually bump it in kafka.

```