### PR TITLE
Bump jackson to 2.18.9 and jetty to 12.0.36 for security CVEs (4.0)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -66,12 +66,12 @@ versions += [
   gradle: "8.10.2",
   grgit: "4.1.1",
   httpclient: "4.5.14",
-  jackson: "2.18.8",
+  jackson: "2.18.9",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
   // When upgrading Jetty, verify that it does not use the SLF4J 2.x fluent API
   // (e.g. Logger.atDebug()) in production code, as Kafka uses SLF4J 1.7.x.
-  jetty: "12.0.34",
+  jetty: "12.0.36",
   jersey: "3.1.10",
   jline: "3.25.1",
   jmh: "1.37",


### PR DESCRIPTION
## Summary
Bumps security-flagged dependencies on the `4.0` branch to their first patched releases. Single-file change to `gradle/dependencies.gradle`.

| Dependency | From | To | Tickets (CVE) |
|---|---|---|---|
| jackson-databind | 2.18.8 | **2.18.9** | KSECURITY-2861 (CVE-2026-59889), KSECURITY-2859 (GHSA-mhm7-754m-9p8w) |
| jetty | 12.0.34 | **12.0.36** | KSECURITY-2848 (CVE-2026-10050), KSECURITY-2846 (CVE-2026-10051), KSECURITY-2845 (CVE-2026-6790), KSECURITY-2844 (CVE-2026-8384) |

jetty `12.0.36` covers all four jetty CVEs (6790/8384 need ≥12.0.35; 10050/10051 need ≥12.0.36). On 4.0 the jackson fix lands on the 2.18.x line (2.18.9). netty CVE-2026-59901 / KSECURITY-2857 is scoped to 3.5–3.9 and does not apply to 4.0. Both target versions verified present on Maven Central.

## Notes
- Patch-level bumps only; no public API impact.
- Companion PR opens the equivalent bumps on `4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)