### PR TITLE
[KSECURITY-2646] Bump at.yawk.lz4:lz4-java to mitigate CVE-2025-66566

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -108,7 +108,7 @@ versions += [
   kafka_32: "3.2.3",
   kafka_33: "3.3.1",
   kafka_34: "3.4.1",
-  lz4: "1.8.1",
+  lz4: "1.10.2",
   mavenArtifact: "3.8.8",
   metrics: "2.2.0",
   mockito: "4.9.0",


### PR DESCRIPTION
Bump `at.yawk.lz4:lz4-java` to mitigate CVE-2025-66566.