### PR TITLE
KSECURITY-2558: Bump jetty to version 9.4.58.v20250814 in 3.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -71,7 +71,7 @@ versions += [
   jacksonDatabind: "2.16.0",
   jacoco: "0.8.7",
   javassist: "3.27.0-GA",
-  jetty: "9.4.57.v20241219",
+  jetty: "9.4.58.v20250814",
   jersey: "2.34",
   jline: "3.21.0",
   jmh: "1.35",


### PR DESCRIPTION
Bump jetty to version 9.4.58.v20250814 on branch 3.3