### PR TITLE
Fix SSL certificate verification failure in system test worker provisioning

### DIFF
--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -96,7 +96,8 @@ get_kafka() {
 }
 
 # Install Kibosh
-apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev
+apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev ca-certificates
+update-ca-certificates --fresh
 pushd /opt
 rm -rf /opt/kibosh
 git clone -q  https://github.com/confluentinc/kibosh.git


### PR DESCRIPTION
Root Cause: The Vagrant workers use Ubuntu 14.04 (Trusty), which reached
end-of-life in April 2019. The CA certificate bundle on these workers is outdated
and does not include the certificate authorities needed to verify GitHub's current
SSL certificate chain. GitHub (or their CA provider) rotated certificates, causing
the verification to fail on systems with older CA bundles.

Solution
Refresh the CA certificate store during worker provisioning by:

Installing/updating the ca-certificates package
Running update-ca-certificates --fresh to rebuild the certificate store