### PR TITLE
KSECURITY-2690: Upgrade Jetty from 9.4.59 to 9.4.60 (3.9)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -100,7 +100,7 @@ versions += [
   jackson: "2.16.2",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
-  jetty: "9.4.59",
+  jetty: "9.4.60",
   jersey: "2.47",
   jline: "3.25.1",
   jmh: "1.37",


### PR DESCRIPTION
## Summary

Upgrade `org.eclipse.jetty:jetty-*` (jetty-server, jetty-client, jetty-servlet, jetty-servlets) from `9.4.59` to `9.4.60` on the `3.9` branch to fix [CVE-2026-2332](https://nvd.nist.gov/vuln/detail/CVE-2026-2332) ([GHSA-355h-qmc2-wpwf](https://github.com/advisories/GHSA-355h-qmc2-wpwf), CVSS 7.4 HIGH). Jetty's HTTP/1.1 parser terminates chunk extension parsing at \`\r\n\` inside quoted strings, enabling HTTP request smuggling via crafted \`Transfer-Encoding: chunked\` payloads.

Jira: [KSECURITY-2690](https://confluentinc.atlassian.net/browse/KSECURITY-2690).

## What changed

Single line in `gradle/dependencies.gradle`: `jetty: "9.4.59"` → `jetty: "9.4.60"`.

The four Jetty libraries used by this repo (`jettyServer`, `jettyClient`, `jettyServlet`, `jettyServlets`) all reference `$versions.jetty`, so they are upgraded together with one change.

## Why this approach is correct

- **9.4.60 is the first patched 9.4.x version** listed in [GHSA-355h-qmc2-wpwf](https://github.com/advisories/GHSA-355h-qmc2-wpwf) for the 9.4.0–9.4.59 vulnerable range. The other patched lines (10.0.28, 11.0.28, 12.0.33, 12.1.7) are major-version jumps that this maintenance branch is too old to absorb without a substantial refactor; staying on 9.4.x and bumping the patch level is the minimal-risk fix appropriate for a release branch.
- **Jetty 9.4 is EOL on public Maven Central** (latest there is `9.4.58.v20250814`). Confluent has access to sponsored 9.4.x releases via the internal CodeArtifact repositories already wired into `build.gradle` in [#1893](https://github.com/confluentinc/kafka/pull/1893) (Feb 2026). The same channel was used for the prior 9.4.58 → 9.4.59 bump on this branch.
- **Sister ticket [KSECURITY-2689](https://confluentinc.atlassian.net/browse/KSECURITY-2689)** has already merged the equivalent 9.4.59 → 9.4.60 change on `confluentinc/ce-kafka` 7.9.x in [ce-kafka#30336](https://github.com/confluentinc/ce-kafka/pull/30336), confirming 9.4.60 resolves cleanly through the internal repo and tests pass.

## Why this is safe

- **Patch-level bump within a stable maintenance line.** Jetty 9.4.x is a long-term maintenance line; 9.4.60 only contains the security fix and bug fixes — no API changes, no new public methods, no behavior changes outside the chunked-encoding parser.
- **Same artifact coordinates and same compile-time API.** No source changes needed in this repo.
- **Scoped to 9.4.x maintenance branches (3.4–3.9) only.** Master, 4.0, and 4.1 are already on Jetty `12.0.34` (above the `12.0.33` fix) and need no change.
- **Library/distribution repo only** — no Halyard/k8s configs in this repo; downstream consumers (ce-kafka, CP) will pick up 9.4.60 when they consume the new release tag.

## References

- CVE: [CVE-2026-2332](https://nvd.nist.gov/vuln/detail/CVE-2026-2332)
- GHSA: [GHSA-355h-qmc2-wpwf](https://github.com/advisories/GHSA-355h-qmc2-wpwf)
- Sister ce-kafka PR (7.9.x equivalent, merged): [ce-kafka#30336](https://github.com/confluentinc/ce-kafka/pull/30336)
- Internal Maven repos enabling 9.4.x sponsored releases: [#1893](https://github.com/confluentinc/kafka/pull/1893)

Companion PRs (same fix on other 3.x branches):
- [#2035](https://github.com/confluentinc/kafka/pull/2035) (3.4)
- [#2036](https://github.com/confluentinc/kafka/pull/2036) (3.5)
- [#2037](https://github.com/confluentinc/kafka/pull/2037) (3.6)
- [#2038](https://github.com/confluentinc/kafka/pull/2038) (3.7)
- [#2039](https://github.com/confluentinc/kafka/pull/2039) (3.8)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KSECURITY-2690]: https://confluentinc.atlassian.net/browse/KSECURITY-2690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KSECURITY-2689]: https://confluentinc.atlassian.net/browse/KSECURITY-2689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ