### PR TITLE
CPKAFKA-12204: Fix StreamsGroupCommand not displaying offsets for repartition topics

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -460,12 +460,15 @@ public class StreamsGroupCommand {
 
         Map<TopicPartition, OffsetAndMetadata> getCommittedOffsets(String groupId) {
             try {
-                var sourceTopics = adminClient.describeStreamsGroups(
+                var subtopologies = adminClient.describeStreamsGroups(
                     List.of(groupId),
                     withTimeoutMs(new DescribeStreamsGroupsOptions())
                 ).all().get().get(groupId)
-                    .subtopologies().stream()
-                    .flatMap(subtopology -> subtopology.sourceTopics().stream())
+                    .subtopologies();
+                var sourceTopics = subtopologies.stream()
+                    .flatMap(subtopology -> Stream.concat(
+                        subtopology.sourceTopics().stream(),
+                        subtopology.repartitionSourceTopics().keySet().stream()))
                     .collect(Collectors.toSet());
 
                 var allTopicPartitions = adminClient.listStreamsGroupOffsets(


### PR DESCRIPTION
The `kafka-streams-groups.sh --describe` command does not display committed offsets for repartition topics. They show as `-` instead of actual values, while offset data for regular source topics is displayed correctly.

The root cause is in `StreamsGroupCommand.getCommittedOffsets()`, which filters committed offsets to only include topics from `subtopology.sourceTopics()`. Repartition topics are listed under `repartitionSourceTopics()` instead, so their committed offsets get dropped. Meanwhile, `getTopicPartitions()` correctly includes both `sourceTopics()` and `repartitionSourceTopics()` when determining which topic-partitions to display, so repartition topics appear in the output but without their offset data.

The fix adds `repartitionSourceTopics()` to the filter in `getCommittedOffsets()`, consistent with what `getTopicPartitions()` already does.