### PR TITLE
[KSECURITY-2626] Fix commons-lang3 to 3.18.0 in 3.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,10 +177,6 @@ allprojects {
           // be explicit about the commonsLang version instead of relying on the transitive versions
           libs.commonsLang
         )
-        // CVE-2025-48924: Replace vulnerable commons-lang 2.x with commons-lang3 3.18.0
-        dependencySubstitution {
-          substitute module('commons-lang:commons-lang') using module('org.apache.commons:commons-lang3:3.18.0')
-        }
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -173,8 +173,14 @@ allprojects {
           libs.nettyHandler,
           libs.nettyTransportNativeEpoll,
 	  // be explicit about the reload4j version instead of relying on the transitive versions
-	  libs.log4j
+	  libs.log4j,
+          // be explicit about the commonsLang version instead of relying on the transitive versions
+          libs.commonsLang
         )
+        // CVE-2025-48924: Replace vulnerable commons-lang 2.x with commons-lang3 3.18.0
+        dependencySubstitution {
+          substitute module('commons-lang:commons-lang') using module('org.apache.commons:commons-lang3:3.18.0')
+        }
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -172,8 +172,8 @@ allprojects {
           // ZooKeeper (potentially older and containing CVEs)
           libs.nettyHandler,
           libs.nettyTransportNativeEpoll,
-	  // be explicit about the reload4j version instead of relying on the transitive versions
-	  libs.log4j,
+          // be explicit about the reload4j version instead of relying on the transitive versions
+          libs.log4j,
           // be explicit about the commonsLang version instead of relying on the transitive versions
           libs.commonsLang
         )

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -28,7 +28,7 @@ import java.util.{Locale, Properties, UUID}
 import kafka.utils.{CoreUtils, Exit, Logging}
 
 import scala.jdk.CollectionConverters._
-import org.apache.commons.lang3.text.StrSubstitutor
+import org.apache.commons.lang.text.StrSubstitutor
 import org.apache.directory.api.ldap.model.entry.{DefaultEntry, Entry}
 import org.apache.directory.api.ldap.model.ldif.LdifReader
 import org.apache.directory.api.ldap.model.name.Dn

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -28,7 +28,7 @@ import java.util.{Locale, Properties, UUID}
 import kafka.utils.{CoreUtils, Exit, Logging}
 
 import scala.jdk.CollectionConverters._
-import org.apache.commons.lang.text.StrSubstitutor
+import org.apache.commons.lang3.text.StrSubstitutor
 import org.apache.directory.api.ldap.model.entry.{DefaultEntry, Entry}
 import org.apache.directory.api.ldap.model.ldif.LdifReader
 import org.apache.directory.api.ldap.model.name.Dn

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -83,6 +83,7 @@ versions += [
   commonsBeanutils: "1.11.0",
   commonsCli: "1.4",
   commonsIo: "2.16.0", // ZooKeeper dependency. Do not use, this is going away.
+  commonsLang: "3.18.0",
   commonsValidator: "1.7",
   dropwizardMetrics: "4.1.12.1",
   gradle: "8.2.1",
@@ -169,6 +170,7 @@ libs += [
   caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",
   commonsBeanutils: "commons-beanutils:commons-beanutils:$versions.commonsBeanutils",
+  commonsLang: "org.apache.commons:commons-lang3:$versions.commonsLang",
   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
   commonsCodec: "commons-codec:commons-codec:$versions.commonsCodec",
   commonsIo: "commons-io:commons-io:$versions.commonsIo",


### PR DESCRIPTION
See here: [CVE-2025-48924](https://confluentinc.atlassian.net/browse/KSECURITY-2626)