### PR TITLE
KSECURITY-2670: Upgrade ZooKeeper from 3.8.4 to 3.8.6 (3.8)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -170,7 +170,7 @@ versions += [
   snappy: "1.1.10.5",
   spotbugs: "4.8.0",
   zinc: "1.9.2",
-  zookeeper: "3.8.4",
+  zookeeper: "3.8.6",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   zstd: "1.5.6-4"


### PR DESCRIPTION
## Summary
- Upgrade `org.apache.zookeeper:zookeeper` from 3.8.4 to 3.8.6 to fix **CVE-2026-24281**
- Jira: https://confluentinc.atlassian.net/browse/KSECURITY-2670

## Test plan
- [ ] Verify ZooKeeper dependency version in dependency tree: `./gradlew allDeps | grep zookeeper`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)