### PR TITLE
Revert "KSECURITY-2670: Upgrade ZooKeeper from 3.8.4 to 3.8.6" (3.8)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -170,7 +170,7 @@ versions += [
   snappy: "1.1.10.5",
   spotbugs: "4.8.0",
   zinc: "1.9.2",
-  zookeeper: "3.8.6",
+  zookeeper: "3.8.4",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   zstd: "1.5.6-4"


### PR DESCRIPTION
Reverts #2001.

## Summary
Revert the ZooKeeper 3.8.4 → 3.8.6 upgrade (KSECURITY-2670) because it silently disables broker logging, breaking every system test.

## Root cause
ZooKeeper 3.8.5+'s parent POM declares `<slf4j.version>2.0.13</slf4j.version>` (was `1.7.30` in 3.8.4). Gradle resolves dependency conflicts to the highest version, so `org.slf4j:slf4j-api:2.0.13` wins over Kafka's pin of `1.7.36`. The shipped binding `slf4j-reload4j:1.7.36` is a 1.7.x-style binding, which `slf4j-api` 2.x ignores.

Symptom chain (from `server-start-stdout-stderr.log` and `test_log.info`):
```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J(W): Ignoring binding found at [.../slf4j-reload4j-1.7.36.jar!/...]
```
- `/mnt/kafka/kafka-operational-logs/` is never created (log4j writes nothing).
- `kafkatest.services.kafka.kafka.wait_for_start()` greps for `Kafka\s*Server.*started` in the operational log → never matches → 60 s timeout → every test fails in `setUp`.
