### PR TITLE
fix: Hide servlet info from Connect UI

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -41,6 +41,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -200,6 +201,9 @@ public class RestServer {
         StatisticsHandler statsHandler = new StatisticsHandler();
         statsHandler.setHandler(handlers);
         jettyServer.setHandler(statsHandler);
+        jettyServer.setErrorHandler(new ErrorHandler() {{
+            setShowServlet(false);
+        }});
         jettyServer.setStopTimeout(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
         jettyServer.setStopAtShutdown(true);
 


### PR DESCRIPTION
This PR fixes the issue where the error response page was showing the line
SERVLET:org.glassfish.jersey.servlet.ServletContainer-xxxxxx.