### PR TITLE
MINOR: Fix SSL certificate verification failure in system test worker provisioning

### DIFF
--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -96,7 +96,8 @@ get_kafka() {
 }
 
 # Install Kibosh
-apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev
+apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev ca-certificates
+update-ca-certificates --fresh
 pushd /opt
 rm -rf /opt/kibosh
 git clone -q  https://github.com/confluentinc/kibosh.git


### PR DESCRIPTION
Similar fix has been merged in trunk : https://github.com/apache/kafka/pull/21431

Update CA certificates on Ubuntu 14.04 Vagrant workers to fix SSL certificate  verification failures when cloning the kibosh repository during system test setup.

### Problem

Starting around February 7-9, 2026, system tests using Vagrant workers began  failing during worker provisioning with the following error:

```
fatal: unable to access 'https://github.com/confluentinc/kibosh.git/':
server certificate verification failed. CAfile:
/etc/ssl/certs/ca-certificates.crt CRLfile: none
```

**Root Cause:** The Vagrant workers use Ubuntu 14.04 (Trusty), which reached
end-of-life in April 2019. The CA certificate bundle on these workers is outdated
and does not include the certificate authorities needed to verify GitHub's current
SSL certificate chain. GitHub (or their CA provider) rotated certificates, causing
the verification to fail on systems with older CA bundles.

### Solution

Refresh the CA certificate store during worker provisioning by:
1. Installing/updating the `ca-certificates` package
2. Running `update-ca-certificates --fresh` to rebuild the certificate store

This ensures workers have an updated certificate store that can verify GitHub's  SSL certificate chain.


