### PR TITLE
MINOR: consolidate cflt_* cost-allocation tags on system-test resources [4.3]

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,10 +6,10 @@ locals {
     "Owner": "ce-kafka",
     "role": "ce-kafka",
     "cflt_environment": "devel",
-    "cflt_partition": "onprem",
+    "cflt_partition": "operational-tools",
     "cflt_managed_by": "iac",
-    "cflt_managed_id": "ce-kafka",
-    "cflt_service": "ce-kafka"
+    "cflt_managed_id": "kafka",
+    "cflt_service": "kafka-system-test"
   }
 }
 

--- a/vagrant/aws-packer.json
+++ b/vagrant/aws-packer.json
@@ -36,7 +36,9 @@
       "distro": "{{user `linux_distro`}}",
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "tags": {
       "Owner": "ce-kafka",
@@ -46,12 +48,28 @@
       "CreatedBy": "kafka-system-test",
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
+    },
+    "snapshot_tags": {
+      "Owner": "ce-kafka",
+      "Service": "ce-kafka",
+      "Type": "Base",
+      "role": "ce-kafka",
+      "CreatedBy": "kafka-system-test",
+      "cflt_managed_by": "iac",
+      "cflt_managed_id": "kafka",
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "run_volume_tags": {
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "launch_block_device_mappings": [{
       "device_name": "/dev/sda1",

--- a/vagrant/worker-ami.json
+++ b/vagrant/worker-ami.json
@@ -40,6 +40,8 @@
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
       "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools",
       "Name": "{{user `instance_name`}}"
     },
     "tags": {
@@ -51,6 +53,8 @@
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
       "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools",
       "Name": "{{user `instance_name`}}",
       "ResourceUrl": "{{user `resource_url`}}",
       "NightlyRun": "{{user `nightly_run`}}",
@@ -58,10 +62,25 @@
       "JdkVersion": "{{user `jdk_version`}}",
       "Arch": "{{user `jdk_arch`}}"
     },
+    "snapshot_tags": {
+      "Owner": "ce-kafka",
+      "Service": "ce-kafka",
+      "Type": "Worker",
+      "role": "kafka-worker",
+      "CreatedBy": "kafka-system-test",
+      "cflt_managed_by": "iac",
+      "cflt_managed_id": "kafka",
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools",
+      "Name": "{{user `instance_name`}}"
+    },
     "run_volume_tags": {
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "launch_block_device_mappings": [{
       "device_name": "/dev/sda1",


### PR DESCRIPTION
Backport to `4.3`. Clean cherry-pick — all three files were byte-identical between `master` and `4.3`.

## What this changes

System-test resources created from this repository are tagged with the `cflt_*` set that drives cloud cost reporting, and those tags are currently inconsistent across Terraform and Packer. This standardises them so system-test cost can be attributed to a single owner. Tracked as DPA-2804.

| Tag | Value | Change |
|---|---|---|
| `cflt_service` | `kafka-system-test` | was `ce-kafka` in Terraform; the Packer templates already carried this value |
| `cflt_managed_id` | `kafka` | was `ce-kafka` in Terraform |
| `cflt_partition` | `operational-tools` | was `onprem`; added to the Packer templates |
| `cflt_environment` | `devel` | added to the Packer templates |
| `cflt_managed_by` | `iac` | unchanged |

## Why this branch

System tests run per release line on a nightly schedule, and the tagging code lives in the repository under test — so a fix only takes effect on a release line once it is present on that branch. `4.3` is the newest line in the daily tier, making it the highest-traffic target and the first backport. Older lines follow once this is validated.

## Changes by file

- **`terraform/main.tf`** — `cflt_service`, `cflt_managed_id` and `cflt_partition` in `locals.common_tags`, which feeds the provider's `default_tags` and so covers the worker instances. This is the substantive fix: workers and volumes from this repo were reporting against the `ce-kafka` repository name.
- **`vagrant/aws-packer.json`, `vagrant/worker-ami.json`** — Packer templates, despite the legacy directory name. `cflt_environment` and `cflt_partition` added to `run_tags`, `tags` and `run_volume_tags`, as neither key existed in either template. New `snapshot_tags` block so the EBS snapshot backing each AMI is no longer untagged — Packer's `tags` covers the AMI only, and the snapshot is the billed artifact.

`Service` and `CreatedBy` are unchanged: the AMI garbage collector filters on both (`terraform/kafka_runner/package_ami.py:187-188`), so renaming either would silently stop AMI and snapshot cleanup. `SemaphoreWorkflowUrl` and `SemaphoreJobId` are likewise untouched, as the instance reapers match on them. The `Vagrantfile` is not modified.

Tag values only — no variable, resource or provisioner changes, and no change to how the build or the tests run.

## Testing

Both Packer templates validated as JSON. Verified by a branch-builder run against this branch, confirming instances, images, volumes and snapshots all carry `cflt_service=kafka-system-test`, and that no instances survive the workflow.
