### PR TITLE
MINOR: tag kst-* cost-classification tags at resource-creation time [4.3]

### DIFF
--- a/terraform/kafka_runner/run-test.py
+++ b/terraform/kafka_runner/run-test.py
@@ -20,6 +20,53 @@ from terraform.kafka_runner.util import INSTANCE_TYPE, ABS_KAFKA_DIR, JOB_ID, AW
 from terraform.kafka_runner.util import setup_virtualenv, parse_args, parse_bool
 from ssh_checkers.aws_checker import aws_ssh_checker
 
+def derive_kst_tags(args, env=None):
+    """kst-* cost-classification tags for this run (DPA-2804).
+
+    Applied at `terraform apply` via var.kst_tags -> the provider default_tags, so
+    they land on the worker instances and their volumes at creation. Values come
+    from the Semaphore / config.sh environment and run args; anything we cannot
+    determine is "unknown" (an empty tag reads as untagged in Cost Explorer).
+    """
+    env = os.environ if env is None else env
+
+    bucket_key = env.get("BUCKET_KEY", "")
+    if not bucket_key:
+        task = "unknown"
+    elif "branch-builder" in bucket_key:
+        task = "branch-builder"
+    else:
+        task = "scheduler-system-test-kafka"
+
+    # KST_BRANCH is the pre-rewrite value the trunk pipeline exports before it
+    # rewrites KAFKA_BRANCH trunk->master; fall back to KAFKA_BRANCH otherwise.
+    branch = env.get("KST_BRANCH") or env.get("KAFKA_BRANCH") or "unknown"
+
+    jdk_arch = (getattr(args, "jdk_arch", "") or "").lower()
+    if jdk_arch in ("aarch64", "arm64"):
+        arch = "arm64"
+    elif jdk_arch in ("x64", "x86", "amd64", "x86_64"):
+        arch = "x86"
+    else:
+        arch = "unknown"
+
+    workflow_url = getattr(args, "build_url", "") or env.get("SEMAPHORE_WORKFLOW_URL", "")
+    if not workflow_url:
+        wf_id = env.get("SEMAPHORE_WORKFLOW_ID")
+        workflow_url = (
+            "https://semaphore.ci.confluent.io/workflows/{}".format(wf_id)
+            if wf_id else "unknown"
+        )
+
+    return {
+        "kst-task": task,
+        "kst-branch": branch,
+        "kst-arch": arch,
+        "kst-SemaphoreTask": env.get("SEMAPHORE_TASK_NAME") or "unknown",
+        "kst-SemaphoreWorkflowURL": workflow_url,
+    }
+
+
 class KafkaRunner:
     kafka_dir = ABS_KAFKA_DIR
     cluster_file_name = f"{kafka_dir}/tf-cluster.json"
@@ -165,7 +212,8 @@ class KafkaRunner:
             "build_url": self.args.build_url,
             "subnet_id": IPV6_SUBNET_ID if IS_IPV6_RUN else IPV4_SUBNET_ID,
             "ipv6_address_count": 1 if IS_IPV6_RUN else 0,
-            "job_id": JOB_ID
+            "job_id": JOB_ID,
+            "kst_tags": derive_kst_tags(self.args)
         }
         with open(self.tf_variables_file, 'w') as f:
             json.dump(vars, f)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,7 +25,10 @@ terraform {
 provider "aws" {
   region = var.ec2_region
   default_tags {
-    tags = local.common_tags
+    # local.common_tags = static cflt_* etc.; var.kst_tags = per-run kst-*
+    # cost-classification tags (DPA-2804), so instances and their volumes are
+    # tagged at creation. Empty map by default, so plans without it still apply.
+    tags = merge(local.common_tags, var.kst_tags)
   }
 }
 

--- a/terraform/variable.tf
+++ b/terraform/variable.tf
@@ -55,3 +55,9 @@ variable "security_group" {
   description = "security group id"
   default = "sg-03364f9fef903b17d"
 }
+
+variable "kst_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Per-run kst-* cost-classification tags (DPA-2804), merged into default_tags by the provider."
+}


### PR DESCRIPTION
## What this changes

System-test cost is being made attributable by run-type (nightly vs branch-builder), release line, and architecture. A companion change already puts `cflt_service=kafka-system-test` on every resource (the "who pays" tag); this adds the `kst-*` breakdown tags, applied **at resource-creation time**.

It reuses the mechanism that already stamps `SemaphoreBuildUrl` / `SemaphoreJobId` on the workers: values are computed in `run-test.py`, written to the tfvars, and applied by `terraform apply`. Terraform has no build cache, so per-run values here are safe. Tracked as DPA-2804.

## Changes (3 files)

**`terraform/kafka_runner/run-test.py`** — `derive_kst_tags()` builds five `kst-*` values from the CI environment and run args, and they're written into the tfvars as `kst_tags`:

| tag | source |
|---|---|
| `kst-task` | `BUCKET_KEY` → contains `branch-builder`? |
| `kst-branch` | `KST_BRANCH` or `KAFKA_BRANCH` |
| `kst-arch` | `--jdk-arch` normalised (`x64`→`x86`, `aarch64`→`arm64`) |
| `kst-SemaphoreTask` | `SEMAPHORE_TASK_NAME` |
| `kst-SemaphoreWorkflowURL` | `--build-url` |

Undeterminable values become `"unknown"` rather than empty.

**`terraform/variable.tf`** — new `kst_tags` map, `default = {}` (existing tfvars still plan).

**`terraform/main.tf`** — `default_tags` becomes `merge(local.common_tags, var.kst_tags)`, so the tags propagate to the worker instances and their volumes at creation.

## Scope

Covers instances + volumes. AMIs/snapshots are intentionally not covered — they're built by Packer, where per-run values at build time break the image cache; they keep `cflt_service` (still counted in the total), just without the per-run breakdown.

## Testing

`derive_kst_tags()` was exercised standalone across nightly, branch-builder, the `KST_BRANCH` override, and the empty (`unknown`) case. `run-test.py` parses clean. Tag-only change — no behaviour change to the build or tests.

Please confirm in review that `terraform plan` shows an in-place tag update with no forced replacement on the `aws_instance` resource.
