### PR TITLE
[KSECURITY-2650] Bump log4j to 2.25.3 to mitigate CVE-2025-68161

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Loggers.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Loggers.java
@@ -202,7 +202,7 @@ public class Loggers {
         LoggerContext context = (LoggerContext) LogManager.getContext(false);
         var results = new HashMap<String, org.apache.logging.log4j.Logger>();
         context.getConfiguration().getLoggers().forEach((name, logger) -> results.put(name, LogManager.getLogger(name)));
-        context.getLoggerRegistry().getLoggers().forEach(logger -> results.put(logger.getName(), logger));
+        context.getLoggers().forEach(logger -> results.put(logger.getName(), logger));
         return results;
     }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -107,7 +107,7 @@ versions += [
   kafka_37: "3.7.2",
   kafka_38: "3.8.1",
   kafka_39: "3.9.0",
-  log4j2: "2.24.3",
+  log4j2: "2.25.3",
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   lz4: "1.10.1",
   mavenArtifact: "3.9.6",


### PR DESCRIPTION
Delete this text and replace it with a detailed description of your change. The 
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including 
rationale) for the proposed change. Unit and/or integration tests are expected
for any behavior change and system tests should be considered for larger
changes.
