### PR TITLE
[KSECURITY-2653] Bump jose4j to 0.9.6 to mitigate CVE-2024-29371

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -82,7 +82,7 @@ versions += [
   jakartaServletApi: "6.1.0",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
-  jose4j: "0.9.4",
+  jose4j: "0.9.6",
   junit: "5.10.2",
   jqwik: "1.8.3",
   kafka_0110: "0.11.0.3",


### PR DESCRIPTION
Bump jose4j to 0.9.6 to mitigate CVE-2024-29371
