### PR TITLE
MINOR: Fixed metrics decompression (#22327)

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -180,6 +180,9 @@
       <allow pkg="org.apache.kafka.clients.admin" />
       <!-- for testing -->
       <allow pkg="org.apache.kafka.common.errors" />
+      <!-- for PushTelemetryRequest decompression and tests -->
+      <allow pkg="io.opentelemetry.proto"/>
+      <allow pkg="org.apache.kafka.common.telemetry" />
     </subpackage>
 
     <subpackage name="serialization">

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -53,6 +53,8 @@
               files="(SaslServerAuthenticator|SaslAuthenticatorTest).java"/>
     <suppress checks="NPath"
               files="SaslServerAuthenticator.java"/>
+    <suppress checks="NPathComplexity"
+              files="ClientTelemetryReporter.java"/>
     <suppress checks="ClassFanOutComplexity"
               files="Errors.java"/>
     <suppress checks="ClassFanOutComplexity"

--- a/clients/src/main/java/org/apache/kafka/common/requests/PushTelemetryRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/PushTelemetryRequest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.telemetry.internals.ClientTelemetryUtils;
 
 import java.nio.ByteBuffer;
 
@@ -84,15 +85,10 @@ public class PushTelemetryRequest extends AbstractRequest {
         return OTLP_CONTENT_TYPE;
     }
 
-    public ByteBuffer metricsData() {
+    public ByteBuffer metricsData(int maxDecompressedBytes) {
         CompressionType cType = CompressionType.forId(this.data.compressionType());
         return (cType == CompressionType.NONE) ?
-            ByteBuffer.wrap(this.data.metrics()) : decompressMetricsData(cType, this.data.metrics());
-    }
-
-    private static ByteBuffer decompressMetricsData(CompressionType compressionType, byte[] metrics) {
-        // TODO: Add support for decompression of metrics data
-        return ByteBuffer.wrap(metrics);
+            ByteBuffer.wrap(this.data.metrics()) : ClientTelemetryUtils.decompress(this.data.metrics(), cType, maxDecompressedBytes);
     }
 
     public static PushTelemetryRequest parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
@@ -42,11 +42,10 @@ import org.apache.kafka.common.requests.PushTelemetryRequest;
 import org.apache.kafka.common.requests.PushTelemetryResponse;
 import org.apache.kafka.common.telemetry.ClientTelemetryState;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.ByteBuffer;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -713,12 +712,12 @@ public class ClientTelemetryReporter implements MetricsReporter {
             }
 
             CompressionType compressionType = ClientTelemetryUtils.preferredCompressionType(localSubscription.acceptedCompressionTypes());
-            ByteBuffer compressedPayload;
+            byte[] compressedPayload;
             try {
                 compressedPayload = ClientTelemetryUtils.compress(payload, compressionType);
-            } catch (Throwable e) {
-                log.debug("Failed to compress telemetry payload for compression: {}, sending uncompressed data", compressionType);
-                compressedPayload = ByteBuffer.wrap(payload);
+            } catch (IOException e) {
+                log.info("Failed to compress telemetry payload for compression: {}, sending uncompressed data", compressionType);
+                compressedPayload = payload;
                 compressionType = CompressionType.NONE;
             }
 
@@ -728,7 +727,7 @@ public class ClientTelemetryReporter implements MetricsReporter {
                     .setSubscriptionId(localSubscription.subscriptionId())
                     .setTerminating(terminating)
                     .setCompressionType(compressionType.id)
-                    .setMetrics(Utils.readBytes(compressedPayload)), true);
+                    .setMetrics(compressedPayload), true);
 
             return Optional.of(requestBuilder);
         }

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
@@ -20,13 +20,20 @@ import io.opentelemetry.proto.metrics.v1.MetricsData;
 
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.TelemetryTooLargeException;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -43,6 +50,8 @@ public class ClientTelemetryUtils {
     public final static Predicate<? super MetricKeyable> SELECTOR_NO_METRICS = k -> false;
 
     public final static Predicate<? super MetricKeyable> SELECTOR_ALL_METRICS = k -> true;
+
+    private static final int DECOMPRESS_READ_BUFFER_BYTES = 8 * 1024;
 
     /**
      * Examine the response data and handle different error code accordingly:
@@ -179,12 +188,35 @@ public class ClientTelemetryUtils {
         return CompressionType.NONE;
     }
 
-    public static ByteBuffer compress(byte[] raw, CompressionType compressionType) {
-        // TODO: Support compression in client telemetry.
-        if (compressionType == CompressionType.NONE) {
-            return ByteBuffer.wrap(raw);
-        } else {
-            throw new UnsupportedOperationException("Compression is not supported");
+    public static byte[] compress(byte[] raw, CompressionType compressionType) throws IOException {
+        try (ByteBufferOutputStream compressedOut = new ByteBufferOutputStream(512)) {
+            try (OutputStream out = compressionType.wrapForOutput(compressedOut, RecordBatch.CURRENT_MAGIC_VALUE)) {
+                out.write(raw);
+                out.flush();
+            }
+            compressedOut.buffer().flip();
+            return Utils.toArray(compressedOut.buffer());
+        }
+    }
+
+    public static ByteBuffer decompress(byte[] metrics, CompressionType compressionType, int maxDecompressedBytes) {
+        ByteBuffer data = ByteBuffer.wrap(metrics);
+        try (InputStream in = compressionType.wrapForInput(data, RecordBatch.CURRENT_MAGIC_VALUE, BufferSupplier.create());
+            ByteBufferOutputStream out = new ByteBufferOutputStream(512)) {
+            byte[] bytes = new byte[Math.min(data.capacity() * 2, DECOMPRESS_READ_BUFFER_BYTES)];
+            int nRead;
+            int totalRead = 0;
+            while ((nRead = in.read(bytes, 0, bytes.length)) != -1) {
+                totalRead += nRead;
+                if (totalRead > maxDecompressedBytes) {
+                    throw new TelemetryTooLargeException("Decompressed telemetry metrics exceed maximum allowed size: " + maxDecompressedBytes);
+                }
+                out.write(bytes, 0, nRead);
+            }
+            out.buffer().flip();
+            return out.buffer();
+        } catch (IOException e) {
+            throw new KafkaException("Failed to decompress metrics data", e);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/PushTelemetryRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/PushTelemetryRequestTest.java
@@ -17,13 +17,33 @@
 
 package org.apache.kafka.common.requests;
 
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
+import io.opentelemetry.proto.resource.v1.Resource;
+
 import org.apache.kafka.common.message.PushTelemetryRequestData;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.telemetry.internals.ClientTelemetryUtils;
+import org.apache.kafka.common.telemetry.internals.MetricKey;
+import org.apache.kafka.common.telemetry.internals.SinglePointMetric;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PushTelemetryRequestTest {
 
@@ -32,6 +52,67 @@ public class PushTelemetryRequestTest {
         PushTelemetryRequest req = new PushTelemetryRequest(new PushTelemetryRequestData(), (short) 0);
         PushTelemetryResponse response = req.getErrorResponse(0, Errors.CLUSTER_AUTHORIZATION_FAILED.exception());
         assertEquals(Collections.singletonMap(Errors.CLUSTER_AUTHORIZATION_FAILED, 1), response.errorCounts());
+    }
+
+    @ParameterizedTest
+    @EnumSource(CompressionType.class)
+    public void testMetricsDataCompression(CompressionType compressionType) throws IOException {
+        MetricsData metricsData = getMetricsData();
+        PushTelemetryRequest req = getPushTelemetryRequest(metricsData, compressionType);
+
+        ByteBuffer receivedMetricsBuffer = req.metricsData(1024 * 1024);
+        assertNotNull(receivedMetricsBuffer);
+        assertTrue(receivedMetricsBuffer.capacity() > 0);
+
+        MetricsData receivedData = ClientTelemetryUtils.deserializeMetricsData(receivedMetricsBuffer);
+        assertEquals(metricsData, receivedData);
+    }
+
+    private PushTelemetryRequest getPushTelemetryRequest(MetricsData metricsData, CompressionType compressionType) throws IOException {
+        byte[] data = metricsData.toByteArray();
+        byte[] compressedData = ClientTelemetryUtils.compress(data, compressionType);
+        if (compressionType != CompressionType.NONE) {
+            assertTrue(compressedData.length < data.length);
+        } else {
+            assertArrayEquals(compressedData, data);
+        }
+
+        return new PushTelemetryRequest.Builder(
+            new PushTelemetryRequestData()
+                .setMetrics(compressedData)
+                .setCompressionType(compressionType.id)).build();
+    }
+
+    private MetricsData getMetricsData() {
+        List<Metric> metricsList = new ArrayList<>();
+        metricsList.add(SinglePointMetric.sum(
+                new MetricKey("metricName"), 1.0, true, Instant.now(), null, Collections.emptySet())
+            .builder().build());
+        metricsList.add(SinglePointMetric.sum(
+                new MetricKey("metricName1"), 100.0, false, Instant.now(),  Instant.now(), Collections.emptySet())
+            .builder().build());
+        metricsList.add(SinglePointMetric.deltaSum(
+                new MetricKey("metricName2"), 1.0, true, Instant.now(), Instant.now(), Collections.emptySet())
+            .builder().build());
+        metricsList.add(SinglePointMetric.gauge(
+                new MetricKey("metricName3"), 1.0, Instant.now(), Collections.emptySet())
+            .builder().build());
+        metricsList.add(SinglePointMetric.gauge(
+                new MetricKey("metricName4"), Long.valueOf(100), Instant.now(), Collections.emptySet())
+            .builder().build());
+
+        MetricsData.Builder builder = MetricsData.newBuilder();
+        for (Metric metric : metricsList) {
+            ResourceMetrics rm = ResourceMetrics.newBuilder()
+                .setResource(Resource.newBuilder().build())
+                .addScopeMetrics(ScopeMetrics.newBuilder()
+                    .addMetrics(metric)
+                    .build()
+                ).build();
+            builder.addResourceMetrics(rm);
+        }
+
+        return builder.build();
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
@@ -17,12 +17,18 @@
 package org.apache.kafka.common.telemetry.internals;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.TelemetryTooLargeException;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,9 +36,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -111,5 +119,47 @@ public class ClientTelemetryUtilsTest {
     public void testPreferredCompressionType() {
         assertEquals(CompressionType.NONE, ClientTelemetryUtils.preferredCompressionType(Collections.emptyList()));
         assertEquals(CompressionType.NONE, ClientTelemetryUtils.preferredCompressionType(null));
+    }
+
+    @ParameterizedTest
+    @EnumSource(CompressionType.class)
+    public void testCompressDecompress(CompressionType compressionType) throws IOException {
+        byte[] testString = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes(StandardCharsets.UTF_8);
+        byte[] compressed = ClientTelemetryUtils.compress(testString, compressionType);
+        assertNotNull(compressed);
+        if (compressionType != CompressionType.NONE) {
+            assertTrue(compressed.length < testString.length);
+        } else {
+            assertArrayEquals(testString, compressed);
+        }
+        ByteBuffer decompressed = ClientTelemetryUtils.decompress(compressed, compressionType, 1024 * 1024);
+        assertNotNull(decompressed);
+        byte[] actualResult = Utils.toArray(decompressed);
+        assertArrayEquals(testString, actualResult);
+    }
+
+    @Test
+    public void testDecompressExceedingMaxSizeThrows() throws IOException {
+        // Compress a large payload using the existing compress API (via MetricsData)
+        // then verify decompression with a small limit throws
+        byte[] testString = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes(StandardCharsets.UTF_8);
+        byte[] compressed = ClientTelemetryUtils.compress(testString, CompressionType.GZIP);
+
+        // Set limit smaller than the actual decompressed size
+        int smallLimit = compressed.length - 1;
+        TelemetryTooLargeException ex = assertThrows(TelemetryTooLargeException.class,
+            () -> ClientTelemetryUtils.decompress(compressed, CompressionType.GZIP, smallLimit));
+        assertTrue(ex.getMessage().contains("Decompressed telemetry metrics exceed maximum allowed size: " + smallLimit));
+    }
+
+    @Test
+    public void testDecompressWithPayloadSizeSucceeds() throws IOException {
+        byte[] testString = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes(StandardCharsets.UTF_8);
+        byte[] compressed = ClientTelemetryUtils.compress(testString, CompressionType.GZIP);
+
+        // Set limit to exact limit prior compression.
+        ByteBuffer result = ClientTelemetryUtils.decompress(compressed, CompressionType.GZIP, testString.length);
+        assertNotNull(result);
+        assertArrayEquals(testString, Utils.toArray(result));
     }
 }

--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -176,8 +176,8 @@ public class ClientMetricsManager implements Closeable {
         byte[] metrics = request.data().metrics();
         if (metrics != null && metrics.length > 0) {
             try {
-                receiverPlugin.exportMetrics(requestContext, request);
-            } catch (Throwable exception) {
+                receiverPlugin.exportMetrics(requestContext, request, clientTelemetryMaxBytes);
+            } catch (Exception exception) {
                 clientInstance.lastKnownError(Errors.INVALID_RECORD);
                 return request.errorResponse(0, Errors.INVALID_RECORD);
             }

--- a/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsReceiverPlugin.java
+++ b/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsReceiverPlugin.java
@@ -44,12 +44,12 @@ public class ClientMetricsReceiverPlugin {
         receivers.add(receiver);
     }
 
-    public DefaultClientTelemetryPayload getPayLoad(PushTelemetryRequest request) {
-        return new DefaultClientTelemetryPayload(request);
+    public DefaultClientTelemetryPayload getPayLoad(PushTelemetryRequest request, int maxDecompressedBytes) {
+        return new DefaultClientTelemetryPayload(request, maxDecompressedBytes);
     }
 
-    public void exportMetrics(RequestContext context, PushTelemetryRequest request) {
-        DefaultClientTelemetryPayload payload = getPayLoad(request);
+    public void exportMetrics(RequestContext context, PushTelemetryRequest request, int maxDecompressedBytes) {
+        DefaultClientTelemetryPayload payload = getPayLoad(request, maxDecompressedBytes);
         for (ClientTelemetryReceiver receiver : receivers) {
             receiver.exportMetrics(context, payload);
         }

--- a/server/src/main/java/org/apache/kafka/server/metrics/DefaultClientTelemetryPayload.java
+++ b/server/src/main/java/org/apache/kafka/server/metrics/DefaultClientTelemetryPayload.java
@@ -32,11 +32,11 @@ public class DefaultClientTelemetryPayload implements ClientTelemetryPayload {
     final private String metricsContentType;
     final private ByteBuffer metricsData;
 
-    DefaultClientTelemetryPayload(PushTelemetryRequest request) {
+    DefaultClientTelemetryPayload(PushTelemetryRequest request, int maxDecompressedBytes) {
         this.clientInstanceId = request.data().clientInstanceId();
         this.isClientTerminating = request.data().terminating();
         this.metricsContentType = request.metricsContentType();
-        this.metricsData = request.metricsData();
+        this.metricsData = request.metricsData(maxDecompressedBytes);
     }
 
     @Override

--- a/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsReceiverPluginTest.java
+++ b/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsReceiverPluginTest.java
@@ -52,7 +52,7 @@ public class ClientMetricsReceiverPluginTest {
 
         byte[] metrics = "test-metrics".getBytes(StandardCharsets.UTF_8);
         clientMetricsReceiverPlugin.exportMetrics(ClientMetricsTestUtils.requestContext(),
-            new PushTelemetryRequest.Builder(new PushTelemetryRequestData().setMetrics(metrics), true).build());
+            new PushTelemetryRequest.Builder(new PushTelemetryRequestData().setMetrics(metrics), true).build(), 1024 * 1024);
 
         assertEquals(1, telemetryReceiver.exportMetricsInvokedCount);
         assertEquals(1, telemetryReceiver.metricsData.size());


### PR DESCRIPTION
Minor fix for fixing decompression.

Reviewers: Andrew Schofield <aschofield@confluent.io>

3.7 backport adaptations:
- Adapted ClientTelemetryUtils.{compress,decompress} to call CompressionType.wrapFor{Input,Output} directly, since the `org.apache.kafka.common.compress.Compression` builder does not exist on 3.7.
- Updated ClientTelemetryReporter caller to the new `byte[] compress(...) throws IOException` signature (was returning ByteBuffer on 3.7).
- Dropped the `clientMetricsStats.recordPluginExport(...)` call in ClientMetricsManager.processPushTelemetryRequest — the stats field does not exist on 3.7.
- Replaced `MetricConfigs.CLIENT_TELEMETRY_MAX_BYTES_DEFAULT` in ClientMetricsReceiverPluginTest with a literal `1024 * 1024` (the constant does not exist on 3.7).
- Removed cherry-picked test assertions in testPreferredCompressionType that asserted master's preference-selection behavior; 3.7 impl always returns CompressionType.NONE.
- Skipped cherry-picked additions to ClientMetricsManagerTest (testCacheEviction, testPushTelemetryPluginException, metrics-stats assertions, etc.) — these depend on the ClientMetricsStats subsystem that does not exist on 3.7.
- checkstyle/import-control.xml: allowed `io.opentelemetry.proto` and `org.apache.kafka.common.telemetry` imports under the `requests` subpackage to support the new test.
- checkstyle/suppressions.xml: suppressed NPathComplexity on ClientTelemetryReporter.java — the added try/catch around the compress call pushed it past the 500 threshold.
