### PR TITLE
DPA-3043: jammy worker AMI + eth0 fix for ccs-kafka 4.0

### DIFF
--- a/terraform/resources/terraform-worker-config.sh
+++ b/terraform/resources/terraform-worker-config.sh
@@ -1,6 +1,7 @@
 # Check AMI_ID present or not as env variable if not then set
 AMI_ID() {
-  echo "ami-29ebb519"
+  # Ubuntu 22.04 jammy (Nitro-compatible) for c6a. DPA-3043
+  echo "ami-021c7f7dcbd49b417"
 }
 
 if [ -z "${AMI_ID}" ]; then

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -43,7 +43,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 if [ -z `which javac` ]; then
     apt-get -y update
-    apt-get install -y software-properties-common python-software-properties binutils java-common
+    apt-get install -y software-properties-common binutils java-common
 
     echo "===> Installing JDK..." 
 
@@ -197,7 +197,17 @@ chmod a+rwx /mnt
 
 # Run ntpdate once to sync to ntp servers
 # use -u option to avoid port collision in case ntp daemon is already running
-ntpdate -u pool.ntp.org
+command -v ntpdate >/dev/null 2>&1 && ntpdate -u pool.ntp.org || true
+
+# Force legacy "eth0" NIC naming (jammy/Nitro default ens5; kafka trogdor net-fault tests target eth0). DPA-3043
+if [ -f /etc/default/grub ]; then
+    if grep -q '^GRUB_CMDLINE_LINUX=' /etc/default/grub; then
+        sed -i 's/^GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 net.ifnames=0 biosdevname=0"/' /etc/default/grub
+    else
+        echo 'GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"' >> /etc/default/grub
+    fi
+    update-grub
+fi
 # Install ntp daemon - it will automatically start on boot
 apt-get -y install ntp
 


### PR DESCRIPTION
## Why (cost reduction)

Part of the **ccs-kafka system-test cost-reduction** effort — migrating the nightly system-test worker fleet from the 2015-era `c4.large` to the cheaper, faster **`c6a.large`**: **−26% NetAmortized (~$7–7.6K/yr NetAmortized, fleet-wide)**, faster runtime on every branch, zero instance-type regressions. `c6a` is a Nitro instance that the old Ubuntu 14.04 worker AMI cannot boot, so this PR provides the Nitro-capable **Ubuntu 22.04** base AMI (+ jammy/eth0 fixes) that unblocks the instance-type switch. Paired with the kafka-overlay PR that sets `INSTANCE_TYPE=c6a.large`.

📄 Full design, validation & cost write-up: [ccs-kafka System-Test Cost Optimization](https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/6099009707)

---

## What
Jammy worker AMI + eth0 fix for **ccs-kafka 4.0** — same change as trunk [#2126](https://github.com/confluentinc/kafka/pull/2126). Base AMI `ami-29ebb519` (Ubuntu 14.04) → `ami-021c7f7dcbd49b417` (Ubuntu 22.04 jammy, Nitro/ENA); base.sh: drop `python-software-properties`, guard `ntpdate`, add `net.ifnames=0` (eth0). Part of [DPA-3043](https://confluentinc.atlassian.net/browse/DPA-3043); pairs with kafka-overlay PR [#1084](https://github.com/confluentinc/kafka-overlay/pull/1084).

JDK 17 · 64 workers. Validation: [workflow](https://semaphore.ci.confluent.io/workflows/c8003646-f968-401c-a767-c94c60837999).

## ✅ Validation — FINAL (settled 2026-08-25)

**c6a.large validated — ready for review.**  Every test failure is a known corpus-flaky test that **also fails on the stock c4 baseline**; **0 `Cannot find device eth0` errors**; 0 instance-type regressions.

- [`c8003646`](https://semaphore.ci.confluent.io/workflows/c8003646-f968-401c-a767-c94c60837999): 256 min (64 workers) · 1099 run · 1089 passed · **3 failed** (`network_degrade.test_latency` ×2, `replica_verification.test_replica_lags` — all flaky) · **0 eth0**.
- **"Pipeline failed" is expected here**: the stock **c4 baseline is also `failed`** (its 1 failed test `ConnectDistributedTest.test_dynamic_logging` is corpus-flaky). The Semaphore flag only means ≥1 flaky test failed all `--deflake 3` reruns — evaluation is per-test.
- **Settled per-run cost** (Cost Explorer, `SemaphoreBuildUrl` tag, fully propagated): c6a **$0.0247/inst-hr NetAmortized vs c4 $0.0335 = −26%** (Unblended gross list −22%). This run ≈ **$7.22**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DPA-3043]: https://confluentinc.atlassian.net/browse/DPA-3043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ