### PR TITLE
KSECURITY-2670: Upgrade ZooKeeper from 3.8.4 to 3.8.6 (3.5)

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2196,7 +2196,7 @@ class ReplicaManagerTest {
         .setLeaderEpoch(leaderEpochFromLeader)
         .setEndOffset(offsetFromLeader)).asJava,
       BrokerEndPoint(1, "host1" ,1), time)
-    val replicaManager = new ReplicaManager(
+    val replicaManager: ReplicaManager = new ReplicaManager(
       metrics = metrics,
       config = config,
       time = time,

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ group=org.apache.kafka
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - streams/quickstart/java/pom.xml
 version=7.5.14-0-ccs
-scalaVersion=2.13.10
+scalaVersion=2.13.11
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -27,8 +27,8 @@ ext {
 }
 
 // Add Scala version
-def defaultScala212Version = '2.12.15'
-def defaultScala213Version = '2.13.10'
+def defaultScala212Version = '2.12.18'
+def defaultScala213Version = '2.13.11'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.12') {
     versions["scala"] = defaultScala212Version

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -131,7 +131,7 @@ versions += [
   swaggerAnnotations: "2.2.8",
   swaggerJaxrs2: "2.2.8",
   zinc: "1.8.0",
-  zookeeper: "3.8.4",
+  zookeeper: "3.8.6",
   zstd: "1.5.5-1"
 ]
 libs += [


### PR DESCRIPTION
## Summary
- Upgrade `org.apache.zookeeper:zookeeper` from 3.8.4 to 3.8.6 to fix **CVE-2026-24281**
- Jira: https://confluentinc.atlassian.net/browse/KSECURITY-2670

## Build fixups required by the ZooKeeper upgrade
ZooKeeper 3.8.6 (and its bumped transitive deps — slf4j 2.0.x, logback 1.3.x, jline 3.x, netty 4.1.130, jetty 9.4.58) ships class files that the Scala 2.13.10 / 2.12.15 classfile parser cannot decode, manifesting as `bad constant pool index: 0 at pos: 1449` while compiling `core/src/main/scala/kafka/admin/AclCommand.scala`. The 2.13.11 / 2.12.18 patch releases fixed the parser. Three follow-on changes were therefore needed in this PR:

1. **`gradle.properties`** — `scalaVersion` 2.13.10 → 2.13.11 (fixes the main `core:compileScala` task).
2. **`gradle/dependencies.gradle`** — `defaultScala212Version` 2.12.15 → 2.12.18 and `defaultScala213Version` 2.13.10 → 2.13.11 (fixes the `make check-scala-compatibility` cross-compile that runs `-PscalaVersion=2.12`).
3. **`core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala`** — added explicit `: ReplicaManager` type to the recursive `val replicaManager`, which Scala 2.13.11 newly requires (its inner `override createFetcherThread` body references `replicaManager`, making it self-referential).

## Test plan
- [ ] Verify ZooKeeper dependency version in dependency tree: `./gradlew allDeps | grep zookeeper`
- [ ] CI passes (build + cross-compile + unit/integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)