### PR TITLE
MINOR: Move the gradle jvmargs to Semaphore Tests step

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -99,6 +99,7 @@ blocks:
             - |
               ./gradlew \
                 unitTest integrationTest --no-daemon --stacktrace --continue \
+                -Dorg.gradle.jvmargs="-Xmx6g -Xss4m -XX:+UseParallelGC" \
                 -PtestLoggingEvents=started,passed,skipped,failed -PmaxParallelForks=2 \
                 -PignoreFailures=true -PmaxTestRetries=1 -PmaxTestRetryFailures=5 
               gradle_exit=$?

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,5 +28,5 @@ scalaVersion=2.13.15
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 swaggerVersion=2.2.25
 task=build
-org.gradle.jvmargs=-Xmx6g -Xss4m -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx2g -Xss100m -XX:+UseParallelGC
 org.gradle.parallel=true


### PR DESCRIPTION
- move gradle jvmargs changes to Semaphore CI from gradle.properties 