### PR TITLE
MINOR: Fix JDK version, architecture parameters and SSL certificate verification in system tes

### DIFF
--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -61,6 +61,7 @@ elif [[ ! "$JDK_FULL" =~ ^[0-9]+(u[0-9]+|(\.[0-9]+)+)?-linux-(x64|aarch64)$ ]]; 
 fi
 
 echo "JDK_MAJOR=$JDK_MAJOR JDK_ARCH=$JDK_ARCH JDK_FULL=$JDK_FULL"
+export DEBIAN_FRONTEND=noninteractive
 
 if [ -z `which javac` ]; then
     apt-get -y update

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -96,7 +96,8 @@ get_kafka() {
 }
 
 # Install Kibosh
-apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev
+apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev ca-certificates
+update-ca-certificates --fresh
 pushd /opt
 rm -rf /opt/kibosh
 git clone -q  https://github.com/confluentinc/kibosh.git

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -32,14 +32,35 @@ fetch_jdk_tgz() {
 
   if [ ! -e $path ]; then
     mkdir -p $(dirname $path)
-    curl --retry 5 -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-${jdk_version}.tar.gz" -o $path
+    curl --retry 5 -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk/jdk-${jdk_version}.tar.gz" -o $path
   fi
 }
 
-JDK_MAJOR="${JDK_MAJOR:-17}"
-JDK_FULL="${JDK_FULL:-17-linux-x64}"
-echo "JDK_MAJOR=$JDK_MAJOR JDK_ARCH=$JDK_ARCH"
-export DEBIAN_FRONTEND=noninteractive
+# Validate JDK_MAJOR - must be a version number (e.g., 17, 25.0.1), default to 17 if empty or invalid
+if [[ -z "$JDK_MAJOR" ]]; then
+    JDK_MAJOR="17"
+elif [[ ! "$JDK_MAJOR" =~ ^[0-9]+(u[0-9]+|(\.[0-9]+)+)?$ ]]; then
+    echo "WARNING: Invalid JDK_MAJOR format '$JDK_MAJOR'. Expected format: 17, 21.0.1, 25.0.2. Defaulting to 17."
+    JDK_MAJOR="17"
+fi
+
+# Validate JDK_ARCH - default to x64 if empty or invalid
+if [[ -z "$JDK_ARCH" ]]; then
+    JDK_ARCH="x64"
+elif [[ ! "$JDK_ARCH" =~ ^(x64|aarch64)$ ]]; then
+    echo "WARNING: Invalid JDK_ARCH format '$JDK_ARCH'. Expected: x64 or aarch64. Defaulting to x64."
+    JDK_ARCH="x64"
+fi
+
+# Use JDK_FULL if provided and valid, otherwise construct from JDK_MAJOR and JDK_ARCH
+if [[ -z "$JDK_FULL" ]]; then
+    JDK_FULL="${JDK_MAJOR}-linux-${JDK_ARCH}"
+elif [[ ! "$JDK_FULL" =~ ^[0-9]+(u[0-9]+|(\.[0-9]+)+)?-linux-(x64|aarch64)$ ]]; then
+    echo "WARNING: Invalid JDK_FULL format '$JDK_FULL'. Constructing from JDK_MAJOR and JDK_ARCH."
+    JDK_FULL="${JDK_MAJOR}-linux-${JDK_ARCH}"
+fi
+
+echo "JDK_MAJOR=$JDK_MAJOR JDK_ARCH=$JDK_ARCH JDK_FULL=$JDK_FULL"
 
 if [ -z `which javac` ]; then
     apt-get -y update


### PR DESCRIPTION
Cherry pick
https://github.com/apache/kafka/pull/21394
https://github.com/apache/kafka/pull/21431

System Test Branch builder for 4.2 failing with this 
https://semaphore.ci.confluent.io/jobs/859f45d1-43dd-4fbc-8e38-b12a8c0f7855#L2995
`'https://github.com/confluentinc/kibosh.git/': server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none`

similar fix we did in trunk : https://github.com/apache/kafka/pull/21431
