### PR TITLE
MINOR : Handle error for client telemetry push (#19881)

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -177,7 +177,7 @@ public class ClientMetricsManager implements Closeable {
         if (metrics != null && metrics.length > 0) {
             try {
                 receiverPlugin.exportMetrics(requestContext, request);
-            } catch (Exception exception) {
+            } catch (Throwable exception) {
                 clientInstance.lastKnownError(Errors.INVALID_RECORD);
                 return request.errorResponse(0, Errors.INVALID_RECORD);
             }


### PR DESCRIPTION
Update catch to handle compression errors

Before :

![image](https://github.com/user-attachments/assets/c5ca121e-ba0c-4664-91f1-20b54abf67cc)

After
```
Sent message: KR Message 376
[kafka-producer-network-thread | kr-kafka-producer] INFO
org.apache.kafka.common.telemetry.internals.ClientTelemetryReporter -
KR: Failed to compress telemetry payload for compression: zstd, sending
uncompressed data
Sent message: KR Message 377
```

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Bill Bejeck <bbejeck@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
