### PR TITLE
Fix flaky SecurityTest.test_client_ssl_endpoint_validation_failure [KSECURITY-1974]

### DIFF
--- a/tests/kafkatest/tests/core/security_test.py
+++ b/tests/kafkatest/tests/core/security_test.py
@@ -52,7 +52,7 @@ class SecurityTest(EndToEndTest):
                 node.account.ssh("grep %s %s" % (error, self.producer.LOG_FILE))
             for node in self.consumer.nodes:
                 node.account.ssh("grep %s %s" % (error, self.consumer.LOG_FILE))
-        except RemoteCommandError:
+        except (RemoteCommandError, TimeoutError):
             return False
 
         return True
@@ -115,7 +115,7 @@ class SecurityTest(EndToEndTest):
                 pass
 
             error = 'SSLHandshakeException' if security_protocol == 'SSL' else 'INVALID_REPLICATION_FACTOR'
-            wait_until(lambda: self.producer_consumer_have_expected_error(error), timeout_sec=30)
+            wait_until(lambda: self.producer_consumer_have_expected_error(error), timeout_sec=60)
             self.producer.stop()
             self.consumer.stop()
 


### PR DESCRIPTION
## Summary
- Fixes flaky test: `kafkatest.tests.core.security_test.SecurityTest.test_client_ssl_endpoint_validation_failure`
- Root cause: `producer_consumer_have_expected_error` only caught `RemoteCommandError` but not `TimeoutError`. When SSH connections to remote nodes time out during log grep operations, the `TimeoutError` propagates up and fails the test instead of being treated as "error not yet found".
- Fix:
  - Catch `TimeoutError` in addition to `RemoteCommandError` in `producer_consumer_have_expected_error` so SSH timeouts are retried
  - Increase `wait_until` timeout from 30s to 60s for the expected error grep to accommodate slow environments

## Jira
KSECURITY-1974: https://confluentinc.atlassian.net/browse/KSECURITY-1974

## Test plan
- [ ] Semaphore CI passes on this branch
- [ ] Verify the test no longer fails intermittently with SSH `TimeoutError`

Generated with [Claude Code](https://claude.com/claude-code)