### PR TITLE
MINOR: More conservative build host. (#1831)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,7 +17,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu24-04-arm64-4
+    type: s1-prod-ubuntu24-04-arm64-3
 fail_fast:
   cancel:
     when: "true"
@@ -99,7 +99,7 @@ blocks:
             - |
               ./gradlew \
                 unitTest integrationTest --no-daemon --stacktrace --continue \
-                -PtestLoggingEvents=started,passed,skipped,failed -PmaxParallelForks=4 \
+                -PtestLoggingEvents=started,passed,skipped,failed -PmaxParallelForks=2 \
                 -PignoreFailures=true -PmaxTestRetries=1 -PmaxTestRetryFailures=5 
               gradle_exit=$?
               

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,5 +28,5 @@ scalaVersion=2.13.16
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 swaggerVersion=2.2.25
 task=build
-org.gradle.jvmargs=-Xmx2g -Xss100m -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx6g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true


### PR DESCRIPTION
* AK uses gradle based build system on ASF hosted machines, whose public information is not readily available. However, looking at the recommendations for donors: https://infra.apache.org/hosting-external-agent.html, we see host with min 16GB is required.
* Existing host appears to be too generous, changing the type to be more conservative (s1-prod-ubuntu24-04-arm64-3)
