### PR TITLE
MINOR: Fix SSL certificate verification failure in system test worker provisioning

### DIFF
--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -96,7 +96,8 @@ get_kafka() {
 }
 
 # Install Kibosh
-apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev
+apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev ca-certificates
+update-ca-certificates --fresh
 pushd /opt
 rm -rf /opt/kibosh
 git clone -q  https://github.com/confluentinc/kibosh.git


### PR DESCRIPTION
## Summary
- Backport fix for SSL certificate verification failure during system test AMI provisioning
- Cherry-pick of ee72f90742088b401af7572c7cb499394c0521f7 from master

## Problem
System tests on branch 4.0 are failing during Packer AMI build with:
```
server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
```

This occurs when provisioning scripts attempt to `git clone` repositories (e.g., `confluentinc/kibosh.git`) on the worker AMI.

**Failed Job:** https://semaphore.ci.confluent.io/jobs/8767b502-9a3a-4916-9f7f-84edffa71379#L3567

## Root Cause
SSL/TLS certificate verification is failing due to outdated or missing CA certificates in the base AMI.

## Fix
Apply the SSL certificate fix from master (#21431) to ensure proper certificate verification during worker provisioning.

## Test Plan
- [ ] Verify system tests pass on 4.0 branch after this change

---


