### PR TITLE
MINOR: consolidate cflt_* and add kst-* creation-time tags

### DIFF
--- a/terraform/kafka_runner/run-test.py
+++ b/terraform/kafka_runner/run-test.py
@@ -20,6 +20,46 @@ from terraform.kafka_runner.util import INSTANCE_TYPE, ABS_KAFKA_DIR, JOB_ID, AW
 from terraform.kafka_runner.util import setup_virtualenv, parse_args, parse_bool
 from ssh_checkers.aws_checker import aws_ssh_checker
 
+def derive_kst_tags(args, env=None):
+    """kst-* cost-classification tags for this run (DPA-2804), applied via var.kst_tags."""
+    env = os.environ if env is None else env
+
+    bucket_key = env.get("BUCKET_KEY", "")
+    if not bucket_key:
+        task = "unknown"
+    elif "branch-builder" in bucket_key:
+        task = "branch-builder"
+    else:
+        task = "scheduler-system-test-kafka"
+
+    # KST_BRANCH = the trunk pipeline's pre-rewrite value (trunk->master); else KAFKA_BRANCH.
+    branch = env.get("KST_BRANCH") or env.get("KAFKA_BRANCH") or "unknown"
+
+    jdk_arch = (getattr(args, "jdk_arch", "") or "").lower()
+    if jdk_arch in ("aarch64", "arm64"):
+        arch = "arm64"
+    elif jdk_arch in ("x64", "x86", "amd64", "x86_64"):
+        arch = "x86"
+    else:
+        arch = "unknown"
+
+    workflow_url = getattr(args, "build_url", "") or env.get("SEMAPHORE_WORKFLOW_URL", "")
+    if not workflow_url:
+        wf_id = env.get("SEMAPHORE_WORKFLOW_ID")
+        workflow_url = (
+            "https://semaphore.ci.confluent.io/workflows/{}".format(wf_id)
+            if wf_id else "unknown"
+        )
+
+    return {
+        "kst-task": task,
+        "kst-branch": branch,
+        "kst-arch": arch,
+        "kst-SemaphoreTask": env.get("SEMAPHORE_PIPELINE_NAME") or "unknown",
+        "kst-SemaphoreWorkflowURL": workflow_url,
+    }
+
+
 class KafkaRunner:
     kafka_dir = ABS_KAFKA_DIR
     cluster_file_name = f"{kafka_dir}/tf-cluster.json"
@@ -165,7 +205,8 @@ class KafkaRunner:
             "build_url": self.args.build_url,
             "subnet_id": IPV6_SUBNET_ID if IS_IPV6_RUN else IPV4_SUBNET_ID,
             "ipv6_address_count": 1 if IS_IPV6_RUN else 0,
-            "job_id": JOB_ID
+            "job_id": JOB_ID,
+            "kst_tags": derive_kst_tags(self.args)
         }
         with open(self.tf_variables_file, 'w') as f:
             json.dump(vars, f)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,10 +6,10 @@ locals {
     "Owner": "ce-kafka",
     "role": "ce-kafka",
     "cflt_environment": "devel",
-    "cflt_partition": "onprem",
+    "cflt_partition": "operational-tools",
     "cflt_managed_by": "iac",
-    "cflt_managed_id": "ce-kafka",
-    "cflt_service": "ce-kafka"
+    "cflt_managed_id": "kafka",
+    "cflt_service": "kafka-system-test"
   }
 }
 
@@ -25,7 +25,7 @@ terraform {
 provider "aws" {
   region = var.ec2_region
   default_tags {
-    tags = local.common_tags
+    tags = merge(local.common_tags, var.kst_tags)
   }
 }
 

--- a/terraform/variable.tf
+++ b/terraform/variable.tf
@@ -55,3 +55,9 @@ variable "security_group" {
   description = "security group id"
   default = "sg-03364f9fef903b17d"
 }
+
+variable "kst_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Per-run kst-* cost-classification tags (DPA-2804), merged into default_tags by the provider."
+}

--- a/vagrant/aws-packer.json
+++ b/vagrant/aws-packer.json
@@ -36,7 +36,9 @@
       "distro": "{{user `linux_distro`}}",
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "tags": {
       "Owner": "ce-kafka",
@@ -46,12 +48,28 @@
       "CreatedBy": "kafka-system-test",
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
+    },
+    "snapshot_tags": {
+      "Owner": "ce-kafka",
+      "Service": "ce-kafka",
+      "Type": "Base",
+      "role": "ce-kafka",
+      "CreatedBy": "kafka-system-test",
+      "cflt_managed_by": "iac",
+      "cflt_managed_id": "kafka",
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "run_volume_tags": {
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "launch_block_device_mappings": [{
       "device_name": "/dev/sda1",

--- a/vagrant/worker-ami.json
+++ b/vagrant/worker-ami.json
@@ -58,10 +58,28 @@
       "JdkVersion": "{{user `jdk_version`}}",
       "Arch": "{{user `jdk_arch`}}"
     },
+    "snapshot_tags": {
+      "Owner": "ce-kafka",
+      "Service": "ce-kafka",
+      "Type": "Worker",
+      "role": "kafka-worker",
+      "CreatedBy": "kafka-system-test",
+      "cflt_managed_by": "iac",
+      "cflt_managed_id": "kafka",
+      "cflt_service": "kafka-system-test",
+      "Name": "{{user `instance_name`}}",
+      "ResourceUrl": "{{user `resource_url`}}",
+      "NightlyRun": "{{user `nightly_run`}}",
+      "Distro": "{{user `linux_distro`}}",
+      "JdkVersion": "{{user `jdk_version`}}",
+      "Arch": "{{user `jdk_arch`}}"
+    },
     "run_volume_tags": {
       "cflt_managed_by": "iac",
       "cflt_managed_id": "kafka",
-      "cflt_service": "kafka-system-test"
+      "cflt_service": "kafka-system-test",
+      "cflt_environment": "devel",
+      "cflt_partition": "operational-tools"
     },
     "launch_block_device_mappings": [{
       "device_name": "/dev/sda1",


### PR DESCRIPTION
## Why

System-test resources in AWS can't currently be attributed to a single owner or broken down by run type — the `cflt_service` tag is spread across several values, and there's no per-run classification. This backports the tagging change (validated on `4.3`) to `master`, whose nightly scheduler runs system tests on this line, so its runs report cost consistently.

**1. Consolidate cost attribution (`cflt_*`):**
- `cflt_service` → `kafka-system-test`; `cflt_managed_id` → `kafka`; `cflt_partition` → `operational-tools`.
- Added `cflt_environment` + `cflt_partition` to the Packer templates and a `snapshot_tags` block so the EBS snapshots behind each AMI are tagged too.

**2. Add per-run classification (`kst-*`)** — applied at `terraform apply` via a `kst_tags` map merged into the provider `default_tags`, so the worker instances and their volumes carry them at creation:
`kst-task` (nightly vs branch-builder), `kst-branch`, `kst-arch`, `kst-SemaphoreTask` (pipeline name), `kst-SemaphoreWorkflowURL`. Undeterminable values become `unknown`, never empty.

## Changes (5 files)
- `terraform/main.tf` — cflt values in `common_tags`; `default_tags` → `merge(local.common_tags, var.kst_tags)`.
- `terraform/variable.tf` — new `kst_tags` map (`default = {}`).
- `terraform/kafka_runner/run-test.py` — `derive_kst_tags()` + the value written into the tfvars beside `job_id`.
- `vagrant/aws-packer.json`, `vagrant/worker-ami.json` — cflt values + `cflt_environment`/`cflt_partition` + `snapshot_tags`.

## Not changed (deliberately)
`Service`, `Type`, `CreatedBy` — the AMI garbage collector filters on them, so renaming would silently stop AMI/snapshot cleanup.

## Scope
`kst-*` covers instances + volumes. AMIs/snapshots keep `cflt_service` only — per-run values in the Packer build would break the base-AMI cache; that storage slice stays attributed at the service level.

## Testing
Tag-only change — no variable/resource/provisioner behaviour change; both Packer templates validate as JSON and `run-test.py` parses. Please confirm in review that `terraform plan` shows an in-place tag update with **no `forces replacement`** on the `aws_instance` resource.
