### PR TITLE
MINOR: Fail the build job on gradle test failures

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -91,10 +91,23 @@ blocks:
       jobs:
         - name: Unit tests and Integration tests
           commands:
-            - './gradlew 
-                unitTest integrationTest --no-daemon --stacktrace --continue 
-                -PtestLoggingEvents=started,passed,skipped,failed -PmaxParallelForks=4 
-                -PignoreFailures=true -PmaxTestRetries=1 -PmaxTestRetryFailures=5'
+            - |
+              # Stop the script if any command fails
+              set -euo pipefail
+              
+              ./gradlew \
+                unitTest integrationTest --no-daemon --stacktrace --continue \
+                -PtestLoggingEvents=started,passed,skipped,failed -PmaxParallelForks=4 \
+                -PignoreFailures=true -PmaxTestRetries=1 -PmaxTestRetryFailures=5 
+              gradle_exit=$?
+              
+              # Check and exit accordingly
+              if [ "$gradle_exit" -ne 0 ]; then
+                echo "❌ Gradle exited with code $gradle_exit — failing the job."
+                exit "$gradle_exit"
+              else
+                echo "✅ Gradle completed successfully (exit code 0)."
+              fi
           execution_time_limit:
             minutes: 120
       epilogue:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -45,6 +45,11 @@ global_job_config:
       - checkout
       - sem-version java 21
       - sem-version go 1.16.15
+      - sem-version python 3.11
+      - python --version
+      - python -m venv junitparser
+      - source junitparser/bin/activate
+      - pip install junitparser
       - git config --global url."git@github.com:".insteadOf "https://github.com/"
       - export SEMAPHORE_CACHE_DIR=/home/semaphore
       - source scripts/set_env_vars.sh
@@ -92,28 +97,36 @@ blocks:
         - name: Unit tests and Integration tests
           commands:
             - |
-              # Stop the script if any command fails
-              set -euo pipefail
-              
               ./gradlew \
                 unitTest integrationTest --no-daemon --stacktrace --continue \
                 -PtestLoggingEvents=started,passed,skipped,failed -PmaxParallelForks=4 \
                 -PignoreFailures=true -PmaxTestRetries=1 -PmaxTestRetryFailures=5 
               gradle_exit=$?
               
-              # Check and exit accordingly
+              # Check and gradle exit accordingly
               if [ "$gradle_exit" -ne 0 ]; then
                 echo "❌ Gradle exited with code $gradle_exit — failing the job."
                 exit "$gradle_exit"
               else
                 echo "✅ Gradle completed successfully (exit code 0)."
               fi
+              
+              shopt -s globstar
+              python scripts/check_test_failures.py **/build/test-results/**/TEST-*.xml
+              check_exit=$?
+
+              test-results publish --name Test-Suite --trim-output-to 1024 --omit-output-for-passed **/build/test-results/**/TEST-*.xml || true
+
+              # Check if check_test_failures.py returned non-zero exit code
+              if [ "$check_exit" -ne 0 ]; then
+                echo "❌ check_test_failures.py returned $check_exit"
+                exit "$check_exit"
+              fi
           execution_time_limit:
             minutes: 120
       epilogue:
         always:
           commands:
-            - shopt -s globstar && test-results publish --name Test-Suite --trim-output-to 1024 --omit-output-for-passed **/build/test-results/**/TEST-*.xml
             - |
               echo "Job creation time: $((SEMAPHORE_JOB_CREATION_TIME * 1000))"
               echo "Current time: $(date +%s%3N)"

--- a/scripts/check_test_failures.py
+++ b/scripts/check_test_failures.py
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import glob
+from xml.etree import ElementTree
+from junitparser import JUnitXml
+
+
+def count_test_results(xml_files):
+    total_passed = 0
+    total_failures = 0
+    total_rerun_failures = 0
+    total_skipped = 0
+
+    for junit_xml_file in xml_files:
+        print(f"Reading file - {junit_xml_file}")
+        passed = 0
+        skipped = 0
+        failures = 0
+        rerun_failures = 0
+        try:
+            xml = JUnitXml.fromfile(junit_xml_file)
+            passed = xml.tests - xml.failures - xml.skipped
+            skipped = xml.skipped
+
+            context = ElementTree.iterparse(junit_xml_file, events=("start", "end"))
+            failures, rerun_failures = parse_failures_and_rerun_tests(context)
+
+            print(f"Counts from file: {junit_xml_file}. Passed={passed}, "
+                  f"Failures={failures}, rerun failures={rerun_failures}, skipped={skipped}")
+
+        except Exception as e:
+            print(f"Unexpected error while processing test xml for {junit_xml_file}: {e}")
+            failures += failures
+
+        total_passed += passed
+        total_failures += failures
+        total_rerun_failures += rerun_failures
+        total_skipped += skipped
+
+    return total_passed, total_failures, total_rerun_failures, total_skipped
+
+def parse_failures_and_rerun_tests(context):
+    failures = 0
+    rerun_failures = 0
+    for event, elem in context:
+        if event == "start" and elem.tag == "testcase":
+            testcase_has_failure = False
+            testcase_has_rerun_failure = False
+        elif event == "end" and elem.tag == "testcase":
+            if testcase_has_failure and not testcase_has_rerun_failure:
+                failures += 1
+            elif testcase_has_rerun_failure:
+                rerun_failures += 1
+        elif event == "end" and elem.tag == "failure":
+            testcase_has_failure = True
+        elif event == "end" and (elem.tag == "rerunFailure" or elem.tag == "rerunError"):
+            testcase_has_rerun_failure = True
+    return failures, rerun_failures
+
+def main():
+    xml_files = []
+    for path in sys.argv[1:]:
+        xml_files.extend(glob.glob(path, recursive=True))
+
+    passed, failures, rerun_failures, skipped = count_test_results(xml_files)
+
+    print(f"Test results:\nPassed: {passed}, Failures: {failures}, Rerun Failures: {rerun_failures}, "
+          f"Skipped: {skipped}")
+
+    if rerun_failures > 0 or failures > 0:
+        sys.exit(rerun_failures + failures)
+
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* **Issue:** The `confluent/kafka` builds are currently not reporting test failures in GitHub checks — the status always appears as green, even when tests fail.
  **Examples:**

  * [https://github.com/confluentinc/kafka/pull/1813](https://github.com/confluentinc/kafka/pull/1813)
  * [https://github.com/confluentinc/kafka/pull/1810](https://github.com/confluentinc/kafka/pull/1810)

- Updated the Semaphore configuration to ensure the build job fails when Gradle tests fail.
- Added `scripts/check_test_failures.py` (from the `ce-kafka/7.4.x` repository) to parse and detect test failures.
