### PR TITLE
KSECURITY-2558: Bump jetty to version 12.0.25 in 4.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jackson: "2.16.2",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
-  jetty: "12.0.15",
+  jetty: "12.0.25",
   jersey: "3.1.9",
   jline: "3.25.1",
   jmh: "1.37",


### PR DESCRIPTION
Bump jetty to version 12.0.25 on branch 4.0