### PR TITLE
KSECURITY-2864: bump lz4 to 1.11.1 (3.5)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -108,7 +108,7 @@ versions += [
   kafka_32: "3.2.3",
   kafka_33: "3.3.1",
   kafka_34: "3.4.1",
-  lz4: "1.10.2",
+  lz4: "1.11.1",
   mavenArtifact: "3.9.15",
   metrics: "2.2.0",
   mockito: "4.9.0",


### PR DESCRIPTION
## Summary
Fixes [KSECURITY-2864](https://confluentinc.atlassian.net/browse/KSECURITY-2864) / **CVE-2026-59949**.

Bumps `at.yawk.lz4:lz4-java` from 1.10.2 to 1.11.1 on `3.5`. The CVE is an out-of-bounds read in the JNI-based XXHash implementation (CVSS 6.5, medium): insufficient validation of byte-array/offset/length arguments to native XXHash methods can crash the JVM. Fixed in 1.11.1.

## Change
One-line version bump in `gradle/dependencies.gradle`. Package coordinates and the `net.jpountz` Java package are unchanged, so it is drop-in.

## Compatibility
`CompressionType` hardcodes LZ4 levels (MIN=1, MAX=17, DEFAULT=9) sourced from `net.jpountz.lz4.LZ4Constants`. Verified 1.11.1 still defines `DEFAULT_COMPRESSION_LEVEL = 9` and `MAX_COMPRESSION_LEVEL = 17`, so those levels remain valid.

## Verification
`./gradlew allDeps | grep lz4-java` should resolve `at.yawk.lz4:lz4-java` to 1.11.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KSECURITY-2864]: https://confluentinc.atlassian.net/browse/KSECURITY-2864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ