### PR TITLE
[KSECURITY-2713] Upgrade maven-artifact to 3.9.16 to fix CVE-2025-67030

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -242,10 +242,10 @@ License Version 2.0:
 - log4j-slf4j-impl-2.25.4
 - log4j-1.2-api-2.25.4
 - lz4-java-1.10.2
-- maven-artifact-3.9.11
+- maven-artifact-3.9.16
 - metrics-core-2.2.0
 - opentelemetry-proto-1.0.0-alpha
-- plexus-utils-3.5.1
+- plexus-utils-3.6.1
 - rocksdbjni-9.7.3
 - scala-library-2.13.15
 - scala-logging_2.13-3.9.5

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -115,7 +115,7 @@ versions += [
   // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/internal/CompressionType.java#L73-L74
   // https://github.com/yawkat/lz4-java/blob/main/src/java/net/jpountz/lz4/LZ4Constants.java#L23-L24
   lz4: "1.10.2",
-  mavenArtifact: "3.9.11",
+  mavenArtifact: "3.9.16",
   metrics: "2.2.0",
   mockito: "5.14.2",
   opentelemetryProto: "1.0.0-alpha",


### PR DESCRIPTION
Bumps org.apache.maven:maven-artifact from 3.9.11 to 3.9.16, which transitively pulls in org.codehaus.plexus:plexus-utils 3.6.1 (the fixed version for CVE-2025-67030) via Maven's parent POM dependencyManagement.
