### PR TITLE
Fix flaky SecurityRollingUpgrade.test_rolling_upgrade_sasl_mechanism_phase_two [KSECURITY-2393]

### DIFF
--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -39,6 +39,8 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
         self.producer_throughput = 100
         self.num_producers = 1
         self.num_consumers = 1
+        self.producer_start_timeout_sec = 60
+        self.consumer_start_timeout_sec = 120
         self.zk = ZookeeperService(self.test_context, num_nodes=1)
         self.kafka = KafkaService(self.test_context, num_nodes=3, zk=self.zk, topics={self.topic: {
             "partitions": 3,


### PR DESCRIPTION
## Summary
- Fixes flaky test: `TestSecurityRollingUpgrade.test_rolling_upgrade_sasl_mechanism_phase_two`
- Root cause: Default `producer_start_timeout_sec` (20s) and `consumer_start_timeout_sec` (60s) from `ProduceConsumeValidateTest` are too tight for SASL mechanism rolling upgrade scenarios where brokers need extra time to stabilize after bouncing with security config changes
- Fix: Override timeouts in `setUp()` — producer timeout increased to 60s, consumer timeout to 120s

## Jira
- KSECURITY-2393: https://confluentinc.atlassian.net/browse/KSECURITY-2393

## Test plan
- [ ] CI passes on this branch
- [ ] `test_rolling_upgrade_sasl_mechanism_phase_two` no longer fails intermittently with producer/consumer timeouts

Generated with [Claude Code](https://claude.com/claude-code)