### PR TITLE
[KSECURITY-2626] Fix commons-lang3 to 3.18.0 in 3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,8 +177,14 @@ allprojects {
           libs.nettyHandler,
           libs.nettyTransportNativeEpoll,
 	  // be explicit about the reload4j version instead of relying on the transitive versions
-	  libs.log4j
+	  libs.log4j,
+          // be explicit about the commonsLang version instead of relying on the transitive versions
+          libs.commonsLang
         )
+        // CVE-2025-48924: Replace vulnerable commons-lang 2.x with commons-lang3 3.18.0
+        dependencySubstitution {
+          substitute module('commons-lang:commons-lang') using module('org.apache.commons:commons-lang3:3.18.0')
+        }
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -176,8 +176,8 @@ allprojects {
           // ZooKeeper (potentially older and containing CVEs)
           libs.nettyHandler,
           libs.nettyTransportNativeEpoll,
-	  // be explicit about the reload4j version instead of relying on the transitive versions
-	  libs.log4j,
+          // be explicit about the reload4j version instead of relying on the transitive versions
+          libs.log4j,
           // be explicit about the commonsLang version instead of relying on the transitive versions
           libs.commonsLang
         )

--- a/build.gradle
+++ b/build.gradle
@@ -181,10 +181,6 @@ allprojects {
           // be explicit about the commonsLang version instead of relying on the transitive versions
           libs.commonsLang
         )
-        // CVE-2025-48924: Replace vulnerable commons-lang 2.x with commons-lang3 3.18.0
-        dependencySubstitution {
-          substitute module('commons-lang:commons-lang') using module('org.apache.commons:commons-lang3:3.18.0')
-        }
       }
     }
   }

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -28,7 +28,7 @@ import java.util.{Locale, Properties, UUID}
 import kafka.utils.{CoreUtils, Exit, Logging}
 
 import scala.jdk.CollectionConverters._
-import org.apache.commons.lang3.text.StrSubstitutor
+import org.apache.commons.lang.text.StrSubstitutor
 import org.apache.directory.api.ldap.model.entry.{DefaultEntry, Entry}
 import org.apache.directory.api.ldap.model.ldif.LdifReader
 import org.apache.directory.api.ldap.model.name.Dn

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -28,7 +28,7 @@ import java.util.{Locale, Properties, UUID}
 import kafka.utils.{CoreUtils, Exit, Logging}
 
 import scala.jdk.CollectionConverters._
-import org.apache.commons.lang.text.StrSubstitutor
+import org.apache.commons.lang3.text.StrSubstitutor
 import org.apache.directory.api.ldap.model.entry.{DefaultEntry, Entry}
 import org.apache.directory.api.ldap.model.ldif.LdifReader
 import org.apache.directory.api.ldap.model.name.Dn

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -62,6 +62,7 @@ versions += [
   checkstyle: "8.36.2",
   commonsCli: "1.4",
   commonsIo: "2.16.0", // ZooKeeper dependency. Do not use, this is going away.
+  commonsLang: "3.18.0",
   dropwizardMetrics: "4.1.12.1",
   gradle: "7.6",
   grgit: "4.1.1",
@@ -145,6 +146,7 @@ libs += [
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",
   commonsCodec: "commons-codec:commons-codec:$versions.commonsCodec",
   commonsIo: "commons-io:commons-io:$versions.commonsIo",
+  commonsLang: "org.apache.commons:commons-lang3:$versions.commonsLang",
   easymock: "org.easymock:easymock:$versions.easymock",
   jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
   jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",


### PR DESCRIPTION
See here: [CVE-2025-48924](https://confluentinc.atlassian.net/browse/KSECURITY-2626)