### PR TITLE
MINOR: Exclude .claude/** from Apache Rat license check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -319,6 +319,7 @@ if (repo != null) {
         'CONTRIBUTING.md',
         'PULL_REQUEST_TEMPLATE.md',
         '.github/**',
+        '.claude/**',
         'gradlew',
         'gradlew.bat',
         'gradle/wrapper/gradle-wrapper.properties',


### PR DESCRIPTION
## Summary
- `./gradlew rat` currently fails on `master` because `.claude/skills/ak-to-ck-sync/SKILL.md` (added in #2144) has no license header.
- Exclude `.claude/**` from the rat check, the same way `.github/**` is already excluded, since it holds Claude Code tooling config rather than licensable source.

## Test plan
- [x] `./gradlew rat` fails on master before this change (unapproved license on `.claude/skills/ak-to-ck-sync/SKILL.md`)
- [x] `./gradlew rat` passes with this change