### PR TITLE
MINOR: Fix NPathComplexity error in build pipeline

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
@@ -708,9 +708,15 @@ public class ClientTelemetryReporter implements MetricsReporter {
                 return Optional.empty();
             }
 
-            Object[] compressionData = compressPayload(payload, localSubscription.acceptedCompressionTypes());
-            CompressionType compressionType = (CompressionType) compressionData[0];
-            ByteBuffer compressedPayload = (ByteBuffer) compressionData[1];
+            CompressionType compressionType = ClientTelemetryUtils.preferredCompressionType(localSubscription.acceptedCompressionTypes());
+            ByteBuffer compressedPayload;
+            try {
+                compressedPayload = ClientTelemetryUtils.compress(payload, compressionType);
+            } catch (Throwable e) {
+                log.debug("Failed to compress telemetry payload for compression: {}, sending uncompressed data", compressionType);
+                compressedPayload = ByteBuffer.wrap(payload);
+                compressionType = CompressionType.NONE;
+            }
 
             AbstractRequest.Builder<?> requestBuilder = new PushTelemetryRequest.Builder(
                 new PushTelemetryRequestData()
@@ -721,19 +727,6 @@ public class ClientTelemetryReporter implements MetricsReporter {
                     .setMetrics(Utils.readBytes(compressedPayload)), true);
 
             return Optional.of(requestBuilder);
-        }
-
-        private Object[] compressPayload(byte[] payload, List<CompressionType> acceptedCompressionTypes) {
-            CompressionType compressionType = ClientTelemetryUtils.preferredCompressionType(acceptedCompressionTypes);
-            ByteBuffer compressedPayload;
-            try {
-                compressedPayload = ClientTelemetryUtils.compress(payload, compressionType);
-            } catch (Throwable e) {
-                log.debug("Failed to compress telemetry payload for compression: {}, sending uncompressed data", compressionType);
-                compressedPayload = ByteBuffer.wrap(payload);
-                compressionType = CompressionType.NONE;
-            }
-            return new Object[]{compressionType, compressedPayload};
         }
 
         /**

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
@@ -696,6 +696,10 @@ public class ClientTelemetryReporter implements MetricsReporter {
                 lock.writeLock().unlock();
             }
 
+            return createPushRequest(localSubscription, terminating);
+        }
+
+        private Optional<Builder<?>> createPushRequest(ClientTelemetrySubscription localSubscription, boolean terminating) {
             byte[] payload;
             try (MetricsEmitter emitter = new ClientTelemetryEmitter(localSubscription.selector(), localSubscription.deltaTemporality())) {
                 emitter.init();


### PR DESCRIPTION
Fix NPathComplexity error in build pipeline 
```
 [ERROR] /home/semaphore/kafka/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java:655:9: NPath Complexity is 554 (max allowed is 500). [NPathComplexity]
```