### PR TITLE
Merge remote-tracking branch 'apache-kafka/4.1' into ccs/4.1

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/HdrHistogram.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/HdrHistogram.java
@@ -92,12 +92,12 @@ public final class HdrHistogram {
     }
 
     /**
-     * Writes to the histogram. Caps recording to highestTrackableValue
+     * Writes to the histogram. Caps recording between 0 and highestTrackableValue.
      *
-     * @param value The value to be recorded. Cannot be negative.
+     * @param value The value to be recorded.
      */
     public void record(long value) {
-        recorder.recordValue(Math.min(value, highestTrackableValue));
+        recorder.recordValue(Math.min(Math.max(value, 0), highestTrackableValue));
     }
 
     /**

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/HdrHistogramTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/HdrHistogramTest.java
@@ -216,10 +216,14 @@ public class HdrHistogramTest {
 
     @Test
     public void testRecordLimit() {
+        long now = System.currentTimeMillis();
         long highestTrackableValue = 10L;
         HdrHistogram hdrHistogram = new HdrHistogram(10L, highestTrackableValue, 3);
 
         hdrHistogram.record(highestTrackableValue + 1000L);
-        assertEquals(highestTrackableValue, hdrHistogram.max(System.currentTimeMillis()));
+        assertEquals(highestTrackableValue, hdrHistogram.max(now));
+
+        hdrHistogram.record(-50L);
+        assertEquals(0, hdrHistogram.max(now + 1000L));
     }
 }

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -2023,3 +2023,29 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     def java_class_name(self):
         return "kafka\.Kafka"
+
+    def describe_consumer_group_members(self, group, node=None, command_config=None):
+        """ Describe a consumer group.
+        """
+        if node is None:
+            node = self.nodes[0]
+        consumer_group_script = self.path.script("kafka-consumer-groups.sh", node)
+
+        if command_config is None:
+            command_config = ""
+        else:
+            command_config = "--command-config " + command_config
+
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --bootstrap-server %s %s --group %s --describe" % \
+               (consumer_group_script,
+                self.bootstrap_servers(self.security_protocol),
+                command_config, group)
+
+        cmd += " --members"
+
+        output_lines = []
+        for line in node.account.ssh_capture(cmd):
+            if not (line.startswith("SLF4J") or line.startswith("GROUP") or line.strip() == ""):
+                output_lines.append(line.strip())
+        return output_lines


### PR DESCRIPTION
```
    Conflicts:
            tests/kafkatest/services/kafka/kafka.py
             - minor conflict due to additional method deprecated_cp_java_class_name in ccs
```