### PR TITLE
KSECURITY-2688: Upgrade log4j2 to 2.25.4 to fix CVE-2026-34477 (4.1)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -238,10 +238,10 @@ License Version 2.0:
 - jetty-util-12.0.34
 - jose4j-0.9.6
 - jspecify-1.0.0
-- log4j-api-2.25.3
-- log4j-core-2.25.3
-- log4j-slf4j-impl-2.25.3
-- log4j-1.2-api-2.25.3
+- log4j-api-2.25.4
+- log4j-core-2.25.4
+- log4j-slf4j-impl-2.25.4
+- log4j-1.2-api-2.25.4
 - lz4-java-1.10.1
 - maven-artifact-3.9.6
 - metrics-core-2.2.0

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -106,7 +106,7 @@ versions += [
   kafka_38: "3.8.1",
   kafka_39: "3.9.1",
   kafka_40: "4.0.0",
-  log4j2: "2.25.3",
+  log4j2: "2.25.4",
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java#L73-L74
   // https://github.com/yawkat/lz4-java/blob/main/src/java/net/jpountz/lz4/LZ4Constants.java#L23-L24


### PR DESCRIPTION
## Summary

Bumps `org.apache.logging.log4j:log4j-core` (and its sibling artifacts `log4j-api`, `log4j-slf4j-impl`, `log4j-1.2-api`, all driven by `$versions.log4j2`) from **2.25.3** to **2.25.4** on the `4.1` release branch to address [CVE-2026-34477](https://nvd.nist.gov/vuln/detail/CVE-2026-34477) ([GHSA-6hg6-v5c8-fphq](https://github.com/advisories/GHSA-6hg6-v5c8-fphq), CVSS v4 6.3, MEDIUM).

The vulnerability is a hostname-verification bypass: the `verifyHostName` attribute on the `<Ssl>` element of the SMTP, Socket, and Syslog appenders was silently ignored in all log4j-core versions through 2.25.3, leaving TLS connections open to MITM regardless of the configured value. 2.25.4 is the only patched release.

## Changes

- `gradle/dependencies.gradle`: `log4j2: "2.25.3"` → `"2.25.4"` (single entry in the `versions` map)
- `LICENSE-binary`: 4 lines for `log4j-{api,core,slf4j-impl,1.2-api}` updated from `2.25.3` to `2.25.4`

No source-code changes, no tests modified — pure dependency version bump.

## Why this is the right fix

- **Only patched version.** Apache Logging only published the fix in 2.25.4; there is no 2.x backport line for users still on older minor versions.
- **Mirrors upstream and the 4.2 branch.** Apache's trunk fix [apache/kafka#21896](https://github.com/apache/kafka/pull/21896) was cherry-picked into the `4.2` line as [apache/kafka#22117](https://github.com/apache/kafka/pull/22117) (commit `2759ea0d` / `063d69a8`). Both `master` and the `4.2` branch in this repo are already on 2.25.4 via that sync. Apache has not backported to 4.0 / 4.1 (those are Confluent-supported), so this PR replays the identical 5-line change here.
- **No alternative.** No Renovatebot PR exists for log4j on this branch, and there are no CP-internal patches to consider.

## Why this is safe

- **Patch-level upgrade.** 2.25.3 → 2.25.4 is a patch release within the same minor — no API, configuration, or runtime behavior changes outside the CVE fix itself.
- **The CVE fix is strictly more conservative.** The patch makes `verifyHostName=true` (and the implicit-true default) actually enforce hostname verification on `<Ssl>` appender elements. Configurations that explicitly set `verifyHostName=false` continue to skip verification. Any operational behavior that breaks here was already silently insecure before 2.25.3 — desired direction of change.
- **Not affected:** `HttpAppender` uses a separate `verifyHostname` attribute that already worked correctly; this PR does not change anything for it.
- **Diff is identical to the merged 4.2 fix** (verified line-for-line against apache/kafka commit `063d69a8`).

## Verification

- [x] Diff matches apache/kafka@063d69a8 (4.2 cherry-pick) line-for-line
- [x] `master` and `4.2` already carry the same change in this repo
- [ ] CI build/tests pass (will run on this PR)

## References

- Jira: [KSECURITY-2688](https://confluentinc.atlassian.net/browse/KSECURITY-2688)
- CVE: [CVE-2026-34477](https://nvd.nist.gov/vuln/detail/CVE-2026-34477)
- GHSA: [GHSA-6hg6-v5c8-fphq](https://github.com/advisories/GHSA-6hg6-v5c8-fphq)
- Upstream trunk fix: [apache/kafka#21896](https://github.com/apache/kafka/pull/21896)
- Upstream 4.2 cherry-pick: [apache/kafka#22117](https://github.com/apache/kafka/pull/22117)
- Apache Logging advisory: https://logging.apache.org/security.html#CVE-2026-34477

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KSECURITY-2688]: https://confluentinc.atlassian.net/browse/KSECURITY-2688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ