### PR TITLE
[KSECURITY-2646] Bump at.yawk.lz4:lz4-java to mitigate CVE-2025-66566

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -127,7 +127,7 @@ versions += [
   kafka_33: "3.3.2",
   kafka_34: "3.4.1",
   kafka_35: "3.5.2",
-  lz4: "1.8.1",
+  lz4: "1.10.2",
   mavenArtifact: "3.8.8",
   metrics: "2.2.0",
   netty: "4.1.125.Final",


### PR DESCRIPTION
Bump `at.yawk.lz4:lz4-java` to mitigate CVE-2025-66566.