### PR TITLE
KSECURITY-2706: Upgrade netty to 4.1.132.Final to fix CVE-2026-33870 (3.9)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -144,7 +144,7 @@ versions += [
   lz4: "1.10.1",
   mavenArtifact: "3.9.15",
   metrics: "2.2.0",
-  netty: "4.1.130.Final",
+  netty: "4.1.132.Final",
   opentelemetryProto: "1.0.0-alpha",
   protobuf: "3.25.5", // a dependency of opentelemetryProto
   pcollections: "4.0.1",


### PR DESCRIPTION
## Summary

Bumps the `netty` version variable in `gradle/dependencies.gradle` from `4.1.130.Final` to `4.1.132.Final` to address [CVE-2026-33870](https://nvd.nist.gov/vuln/detail/CVE-2026-33870) / [GHSA-pwqr-wmgm-9rr8](https://github.com/netty/netty/security/advisories/GHSA-pwqr-wmgm-9rr8) — HTTP request smuggling via chunked transfer-encoding extension quoted-string parsing in `io.netty:netty-codec-http` (CWE-444, CVSS 3.1: 7.5 HIGH).

Tracks [KSECURITY-2706](https://confluentinc.atlassian.net/browse/KSECURITY-2706).

## Why this change is correct and safe

**Why this change is needed:**
- KSECURITY-2706 was opened against this branch by Confluent's security scanner because the declared `netty: "4.1.130.Final"` matches the vulnerable range (`< 4.1.132.Final`) in the CVE database.
- The `netty` version variable in `dependencies.gradle` controls every `io.netty:*` artifact resolved transitively. Bumping it ensures any current or future netty package — including `netty-codec-http` — resolves to the patched version.
- The Kafka build pins `nettyHandler` and `nettyTransportNativeEpoll` explicitly (see `build.gradle`) to override the older, potentially vulnerable netty version that ZooKeeper would otherwise pull in transitively. The comment in `build.gradle` states this is for security reasons.

**Why this change is safe:**
- Patch-level bump on the same minor line: 4.1.130 → 4.1.132. Netty's 4.1.x line is API-stable; releases between patch versions contain bug/security fixes only ([4.1.131 release notes](https://netty.io/news/2025/10/29/4-1-131-Final.html), [4.1.132 release notes](https://netty.io/news/2026/03/27/4-1-132-Final.html)).
- One-line change in a single file (`gradle/dependencies.gradle`); no source code or build logic changes.
- Verified via `./gradlew allDeps` that all transitive `io.netty:*` artifacts resolve to `4.1.132.Final`.

**Note on direct exploitability of CVE-2026-33870 in this branch:**
The CVE affects `io.netty:netty-codec-http`, which is **not currently in this branch's resolved dependency tree** (Kafka 3.x only uses `netty-handler` and `netty-transport-native-epoll`, neither of which transitively pulls in `netty-codec-http`). However the version variable bump is still correct — it (a) closes the scanner finding, and (b) is defensive against any future code path that pulls in `netty-codec-http`.

## Changes

- \`gradle/dependencies.gradle\`: bump \`netty: "4.1.130.Final"\` → \`netty: "4.1.132.Final"\`

## Verification

\`\`\`
cd <repo> && ./gradlew allDeps | grep -E "io\.netty"
\`\`\`

All resolved \`io.netty:*\` artifacts are at \`4.1.132.Final\` after the bump.

## References

- Jira: https://confluentinc.atlassian.net/browse/KSECURITY-2706
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-33870
- GHSA: https://github.com/netty/netty/security/advisories/GHSA-pwqr-wmgm-9rr8
- Netty 4.1.132.Final release: https://netty.io/news/2026/03/27/4-1-132-Final.html

[KSECURITY-2706]: https://confluentinc.atlassian.net/browse/KSECURITY-2706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ