### PR TITLE
DPA 2804: consolidate cflt_* and add kst-* creation-time tags [4.3]

### DIFF
--- a/terraform/kafka_runner/run-test.py
+++ b/terraform/kafka_runner/run-test.py
@@ -20,6 +20,53 @@ from terraform.kafka_runner.util import INSTANCE_TYPE, ABS_KAFKA_DIR, JOB_ID, AW
 from terraform.kafka_runner.util import setup_virtualenv, parse_args, parse_bool
 from ssh_checkers.aws_checker import aws_ssh_checker
 
+def derive_kst_tags(args, env=None):
+    """kst-* cost-classification tags for this run (DPA-2804).
+
+    Applied at `terraform apply` via var.kst_tags -> the provider default_tags, so
+    they land on the worker instances and their volumes at creation. Values come
+    from the Semaphore / config.sh environment and run args; anything we cannot
+    determine is "unknown" (an empty tag reads as untagged in Cost Explorer).
+    """
+    env = os.environ if env is None else env
+
+    bucket_key = env.get("BUCKET_KEY", "")
+    if not bucket_key:
+        task = "unknown"
+    elif "branch-builder" in bucket_key:
+        task = "branch-builder"
+    else:
+        task = "scheduler-system-test-kafka"
+
+    # KST_BRANCH is the pre-rewrite value the trunk pipeline exports before it
+    # rewrites KAFKA_BRANCH trunk->master; fall back to KAFKA_BRANCH otherwise.
+    branch = env.get("KST_BRANCH") or env.get("KAFKA_BRANCH") or "unknown"
+
+    jdk_arch = (getattr(args, "jdk_arch", "") or "").lower()
+    if jdk_arch in ("aarch64", "arm64"):
+        arch = "arm64"
+    elif jdk_arch in ("x64", "x86", "amd64", "x86_64"):
+        arch = "x86"
+    else:
+        arch = "unknown"
+
+    workflow_url = getattr(args, "build_url", "") or env.get("SEMAPHORE_WORKFLOW_URL", "")
+    if not workflow_url:
+        wf_id = env.get("SEMAPHORE_WORKFLOW_ID")
+        workflow_url = (
+            "https://semaphore.ci.confluent.io/workflows/{}".format(wf_id)
+            if wf_id else "unknown"
+        )
+
+    return {
+        "kst-task": task,
+        "kst-branch": branch,
+        "kst-arch": arch,
+        "kst-SemaphoreTask": env.get("SEMAPHORE_TASK_NAME") or "unknown",
+        "kst-SemaphoreWorkflowURL": workflow_url,
+    }
+
+
 class KafkaRunner:
     kafka_dir = ABS_KAFKA_DIR
     cluster_file_name = f"{kafka_dir}/tf-cluster.json"
@@ -165,7 +212,8 @@ class KafkaRunner:
             "build_url": self.args.build_url,
             "subnet_id": IPV6_SUBNET_ID if IS_IPV6_RUN else IPV4_SUBNET_ID,
             "ipv6_address_count": 1 if IS_IPV6_RUN else 0,
-            "job_id": JOB_ID
+            "job_id": JOB_ID,
+            "kst_tags": derive_kst_tags(self.args)
         }
         with open(self.tf_variables_file, 'w') as f:
             json.dump(vars, f)

--- a/terraform/kafka_runner/run-test.py
+++ b/terraform/kafka_runner/run-test.py
@@ -62,7 +62,9 @@ def derive_kst_tags(args, env=None):
         "kst-task": task,
         "kst-branch": branch,
         "kst-arch": arch,
-        "kst-SemaphoreTask": env.get("SEMAPHORE_TASK_NAME") or "unknown",
+        # Semaphore exports no task/scheduler-name var; the pipeline name is the
+        # closest task identity that always exists (e.g. "CCS Kafka Branch Builder").
+        "kst-SemaphoreTask": env.get("SEMAPHORE_PIPELINE_NAME") or "unknown",
         "kst-SemaphoreWorkflowURL": workflow_url,
     }
 

--- a/terraform/kafka_runner/run-test.py
+++ b/terraform/kafka_runner/run-test.py
@@ -21,13 +21,7 @@ from terraform.kafka_runner.util import setup_virtualenv, parse_args, parse_bool
 from ssh_checkers.aws_checker import aws_ssh_checker
 
 def derive_kst_tags(args, env=None):
-    """kst-* cost-classification tags for this run (DPA-2804).
-
-    Applied at `terraform apply` via var.kst_tags -> the provider default_tags, so
-    they land on the worker instances and their volumes at creation. Values come
-    from the Semaphore / config.sh environment and run args; anything we cannot
-    determine is "unknown" (an empty tag reads as untagged in Cost Explorer).
-    """
+    """kst-* cost-classification tags for this run (DPA-2804), applied via var.kst_tags."""
     env = os.environ if env is None else env
 
     bucket_key = env.get("BUCKET_KEY", "")
@@ -38,8 +32,7 @@ def derive_kst_tags(args, env=None):
     else:
         task = "scheduler-system-test-kafka"
 
-    # KST_BRANCH is the pre-rewrite value the trunk pipeline exports before it
-    # rewrites KAFKA_BRANCH trunk->master; fall back to KAFKA_BRANCH otherwise.
+    # KST_BRANCH = the trunk pipeline's pre-rewrite value (trunk->master); else KAFKA_BRANCH.
     branch = env.get("KST_BRANCH") or env.get("KAFKA_BRANCH") or "unknown"
 
     jdk_arch = (getattr(args, "jdk_arch", "") or "").lower()
@@ -62,8 +55,6 @@ def derive_kst_tags(args, env=None):
         "kst-task": task,
         "kst-branch": branch,
         "kst-arch": arch,
-        # Semaphore exports no task/scheduler-name var; the pipeline name is the
-        # closest task identity that always exists (e.g. "CCS Kafka Branch Builder").
         "kst-SemaphoreTask": env.get("SEMAPHORE_PIPELINE_NAME") or "unknown",
         "kst-SemaphoreWorkflowURL": workflow_url,
     }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,7 +25,10 @@ terraform {
 provider "aws" {
   region = var.ec2_region
   default_tags {
-    tags = local.common_tags
+    # local.common_tags = static cflt_* etc.; var.kst_tags = per-run kst-*
+    # cost-classification tags (DPA-2804), so instances and their volumes are
+    # tagged at creation. Empty map by default, so plans without it still apply.
+    tags = merge(local.common_tags, var.kst_tags)
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,10 +6,10 @@ locals {
     "Owner": "ce-kafka",
     "role": "ce-kafka",
     "cflt_environment": "devel",
-    "cflt_partition": "onprem",
+    "cflt_partition": "operational-tools",
     "cflt_managed_by": "iac",
-    "cflt_managed_id": "ce-kafka",
-    "cflt_service": "ce-kafka"
+    "cflt_managed_id": "kafka",
+    "cflt_service": "kafka-system-test"
   }
 }
 

--- a/terraform/variable.tf
+++ b/terraform/variable.tf
@@ -55,3 +55,9 @@ variable "security_group" {
   description = "security group id"
   default = "sg-03364f9fef903b17d"
 }
+
+variable "kst_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Per-run kst-* cost-classification tags (DPA-2804), merged into default_tags by the provider."
+}

--- a/vagrant/aws-packer.json
+++ b/vagrant/aws-packer.json
@@ -36,7 +36,9 @@
       "distro": "{{user `linux_distro`}}",
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "tags": {
       "Owner": "ce-kafka",
@@ -46,12 +48,28 @@
       "CreatedBy": "kafka-system-test",
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
+    },
+    "snapshot_tags": {
+      "Owner": "ce-kafka",
+      "Service": "ce-kafka",
+      "Type": "Base",
+      "role": "ce-kafka",
+      "CreatedBy": "kafka-system-test",
+      "cflt_managed_by": "iac",
+      "cflt_managed_id": "kafka",
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "run_volume_tags": {
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "launch_block_device_mappings": [{
       "device_name": "/dev/sda1",

--- a/vagrant/worker-ami.json
+++ b/vagrant/worker-ami.json
@@ -40,6 +40,8 @@
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
       "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools",
       "Name": "{{user `instance_name`}}"
     },
     "tags": {
@@ -51,6 +53,8 @@
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
       "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools",
       "Name": "{{user `instance_name`}}",
       "ResourceUrl": "{{user `resource_url`}}",
       "NightlyRun": "{{user `nightly_run`}}",
@@ -58,10 +62,25 @@
       "JdkVersion": "{{user `jdk_version`}}",
       "Arch": "{{user `jdk_arch`}}"
     },
+    "snapshot_tags": {
+      "Owner": "ce-kafka",
+      "Service": "ce-kafka",
+      "Type": "Worker",
+      "role": "kafka-worker",
+      "CreatedBy": "kafka-system-test",
+      "cflt_managed_by": "iac",
+      "cflt_managed_id": "kafka",
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools",
+      "Name": "{{user `instance_name`}}"
+    },
     "run_volume_tags": {
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "launch_block_device_mappings": [{
       "device_name": "/dev/sda1",


### PR DESCRIPTION
## What this changes

The full DPA-2804 tagging change for kafka system-test resources on `4.3`, in one PR: the
**cflt-\*** cost-attribution consolidation and the **kst-\*** creation-time cost-breakdown tags.
Supersedes the split PRs #2125 (cflt-\*) and #2139 (kst-\*), which stay open for now.

## Layer 1 — cflt-\* consolidation (who pays)

- `cflt_service`: `ce-kafka` → **`kafka-system-test`** (Terraform; Packer already had it)
- `cflt_managed_id`: `ce-kafka` → **`kafka`** (Terraform) — these resources were reporting under
  the enterprise repo name, so ccs system-test cost was landing in the wrong place
- `cflt_partition`: `onprem` → **`operational-tools`**
- Packer templates gain `cflt_environment` + `cflt_partition` and a `snapshot_tags` block, so
  the EBS snapshots behind each AMI are no longer untagged.
- `Service` / `CreatedBy` unchanged — the AMI garbage collector filters on them.

## Layer 2 — kst-\* creation-time breakdown (which run)

Adds run-type / branch / arch / task / workflow tags to the worker instances and volumes at
`terraform apply`, reusing the mechanism that already stamps `SemaphoreBuildUrl` /
`SemaphoreJobId`. Terraform has no build cache, so per-run values here are safe.

- `run-test.py`: `derive_kst_tags()` computes five `kst-*` from the CI environment and run args;
  written into the tfvars as `kst_tags`.
- `variable.tf`: new `kst_tags` map (`default = {}`).
- `main.tf`: `default_tags` → `merge(local.common_tags, var.kst_tags)`.

| tag | source |
|---|---|
| `kst-task` | `BUCKET_KEY` contains `branch-builder`? |
| `kst-branch` | `KST_BRANCH` or `KAFKA_BRANCH` |
| `kst-arch` | `--jdk-arch` normalised (`x64`→`x86`, `aarch64`→`arm64`) |
| `kst-SemaphoreTask` | `SEMAPHORE_TASK_NAME` |
| `kst-SemaphoreWorkflowURL` | `--build-url` |

Undeterminable values become `"unknown"` rather than empty. `kst-*` covers instances + volumes;
AMIs/snapshots keep `cflt_service` only (per-run values in the Packer build would break the
image cache).

## Testing

Both Packer templates valid JSON; `run-test.py` parses; `derive_kst_tags()` verified standalone
across nightly, branch-builder, the `KST_BRANCH` override, and the empty (`unknown`) case.
Tag-only change — no behaviour change to the build or tests. Please confirm in review that
`terraform plan` shows an in-place tag update with no forced replacement on the `aws_instance`
resource.
