### PR TITLE
KSECURITY-2672: Upgrade Jackson from 2.19.4 to 2.21.1 (4.1)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -63,7 +63,7 @@ versions += [
   gradle: "8.14.1",
   grgit: "4.1.1",
   httpclient: "4.5.14",
-  jackson: "2.19.4",
+  jackson: "2.21.1",
   jacoco: "0.8.13",
   javassist: "3.30.2-GA",
   // When upgrading Jetty, verify that it does not use the SLF4J 2.x fluent API


### PR DESCRIPTION
## Summary
- Upgrade `com.fasterxml.jackson.core` from 2.19.4 to 2.21.1 to fix **GHSA-72hv-8253-57qq**
- Jira: https://confluentinc.atlassian.net/browse/KSECURITY-2672

## Test plan
- [ ] Verify Jackson dependency version: `./gradlew allDeps | grep jackson-core`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)