### PR TITLE
DPA-1489 Fix terraform build

### DIFF
--- a/terraform/cloudinit.yml
+++ b/terraform/cloudinit.yml
@@ -16,5 +16,6 @@ users:
 
 runcmd:
   - bash /vagrant/vagrant/base.sh
+  - sudo chmod a+rwx /mnt
   - python3.11 -m pip install -U pip
   - python3.11 -m pip install -r /vagrant/resources/requirements.txt

--- a/terraform/resources/terraform-worker-config.sh
+++ b/terraform/resources/terraform-worker-config.sh
@@ -1,6 +1,6 @@
 # Check AMI_ID present or not as env variable if not then set
 AMI_ID() {
-  echo "ami-29ebb519"
+  echo "ami-5189a661"
 }
 
 if [ -z "${AMI_ID}" ]; then

--- a/vagrant/aws-packer.json
+++ b/vagrant/aws-packer.json
@@ -9,8 +9,7 @@
     "ssh_account": "ubuntu",
     "linux_distro": "ubuntu",
     "jdk_version": "8",
-    "jdk_arch": "x64",
-    "enable_ena_driver_install": "true"
+    "jdk_arch": "x64"
 
   },
   "builders": [{
@@ -39,8 +38,7 @@
       "volume_size": 60,
       "volume_type": "gp3",
       "delete_on_termination": true
-    }],
-    "ena_support": true
+    }]
   }],
   "provisioners": [
     {

--- a/vagrant/worker-ami.json
+++ b/vagrant/worker-ami.json
@@ -60,7 +60,10 @@
         "sudo mkdir -p ~/.m2",
         "sudo chown -R {{user `ssh_account`}}:{{user `ssh_account`}} ~/.m2",
         "sudo chown -R {{user `ssh_account`}}:{{user `ssh_account`}} /vagrant",
-        "sudo ln -s /vagrant /opt/kafka"
+        "sudo ln -s /vagrant /opt/kafka",
+        "sudo mkdir -p /mnt",
+        "sudo chmod a+rwx /mnt",
+        "sudo chmod a+rw /opt"
       ]
     },
     {


### PR DESCRIPTION
After migrating to terraform, system tests were failing with this error-

```
[INFO:2025-07-14 06:48:13,807]: File "/home/semaphore/kafka-overlay/kafka/tests/kafkatest/services/zookeeper.py", line 95, in start_node
[INFO:2025-07-14 06:48:13,808]: node.account.ssh("mkdir -p %s" % ZookeeperService.DATA)
[INFO:2025-07-14 06:48:13,808]: File "/home/semaphore/kafka-overlay/venv/lib/python3.11/site-packages/ducktape/cluster/remoteaccount.py", line 35, in wrapper
[INFO:2025-07-14 06:48:13,808]: return method(self, *args, **kwargs)
[INFO:2025-07-14 06:48:13,808]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[INFO:2025-07-14 06:48:13,808]: File "/home/semaphore/kafka-overlay/venv/lib/python3.11/site-packages/ducktape/cluster/remoteaccount.py", line 310, in ssh
[INFO:2025-07-14 06:48:13,808]: raise RemoteCommandError(self, cmd, exit_status, stderr.read())
[INFO:2025-07-14 06:48:13,808]: ducktape.cluster.remoteaccount.RemoteCommandError: ubuntu@ccs-kafka-24: Command 'mkdir -p /mnt/zookeeper/data' returned non-zero exit status 1. Remote error message: b'mkdir: cannot create directory \xe2\x80\x98/mnt/zookeeper\xe2\x80\x99: Permission denied\n'
```

Creating the directory and providing all required permissions after the instance is up