### PR TITLE
MINOR: Fix SSL certificate verification failure in system test worker provisioning

### DIFF
--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -96,7 +96,8 @@ get_kafka() {
 }
 
 # Install Kibosh
-apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev
+apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev ca-certificates
+update-ca-certificates --fresh
 pushd /opt
 rm -rf /opt/kibosh
 git clone -q  https://github.com/confluentinc/kibosh.git


### PR DESCRIPTION
## Summary
- Backport fix for SSL certificate verification failure during system test AMI provisioning
- Cherry-pick of ee72f90742088b401af7572c7cb499394c0521f7 from master

## Problem
System tests on branch 3.8 are failing during Packer AMI build with:
```
server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
```

This occurs when provisioning scripts attempt to `git clone` repositories (e.g., `confluentinc/kibosh.git`) on the worker AMI.

**Failed Job:** https://semaphore.ci.confluent.io/jobs/f134e346-c2ea-4f15-8184-7353c52d2913#L4300
https://semaphore.ci.confluent.io/projects/kafka-overlay/schedulers/37aa4f0b-3b01-4f5a-9d0b-2a2a709b451a

## Root Cause
SSL/TLS certificate verification is failing due to outdated or missing CA certificates in the base AMI.

## Fix
Apply the SSL certificate fix from master (#21431) to ensure proper certificate verification during worker provisioning.

## Test Plan
- [ ] Verify system tests pass on 3.8 branch after this change

---


