### PR TITLE
Revert "KSECURITY-2677: bump Jetty 12.0.25 -> 12.0.32"

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jackson: "2.18.6",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
-  jetty: "12.0.32",
+  jetty: "12.0.25",
   jersey: "3.1.11",
   jline: "3.25.1",
   jmh: "1.37",


### PR DESCRIPTION
## Summary
- Reverts #1974 (Jetty 12.0.25 -> 12.0.32 bump)
- Jetty upgrade in CP 8.0+ is on hold until Jetty 12.0.34 with fluent logging removed
- See [Slack thread](https://confluent.slack.com/archives/C04JK67QSQ3/p1774368137082869?thread_ts=1774284016.758729&cid=C04JK67QSQ3) for context

## Test plan
- [ ] CI passes on 8.0.2-cp6 branch