### PR TITLE
[8.0.2-cp9] Bump jackson-databind to 2.18.8 (CVE-2026-54512, CVE-2026-54513)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -67,7 +67,7 @@ versions += [
   gradle: "8.10.2",
   grgit: "4.1.1",
   httpclient: "4.5.14",
-  jackson: "2.18.6",
+  jackson: "2.18.8",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
   jetty: "12.0.34",


### PR DESCRIPTION
## Summary
- Bump jackson from 2.18.6 to 2.18.8
- Fixes CVE-2026-54512 and CVE-2026-54513
