### PR TITLE
MINOR: Update semaphore instance type to avoid build crashes in Semaphore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,7 +17,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu24-04-arm64-1
+    type: s1-prod-ubuntu24-04-arm64-3
 fail_fast:
   cancel:
     when: "true"

--- a/scripts/set_downstream_branch.sh
+++ b/scripts/set_downstream_branch.sh
@@ -33,6 +33,7 @@ kafkaMuckrakeVersionMap["3.5"]="7.5.x"
 kafkaMuckrakeVersionMap["3.6"]="7.6.x"
 kafkaMuckrakeVersionMap["3.7"]="7.7.x"
 kafkaMuckrakeVersionMap["3.8"]="7.8.x"
+kafkaMuckrakeVersionMap["3.9"]="7.9.x"
 kafkaMuckrakeVersionMap["trunk"]="master"
 kafkaMuckrakeVersionMap["master"]="master"
 


### PR DESCRIPTION
PR builds are crashing due to OOM. This is to fix the errors.
also update ak -> ce version  mapping in scripts/set_downstream_branch.sh
