### PR TITLE
KSECURITY-2672: Upgrade Jackson from 2.16.2 to 2.18.6 (3.7)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -106,7 +106,7 @@ versions += [
   gradle: "8.6",
   grgit: "4.1.1",
   httpclient: "4.5.14",
-  jackson: "2.16.2",
+  jackson: "2.18.6",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
   jetty: "9.4.59",


### PR DESCRIPTION
## Summary
- Upgrade `com.fasterxml.jackson.core` from 2.16.2 to 2.18.6 to fix **GHSA-72hv-8253-57qq**
- Jira: https://confluentinc.atlassian.net/browse/KSECURITY-2672

## Test plan
- [ ] Verify Jackson dependency version: `./gradlew allDeps | grep jackson-core`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)