### PR TITLE
Use same host as trunk (Backport #1831)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,7 +17,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu24-04-arm64-1
+    type: s1-prod-ubuntu24-04-arm64-3
 fail_fast:
   cancel:
     when: "true"

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,5 +28,5 @@ scalaVersion=2.13.15
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 swaggerVersion=2.2.25
 task=build
-org.gradle.jvmargs=-Xmx2g -Xss100m -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx6g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true


### PR DESCRIPTION
This is a backport of https://github.com/confluentinc/kafka/pull/1831, matching the host size, as recent builds on `8.0.2-*` branches triggerd the OOM killer.

- `s1-prod-ubuntu24-04-amd64-1` (which we currently use for `8.0.2-cp3`) is [c6a.xlarge](https://aws.amazon.com/ec2/instance-types/c6a/) - 4 CPU cores, 8 G RAM, 80G disk.
- s1-prod-ubuntu24-04-amd64-3` (which this PR bumps to) is 
[c6a.4xlarge](https://aws.amazon.com/ec2/instance-types/c6a/) - 16 CPU cores, 32 G RAM, 200G disk.

---

* AK uses gradle based build system on ASF hosted machines, whose public information is not readily available. However, looking at the recommendations for donors: https://infra.apache.org/hosting-external-agent.html, we see host with min 16GB is required.
* Existing host appears to be too generous, changing the type to be more conservative (s1-prod-ubuntu24-04-arm64-3)

Co-authored-by: Sushant Mahajan <smahajan@confluent.io>
