### PR TITLE
KSECURITY-2558: Bump jetty to version 9.4.58.v20250814 in 3.7

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -108,7 +108,7 @@ versions += [
   jackson: "2.16.2",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
-  jetty: "9.4.57.v20241219",
+  jetty: "9.4.58.v20250814",
   jersey: "2.39.1",
   jline: "3.25.1",
   jmh: "1.37",


### PR DESCRIPTION
Bump jetty to version 9.4.58.v20250814 on branch 3.7