### PR TITLE
KSECURITY-2670: Upgrade ZooKeeper from 3.8.4 to 3.8.6 with SLF4J version pin (3.8)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -265,6 +265,11 @@ allprojects {
           libs.protobuf,
           // be explicit about the reload4j version instead of relying on the transitive versions
           libs.log4j,
+          // ZooKeeper 3.8.5+ inherits slf4j-api 2.x via its parent POM, but Kafka ships the
+          // slf4j 1.7.x binding which is incompatible with slf4j-api 2.x (NOP fallback).
+          // Force the slf4j stack to 1.7.x to keep broker logging functional. See KSECURITY-2670.
+          libs.slf4jApi,
+          libs.slf4jlog4j,
           // be explicit about the commonsLang version instead of relying on the transitive versions
           libs.commonsLang
         )

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -170,7 +170,7 @@ versions += [
   snappy: "1.1.10.5",
   spotbugs: "4.8.0",
   zinc: "1.9.2",
-  zookeeper: "3.8.4",
+  zookeeper: "3.8.6",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   zstd: "1.5.6-4"


### PR DESCRIPTION
## Summary

Re-applies the upgrade of `org.apache.zookeeper:zookeeper` from `3.8.4` to `3.8.6` to fix [CVE-2026-24281](https://nvd.nist.gov/vuln/detail/CVE-2026-24281) ([GHSA-7xrh-hqfc-g7qr](https://github.com/advisories/GHSA-7xrh-hqfc-g7qr), CVSS 7.4 HIGH) on the `3.8` branch. The previous attempt ([#2001](https://github.com/confluentinc/kafka/pull/2001)) was reverted in [#2020](https://github.com/confluentinc/kafka/pull/2020) because the upgrade silently broke broker logging via a transitive `slf4j-api` version conflict. This PR re-applies the upgrade and adds the missing version pin so the regression cannot recur.

Jira: [KSECURITY-2670](https://confluentinc.atlassian.net/browse/KSECURITY-2670). Same conceptual change as [#2022](https://github.com/confluentinc/kafka/pull/2022) (3.9), adapted for this branch's library naming (`slf4jlog4j` here vs. `slf4jReload4j` on 3.9).

## Why was the previous attempt reverted?

ZooKeeper 3.8.5+ inherits `slf4j.version=2.0.13` from its [parent POM](https://repo1.maven.org/maven2/org/apache/zookeeper/parent/3.8.6/parent-3.8.6.pom). With Gradle's default conflict-resolution strategy (highest version wins), `slf4j-api:2.0.13` overrode Kafka's explicit `slf4j-api:1.7.36`. The shipped 1.7.x binding is ignored by `slf4j-api 2.x` via its new `ServiceLoader`-based provider lookup, so logging silently fell through to the NOP logger. That broke the broker's operational logs and surfaced as 1000+ ccs-kafka system test failures across 7.6.x-7.9.x RCs (`wait_for_start()` timed out grepping for `Kafka Server started`). [Slack root-cause writeup](https://confluent.slack.com/archives/C026X7YGP1D/p1777356292267159?thread_ts=1777292309.220069).

## What changed

Two files, six lines total:

1. **`gradle/dependencies.gradle`**: `zookeeper: \"3.8.4\"` → `zookeeper: \"3.8.6\"` — the actual security fix.
2. **`build.gradle`**: add `libs.slf4jApi` and `libs.slf4jlog4j` to the project-wide `force(...)` block in `configurations.all { resolutionStrategy { ... } }`.

## Why this approach is correct

This follows an **already-established pattern** in this build file. Several libraries are force-pinned for the exact same reason — to avoid being silently upgraded by a transitive dependency:

- `libs.log4j` — *\"be explicit about the reload4j version instead of relying on the transitive versions\"*
- `libs.nettyHandler`, `libs.nettyTransportNativeEpoll` — *\"be explicit about the Netty dependency version instead of relying on the version set by ZooKeeper (potentially older and containing CVEs)\"*
- `libs.javassist`, `libs.scalaLibrary`, `libs.scalaReflect`, `libs.commonsBeanutils`, `libs.jacksonAnnotations`, `libs.protobuf`, `libs.commonsLang`

Adding `slf4jApi` and `slf4jlog4j` to this list is the natural extension and keeps the entire SLF4J 1.7.x stack pinned regardless of what any future dep tries to pull in transitively.

Alternatives considered and rejected:
- **Exclude `slf4j-api` from the ZooKeeper dependency only** (Jan Werner's literal suggestion in the Slack thread): same runtime effect, but only protects against ZooKeeper specifically. A global force protects against any future dep that drags in SLF4J 2.x.
- **Upgrade the whole project to SLF4J 2.x**: bigger change, broader risk surface, not appropriate for an emergency patch on a release branch.

## Why this is safe

- **Runtime compatibility**: ZK 3.8.6 was compiled against `slf4j-api:2.0.13`, but SLF4J 2.x preserved the `org.slf4j.Logger` API surface used by 1.7.x callers. The breaking change in 2.x was the binding mechanism (`ServiceLoader` vs. `StaticLoggerBinder`) — invisible to API callers. ZK 3.8.6's source uses standard `LOG.info/warn/error` calls.
- **No public API changes**: only build-file changes.
- **Validation on 3.9 (#2022)**: `:core:dependencies` confirmed `zookeeper:3.8.6 -> slf4j-api:2.0.13 -> 1.7.36` (force took effect), and `:core:test --tests \"kafka.zookeeper.*\" \"kafka.zk.*\"` passed (67 tasks, including the full `ZkMigrationIntegrationTest` matrix across MetadataVersions 3.6-IV1 through 3.9-IV0). The 3.8 change is conceptually identical, so the same runtime guarantees apply.

## References

- CVE: [CVE-2026-24281](https://nvd.nist.gov/vuln/detail/CVE-2026-24281)
- GHSA: [GHSA-7xrh-hqfc-g7qr](https://github.com/advisories/GHSA-7xrh-hqfc-g7qr)
- Apache fix commit: [apache/zookeeper@66c4efe](https://github.com/apache/zookeeper/commit/66c4efecdda1302d9cfb3af9eedb122b74452bf3) (ZOOKEEPER-4986)
- Original upgrade PR (reverted): [#2001](https://github.com/confluentinc/kafka/pull/2001)
- Revert PR: [#2020](https://github.com/confluentinc/kafka/pull/2020)
- Companion PR for 3.9: [#2022](https://github.com/confluentinc/kafka/pull/2022)
- Slack root-cause thread: https://confluent.slack.com/archives/C026X7YGP1D/p1777292309220069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KSECURITY-2670]: https://confluentinc.atlassian.net/browse/KSECURITY-2670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ