### PR TITLE
KSECURITY-2693: Bump maven-artifact to 3.9.15 to fix CVE-2025-67030

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -241,7 +241,7 @@ jetty-util-9.4.57.v20241219
 jetty-util-ajax-9.4.57.v20241219
 jose4j-0.9.4
 lz4-java-1.8.1
-maven-artifact-3.9.6
+maven-artifact-3.9.15
 metrics-core-4.1.12.1
 metrics-core-2.2.0
 netty-buffer-4.1.118.Final
@@ -254,7 +254,7 @@ netty-transport-classes-epoll-4.1.118.Final
 netty-transport-native-epoll-4.1.118.Final
 netty-transport-native-unix-common-4.1.118.Final
 opentelemetry-proto-1.0.0-alpha
-plexus-utils-3.5.1
+plexus-utils-3.6.1
 reflections-0.10.2
 reload4j-1.2.25
 rocksdbjni-7.9.2

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -148,7 +148,7 @@ versions += [
   kafka_37: "3.7.2",
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   lz4: "1.10.2",
-  mavenArtifact: "3.9.6",
+  mavenArtifact: "3.9.15",
   metrics: "2.2.0",
   netty: "4.1.130.Final",
   opentelemetryProto: "1.0.0-alpha",


### PR DESCRIPTION
## Summary

Backport of upstream [KAFKA-20373](https://issues.apache.org/jira/browse/KAFKA-20373) ([apache/kafka#21911](https://github.com/apache/kafka/pull/21911)) to the `3.8` branch to address [CVE-2025-67030](https://www.cve.org/CVERecord?id=CVE-2025-67030) — a HIGH-severity (CVSS 8.8) directory traversal in `org.codehaus.plexus.util.Expand.extractFile`.

`plexus-utils` is pulled in transitively by `org.apache.maven:maven-artifact`. Bumping `maven-artifact` to `3.9.15` causes Gradle to resolve `plexus-utils:3.6.1` (the patched version), closing the CVE without introducing a new direct dependency.

## Changes

- `gradle/dependencies.gradle`: `mavenArtifact: "3.9.6"` → `"3.9.15"`
- `LICENSE-binary`:
  - `maven-artifact-3.9.6` → `maven-artifact-3.9.15`
  - `plexus-utils-3.5.1` → `plexus-utils-3.6.1`

## Why this is the right fix

- **Mirrors the upstream community fix.** Apache Kafka master used the exact same approach in [#21911](https://github.com/apache/kafka/pull/21911), which has already been reviewed and accepted by upstream maintainers (Chia-Ping Tsai, Mickael Maison).
- **Fixes the CVE at the only available version.** `maven-artifact 3.9.15` is the only published version whose parent POM declares `plexusUtilsVersion=3.6.1`. Earlier 3.9.x ships `plexus-utils 3.6.0` (still vulnerable); the entire 3.8.x line ships `plexus-utils ≤ 3.3.1`. Pinning `plexus-utils` directly was an alternative, but bumping the parent matches upstream and avoids introducing a constraint that doesn't exist anywhere else in the build.
- **Surface area unchanged for Kafka.** Kafka only consumes `org.apache.maven.artifact.versioning.{DefaultArtifactVersion, VersionRange, InvalidVersionSpecificationException}` (used by Connect for plugin version-range parsing in `PluginUtils`, `PluginDesc`, `DelegatingClassLoader`, etc.). These classes have been ABI-stable across the entire `maven-artifact 3.x` line, so a multi-minor jump (3.8.x → 3.9.15) does not change the API Kafka exercises.
- **No code-path reachability for the vulnerable function.** The vulnerable `Expand.extractFile` method is a ZIP-archive extraction utility from `plexus-utils`. Nothing in Kafka imports `org.codehaus.plexus.*` or invokes archive extraction. CVE scanners still flag the JAR's presence on the classpath, which is what this PR removes.

## Verification

- `./gradlew :connect:runtime:dependencyInsight --dependency org.codehaus.plexus:plexus-utils --configuration runtimeClasspath` resolves `org.codehaus.plexus:plexus-utils:3.6.1` (selected by ancestor `maven-artifact:3.9.15`).
- Diff is identical in shape to the upstream master fix: 2 files changed, 3 insertions, 3 deletions.
- Full build / tests will run via this PR's CI.

## References

- CVE: [CVE-2025-67030](https://www.cve.org/CVERecord?id=CVE-2025-67030) / [GHSA-6fmv-xxpf-w3cw](https://github.com/advisories/GHSA-6fmv-xxpf-w3cw)
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-67030
- Jira: https://confluentinc.atlassian.net/browse/KSECURITY-2693
- Upstream fix: [apache/kafka#21911](https://github.com/apache/kafka/pull/21911) (KAFKA-20373)
- Patch commit: [codehaus-plexus/plexus-utils@6d780b3](https://github.com/codehaus-plexus/plexus-utils/commit/6d780b3378829318ba5c2d29547e0012d5b29642)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)