### PR TITLE
KSECURITY-2672: Upgrade Jackson from 2.16.0 to 2.18.6 (3.4)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -68,7 +68,7 @@ versions += [
   grgit: "4.1.1",
   httpclient: "4.5.14",
   easymock: "4.3",
-  jackson: "2.16.0",
+  jackson: "2.18.6",
   jacksonDatabind: "2.13.5",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",


### PR DESCRIPTION
## Summary
- Upgrade `com.fasterxml.jackson.core` from 2.16.0 to 2.18.6 to fix **GHSA-72hv-8253-57qq**
- Jira: https://confluentinc.atlassian.net/browse/KSECURITY-2672

## Test plan
- [ ] Verify Jackson dependency version: `./gradlew allDeps | grep jackson-core`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)