### PR TITLE
KSECURITY-2677: bump Jetty 12.0.25 -> 12.0.32

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jackson: "2.16.2",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
-  jetty: "12.0.25",
+  jetty: "12.0.32",
   jersey: "3.1.11",
   jline: "3.25.1",
   jmh: "1.37",


### PR DESCRIPTION
## Summary
- Bump Jetty from 12.0.25 to 12.0.32 to fix CVE-2025-11143
- Updated version in `gradle/dependencies.gradle`

## Verification
Ran `./gradlew :connect:runtime:dependencies` and confirmed all Jetty artifacts resolved to 12.0.32:

```
+--- org.eclipse.jetty:jetty-http:{strictly 12.0.32} -> 12.0.32 (c)
+--- org.eclipse.jetty:jetty-server:12.0.32
+--- org.eclipse.jetty:jetty-client:12.0.32
+--- org.eclipse.jetty.ee10:jetty-ee10-servlet:12.0.32
+--- org.eclipse.jetty.ee10:jetty-ee10-servlets:12.0.32
```

Grep for `12.0.25` in dependency tree returns zero matches — vulnerable version fully excluded.

## Test plan
- [ ] CI passes on 8.0.2-cp6 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)