### PR TITLE
[KSECURITY-2644] Fix CVE-2025-12383: org.glassfish.jersey.core:jersey-client in kafka

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
   jetty: "12.0.25",
-  jersey: "3.1.9",
+  jersey: "3.1.10",
   jline: "3.25.1",
   jmh: "1.37",
   hamcrest: "2.2",


### PR DESCRIPTION
The current version of jersey-client used (3.1.9) has a known vulnerability, CVE-2025-12383. Bump the version of jersey used to 3.1.10 to fix it.

