### PR TITLE
Fix shouldSign regex to handle nano version hotfix segment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ ext {
   userMaxTestRetryFailures = project.hasProperty('maxTestRetryFailures') ? maxTestRetryFailures.toInteger() : 0
 
   skipSigning = project.hasProperty('skipSigning') && skipSigning.toBoolean()
-  shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && !version.contains("-alpha") && !version.matches("[0-9]*\\.[0-9]*\\.[0-9]*-[0-9]*-(ccs|ce)")
+  shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && !version.contains("-alpha") && !version.matches("[0-9]*\\.[0-9]*\\.[0-9]*(-[0-9]+)*-(ccs|ce)")
 
   mavenUrl = propertyOrElse(project, 'mavenUrl', '')
   mavenUsername = propertyOrElse(project, 'mavenUsername', '')


### PR DESCRIPTION
## Summary
- The `ci-tools` nano versioning change (DP-17963) introduced a hotfix segment to version strings (e.g., `8.2.1-1-0-ccs` instead of `8.2.1-1-ccs`)
- The `shouldSign` regex in `build.gradle` only matched a single numeric segment before the `-ccs`/`-ce` qualifier, so it failed to recognize nano versions as internal builds
- This caused `shouldSign` to evaluate to `true`, and the build failed because no GPG signatory is configured on CI agents
- Updated the regex from `[0-9]*\.[0-9]*\.[0-9]*-[0-9]*-(ccs|ce)` to `[0-9]*\.[0-9]*\.[0-9]*(-[0-9]+)*-(ccs|ce)` to allow multiple dash-separated numeric segments

## Why this is safe
- The only change is making the ccs/ce version regex more permissive — it still matches all previously matched versions
- The `(-[0-9]+)*` group allows one or more dash-number segments, covering both old (`8.2.1-1-ccs`) and new (`8.2.1-1-0-ccs`) nano version formats
- Non-ccs/ce versions (e.g., Apache releases) are unaffected since they don't end in `-ccs` or `-ce`

## Why this is in the 3.6 branch
All branches from 3.6 through master have the same broken regex. Fixing in 3.6 allows the fix to cascade forward via merges.

## Test plan
- [ ] Verify CI build passes on this branch with nano versioning enabled
- [ ] Confirm `shouldSign` evaluates to `false` for versions like `8.2.1-1-0-ccs`