### PR TITLE
[KSECURITY-2626] Fix commons-lang3 to 3.18.0 in 4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,6 +219,10 @@ allprojects {
           libs.jacksonAnnotations,
           libs.commonsLang
         )
+        // CVE-2025-48924: Replace vulnerable commons-lang 2.x with commons-lang3 3.18.0
+        dependencySubstitution {
+          substitute module('commons-lang:commons-lang') using module('org.apache.commons:commons-lang3:3.18.0')
+        }
       }
     }
   }

--- a/core/src/test/java/kafka/security/minikdc/MiniKdc.java
+++ b/core/src/test/java/kafka/security/minikdc/MiniKdc.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Java;
 import org.apache.kafka.common.utils.Utils;
 
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;


### PR DESCRIPTION
See here: [CVE-2025-48924](https://confluentinc.atlassian.net/browse/KSECURITY-2626)
