### PR TITLE
KSECURITY-2558: Bump jetty to version 12.0.25 in 4.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -67,7 +67,7 @@ versions += [
   jackson: "2.19.0",
   jacoco: "0.8.13",
   javassist: "3.30.2-GA",
-  jetty: "12.0.22",
+  jetty: "12.0.25",
   jersey: "3.1.10",
   jline: "3.30.4",
   jmh: "1.37",


### PR DESCRIPTION
Bump jetty to version 12.0.25 on branch 4.1