### PR TITLE
MINOR: consolidate cflt_* cost-allocation tags on system-test resources

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,10 +6,10 @@ locals {
     "Owner": "ce-kafka",
     "role": "ce-kafka",
     "cflt_environment": "devel",
-    "cflt_partition": "onprem",
+    "cflt_partition": "operational-tools",
     "cflt_managed_by": "iac",
-    "cflt_managed_id": "ce-kafka",
-    "cflt_service": "ce-kafka"
+    "cflt_managed_id": "kafka",
+    "cflt_service": "kafka-system-test"
   }
 }
 

--- a/vagrant/aws-packer.json
+++ b/vagrant/aws-packer.json
@@ -36,7 +36,9 @@
       "distro": "{{user `linux_distro`}}",
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "tags": {
       "Owner": "ce-kafka",
@@ -46,12 +48,28 @@
       "CreatedBy": "kafka-system-test",
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
+    },
+    "snapshot_tags": {
+      "Owner": "ce-kafka",
+      "Service": "ce-kafka",
+      "Type": "Base",
+      "role": "ce-kafka",
+      "CreatedBy": "kafka-system-test",
+      "cflt_managed_by": "iac",
+      "cflt_managed_id": "kafka",
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "run_volume_tags": {
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "launch_block_device_mappings": [{
       "device_name": "/dev/sda1",

--- a/vagrant/worker-ami.json
+++ b/vagrant/worker-ami.json
@@ -40,6 +40,8 @@
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
       "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools",
       "Name": "{{user `instance_name`}}"
     },
     "tags": {
@@ -51,6 +53,8 @@
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
       "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools",
       "Name": "{{user `instance_name`}}",
       "ResourceUrl": "{{user `resource_url`}}",
       "NightlyRun": "{{user `nightly_run`}}",
@@ -58,10 +62,25 @@
       "JdkVersion": "{{user `jdk_version`}}",
       "Arch": "{{user `jdk_arch`}}"
     },
+    "snapshot_tags": {
+      "Owner": "ce-kafka",
+      "Service": "ce-kafka",
+      "Type": "Worker",
+      "role": "kafka-worker",
+      "CreatedBy": "kafka-system-test",
+      "cflt_managed_by": "iac",
+      "cflt_managed_id": "kafka",
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools",
+      "Name": "{{user `instance_name`}}"
+    },
     "run_volume_tags": {
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "launch_block_device_mappings": [{
       "device_name": "/dev/sda1",


### PR DESCRIPTION
## What this changes

System-test resources created from this repository are tagged with the `cflt_*` set that drives cloud cost reporting. Those tags are currently inconsistent: several different `cflt_service` values are in use across Terraform and Packer for what is a single system, so the cost of running system tests cannot be attributed cleanly to one owner.

This standardises the five `cflt_*` tags across every surface in this repo that creates AWS resources. Tracked as DPA-2804.

| Tag | Value | Change |
|---|---|---|
| `cflt_service` | `kafka-system-test` | was `ce-kafka` in Terraform; the Packer templates already carried this value |
| `cflt_managed_id` | `kafka` | was `ce-kafka` in Terraform |
| `cflt_managed_by` | `iac` | unchanged |
| `cflt_environment` | `devel` | added to the Packer templates |
| `cflt_partition` | `operational-tools` | was `onprem`; added to the Packer templates |

Tag values only. No variable, resource or provisioner changes, and no change to how the build or the tests run.

## Changes by file

### `terraform/main.tf`

`cflt_service`, `cflt_managed_id` and `cflt_partition` in `locals.common_tags`, which feeds the AWS provider's `default_tags` and so applies to the worker instances.

This is the substantive fix. Workers and volumes created from this repository were tagged `cflt_service=ce-kafka` **and** `cflt_managed_id=ce-kafka`, so their cost was reported against the `ce-kafka` repository rather than this one. That made system-test spend from this repo effectively invisible, and inflated the figure attributed to `ce-kafka`.

### `vagrant/aws-packer.json` (base AMI) and `vagrant/worker-ami.json` (worker AMI)

These are Packer templates, despite living under `vagrant/` — a legacy directory name from before the Vagrant-to-Terraform migration. They are used by the Terraform run path.

1. `cflt_environment` and `cflt_partition` **added** to `run_tags`, `tags` and `run_volume_tags`. Neither key existed anywhere in either template, so AMIs, Packer builder instances and builder volumes carried no environment or partition classification at all.

2. New `snapshot_tags` block in each template. Packer's `tags` applies to the AMI only. The AMI is metadata; the EBS snapshot holding the actual disk image is the billed artifact, and it was completely untagged. Since `terraform/kafka_runner/package_ami.py` retains AMIs for 30 days, that snapshot storage could not be attributed to anything. This is the largest previously untracked item.

### Why `cflt_partition` becomes `operational-tools`

`onprem` denotes resources supporting the on-premises product. `operational-tools` denotes infrastructure that serves internal engineering and falls under operating expenses. These are CI fleets that exist to run system tests for internal developers — they are not part of any product's customer-facing footprint — so `operational-tools` is the correct classification.

### Why `cflt_managed_id` is `kafka` and not `ccs-kafka`

`cflt_managed_id` records the repository whose code manages the resource. That is `confluentinc/kafka`, so the value is `kafka`. `ccs-kafka` describes the product line rather than a repository and would not resolve during cost attribution.

## Deliberately unchanged

`Service` and `CreatedBy` are load-bearing. The AMI garbage collector filters on both:

```python
# terraform/kafka_runner/package_ami.py:187-188
for image in ec2.images.filter(Owners=[AWS_ACCOUNT_ID], Filters=[
        {'Name': 'tag:Service',   'Values': ['ce-kafka']},
        {'Name': 'tag:CreatedBy', 'Values': ['kafka-system-test']}]):
```

Renaming either would silently stop AMI and snapshot cleanup, growing storage cost rather than reducing it. `Service` therefore stays `ce-kafka` even though `cflt_service` no longer does. The two tags are unrelated: one drives cleanup, the other drives cost reporting.

Also untouched:

- `SemaphoreWorkflowUrl` — the instance reaper terminates workers by matching on it
- `SemaphoreJobId` — read by the EC2 and EKS cleanup tasks
- `Owner`, `role`, `ducktape`, `Name`, `Type`, `SemaphoreBuildUrl`
- `Vagrantfile` — only reachable when the Vagrant provisioning path is selected, which no current job does

`NightlyRun` and `ResourceUrl` still resolve to empty strings, because no caller passes those Packer variables. They are left as-is; a follow-up change replaces them rather than populating them.

## Testing

Both Packer templates were validated as JSON.

Verified by a branch-builder system-test run with a reduced worker count, then confirming each resource kind carries the new values:

```bash
aws ec2 describe-instances  --filters "Name=tag:cflt_service,Values=kafka-system-test"
aws ec2 describe-images     --owners self    --filters "Name=tag:cflt_service,Values=kafka-system-test"
aws ec2 describe-volumes    --filters "Name=tag:cflt_service,Values=kafka-system-test"
aws ec2 describe-snapshots  --owner-ids self --filters "Name=tag:cflt_service,Values=kafka-system-test"
```

Two of these warrant attention:

- `describe-snapshots` is new coverage. An empty result means `snapshot_tags` did not take effect.
- `describe-volumes` confirms whether `default_tags` reaches instance root volumes, since `main.tf` sets no explicit `volume_tags`. If volumes come back untagged while instances are tagged, a follow-up adding `volume_tags` to the `aws_instance` block is needed.

Also confirmed: no instances survive the workflow, so the reaper still matches on `SemaphoreWorkflowUrl`, and AMI cleanup still runs after the 30-day window.

Cloud cost-allocation tags are not applied retroactively, so reporting reflects the new values only from the point they go live.
