### PR TITLE
DPA-3043: jammy worker AMI + eth0 fix for ccs-kafka 4.4

### DIFF
--- a/terraform/resources/terraform-worker-config.sh
+++ b/terraform/resources/terraform-worker-config.sh
@@ -1,6 +1,7 @@
 # Check AMI_ID present or not as env variable if not then set
+# Ubuntu 22.04 (jammy) — Nitro-compatible base (ENA + NVMe) required for modern instances (c6a). DPA-3043.
 AMI_ID() {
-  echo "ami-5189a661"
+  echo "ami-021c7f7dcbd49b417"
 }
 
 if [ -z "${AMI_ID}" ]; then

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -65,7 +65,7 @@ echo "JDK_MAJOR=$JDK_MAJOR JDK_ARCH=$JDK_ARCH JDK_FULL=$JDK_FULL"
 
 if [ -z `which javac` ]; then
     apt-get -y update
-    apt-get install -y software-properties-common python-software-properties binutils java-common
+    apt-get install -y software-properties-common binutils java-common
 
     echo "===> Installing JDK..." 
 
@@ -215,9 +215,9 @@ if [ ! -e /mnt ]; then
 fi
 chmod a+rwx /mnt
 
-# Run ntpdate once to sync to ntp servers
+# Run ntpdate once to sync to ntp servers (absent on Ubuntu 22+; timesyncd already syncs)
 # use -u option to avoid port collision in case ntp daemon is already running
-ntpdate -u pool.ntp.org
+command -v ntpdate >/dev/null 2>&1 && ntpdate -u pool.ntp.org || true
 # Install ntp daemon - it will automatically start on boot
 apt-get -y install ntp
 

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -221,6 +221,18 @@ command -v ntpdate >/dev/null 2>&1 && ntpdate -u pool.ntp.org || true
 # Install ntp daemon - it will automatically start on boot
 apt-get -y install ntp
 
+# Force legacy "eth0" NIC naming. Ubuntu 22.04 on Nitro (c6a/c7) uses predictable names
+# (ens5), but kafka trogdor network-fault tests (network_degrade, round_trip_fault) target
+# eth0. net.ifnames=0 restores eth0; cloud-init regenerates netplan for it on boot. DPA-3043.
+if [ -f /etc/default/grub ]; then
+    if grep -q '^GRUB_CMDLINE_LINUX=' /etc/default/grub; then
+        sed -i 's/^GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 net.ifnames=0 biosdevname=0"/' /etc/default/grub
+    else
+        echo 'GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"' >> /etc/default/grub
+    fi
+    update-grub
+fi
+
 # Increase the ulimit
 mkdir -p /etc/security/limits.d
 echo "* soft nofile 128000" >> /etc/security/limits.d/nofile.conf


### PR DESCRIPTION
## Why (cost reduction)

Part of the **ccs-kafka system-test cost-reduction** effort — migrating the nightly system-test worker fleet from the 2015-era `c4.large` to the cheaper, faster **`c6a.large`**: **−26% NetAmortized (~$7–7.6K/yr NetAmortized, fleet-wide)**, faster runtime on every branch, zero instance-type regressions. `c6a` is a Nitro instance that the old Ubuntu 14.04 worker AMI cannot boot, so this PR provides the Nitro-capable **Ubuntu 22.04** base AMI (+ jammy/eth0 fixes) that unblocks the instance-type switch. Paired with the kafka-overlay PR that sets `INSTANCE_TYPE=c6a.large`.

📄 Full design, validation & cost write-up: [ccs-kafka System-Test Cost Optimization](https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/6099009707)

---

## What

Ubuntu 22.04 (jammy) worker base AMI + eth0 fix for **ccs-kafka 4.4** system tests — same change as trunk [#2126](https://github.com/confluentinc/kafka/pull/2126), cherry-picked onto `4.4`.

Part of **[DPA-3043](https://confluentinc.atlassian.net/browse/DPA-3043)** instance-type modernization (4.4 lane). Pairs with kafka-overlay PR [#1080](https://github.com/confluentinc/kafka-overlay/pull/1080) (`INSTANCE_TYPE=c6a.large`).

## Changes (2 files)
- `terraform/resources/terraform-worker-config.sh`: base AMI `ami-5189a661` (Ubuntu 14.04, can't boot Nitro) → `ami-021c7f7dcbd49b417` (Ubuntu 22.04 jammy, ENA) — required for c6a.
- `vagrant/base.sh`: drop `python-software-properties`, guard `ntpdate` (gone in 22.04), add `net.ifnames=0` so the NIC is `eth0` (trogdor network-fault tests). Validated on trunk (branch builder: 9 net-fault tests, 0 failed).

## ✅ Validation — FINAL (settled 2026-08-25)

**c6a.large validated — ready for review.**  Every test failure is a known corpus-flaky test that **also fails on the stock c4 baseline**; **0 `Cannot find device eth0` errors**; 0 instance-type regressions.

- **Round 2** [`383e170d`](https://semaphore.ci.confluent.io/workflows/383e170d-8bed-4f5c-9180-aea8961b35bb): 610 min · 1207 run · 1195 passed · 1 flaky · **2 failed** (`network_degrade.test_rate`, `replica_verification.test_replica_lags` — both flaky) · **0 eth0**.
- **Round 1** [`e9160048`](https://semaphore.ci.confluent.io/workflows/e9160048-bcae-493f-8ea5-6d5031b9b3f5): same flaky-only result — Round 2 reproduces it.
- **"Pipeline failed" is expected here**: the stock **c4 baseline is also `failed`** (its 1 failed test `ConnectDistributedTest.test_dynamic_logging` is corpus-flaky). The Semaphore flag only means ≥1 flaky test failed all `--deflake 3` reruns — evaluation is per-test.
- **Settled per-run cost** (Cost Explorer, `SemaphoreBuildUrl` tag, fully propagated): c6a **$0.0247/inst-hr NetAmortized vs c4 $0.0335 = −26%** (Unblended gross list −22%). This run ≈ **$7.92**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DPA-3043]: https://confluentinc.atlassian.net/browse/DPA-3043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ