### PR TITLE
Change ci_tools import path

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -23,7 +23,7 @@ import re
 import subprocess
 import sys
 
-from confluent.ci.scripts.ci_utils import run_cmd, regex_replace, replace
+from ci_tools.utils import run_cmd, regex_replace, replace
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
due to migration to confluent-devtools, we need to update the import path of ci_tools
