### PR TITLE
KSECURITY-2870: Bump log4j to 2.25.5

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -236,10 +236,10 @@ License Version 2.0:
 - jetty-session-12.0.36
 - jetty-util-12.0.36
 - jose4j-0.9.4
-- log4j-api-2.25.4
-- log4j-core-2.25.4
-- log4j-slf4j-impl-2.25.4
-- log4j-1.2-api-2.25.4
+- log4j-api-2.25.5
+- log4j-core-2.25.5
+- log4j-slf4j-impl-2.25.5
+- log4j-1.2-api-2.25.5
 - lz4-java-1.10.1
 - maven-artifact-3.9.15
 - metrics-core-2.2.0

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -108,7 +108,7 @@ versions += [
   kafka_37: "3.7.2",
   kafka_38: "3.8.1",
   kafka_39: "3.9.0",
-  log4j2: "2.25.4",
+  log4j2: "2.25.5",
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java#L73-L74
   // https://github.com/yawkat/lz4-java/blob/main/src/java/net/jpountz/lz4/LZ4Constants.java#L23-L24


### PR DESCRIPTION
Cherry pick of KAFKA-20791:

> Upgrade log4j2 from 2.25.4 to 2.25.5.
>
> Reviewers: Mickael Maison <mickael.maison@gmail.com>
