### PR TITLE
[KSECURITY-2626] Fix commons-lang3 to 3.18.0 in 3.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,10 @@ allprojects {
           libs.commonsBeanutils,
           libs.commonsLang
         )
+        // CVE-2025-48924: Replace vulnerable commons-lang 2.x with commons-lang3 3.18.0
+        dependencySubstitution {
+          substitute module('commons-lang:commons-lang') using module('org.apache.commons:commons-lang3:3.18.0')
+        }
       }
     }
   }

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -28,7 +28,7 @@ import java.util.{Locale, Properties, UUID}
 import kafka.utils.{CoreUtils, Exit, Logging}
 
 import scala.jdk.CollectionConverters._
-import org.apache.commons.lang.text.StrSubstitutor
+import org.apache.commons.lang3.text.StrSubstitutor
 import org.apache.directory.api.ldap.model.entry.{DefaultEntry, Entry}
 import org.apache.directory.api.ldap.model.ldif.LdifReader
 import org.apache.directory.api.ldap.model.name.Dn


### PR DESCRIPTION
See here: [CVE-2025-48924](https://confluentinc.atlassian.net/browse/KSECURITY-2626)