### PR TITLE
update jersey version

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -71,7 +71,7 @@ versions += [
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
   jetty: "12.0.25",
-  jersey: "3.1.9",
+  jersey: "3.1.11",
   jline: "3.25.1",
   jmh: "1.37",
   hamcrest: "2.2",


### PR DESCRIPTION
Update jersey version to address cve: 

In Eclipse Jersey versions 2.45, 3.0.16, 3.1.9 a race condition can cause ignoring of critical SSL configurations - such as mutual authentication, custom key/trust stores, and other security settings. This issue may result in SSLHandshakeException under normal circumstances, but under certain conditions, it could lead to unauthorized trust in insecure servers (see PoC)

Updating to version 3.1.11