### PR TITLE
KSECURITY-2675: bump jackson 2.16.2 -> 2.18.6

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -67,7 +67,7 @@ versions += [
   gradle: "8.10.2",
   grgit: "4.1.1",
   httpclient: "4.5.14",
-  jackson: "2.16.2",
+  jackson: "2.18.6",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
   jetty: "12.0.25",


### PR DESCRIPTION
## Summary
- Bump Jackson from 2.16.2 to 2.18.6 to fix GHSA-72hv-8253-57qq in jackson-core
- Updated version in `gradle/dependencies.gradle`

## Verification
Ran `./gradlew :clients:dependencies` and confirmed all jackson-core resolved to 2.18.6:

```
+--- com.fasterxml.jackson.core:jackson-core:{strictly 2.18.6} -> 2.18.6 (c)
+--- com.fasterxml.jackson.core:jackson-core:2.18.6
```

Grep for `jackson-core.*2.16` in dependency tree returns zero matches — vulnerable version fully excluded.

## Test plan
- [ ] CI passes on 8.0.2-cp6 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)