### PR TITLE
DPA-3337: bake Uptycs EDR sensor into ccs-kafka system-test AMIs + Ubuntu 22 base bump (flag-gated)

### DIFF
--- a/terraform/kafka_runner/package_ami.py
+++ b/terraform/kafka_runner/package_ami.py
@@ -56,7 +56,7 @@ def compute_packer_hash(**extras):
     def with_extension(extension):
         return glob.glob(os.path.join(dirname, '*.%s' % extension))
 
-    file_list = with_extension('sh') + with_extension('json') + [
+    file_list = with_extension('sh') + with_extension('json') + with_extension('service') + with_extension('conf') + [
         os.path.join(BASE_KAFKA_DIR, "resources/requirements.txt")]
 
     logging.info('Files considered for packer_hash: %s', ', '.join(file_list))

--- a/terraform/kafka_runner/package_ami.py
+++ b/terraform/kafka_runner/package_ami.py
@@ -58,6 +58,9 @@ def compute_packer_hash(**extras):
 
     file_list = with_extension('sh') + with_extension('json') + with_extension('service') + with_extension('conf') + [
         os.path.join(BASE_KAFKA_DIR, "resources/requirements.txt")]
+    # When baking Uptycs, hash the staged sensor deb so a new sensor build busts the base-AMI cache.
+    if str(extras.get('enable_uptycs', '')).lower() == 'true' and os.path.exists('/tmp/uptycs-protect.deb'):
+        file_list = file_list + ['/tmp/uptycs-protect.deb']
 
     logging.info('Files considered for packer_hash: %s', ', '.join(file_list))
     logging.info('Extras considered for packer_hash: %s', extras)

--- a/terraform/kafka_runner/run-test.py
+++ b/terraform/kafka_runner/run-test.py
@@ -264,7 +264,8 @@ def main():
                     ssh_account=ssh_account,
                     instance_name=args.instance_name,
                     jdk_version=args.jdk_version,
-                    jdk_arch=args.jdk_arch
+                    jdk_arch=args.jdk_arch,
+                    enable_uptycs=args.enable_uptycs
                 )
             else:
                 logging.info(f"using existing ami: {args.existing_ami}")

--- a/terraform/kafka_runner/util.py
+++ b/terraform/kafka_runner/util.py
@@ -172,6 +172,7 @@ def parse_args():
     parser.add_argument("--nightly", action="store_true", default=False, help="Mark this as a nightly run")
     parser.add_argument("--new-globals", action="store", type=str, default=None, help="Additional global params to be passed in ducktape")
     parser.add_argument("--arm-image", action="store_true", help="load the ARM based image of specified distro")
+    parser.add_argument("--enable-uptycs", action="store", type=parse_bool, default=False, help="Bake the Uptycs EDR sensor into the worker AMI (DPA-3337)")
     parser.add_argument("--existing-ami", action="store", type=str, default=None, help="AMI ID to use for the instance, skipping ami creation")
     args, rest = parser.parse_known_args(sys.argv[1:])
 

--- a/terraform/resources/terraform-worker-config.sh
+++ b/terraform/resources/terraform-worker-config.sh
@@ -1,6 +1,7 @@
 # Check AMI_ID present or not as env variable if not then set
+# Ubuntu 22.04 (jammy) — systemd base required by the Uptycs EDR bake (DPA-3337)
 AMI_ID() {
-  echo "ami-5189a661"
+  echo "ami-021c7f7dcbd49b417"
 }
 
 if [ -z "${AMI_ID}" ]; then

--- a/vagrant/aws-packer.json
+++ b/vagrant/aws-packer.json
@@ -10,8 +10,8 @@
     "linux_distro": "ubuntu",
     "jdk_version": "8",
     "jdk_arch": "x64",
-    "enable_ena_driver_install": "true"
-
+    "enable_ena_driver_install": "true",
+    "enable_uptycs": "false"
   },
   "builders": [{
     "type": "amazon-ebs",
@@ -75,6 +75,36 @@
       "type": "shell",
       "scripts": [
         "../vagrant/base.sh"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "/tmp/uptycs-protect.deb",
+      "destination": "/tmp/uptycs-protect.deb"
+    },
+    {
+      "type": "file",
+      "source": "../vagrant/install-uptycs-sensor.sh",
+      "destination": "/tmp/install-uptycs-sensor.sh"
+    },
+    {
+      "type": "file",
+      "source": "../vagrant/uptycs-sensor-install.service",
+      "destination": "/tmp/uptycs-sensor-install.service"
+    },
+    {
+      "type": "file",
+      "source": "../vagrant/osqueryd-resource-limits.conf",
+      "destination": "/tmp/osqueryd-resource-limits.conf"
+    },
+    {
+      "environment_vars": [
+        "ENABLE_UPTYCS={{ user `enable_uptycs` }}"
+      ],
+      "execute_command": "echo 'packer' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+      "type": "shell",
+      "scripts": [
+        "../vagrant/stage-uptycs-sensor.sh"
       ]
     }
   ]

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -65,7 +65,7 @@ echo "JDK_MAJOR=$JDK_MAJOR JDK_ARCH=$JDK_ARCH JDK_FULL=$JDK_FULL"
 
 if [ -z `which javac` ]; then
     apt-get -y update
-    apt-get install -y software-properties-common python-software-properties binutils java-common
+    apt-get install -y software-properties-common binutils java-common
 
     echo "===> Installing JDK..." 
 

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -215,9 +215,9 @@ if [ ! -e /mnt ]; then
 fi
 chmod a+rwx /mnt
 
-# Run ntpdate once to sync to ntp servers
+# Run ntpdate once to sync to ntp servers (absent on Ubuntu 22+; timesyncd already syncs)
 # use -u option to avoid port collision in case ntp daemon is already running
-ntpdate -u pool.ntp.org
+command -v ntpdate >/dev/null 2>&1 && ntpdate -u pool.ntp.org || true
 # Install ntp daemon - it will automatically start on boot
 apt-get -y install ntp
 


### PR DESCRIPTION
## What
Bakes the **Uptycs EDR sensor** into the ccs-kafka (`confluentinc/kafka`) system-test worker AMIs, gated by `ENABLE_UPTYCS` (default **off** → no change to existing runs). ccs-kafka counterpart of the ce-kafka work, reusing the shared ducktape-common tooling.

Because the sensor requires a **systemd** base and ccs's committed base was **EOL Ubuntu 14.04 (trusty, no systemd)**, this PR also carries the prerequisite **base modernization to Ubuntu 22.04 (jammy)**.

## Changes
**EDR bake (thin — mirrors the ce-kafka centralized shape):**
- `vagrant/aws-packer.json` — `enable_uptycs` var + file-provision the sensor deb/scripts and run `stage-uptycs-sensor.sh` under `ENABLE_UPTYCS`.
- `terraform/kafka_runner/{util,run-test,package_ami}.py` — thread `--enable-uptycs` → `package_worker_ami` → Packer `-var`; `compute_packer_hash` also hashes `*.service`/`*.conf`.

**Base bump (prerequisite, in this story):**
- `terraform/resources/terraform-worker-config.sh` — default worker AMI trusty `ami-5189a661` → stock jammy `ami-021c7f7dcbd49b417` (ce's ARM lane already runs stock jammy; no custom image).
- `vagrant/base.sh` — jammy port: drop `python-software-properties` (L68, obsolete on jammy), guard `ntpdate` (L220, absent on jammy).

The sensor **scripts + cross-account deb pull** are **not** in this repo — they come from the shared **ducktape-common** (`dpa-3333-uptycs-edr`) and are staged into `vagrant/` at build time by the driver's `edr-prepull.sh`. Pairs with the internal kafka-overlay `dpa-3337-uptycs-ccs` driver branch ([#1071](https://github.com/confluentinc/kafka-overlay/pull/1071)).

> ⚠️ **Blast radius:** the base bump changes the base image for **all** ccs branch-builder + nightly system tests — wants full-suite eyes + owner review before merge, then extend to the `4.x` lanes.

## Validation
On the **committed jammy default** (no `AMI_ID` override). Evidence: `Debug/DPA-3321/runs/ccs-*`; live status on the [ccs-kafka EDR Confluence page](https://confluentinc.atlassian.net/wiki/pages/viewpage.action?pageId=5962137650).

**Base-OS journey** (one fix surfaced per bake — trusty → jammy): trusty ❌ `systemctl` 127 → jammy ❌ `base.sh:68` → jammy ❌ `base.sh:220` → **jammy ✅ Uptycs baked, 14/14**.

**Branch-builder `ENABLE_UPTYCS` matrix (x86, jammy base):**
| Flag | Result |
|---|---|
| on | ✅ sensor baked (`enabled uptycs-sensor-install.service`) + cluster up, 14/14 |
| off | ✅ absent (bake skipped, no metric), 14/14 |

**Full nightly (production path, `ENABLE_UPTYCS=true`) — no EDR regression:**
| Run | Tests | Failures | EDR-attributable |
|---|---|---|---|
| [ccs nightly](https://semaphore.ci.confluent.io/workflows/3fc27fb5-3ce3-41da-a99d-22da87e5cd8d) | 1207 | 4 | **0** (3× Trogdor worker-stop, 1 replica-lag timeout — all functional) |

Sensor-baked jammy AMI booted the fleet and ran the full ccs suite; zero EDR signatures in any failure (4/1207 = 0.3% clean flake profile). **Full-nightly `ENABLE_UPTYCS=false` control run queued.**

## Coordinated PRs
- kafka-overlay [#1071](https://github.com/confluentinc/kafka-overlay/pull/1071) — the ccs driver wiring (base `trunk`)
- ducktape-common [#113](https://github.com/confluentinc/ducktape-common/pull/113) — shared assets (reused as-is)

Tracking: DPA-3337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
